### PR TITLE
Let Casts Start Mid-Arc: Wizard-Time Project Seeding (#531 Stage A)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -543,6 +543,13 @@ transition_timeout_seconds = 900
 # process-local registry. Run the API single-worker, or accept that status
 # polls answered by a non-writing worker report stage "idle" mid-transition.
 
+[orrery.retrograde.projects]
+# Wizard-time long-arc generation is opt-in in the model and enabled in the
+# shipped configuration. Every accepted intent starts on its first stage.
+enabled = true
+# Cast-wide bound after deterministic one-project-per-character arbitration.
+max_seeded_projects = 3
+
 [orrery.retrograde.graph]
 # R3 candidate-graph sampling calibration (issue #442). The graph rolls
 # dangling-edge ingredients the seed model must reconcile; these knobs set

--- a/nexus/agents/orrery/retrograde_expansion.py
+++ b/nexus/agents/orrery/retrograde_expansion.py
@@ -958,6 +958,11 @@ def _project_plan_issues(
     issues: list[str] = []
     threads_by_seed = {thread.seed_id: thread for thread in response.thread_plan}
     projects_by_seed = {project.seed_id: project for project in response.project_plan}
+    dead_character_refs = {
+        normalize_entity_ref(death.entity_ref)
+        for death in response.death_plan
+        if death.entity_kind == "character"
+    }
     for project in response.project_plan:
         candidate = candidates_by_id.get(project.seed_id)
         if candidate is None or project.seed_id not in response.selected_seed_ids:
@@ -986,6 +991,25 @@ def _project_plan_issues(
             issues.append(
                 f"project plan seed {project.seed_id!r} changes target_ref "
                 f"from {intent.target_ref!r} to {project.target_ref!r}"
+            )
+        if normalize_entity_ref(project.actor_ref) in dead_character_refs:
+            issues.append(
+                f"project plan seed {project.seed_id!r} actor_ref "
+                f"{project.actor_ref!r} appears in death_plan"
+            )
+        if (
+            project.project_type
+            in {
+                "recruit_ally",
+                "pursue_romance",
+                "court_patron",
+                "seek_redemption",
+            }
+            and planned_target in dead_character_refs
+        ):
+            issues.append(
+                f"project plan seed {project.seed_id!r} character target_ref "
+                f"{project.target_ref!r} appears in death_plan"
             )
         thread = threads_by_seed.get(project.seed_id)
         if thread is not None and thread.status != "woven":

--- a/nexus/agents/orrery/retrograde_expansion.py
+++ b/nexus/agents/orrery/retrograde_expansion.py
@@ -15,6 +15,8 @@ from nexus.agents.orrery.retrograde_packet import (
     NAMED_SEED_NPCS_HEADING,
 )
 from nexus.agents.orrery.retrograde_seed_candidates import (
+    RetrogradeProjectType,
+    validate_project_target_shape,
     validate_seed_candidate_response,
 )
 from nexus.agents.orrery.retrograde_vocabulary import (
@@ -222,6 +224,43 @@ class RetrogradeExpansionDeathPlan(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
 
+class RetrogradeProjectPlan(BaseModel):
+    """One stage-one project start carried forward from a woven seed."""
+
+    seed_id: str = Field(min_length=1)
+    project_type: RetrogradeProjectType
+    actor_ref: EntityRef
+    target_ref: Optional[EntityRef] = None
+    rationale: str = Field(min_length=1, max_length=700)
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_typed_target(self) -> "RetrogradeProjectPlan":
+        validate_project_target_shape(
+            project_type=self.project_type,
+            target_ref=self.target_ref,
+            context=f"project plan for seed {self.seed_id!r}",
+        )
+        return self
+
+
+class RetrogradeWireProjectPlan(BaseModel):
+    """Provider-facing twin of :class:`RetrogradeProjectPlan`."""
+
+    seed_id: str = Field(min_length=1)
+    project_type: RetrogradeProjectType
+    actor_ref: EntityRef
+    target_ref: str = Field(
+        default="",
+        max_length=ENTITY_REF_MAX_LENGTH,
+        description="Compact target ref, or an empty string when targetless.",
+    )
+    rationale: str = Field(min_length=1, max_length=700)
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
 class RetrogradeExpansionThreadPlan(BaseModel):
     """Accounting for one selected seed after R6 weaving."""
 
@@ -334,6 +373,7 @@ class RetrogradeExpansionWireResponse(BaseModel):
     mechanical_plan: list[RetrogradeExpansionWireMechanicPlan] = Field(
         default_factory=list
     )
+    project_plan: list[RetrogradeWireProjectPlan] = Field(default_factory=list)
     thread_plan: list[RetrogradeExpansionWireThreadPlan] = Field(default_factory=list)
     coverage_notes: list[str] = Field(default_factory=list)
     coordinates: Optional[Coordinates] = Field(
@@ -368,6 +408,7 @@ class RetrogradeExpansionPlanResponse(BaseModel):
         default_factory=list
     )
     death_plan: list[RetrogradeExpansionDeathPlan] = Field(default_factory=list)
+    project_plan: list[RetrogradeProjectPlan] = Field(default_factory=list)
     thread_plan: list[RetrogradeExpansionThreadPlan] = Field(default_factory=list)
     coverage_notes: list[str] = Field(default_factory=list)
     coordinates: Optional[Coordinates] = Field(
@@ -409,6 +450,14 @@ class RetrogradeExpansionPlanResponse(BaseModel):
             raise ValueError(
                 f"Duplicate death_plan entities: {sorted(duplicate_deaths)}"
             )
+        duplicate_project_seeds = _duplicates(
+            [project.seed_id for project in self.project_plan]
+        )
+        if duplicate_project_seeds:
+            raise ValueError(
+                "Duplicate project_plan seed_id values: "
+                f"{sorted(duplicate_project_seeds)}"
+            )
         return self
 
 
@@ -449,6 +498,13 @@ def _expand_wire_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
 
     data = dict(payload)
     if "mechanical_plan" not in data:
+        data["project_plan"] = [
+            {
+                **dict(project),
+                "target_ref": _none_if_empty(project.get("target_ref")),
+            }
+            for project in data.get("project_plan") or []
+        ]
         return data
 
     event_plan = []
@@ -516,12 +572,19 @@ def _expand_wire_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
         row["note"] = _none_if_empty(row.get("note"))
         thread_plan.append(row)
 
+    project_plan = []
+    for project in data.get("project_plan") or []:
+        row = dict(project)
+        row["target_ref"] = _none_if_empty(row.get("target_ref"))
+        project_plan.append(row)
+
     return {
         "event_plan": event_plan,
         "entity_tag_plan": entity_tag_plan,
         "pair_tag_plan": pair_tag_plan,
         "relationship_plan": relationship_plan,
         "death_plan": death_plan,
+        "project_plan": project_plan,
         "thread_plan": thread_plan,
         "coverage_notes": data.get("coverage_notes") or [],
         "coordinates": data.get("coordinates"),
@@ -608,6 +671,9 @@ def render_expansion_prompt(
         "invalid.\n"
         "If a mechanical plan cannot satisfy the hard validation rules, omit "
         "that mechanical item or reject/defer the seed.\n"
+        "For each woven seed with project_intent, carry that exact intent into "
+        "project_plan with a character actor_ref. If you drop the intent, omit "
+        "the project row and explain the drop in that seed's thread note.\n"
         "Return JSON only.\n\n"
         "RETROGRADE_EXPANSION_REQUEST:\n"
         f"{json.dumps(prompt_payload, indent=2, sort_keys=True)}"
@@ -655,6 +721,9 @@ def validate_expansion_plan(
         selected_seed_ids=selected_seed_ids,
         selected_junctions=selected_junctions,
         vocabulary=vocabulary,
+        candidates_by_id={
+            candidate.seed_id: candidate for candidate in candidates.candidates
+        },
         known_entity_keys=_packet_known_entity_keys(packet),
         max_new_entity_stubs=_budget_entity_stub_cap(seed_generation_request),
     )
@@ -746,6 +815,7 @@ def _expansion_contract_issues(
     selected_seed_ids: set[str],
     selected_junctions: list[dict[str, Any]],
     vocabulary: SeedEligibleVocabulary,
+    candidates_by_id: Mapping[str, Any],
     known_entity_keys: Optional[set[tuple[str, str]]] = None,
     max_new_entity_stubs: Optional[int] = None,
 ) -> list[str]:
@@ -843,6 +913,13 @@ def _expansion_contract_issues(
             )
         )
 
+    issues.extend(
+        _project_plan_issues(
+            response=response,
+            candidates_by_id=candidates_by_id,
+        )
+    )
+
     events_by_ref = {event.event_ref: event for event in response.event_plan}
     for death in response.death_plan:
         issues.extend(
@@ -868,6 +945,65 @@ def _expansion_contract_issues(
         )
     )
     issues.extend(_commit_readiness_issues(response.commit_readiness))
+    return issues
+
+
+def _project_plan_issues(
+    *,
+    response: RetrogradeExpansionPlanResponse,
+    candidates_by_id: Mapping[str, Any],
+) -> list[str]:
+    """Keep R6 project rows faithful to the selected seed intent."""
+
+    issues: list[str] = []
+    threads_by_seed = {thread.seed_id: thread for thread in response.thread_plan}
+    projects_by_seed = {project.seed_id: project for project in response.project_plan}
+    for project in response.project_plan:
+        candidate = candidates_by_id.get(project.seed_id)
+        if candidate is None or project.seed_id not in response.selected_seed_ids:
+            issues.append(
+                f"project plan references non-selected seed {project.seed_id!r}"
+            )
+            continue
+        intent = candidate.project_intent
+        if intent is None:
+            issues.append(
+                f"project plan seed {project.seed_id!r} has no project_intent"
+            )
+            continue
+        if project.project_type != intent.project_type:
+            issues.append(
+                f"project plan seed {project.seed_id!r} changes project_type "
+                f"from {intent.project_type!r} to {project.project_type!r}"
+            )
+        planned_target = (
+            normalize_entity_ref(project.target_ref) if project.target_ref else None
+        )
+        intended_target = (
+            normalize_entity_ref(intent.target_ref) if intent.target_ref else None
+        )
+        if planned_target != intended_target:
+            issues.append(
+                f"project plan seed {project.seed_id!r} changes target_ref "
+                f"from {intent.target_ref!r} to {project.target_ref!r}"
+            )
+        thread = threads_by_seed.get(project.seed_id)
+        if thread is not None and thread.status != "woven":
+            issues.append(
+                f"project plan seed {project.seed_id!r} is {thread.status}, not woven"
+            )
+
+    for seed_id in response.selected_seed_ids:
+        candidate = candidates_by_id.get(seed_id)
+        if candidate is None or candidate.project_intent is None:
+            continue
+        thread = threads_by_seed.get(seed_id)
+        if thread is None or thread.status != "woven" or seed_id in projects_by_seed:
+            continue
+        if not thread.note:
+            issues.append(
+                f"woven seed {seed_id!r} drops project_intent without a thread note"
+            )
     return issues
 
 
@@ -927,6 +1063,13 @@ def _collect_plan_entity_keys(
         )
     for death in response.death_plan:
         keys.add((death.entity_kind, normalize_entity_ref(death.entity_ref)))
+    for project in response.project_plan:
+        keys.add(("character", normalize_entity_ref(project.actor_ref)))
+        if project.target_ref:
+            target_kind = (
+                "place" if project.project_type == "plan_relocation" else "character"
+            )
+            keys.add((target_kind, normalize_entity_ref(project.target_ref)))
     return keys
 
 
@@ -1370,6 +1513,10 @@ def _hard_validation_rules() -> list[str]:
             "rows; express faction/place pressure through events or pair tags."
         ),
         (
+            "project_plan may carry only a woven selected seed's exact "
+            "project_intent; explain any dropped woven intent in thread_plan.note."
+        ),
+        (
             "Entity refs (subject_ref, object_ref, location_ref) "
             f"are proper names of at most {ENTITY_REF_MAX_LENGTH} characters "
             "-- never sentences or descriptive phrases. New implied entities "
@@ -1385,8 +1532,16 @@ def _prompt_response_contract() -> dict[str, Any]:
         "top_level_fields": [
             "event_plan",
             "mechanical_plan",
+            "project_plan",
             "thread_plan",
             "coverage_notes",
+        ],
+        "project_plan_fields": [
+            "seed_id",
+            "project_type",
+            "actor_ref",
+            "target_ref",
+            "rationale",
         ],
         "mechanical_plan_fields": {
             "common": ["plan", "subject_ref", "subject_kind", "source_event_ref"],

--- a/nexus/agents/orrery/retrograde_orchestrator.py
+++ b/nexus/agents/orrery/retrograde_orchestrator.py
@@ -13,6 +13,8 @@ new-story wizard fires at the ready -> narrative transition:
    as the wizard transition writes, so a blocked persistence rolls back the
    whole world and the slot stays in wizard-ready for a loud, retryable
    failure -- a history-less world can never silently enter narrative mode.
+   Its final in-transaction write is a genesis checkpoint at the synthetic
+   prologue, making wizard-born projection rows an honest replay base.
 3. ``embed_retrograde_history_summaries`` runs the summary embedding lifecycle
    for the new rows after the transaction commits.
 4. ``build_wizard_history_surface`` projects the persistence manifest into
@@ -262,6 +264,9 @@ def persist_retrograde_history(
         summaries_enabled=retrieval_settings.summaries_enabled,
         recorded_at_chunk_id=recorded_at_chunk_id,
         epistemics_settings=epistemics_settings,
+        project_seeding_enabled=settings.orrery.retrograde.projects.enabled,
+        max_seeded_projects=(settings.orrery.retrograde.projects.max_seeded_projects),
+        project_settings=settings.orrery.projects,
     )
 
     blockers = list(dry_manifest["execute_blockers"])
@@ -308,7 +313,35 @@ def persist_retrograde_history(
         summaries_enabled=retrieval_settings.summaries_enabled,
         recorded_at_chunk_id=recorded_at_chunk_id,
         epistemics_settings=epistemics_settings,
+        project_seeding_enabled=settings.orrery.retrograde.projects.enabled,
+        max_seeded_projects=(settings.orrery.retrograde.projects.max_seeded_projects),
+        project_settings=settings.orrery.projects,
     )
+    from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
+
+    prologue_chunk_id = manifest["prologue_anchor"]["chunk_id"]
+    if prologue_chunk_id is None:
+        raise RuntimeError("Retrograde persistence produced no prologue chunk")
+    checkpoint_id = capture_state_checkpoint_sync(
+        cur,
+        chunk_id=int(prologue_chunk_id),
+        label="genesis",
+    )
+    if checkpoint_id is None:
+        cur.execute(
+            "SELECT id FROM state_checkpoints "
+            "WHERE chunk_id = %s AND label = 'genesis'",
+            (prologue_chunk_id,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            raise RuntimeError("Genesis checkpoint insert reported no row")
+        checkpoint_id = int(row[0] if not hasattr(row, "keys") else row["id"])
+    manifest["genesis_checkpoint"] = {
+        "id": checkpoint_id,
+        "chunk_id": int(prologue_chunk_id),
+        "label": "genesis",
+    }
     logger.info(
         "Retrograde persistence executed for slot %s: %s",
         bundle.slot,
@@ -397,6 +430,8 @@ def build_wizard_history_surface(
         "woven_seeds": sum(1 for status in thread_statuses if status == "woven"),
         "deferred_seeds": sum(1 for status in thread_statuses if status == "deferred"),
         "rejected_seeds": sum(1 for status in thread_statuses if status == "rejected"),
+        "projects": counters.get("projects_inserted", 0)
+        + counters.get("projects_would_insert", 0),
     }
     return {
         "weird_level": bundle.weird.get("level"),

--- a/nexus/agents/orrery/retrograde_orchestrator.py
+++ b/nexus/agents/orrery/retrograde_orchestrator.py
@@ -28,6 +28,7 @@ the API can expose them while the transition request is in flight.
 
 from __future__ import annotations
 
+import json
 import logging
 import threading
 import time
@@ -36,6 +37,7 @@ from typing import Any, Callable, Mapping, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from nexus.agents.orrery.retrograde_markers import RETROGRADE_PROLOGUE_MARKER
 from nexus.config.settings_models import (
     OrreryRetrogradeRetrievalSettings,
     OrreryRetrogradeWizardSettings,
@@ -252,6 +254,7 @@ def persist_retrograde_history(
     epistemics_settings = settings.orrery.epistemics
 
     _emit(progress, "persistence", {})
+    _raise_if_genesis_checkpoint_exists(cur)
     dry_manifest = build_retrograde_persistence_plan(
         cur,
         packet=bundle.packet,
@@ -328,15 +331,11 @@ def persist_retrograde_history(
         label="genesis",
     )
     if checkpoint_id is None:
-        cur.execute(
-            "SELECT id FROM state_checkpoints "
-            "WHERE chunk_id = %s AND label = 'genesis'",
-            (prologue_chunk_id,),
+        raise RuntimeError(
+            "Genesis checkpoint capture returned no id for prologue chunk "
+            f"{prologue_chunk_id}; capture_state_checkpoint_sync reports this "
+            "only when that (chunk_id, label='genesis') checkpoint already exists"
         )
-        row = cur.fetchone()
-        if row is None:
-            raise RuntimeError("Genesis checkpoint insert reported no row")
-        checkpoint_id = int(row[0] if not hasattr(row, "keys") else row["id"])
     manifest["genesis_checkpoint"] = {
         "id": checkpoint_id,
         "chunk_id": int(prologue_chunk_id),
@@ -348,6 +347,33 @@ def persist_retrograde_history(
         manifest["counters"],
     )
     return manifest
+
+
+def _raise_if_genesis_checkpoint_exists(cur: Any) -> None:
+    """Reject wizard persistence against an already-snapshotted prologue."""
+
+    cur.execute(
+        """
+        /* orrery:retrograde:genesis_invariant */
+        SELECT sc.id, sc.chunk_id
+        FROM state_checkpoints AS sc
+        JOIN narrative_chunks AS nc ON nc.id = sc.chunk_id
+        WHERE sc.label = 'genesis'
+          AND nc.authorial_directives @> %s::jsonb
+        ORDER BY nc.id
+        LIMIT 1
+        """,
+        (json.dumps([RETROGRADE_PROLOGUE_MARKER]),),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return
+    checkpoint_id = int(row[0] if not hasattr(row, "keys") else row["id"])
+    prologue_chunk_id = int(row[1] if not hasattr(row, "keys") else row["chunk_id"])
+    raise RuntimeError(
+        "Retrograde genesis invariant violated: checkpoint "
+        f"{checkpoint_id} already exists at prologue chunk {prologue_chunk_id}"
+    )
 
 
 def embed_retrograde_history_summaries(

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -94,6 +94,14 @@ class _TagRecord:
     entity_kinds: frozenset[str]
 
 
+@dataclass(frozen=True, slots=True)
+class _ProjectRefDecision:
+    """Ref-level project arbitration result shared by stubs and row planning."""
+
+    status: str
+    winning_seed_id: Optional[str] = None
+
+
 def build_retrograde_persistence_plan(
     cur: Any,
     *,
@@ -131,6 +139,16 @@ def build_retrograde_persistence_plan(
         packet=packet,
         seed_candidate_response=seed_candidate_response,
     )
+    if max_seeded_projects <= 0:
+        raise ValueError("max_seeded_projects must be positive")
+    project_ref_decisions = (
+        _arbitrate_project_refs(
+            expansion,
+            max_seeded_projects=max_seeded_projects,
+        )
+        if project_seeding_enabled
+        else {}
+    )
     existing_prologue_id = _find_prologue_chunk_id(cur)
     entity_index = _load_entity_index(cur)
     event_types = _load_event_types(cur)
@@ -144,8 +162,6 @@ def build_retrograde_persistence_plan(
         else None
     )
     project_policy = coerce_project_policy(project_settings)
-    if max_seeded_projects <= 0:
-        raise ValueError("max_seeded_projects must be positive")
 
     manifest = _build_plan(
         cur,
@@ -169,6 +185,7 @@ def build_retrograde_persistence_plan(
         epistemics_settings=epistemics_settings,
         project_seeding_enabled=project_seeding_enabled,
         max_seeded_projects=max_seeded_projects,
+        project_ref_decisions=project_ref_decisions,
         project_policy=project_policy,
         base_timestamp=base_timestamp,
     )
@@ -214,6 +231,7 @@ def build_retrograde_persistence_plan(
         epistemics_settings=epistemics_settings,
         project_seeding_enabled=project_seeding_enabled,
         max_seeded_projects=max_seeded_projects,
+        project_ref_decisions=project_ref_decisions,
         project_policy=project_policy,
         base_timestamp=base_timestamp,
     )
@@ -242,6 +260,7 @@ def _build_plan(
     epistemics_settings: Optional[Any],
     project_seeding_enabled: bool,
     max_seeded_projects: int,
+    project_ref_decisions: Mapping[str, _ProjectRefDecision],
     project_policy: ProjectPolicy,
     base_timestamp: Any,
 ) -> dict[str, Any]:
@@ -259,7 +278,7 @@ def _build_plan(
         entity_index=entity_index,
         create_missing_entities=create_missing_entities,
         inserted_stub_keys=inserted_stub_keys,
-        include_projects=project_seeding_enabled,
+        project_ref_decisions=project_ref_decisions,
     )
     creatable_refs = frozenset(
         (row["entity_kind"], normalize_entity_ref(row["entity_ref"]))
@@ -346,6 +365,7 @@ def _build_plan(
         dry_run=dry_run,
         enabled=project_seeding_enabled,
         max_seeded_projects=max_seeded_projects,
+        project_ref_decisions=project_ref_decisions,
         project_policy=project_policy,
         base_timestamp=base_timestamp,
         prologue_chunk_id=prologue_chunk_id,
@@ -991,6 +1011,7 @@ def _plan_project_rows(
     dry_run: bool,
     enabled: bool,
     max_seeded_projects: int,
+    project_ref_decisions: Mapping[str, _ProjectRefDecision],
     project_policy: ProjectPolicy,
     base_timestamp: Any,
     prologue_chunk_id: Optional[int],
@@ -1026,8 +1047,7 @@ def _plan_project_rows(
         raise ValueError("Retrograde project seeding requires global base_timestamp")
 
     rows: list[dict[str, Any]] = []
-    accepted_by_actor: dict[tuple[str, Any], str] = {}
-    accepted_count = 0
+    accepted_by_entity_id: dict[int, str] = {}
     for project in expansion.project_plan:
         actor = _resolve_entity(
             project.actor_ref,
@@ -1036,32 +1056,29 @@ def _plan_project_rows(
             role="project_actor",
             creatable_refs=creatable_refs,
         )
-        _require_project_resolution(project, actor, role="actor")
-        actor_key: tuple[str, Any]
-        if actor["resolution"] == "resolved":
-            actor_key = ("entity_id", int(actor["entity_id"]))
-        else:
-            actor_key = ("ref", normalize_entity_ref(project.actor_ref))
-        winning_seed = accepted_by_actor.get(actor_key)
-        if winning_seed is not None:
+        decision = project_ref_decisions.get(project.seed_id)
+        if decision is None:
+            raise AssertionError(
+                f"Missing ref-level arbitration for project seed {project.seed_id!r}"
+            )
+        if decision.status == "dropped_duplicate_actor":
             logger.warning(
                 "Retrograde project seed %s dropped for actor %s; seed %s won "
                 "first in R6 project_plan order",
                 project.seed_id,
                 project.actor_ref,
-                winning_seed,
+                decision.winning_seed_id,
             )
             rows.append(
                 _dropped_project_row(
                     project,
                     status="dropped_duplicate_actor",
                     actor=actor,
-                    winning_seed_id=winning_seed,
+                    winning_seed_id=decision.winning_seed_id,
                 )
             )
             continue
-        accepted_by_actor[actor_key] = project.seed_id
-        if accepted_count >= max_seeded_projects:
+        if decision.status == "dropped_cap":
             logger.warning(
                 "Retrograde project seed %s dropped: cast-wide cap %s already met",
                 project.seed_id,
@@ -1075,6 +1092,21 @@ def _plan_project_rows(
                 )
             )
             continue
+        if decision.status != "accepted":
+            raise AssertionError(
+                f"Unknown project ref arbitration status {decision.status!r}"
+            )
+
+        _require_project_resolution(project, actor, role="actor")
+        actor_entity_id = actor.get("entity_id")
+        if actor_entity_id is not None:
+            winning_seed = accepted_by_entity_id.get(int(actor_entity_id))
+            if winning_seed is not None:
+                raise ValueError(
+                    f"Retrograde project seeds {winning_seed!r} and "
+                    f"{project.seed_id!r} use distinct actor refs that resolve "
+                    f"to duplicate entity id {actor_entity_id}"
+                )
 
         target_kind = (
             "place" if project.project_type == "plan_relocation" else "character"
@@ -1175,8 +1207,37 @@ def _plan_project_rows(
                     "started_event_id": started_event_id,
                 }
             )
-        accepted_count += 1
+        if actor_entity_id is not None:
+            accepted_by_entity_id[int(actor_entity_id)] = project.seed_id
     return rows
+
+
+def _arbitrate_project_refs(
+    expansion: RetrogradeExpansionPlanResponse,
+    *,
+    max_seeded_projects: int,
+) -> dict[str, _ProjectRefDecision]:
+    """Choose project seeds by normalized actor ref, then cast-wide cap."""
+
+    decisions: dict[str, _ProjectRefDecision] = {}
+    accepted_by_actor_ref: dict[str, str] = {}
+    accepted_count = 0
+    for project in expansion.project_plan:
+        actor_key = normalize_entity_ref(project.actor_ref)
+        winning_seed = accepted_by_actor_ref.get(actor_key)
+        if winning_seed is not None:
+            decisions[project.seed_id] = _ProjectRefDecision(
+                status="dropped_duplicate_actor",
+                winning_seed_id=winning_seed,
+            )
+            continue
+        if accepted_count >= max_seeded_projects:
+            decisions[project.seed_id] = _ProjectRefDecision(status="dropped_cap")
+            continue
+        decisions[project.seed_id] = _ProjectRefDecision(status="accepted")
+        accepted_by_actor_ref[actor_key] = project.seed_id
+        accepted_count += 1
+    return decisions
 
 
 def _dropped_project_row(
@@ -2409,11 +2470,11 @@ def _plan_entity_stubs(
     entity_index: Mapping[tuple[str, str], Sequence[_EntityRecord]],
     create_missing_entities: bool,
     inserted_stub_keys: frozenset[tuple[str, str]],
-    include_projects: bool,
+    project_ref_decisions: Mapping[str, _ProjectRefDecision],
 ) -> list[dict[str, Any]]:
     refs = _collect_expansion_entity_refs(
         expansion,
-        include_projects=include_projects,
+        project_ref_decisions=project_ref_decisions,
     )
     rows = []
     for key, ref in sorted(refs.items()):
@@ -2443,7 +2504,7 @@ def _plan_entity_stubs(
 def _collect_expansion_entity_refs(
     expansion: RetrogradeExpansionPlanResponse,
     *,
-    include_projects: bool,
+    project_ref_decisions: Mapping[str, _ProjectRefDecision],
 ) -> dict[tuple[str, str], dict[str, Any]]:
     refs: dict[tuple[str, str], dict[str, Any]] = {}
 
@@ -2538,7 +2599,10 @@ def _collect_expansion_entity_refs(
             },
         )
 
-    for project in expansion.project_plan if include_projects else []:
+    for project in expansion.project_plan:
+        decision = project_ref_decisions.get(project.seed_id)
+        if decision is None or decision.status != "accepted":
+            continue
         add_ref(
             project.actor_ref,
             "character",

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import json
+import logging
 import re
 from typing import Any, Mapping, Optional, Sequence
 
@@ -22,6 +23,7 @@ from nexus.agents.orrery.retrograde_expansion import (
     RetrogradeExpansionParticipant,
     RetrogradeExpansionPlanResponse,
     RetrogradeExpansionRelationshipPlan,
+    RetrogradeProjectPlan,
     validate_expansion_plan,
 )
 from nexus.agents.orrery.retrograde_markers import (
@@ -29,7 +31,10 @@ from nexus.agents.orrery.retrograde_markers import (
 )
 from nexus.agents.orrery.retrograde_vocabulary import normalize_entity_ref
 from nexus.agents.orrery.status_family import STATUS_TAGS, level_from_status_tag
+from nexus.agents.orrery.substrate import ProjectPolicy, coerce_project_policy
 from nexus.agents.orrery.tag_writer import apply_status_pair_tag_bestowal
+
+logger = logging.getLogger(__name__)
 
 RETROGRADE_PERSISTENCE_SCHEMA_VERSION = "orrery_retrograde_persistence_plan.v1"
 RETROGRADE_SOURCE_KIND = "retrograde"
@@ -44,6 +49,22 @@ RETROGRADE_PROLOGUE_STORYTELLER_TEXT = (
 )
 EVENT_ROLE_KINDS = frozenset({"actor", "target", "observer", "beneficiary", "witness"})
 MATURATION_EVENT_REF_PATTERN = re.compile(r"^maturation_job_(?P<job_id>[1-9]\d*)_")
+PROJECT_STARTED_EVENT_TYPES = {
+    "plan_relocation": "relocation_plan_started",
+    "recruit_ally": "recruit_ally_started",
+    "build_venture": "build_venture_started",
+    "pursue_romance": "pursue_romance_started",
+    "court_patron": "court_patron_started",
+    "seek_redemption": "seek_redemption_started",
+}
+PROJECT_FIRST_STAGES = {
+    "plan_relocation": "saving",
+    "recruit_ally": "sounding_out",
+    "build_venture": "laying_groundwork",
+    "pursue_romance": "testing_waters",
+    "court_patron": "gaining_notice",
+    "seek_redemption": "owning_the_wrong",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -86,6 +107,9 @@ def build_retrograde_persistence_plan(
     summaries_enabled: bool = True,
     recorded_at_chunk_id: Optional[int] = None,
     epistemics_settings: Optional[Any] = None,
+    project_seeding_enabled: bool = False,
+    max_seeded_projects: int = 3,
+    project_settings: Optional[Any] = None,
 ) -> dict[str, Any]:
     """Build or apply a canonical persistence plan for a Retrograde expansion.
 
@@ -114,6 +138,14 @@ def build_retrograde_persistence_plan(
     pair_tag_ids = _load_pair_tag_ids(cur)
     source_blockers = _source_kind_blockers(cur)
     world_time = _load_world_time(cur)
+    base_timestamp = (
+        _load_base_timestamp(cur)
+        if project_seeding_enabled and expansion.project_plan
+        else None
+    )
+    project_policy = coerce_project_policy(project_settings)
+    if max_seeded_projects <= 0:
+        raise ValueError("max_seeded_projects must be positive")
 
     manifest = _build_plan(
         cur,
@@ -135,6 +167,10 @@ def build_retrograde_persistence_plan(
         recorded_at_chunk_id=recorded_at_chunk_id,
         pair_tag_source_chunk_id=recorded_at_chunk_id,
         epistemics_settings=epistemics_settings,
+        project_seeding_enabled=project_seeding_enabled,
+        max_seeded_projects=max_seeded_projects,
+        project_policy=project_policy,
+        base_timestamp=base_timestamp,
     )
     if dry_run:
         return manifest
@@ -176,6 +212,10 @@ def build_retrograde_persistence_plan(
         recorded_at_chunk_id=effective_recorded_at_chunk_id,
         pair_tag_source_chunk_id=recorded_at_chunk_id,
         epistemics_settings=epistemics_settings,
+        project_seeding_enabled=project_seeding_enabled,
+        max_seeded_projects=max_seeded_projects,
+        project_policy=project_policy,
+        base_timestamp=base_timestamp,
     )
 
 
@@ -200,6 +240,10 @@ def _build_plan(
     recorded_at_chunk_id: Optional[int],
     pair_tag_source_chunk_id: Optional[int],
     epistemics_settings: Optional[Any],
+    project_seeding_enabled: bool,
+    max_seeded_projects: int,
+    project_policy: ProjectPolicy,
+    base_timestamp: Any,
 ) -> dict[str, Any]:
     counters: Counter[str] = Counter()
     reference_issues: list[dict[str, Any]] = []
@@ -215,6 +259,7 @@ def _build_plan(
         entity_index=entity_index,
         create_missing_entities=create_missing_entities,
         inserted_stub_keys=inserted_stub_keys,
+        include_projects=project_seeding_enabled,
     )
     creatable_refs = frozenset(
         (row["entity_kind"], normalize_entity_ref(row["entity_ref"]))
@@ -292,6 +337,25 @@ def _build_plan(
         reference_issues.extend(planned.pop("_reference_issues"))
         relationship_issues.extend(planned.pop("_relationship_issues"))
 
+    # Project starts are a dedicated projection step. On execute, entity stubs
+    # and relationship rows already exist; they never pass through event/tag
+    # planning even though each accepted start emits a ledger-visible event.
+    project_rows = _plan_project_rows(
+        cur,
+        expansion=expansion,
+        dry_run=dry_run,
+        enabled=project_seeding_enabled,
+        max_seeded_projects=max_seeded_projects,
+        project_policy=project_policy,
+        base_timestamp=base_timestamp,
+        prologue_chunk_id=prologue_chunk_id,
+        entity_index=entity_index,
+        creatable_refs=creatable_refs,
+        event_types=event_types,
+    )
+    for project_row in project_rows:
+        counters[f"projects_{project_row['status']}"] += 1
+
     # Deaths plan after events so cause_world_event_id can link to freshly
     # inserted world_events rows on execute.
     death_rows = []
@@ -355,6 +419,11 @@ def _build_plan(
         "relationships_inserted",
         "relationships_already_present",
         "relationships_blocked",
+        "projects_would_insert",
+        "projects_inserted",
+        "projects_dropped_disabled",
+        "projects_dropped_duplicate_actor",
+        "projects_dropped_cap",
         "entity_stubs_would_insert",
         "entity_stubs_inserted",
         "entity_stubs_already_present",
@@ -393,6 +462,7 @@ def _build_plan(
         "entity_tag_rows": entity_tag_rows,
         "pair_tag_rows": pair_tag_rows,
         "relationship_rows": relationship_rows,
+        "project_rows": project_rows,
         "death_rows": death_rows,
         "summary_rows": summary_rows,
         "retrieval": {
@@ -912,6 +982,424 @@ def _plan_relationship_row(
         character2_id=int(object_character_id),
     )
     return {**base, "status": "inserted"}
+
+
+def _plan_project_rows(
+    cur: Any,
+    *,
+    expansion: RetrogradeExpansionPlanResponse,
+    dry_run: bool,
+    enabled: bool,
+    max_seeded_projects: int,
+    project_policy: ProjectPolicy,
+    base_timestamp: Any,
+    prologue_chunk_id: Optional[int],
+    entity_index: Mapping[tuple[str, str], Sequence[_EntityRecord]],
+    creatable_refs: frozenset[tuple[str, str]],
+    event_types: set[str],
+) -> list[dict[str, Any]]:
+    """Plan or insert typed stage-one projects after relationship persistence."""
+
+    if not expansion.project_plan:
+        return []
+    if not enabled:
+        disabled_rows = []
+        for project in expansion.project_plan:
+            logger.warning(
+                "Retrograde project seed %s dropped: project seeding is disabled",
+                project.seed_id,
+            )
+            disabled_rows.append(
+                {
+                    **project.model_dump(mode="json"),
+                    "status": "dropped_disabled",
+                    "project_id": None,
+                    "started_event_id": None,
+                }
+            )
+        return disabled_rows
+    if not project_policy.enabled:
+        raise ValueError(
+            "Retrograde project seeding requires configured [orrery.projects] policy"
+        )
+    if base_timestamp is None:
+        raise ValueError("Retrograde project seeding requires global base_timestamp")
+
+    rows: list[dict[str, Any]] = []
+    accepted_by_actor: dict[tuple[str, Any], str] = {}
+    accepted_count = 0
+    for project in expansion.project_plan:
+        actor = _resolve_entity(
+            project.actor_ref,
+            "character",
+            entity_index,
+            role="project_actor",
+            creatable_refs=creatable_refs,
+        )
+        _require_project_resolution(project, actor, role="actor")
+        actor_key: tuple[str, Any]
+        if actor["resolution"] == "resolved":
+            actor_key = ("entity_id", int(actor["entity_id"]))
+        else:
+            actor_key = ("ref", normalize_entity_ref(project.actor_ref))
+        winning_seed = accepted_by_actor.get(actor_key)
+        if winning_seed is not None:
+            logger.warning(
+                "Retrograde project seed %s dropped for actor %s; seed %s won "
+                "first in R6 project_plan order",
+                project.seed_id,
+                project.actor_ref,
+                winning_seed,
+            )
+            rows.append(
+                _dropped_project_row(
+                    project,
+                    status="dropped_duplicate_actor",
+                    actor=actor,
+                    winning_seed_id=winning_seed,
+                )
+            )
+            continue
+        accepted_by_actor[actor_key] = project.seed_id
+        if accepted_count >= max_seeded_projects:
+            logger.warning(
+                "Retrograde project seed %s dropped: cast-wide cap %s already met",
+                project.seed_id,
+                max_seeded_projects,
+            )
+            rows.append(
+                _dropped_project_row(
+                    project,
+                    status="dropped_cap",
+                    actor=actor,
+                )
+            )
+            continue
+
+        target_kind = (
+            "place" if project.project_type == "plan_relocation" else "character"
+        )
+        target = None
+        if project.target_ref is not None:
+            target = _resolve_entity(
+                project.target_ref,
+                target_kind,
+                entity_index,
+                role="project_target",
+                creatable_refs=creatable_refs,
+            )
+            _require_project_resolution(project, target, role="target")
+        if (
+            target is not None
+            and actor.get("resolution") == "resolved"
+            and target.get("resolution") == "resolved"
+            and actor.get("entity_id") == target.get("entity_id")
+        ):
+            raise ValueError(
+                f"Retrograde project seed {project.seed_id!r} targets its actor"
+            )
+
+        _validate_project_start_dependencies(
+            cur,
+            expansion=expansion,
+            project=project,
+            actor=actor,
+            target=target,
+        )
+        started_event_type = PROJECT_STARTED_EVENT_TYPES[project.project_type]
+        if started_event_type not in event_types:
+            raise ValueError(
+                f"Retrograde project seed {project.seed_id!r} requires missing "
+                f"event type {started_event_type!r}"
+            )
+        next_eligible = base_timestamp + timedelta(
+            hours=project_policy.advance_interval_hours
+        )
+        base = {
+            **project.model_dump(mode="json"),
+            "actor": actor,
+            "target": target,
+            "character_entity_id": actor.get("entity_id"),
+            "target_place_id": target.get("place_id") if target else None,
+            "target_character_entity_id": (
+                target.get("entity_id")
+                if target_kind == "character" and target
+                else None
+            ),
+            "target_faction_entity_id": None,
+            "stage": PROJECT_FIRST_STAGES[project.project_type],
+            "progress": 0,
+            "stall_count": 0,
+            "next_eligible_at_world_time": next_eligible,
+            "source_chunk_id": prologue_chunk_id,
+            "started_event_type": started_event_type,
+        }
+        if dry_run:
+            rows.append(
+                {
+                    **base,
+                    "status": "would_insert",
+                    "project_id": None,
+                    "started_event_id": None,
+                }
+            )
+        else:
+            if prologue_chunk_id is None or actor["resolution"] != "resolved":
+                raise AssertionError(
+                    "project refs and prologue must resolve on execute"
+                )
+            if target is not None and target["resolution"] != "resolved":
+                raise AssertionError("project target must resolve on execute")
+            project_id = _insert_seeded_project(
+                cur,
+                project=project,
+                actor=actor,
+                target=target,
+                stage=PROJECT_FIRST_STAGES[project.project_type],
+                next_eligible=next_eligible,
+                prologue_chunk_id=prologue_chunk_id,
+            )
+            started_event_id = _insert_project_started_event(
+                cur,
+                project=project,
+                actor=actor,
+                target=target,
+                event_type=started_event_type,
+                prologue_chunk_id=prologue_chunk_id,
+            )
+            rows.append(
+                {
+                    **base,
+                    "status": "inserted",
+                    "project_id": project_id,
+                    "started_event_id": started_event_id,
+                }
+            )
+        accepted_count += 1
+    return rows
+
+
+def _dropped_project_row(
+    project: RetrogradeProjectPlan,
+    *,
+    status: str,
+    actor: Mapping[str, Any],
+    winning_seed_id: Optional[str] = None,
+) -> dict[str, Any]:
+    return {
+        **project.model_dump(mode="json"),
+        "status": status,
+        "actor": dict(actor),
+        "winning_seed_id": winning_seed_id,
+        "project_id": None,
+        "started_event_id": None,
+    }
+
+
+def _require_project_resolution(
+    project: RetrogradeProjectPlan,
+    resolved: Mapping[str, Any],
+    *,
+    role: str,
+) -> None:
+    if resolved["resolution"] not in {"resolved", "stub_pending"}:
+        raise ValueError(
+            f"Retrograde project seed {project.seed_id!r} has unresolvable "
+            f"{role} ref {resolved['entity_ref']!r}: {resolved['reason']}"
+        )
+
+
+def _validate_project_start_dependencies(
+    cur: Any,
+    *,
+    expansion: RetrogradeExpansionPlanResponse,
+    project: RetrogradeProjectPlan,
+    actor: Mapping[str, Any],
+    target: Optional[Mapping[str, Any]],
+) -> None:
+    if actor["resolution"] == "resolved":
+        existing_id = _existing_open_project_id(cur, int(actor["entity_id"]))
+        if existing_id is not None:
+            raise ValueError(
+                f"Retrograde project seed {project.seed_id!r} actor "
+                f"{project.actor_ref!r} already has open project {existing_id}"
+            )
+    if project.project_type != "seek_redemption":
+        return
+    if target is None:
+        raise AssertionError("seek_redemption target shape was not validated")
+    if not _has_redemption_wrong(
+        cur,
+        expansion=expansion,
+        actor=actor,
+        target=target,
+    ):
+        raise ValueError(
+            f"Retrograde project seed {project.seed_id!r} seek_redemption "
+            "requires a TARGET->ACTOR wary-or-worse relationship"
+        )
+
+
+def _existing_open_project_id(cur: Any, actor_entity_id: int) -> Optional[int]:
+    cur.execute(
+        """
+        /* orrery:retrograde:existing_open_project */
+        SELECT id FROM character_project_states
+        WHERE character_entity_id = %s
+          AND status IN ('active', 'paused', 'stalled')
+        ORDER BY id LIMIT 1
+        """,
+        (actor_entity_id,),
+    )
+    row = cur.fetchone()
+    return int(_row_value(row, "id", 0)) if row is not None else None
+
+
+def _has_redemption_wrong(
+    cur: Any,
+    *,
+    expansion: RetrogradeExpansionPlanResponse,
+    actor: Mapping[str, Any],
+    target: Mapping[str, Any],
+) -> bool:
+    if actor["resolution"] == "resolved" and target["resolution"] == "resolved":
+        cur.execute(
+            """
+            /* orrery:retrograde:redemption_relationship */
+            SELECT cr.emotional_valence::text
+            FROM character_relationships cr
+            JOIN characters target_c ON target_c.id = cr.character1_id
+            JOIN characters actor_c ON actor_c.id = cr.character2_id
+            WHERE target_c.entity_id = %s AND actor_c.entity_id = %s
+            LIMIT 1
+            """,
+            (target["entity_id"], actor["entity_id"]),
+        )
+        row = cur.fetchone()
+        if row is not None:
+            return _is_wary_or_worse(str(_row_value(row, "emotional_valence", 0)))
+
+    actor_ref = normalize_entity_ref(str(actor["entity_ref"]))
+    target_ref = normalize_entity_ref(str(target["entity_ref"]))
+    for relationship in expansion.relationship_plan:
+        if (
+            relationship.subject_kind == "character"
+            and relationship.object_kind == "character"
+            and normalize_entity_ref(relationship.subject_ref) == target_ref
+            and normalize_entity_ref(relationship.object_ref) == actor_ref
+            and _is_wary_or_worse(
+                _default_emotional_valence(relationship.relationship_type)
+            )
+        ):
+            return True
+    return False
+
+
+def _is_wary_or_worse(value: str) -> bool:
+    match = re.match(r"^([+-]?\d+)\|", value)
+    return match is not None and int(match.group(1)) <= -1
+
+
+def _insert_seeded_project(
+    cur: Any,
+    *,
+    project: RetrogradeProjectPlan,
+    actor: Mapping[str, Any],
+    target: Optional[Mapping[str, Any]],
+    stage: str,
+    next_eligible: Any,
+    prologue_chunk_id: int,
+) -> int:
+    target_place_id = target.get("place_id") if target else None
+    target_character_entity_id = (
+        target.get("entity_id")
+        if target is not None and project.project_type != "plan_relocation"
+        else None
+    )
+    cur.execute(
+        """
+        /* orrery:retrograde:insert_seeded_project */
+        INSERT INTO character_project_states (
+            character_entity_id, project_type, status, stage,
+            target_place_id, target_character_entity_id,
+            target_faction_entity_id, progress, stall_count,
+            next_eligible_at_world_time, source_chunk_id
+        ) VALUES (%s, %s, 'active', %s, %s, %s, NULL, 0, 0, %s, %s)
+        RETURNING id
+        """,
+        (
+            actor["entity_id"],
+            project.project_type,
+            stage,
+            target_place_id,
+            target_character_entity_id,
+            next_eligible,
+            prologue_chunk_id,
+        ),
+    )
+    return int(_row_value(cur.fetchone(), "id", 0))
+
+
+def _insert_project_started_event(
+    cur: Any,
+    *,
+    project: RetrogradeProjectPlan,
+    actor: Mapping[str, Any],
+    target: Optional[Mapping[str, Any]],
+    event_type: str,
+    prologue_chunk_id: int,
+) -> int:
+    target_character_entity_id = (
+        target.get("entity_id")
+        if target is not None and project.project_type != "plan_relocation"
+        else None
+    )
+    location_id = (
+        target.get("place_id")
+        if target is not None and project.project_type == "plan_relocation"
+        else None
+    )
+    payload = {
+        "seed_ids": [project.seed_id],
+        "project_intent": True,
+        "actor": project.actor_ref,
+        "target": project.target_ref,
+    }
+    cur.execute(
+        """
+        /* orrery:retrograde:insert_project_started_event */
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, target_entity_id,
+            location_id, world_layer, source, changed_fields, payload
+        ) VALUES (
+            %s, %s, %s, %s, %s, 'primary'::world_layer_type,
+            'retrograde'::event_source_kind, %s, %s::jsonb
+        ) RETURNING id
+        """,
+        (
+            event_type,
+            prologue_chunk_id,
+            actor["entity_id"],
+            target_character_entity_id,
+            location_id,
+            ["character_project_states"],
+            json.dumps(payload),
+        ),
+    )
+    event_id = int(_row_value(cur.fetchone(), "id", 0))
+    participants = [("actor", int(actor["entity_id"]))]
+    if target_character_entity_id is not None:
+        participants.append(("target", int(target_character_entity_id)))
+    for role, entity_id in participants:
+        cur.execute(
+            """
+            INSERT INTO world_event_entities (event_id, role, entity_id)
+            VALUES (%s, %s::event_role_kind, %s)
+            ON CONFLICT DO NOTHING
+            """,
+            (event_id, role, entity_id),
+        )
+    return event_id
 
 
 def _plan_death_row(
@@ -1902,14 +2390,31 @@ def _load_world_time(cur: Any) -> Any:
     return _row_value(row, "world_time", 0)
 
 
+def _load_base_timestamp(cur: Any) -> Any:
+    cur.execute(
+        """
+        /* orrery:retrograde:base_timestamp */
+        SELECT base_timestamp FROM global_variables WHERE id = true
+        """
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    return _row_value(row, "base_timestamp", 0)
+
+
 def _plan_entity_stubs(
     *,
     expansion: RetrogradeExpansionPlanResponse,
     entity_index: Mapping[tuple[str, str], Sequence[_EntityRecord]],
     create_missing_entities: bool,
     inserted_stub_keys: frozenset[tuple[str, str]],
+    include_projects: bool,
 ) -> list[dict[str, Any]]:
-    refs = _collect_expansion_entity_refs(expansion)
+    refs = _collect_expansion_entity_refs(
+        expansion,
+        include_projects=include_projects,
+    )
     rows = []
     for key, ref in sorted(refs.items()):
         matches = list(entity_index.get(key, []))
@@ -1937,6 +2442,8 @@ def _plan_entity_stubs(
 
 def _collect_expansion_entity_refs(
     expansion: RetrogradeExpansionPlanResponse,
+    *,
+    include_projects: bool,
 ) -> dict[tuple[str, str], dict[str, Any]]:
     refs: dict[tuple[str, str], dict[str, Any]] = {}
 
@@ -2030,6 +2537,30 @@ def _collect_expansion_entity_refs(
                 "role": "object",
             },
         )
+
+    for project in expansion.project_plan if include_projects else []:
+        add_ref(
+            project.actor_ref,
+            "character",
+            source={
+                "plan": "project_plan",
+                "seed_id": project.seed_id,
+                "role": "actor",
+            },
+        )
+        if project.target_ref:
+            target_kind = (
+                "place" if project.project_type == "plan_relocation" else "character"
+            )
+            add_ref(
+                project.target_ref,
+                target_kind,
+                source={
+                    "plan": "project_plan",
+                    "seed_id": project.seed_id,
+                    "role": "target",
+                },
+            )
 
     for death in expansion.death_plan:
         add_ref(

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -1278,6 +1278,33 @@ def _validate_project_start_dependencies(
     actor: Mapping[str, Any],
     target: Optional[Mapping[str, Any]],
 ) -> None:
+    dead_character_refs = {
+        normalize_entity_ref(death.entity_ref)
+        for death in expansion.death_plan
+        if death.entity_kind == "character"
+    }
+    # Resolver project loading joins actor entities with e.is_active = true, so
+    # a dead actor would leave an open project row invisible to gameplay.
+    if normalize_entity_ref(project.actor_ref) in dead_character_refs:
+        raise ValueError(
+            f"Retrograde project seed {project.seed_id!r} actor_ref "
+            f"{project.actor_ref!r} appears in death_plan"
+        )
+    if (
+        project.project_type
+        in {
+            "recruit_ally",
+            "pursue_romance",
+            "court_patron",
+            "seek_redemption",
+        }
+        and project.target_ref is not None
+        and normalize_entity_ref(project.target_ref) in dead_character_refs
+    ):
+        raise ValueError(
+            f"Retrograde project seed {project.seed_id!r} character target_ref "
+            f"{project.target_ref!r} appears in death_plan"
+        )
     if actor["resolution"] == "resolved":
         existing_id = _existing_open_project_id(cur, int(actor["entity_id"]))
         if existing_id is not None:

--- a/nexus/agents/orrery/retrograde_seed_candidates.py
+++ b/nexus/agents/orrery/retrograde_seed_candidates.py
@@ -26,6 +26,15 @@ SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION: SeedCandidateSchemaVersion = (
     "orrery_retrograde_seed_candidates.v0"
 )
 
+RetrogradeProjectType = Literal[
+    "plan_relocation",
+    "recruit_ally",
+    "build_venture",
+    "pursue_romance",
+    "court_patron",
+    "seek_redemption",
+]
+
 
 class RetrogradeSeedCandidateValidationError(ValueError):
     """Raised when a seed candidate response is shaped correctly but illegal."""
@@ -205,6 +214,42 @@ class RetrogradeWireClaimedEdge(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
 
+class RetrogradeProjectIntent(BaseModel):
+    """Optional long-arc project implied by one generated seed."""
+
+    project_type: RetrogradeProjectType
+    target_ref: Optional[EntityRef] = Field(
+        default=None,
+        description="Compact character/place ref when the project type needs one.",
+    )
+    rationale: str = Field(min_length=1, max_length=500)
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_typed_target(self) -> "RetrogradeProjectIntent":
+        validate_project_target_shape(
+            project_type=self.project_type,
+            target_ref=self.target_ref,
+            context="project intent",
+        )
+        return self
+
+
+class RetrogradeWireProjectIntent(BaseModel):
+    """Provider-facing twin of :class:`RetrogradeProjectIntent`."""
+
+    project_type: RetrogradeProjectType
+    target_ref: str = Field(
+        default="",
+        max_length=ENTITY_REF_MAX_LENGTH,
+        description="Compact target ref, or an empty string when targetless.",
+    )
+    rationale: str = Field(min_length=1, max_length=500)
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
 class RetrogradeWireSeedCandidate(BaseModel):
     """Provider-facing seed candidate with compact mechanical refs."""
 
@@ -218,6 +263,7 @@ class RetrogradeWireSeedCandidate(BaseModel):
     )
     defer_or_reject_if: list[str] = Field(default_factory=list)
     claimed_edges: list[RetrogradeWireClaimedEdge] = Field(default_factory=list)
+    project_intent: Optional[RetrogradeWireProjectIntent] = None
 
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
@@ -293,6 +339,10 @@ class RetrogradeSeedCandidate(BaseModel):
             "One or two dangling edges from the request's candidate_graph "
             "that this seed claims and resolves."
         ),
+    )
+    project_intent: Optional[RetrogradeProjectIntent] = Field(
+        default=None,
+        description="Rare optional project generator carried into R6 weaving.",
     )
 
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
@@ -491,6 +541,19 @@ def render_seed_generation_prompt(
         "coverage_functions": seed_generation_request.get("coverage_functions", []),
         "candidate_graph": seed_generation_request.get("candidate_graph", {}),
         "selection_rubric": seed_generation_request.get("selection_rubric", {}),
+        "project_intent_policy": {
+            "optional": True,
+            "rarity": "At most two candidates per cast should carry an intent.",
+            "unresolved_ledger": ["court_patron", "seek_redemption"],
+            "trait_bound_hook": [
+                "build_venture",
+                "pursue_romance",
+                "recruit_ally",
+            ],
+            "target_refs": (
+                "Use the same compact entity-ref language as mechanical_hints."
+            ),
+        },
         "prompt_sections": seed_generation_request.get("prompt_sections", []),
         "response_contract": _prompt_response_contract(),
     }
@@ -510,6 +573,9 @@ def render_seed_generation_prompt(
         "name and required kind.\n"
         "Keep summaries, rationales, and rejection conditions compact.\n"
         "If a mechanical hint cannot satisfy the hard validation rules, omit it.\n"
+        "Project intent is optional and rare: propose it only for a seed serving "
+        "the listed unresolved_ledger or trait_bound_hook functions, and use it "
+        "on at most two candidates in the cast.\n"
         "Return JSON only. Unknown mechanical primitives are invalid.\n\n"
         "RETROGRADE_SEED_GENERATION_REQUEST:\n"
         f"{json.dumps(prompt_payload, indent=2, sort_keys=True)}"
@@ -632,6 +698,12 @@ def _expand_wire_seed_candidate_payload(payload: Mapping[str, Any]) -> dict[str,
         hints = candidate_row.get("mechanical_hints")
         if isinstance(hints, Mapping):
             candidate_row["mechanical_hints"] = _expand_wire_mechanical_hints(hints)
+        project_intent = candidate_row.get("project_intent")
+        if isinstance(project_intent, Mapping):
+            candidate_row["project_intent"] = {
+                **dict(project_intent),
+                "target_ref": _none_if_empty(project_intent.get("target_ref")),
+            }
         expanded_candidates.append(candidate_row)
 
     data["candidates"] = expanded_candidates
@@ -720,6 +792,24 @@ def _none_if_empty(value: Any) -> Any:
     if value == "":
         return None
     return value
+
+
+def validate_project_target_shape(
+    *,
+    project_type: str,
+    target_ref: Optional[str],
+    context: str,
+) -> None:
+    character_targeted = {
+        "recruit_ally",
+        "pursue_romance",
+        "court_patron",
+        "seek_redemption",
+    }
+    if project_type == "build_venture" and target_ref is not None:
+        raise ValueError(f"{context} build_venture forbids a target_ref")
+    if project_type in character_targeted and target_ref is None:
+        raise ValueError(f"{context} {project_type} requires a target_ref")
 
 
 def _literal_or_str(values: list[str]) -> Any:
@@ -950,7 +1040,6 @@ def _candidate_contract_issues(
         issues.append(
             f"{candidate_prefix} uses unknown coverage functions {unknown_coverage}"
         )
-
     events_by_ref: dict[str, RetrogradeSeedEventHint] = {}
     duplicate_event_refs = _duplicates(
         [event.event_ref for event in candidate.mechanical_hints.events]
@@ -1198,6 +1287,7 @@ def _prompt_response_contract() -> dict[str, Any]:
             "mechanical_hints",
             "defer_or_reject_if",
             "claimed_edges",
+            "project_intent",
         ],
         "mechanical_hint_fields": [
             "events",
@@ -1212,6 +1302,7 @@ def _prompt_response_contract() -> dict[str, Any]:
                 "subject_kind|object_kind|relationship_type"
             ),
             "claimed_edges": ("edge_id, open_endpoint_name, open_endpoint_kind"),
+            "project_intent": "project_type, target_ref, rationale",
             "absence": "Use empty strings for absent supporting_event_ref/rationale.",
         },
     }

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1786,6 +1786,22 @@ class OrreryRetrogradeWizardSettings(BaseModel):
     )
 
 
+class OrreryRetrogradeProjectSettings(BaseModel):
+    """Wizard-time project seeding controls."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(
+        default=False,
+        description="Allow R6 project intents to seed stage-one project rows.",
+    )
+    max_seeded_projects: int = Field(
+        default=3,
+        gt=0,
+        description="Positive cast-wide cap after per-character arbitration.",
+    )
+
+
 class OrreryRetrogradeJunctionCountSettings(BaseModel):
     """Shared-entity junction counts by player-facing weirdness level."""
 
@@ -1986,6 +2002,9 @@ class OrreryRetrogradeSettings(BaseModel):
     )
     wizard: OrreryRetrogradeWizardSettings = Field(
         default_factory=OrreryRetrogradeWizardSettings
+    )
+    projects: OrreryRetrogradeProjectSettings = Field(
+        default_factory=OrreryRetrogradeProjectSettings
     )
     graph: OrreryRetrogradeGraphSettings = Field(
         default_factory=OrreryRetrogradeGraphSettings

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -24,6 +24,7 @@ from nexus.config.settings_models import (
     OrreryRevealSettings,
     OrrerySettings,
     OrreryRetrogradeMaturationSettings,
+    OrreryRetrogradeProjectSettings,
     OrreryRetrogradeWeirdGenreBands,
     OrreryRetrogradeWeirdSettings,
     OrrerySunhelmSettings,
@@ -425,3 +426,16 @@ def test_orrery_maturation_accepts_equal_generation_and_selection() -> None:
         generate_candidates=2, select_target=2
     )
     assert settings.generate_candidates == 2
+
+
+def test_retrograde_projects_default_off_and_require_positive_cap() -> None:
+    assert OrreryRetrogradeProjectSettings().enabled is False
+    with pytest.raises(ValidationError):
+        OrreryRetrogradeProjectSettings(max_seeded_projects=0)
+
+
+def test_shipped_retrograde_projects_are_enabled() -> None:
+    settings = load_settings("nexus.toml")
+    assert settings.orrery is not None
+    assert settings.orrery.retrograde.projects.enabled is True
+    assert settings.orrery.retrograde.projects.max_seeded_projects == 3

--- a/tests/test_orrery/test_retrograde_expansion.py
+++ b/tests/test_orrery/test_retrograde_expansion.py
@@ -12,6 +12,7 @@ from nexus.agents.orrery.retrograde_expansion import (
     RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION,
     RetrogradeExpansionWireResponse,
     RetrogradeExpansionValidationError,
+    RetrogradeProjectPlan,
     coerce_expansion_response_payload,
     render_expansion_prompt,
     validate_expansion_plan,
@@ -55,6 +56,7 @@ def test_wire_expansion_response_omits_deterministic_fields() -> None:
     assert set(schema["properties"]) == {
         "event_plan",
         "mechanical_plan",
+        "project_plan",
         "thread_plan",
         "coverage_notes",
         "coordinates",
@@ -131,6 +133,83 @@ def test_wire_expansion_response_coerces_to_full_contract() -> None:
     assert len(response.entity_tag_plan) == 1
     assert len(response.pair_tag_plan) == 1
     assert len(response.relationship_plan) == 1
+
+
+def test_project_plan_carries_exact_woven_seed_intent() -> None:
+    vocabulary = _expansion_test_vocabulary()
+    packet = _packet(vocabulary)
+    seed_response = _seed_response(vocabulary)
+    seed_response["candidates"][0]["project_intent"] = {
+        "project_type": "court_patron",
+        "target_ref": "Vale",
+        "rationale": "The old debt can become patronage.",
+    }
+    payload = _valid_expansion(vocabulary)
+    payload["project_plan"] = [
+        {
+            "seed_id": "seed_001",
+            "project_type": "court_patron",
+            "actor_ref": "Mara",
+            "target_ref": "Vale",
+            "rationale": "Mara courts Vale's backing.",
+        }
+    ]
+
+    response = validate_expansion_plan(
+        payload=payload,
+        packet=packet,
+        seed_candidate_response=seed_response,
+    )
+
+    assert response.project_plan[0].seed_id == "seed_001"
+
+
+def test_woven_seed_must_note_dropped_project_intent() -> None:
+    vocabulary = _expansion_test_vocabulary()
+    packet = _packet(vocabulary)
+    seed_response = _seed_response(vocabulary)
+    seed_response["candidates"][0]["project_intent"] = {
+        "project_type": "build_venture",
+        "target_ref": None,
+        "rationale": "The seed supports a venture.",
+    }
+    payload = _valid_expansion(vocabulary)
+
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="drops project_intent without a thread note",
+    ):
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+
+
+def test_project_plan_rejects_forbidden_target_shape() -> None:
+    with pytest.raises(ValidationError):
+        RetrogradeProjectPlan.model_validate(
+            {
+                "seed_id": "seed_001",
+                "project_type": "build_venture",
+                "actor_ref": "Mara",
+                "target_ref": "Vale",
+                "rationale": "Venture targets are forbidden.",
+            }
+        )
+
+
+def test_project_plan_rejects_unknown_type() -> None:
+    with pytest.raises(ValidationError):
+        RetrogradeProjectPlan.model_validate(
+            {
+                "seed_id": "seed_001",
+                "project_type": "conquer_world",
+                "actor_ref": "Mara",
+                "target_ref": None,
+                "rationale": "Not in the closed project vocabulary.",
+            }
+        )
 
 
 def test_maturation_geo_prompt_and_coordinates_share_r6_schema() -> None:

--- a/tests/test_orrery/test_retrograde_expansion.py
+++ b/tests/test_orrery/test_retrograde_expansion.py
@@ -164,6 +164,54 @@ def test_project_plan_carries_exact_woven_seed_intent() -> None:
     assert response.project_plan[0].seed_id == "seed_001"
 
 
+@pytest.mark.parametrize(
+    ("death_ref", "issue"),
+    [
+        ("MARA", "actor_ref 'Mara' appears in death_plan"),
+        ("VALE", "character target_ref 'Vale' appears in death_plan"),
+    ],
+)
+def test_project_plan_rejects_participant_in_death_plan(
+    death_ref: str,
+    issue: str,
+) -> None:
+    vocabulary = _expansion_test_vocabulary()
+    packet = _packet(vocabulary)
+    seed_response = _seed_response(vocabulary)
+    seed_response["candidates"][0]["project_intent"] = {
+        "project_type": "court_patron",
+        "target_ref": "Vale",
+        "rationale": "The old debt can become patronage.",
+    }
+    payload = _valid_expansion(vocabulary)
+    payload["event_plan"][0]["participants"].append(
+        {"entity_ref": "Vale", "entity_kind": "character", "role": "target"}
+    )
+    payload["death_plan"] = [
+        {
+            "entity_ref": death_ref,
+            "entity_kind": "character",
+            "cause_event_ref": "retro_event_001",
+        }
+    ]
+    payload["project_plan"] = [
+        {
+            "seed_id": "seed_001",
+            "project_type": "court_patron",
+            "actor_ref": "Mara",
+            "target_ref": "Vale",
+            "rationale": "Mara courts Vale's backing.",
+        }
+    ]
+
+    with pytest.raises(RetrogradeExpansionValidationError, match=issue):
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+
+
 def test_woven_seed_must_note_dropped_project_intent() -> None:
     vocabulary = _expansion_test_vocabulary()
     packet = _packet(vocabulary)

--- a/tests/test_orrery/test_retrograde_persistence.py
+++ b/tests/test_orrery/test_retrograde_persistence.py
@@ -883,6 +883,12 @@ class FakeRetrogradePersistenceCursor:
             self.deactivated_entity_ids.append(entity_id)
             self.inactive_entity_ids.add(entity_id)
             self._result = []
+        elif "SELECT to_regclass" in sql:
+            self._result = [{"checkpoint_table": "backstory_secrets"}]
+        elif "jsonb_agg(to_jsonb(t))" in sql:
+            self._result = [{"state": []}]
+        elif "INSERT INTO state_checkpoints" in sql:
+            self._result = [{"id": 904}]
         else:
             raise AssertionError(f"Unexpected SQL: {sql}")
 

--- a/tests/test_orrery/test_retrograde_persistence.py
+++ b/tests/test_orrery/test_retrograde_persistence.py
@@ -740,7 +740,9 @@ class FakeRetrogradePersistenceCursor:
     def execute(self, sql: str, params: Optional[Any] = None) -> None:
         self.statements.append(sql)
         self.params.append(params)
-        if "orrery:retrograde:prologue_chunk" in sql:
+        if "orrery:retrograde:genesis_invariant" in sql:
+            self._result = []
+        elif "orrery:retrograde:prologue_chunk" in sql:
             self._result = []
         elif "orrery:retrograde:entity_catalog" in sql:
             rows = [

--- a/tests/test_orrery/test_retrograde_projects_live.py
+++ b/tests/test_orrery/test_retrograde_projects_live.py
@@ -18,6 +18,8 @@ from nexus.agents.orrery.replay import verify_checkpoints_sync
 from nexus.agents.orrery.resolver import OrreryResolutionDraft
 from nexus.agents.orrery.retrograde_expansion import (
     RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION,
+    RetrogradeExpansionPlanResponse,
+    RetrogradeProjectPlan,
 )
 from nexus.agents.orrery.retrograde_orchestrator import (
     RetrogradeGenerationBundle,
@@ -26,6 +28,7 @@ from nexus.agents.orrery.retrograde_orchestrator import (
 from nexus.agents.orrery.retrograde_persistence import (
     PROJECT_FIRST_STAGES,
     PROJECT_STARTED_EVENT_TYPES,
+    _validate_project_start_dependencies,
     build_retrograde_persistence_plan,
 )
 from nexus.agents.orrery.retrograde_seed_candidates import (
@@ -374,6 +377,79 @@ def test_seek_redemption_requires_target_to_actor_negative_valence(
                 project_seeding_enabled=True,
                 project_settings=load_settings().orrery.projects,
             )
+
+
+def test_writer_rejects_project_participants_in_death_plan(
+    project_db: dict[str, Any],
+) -> None:
+    db = project_db
+    actor_id, actor_ref = db["characters"][0]
+    target_id, target_ref = db["characters"][8]
+    elsewhere_ref = db["characters"][9][1]
+    project = RetrogradeProjectPlan.model_validate(
+        {
+            "seed_id": "seed_dead_participant",
+            "project_type": "court_patron",
+            "actor_ref": actor_ref,
+            "target_ref": target_ref,
+            "rationale": "The patronage arc starts at stage one.",
+        }
+    )
+    actor = {
+        "resolution": "resolved",
+        "entity_id": actor_id,
+        "entity_ref": actor_ref,
+    }
+    target = {
+        "resolution": "resolved",
+        "entity_id": target_id,
+        "entity_ref": target_ref,
+    }
+
+    def expansion_with_death(entity_ref: str) -> RetrogradeExpansionPlanResponse:
+        return RetrogradeExpansionPlanResponse.model_validate(
+            {
+                "selected_seed_ids": [project.seed_id],
+                "death_plan": [
+                    {
+                        "entity_ref": entity_ref,
+                        "entity_kind": "character",
+                    }
+                ],
+                "project_plan": [project.model_dump(mode="json")],
+            }
+        )
+
+    with db["conn"].cursor() as cur:
+        with pytest.raises(
+            ValueError,
+            match="seed_dead_participant.*actor_ref.*death_plan",
+        ):
+            _validate_project_start_dependencies(
+                cur,
+                expansion=expansion_with_death(actor_ref.upper()),
+                project=project,
+                actor=actor,
+                target=target,
+            )
+        with pytest.raises(
+            ValueError,
+            match="seed_dead_participant.*character target_ref.*death_plan",
+        ):
+            _validate_project_start_dependencies(
+                cur,
+                expansion=expansion_with_death(target_ref.upper()),
+                project=project,
+                actor=actor,
+                target=target,
+            )
+        _validate_project_start_dependencies(
+            cur,
+            expansion=expansion_with_death(elsewhere_ref),
+            project=project,
+            actor=actor,
+            target=target,
+        )
 
 
 def test_wizard_genesis_checkpoint_carries_seeded_project_through_replay(

--- a/tests/test_orrery/test_retrograde_projects_live.py
+++ b/tests/test_orrery/test_retrograde_projects_live.py
@@ -238,6 +238,106 @@ def test_writer_dedup_cap_disabled_and_unresolvable_are_loud(
             )
 
 
+def test_cap_dropped_projects_do_not_claim_actor_keys(
+    project_db: dict[str, Any],
+) -> None:
+    """Cap rejects never become false duplicate-actor winners."""
+
+    db = project_db
+    specs = [
+        ("seed_a", "build_venture", db["characters"][0][1], None),
+        ("seed_b1", "build_venture", db["characters"][1][1], None),
+        ("seed_b2", "build_venture", db["characters"][1][1], None),
+    ]
+    packet, seeds, expansion = _contracts(db["vocabulary"], specs)
+    with db["conn"].cursor() as cur:
+        manifest = build_retrograde_persistence_plan(
+            cur,
+            packet=packet,
+            seed_candidate_response=seeds,
+            expansion_plan_payload=expansion,
+            slot=2,
+            dbname="save_02",
+            dry_run=False,
+            project_seeding_enabled=True,
+            max_seeded_projects=1,
+            project_settings=load_settings().orrery.projects,
+        )
+
+    assert [row["status"] for row in manifest["project_rows"]] == [
+        "inserted",
+        "dropped_cap",
+        "dropped_cap",
+    ]
+    assert manifest["counters"]["projects_inserted"] == 1
+    assert manifest["counters"]["projects_dropped_cap"] == 2
+    assert manifest["counters"]["projects_dropped_duplicate_actor"] == 0
+    assert all(
+        row.get("winning_seed_id") is None for row in manifest["project_rows"][1:]
+    )
+
+
+def test_dropped_project_targets_do_not_create_entity_stubs(
+    project_db: dict[str, Any],
+) -> None:
+    """Only accepted project targets participate in entity stub planning."""
+
+    db = project_db
+    nonce = uuid4().hex[:10]
+    accepted_target = f"Accepted Target {nonce}"
+    dropped_target = f"Dropped Target {nonce}"
+    specs = [
+        (
+            "seed_accepted_stub",
+            "recruit_ally",
+            db["characters"][0][1],
+            accepted_target,
+        ),
+        (
+            "seed_dropped_stub",
+            "recruit_ally",
+            db["characters"][1][1],
+            dropped_target,
+        ),
+    ]
+    packet, seeds, expansion = _contracts(db["vocabulary"], specs)
+    with db["conn"].cursor() as cur:
+        manifest = build_retrograde_persistence_plan(
+            cur,
+            packet=packet,
+            seed_candidate_response=seeds,
+            expansion_plan_payload=expansion,
+            slot=2,
+            dbname="save_02",
+            dry_run=False,
+            create_missing_entities=True,
+            project_seeding_enabled=True,
+            max_seeded_projects=1,
+            project_settings=load_settings().orrery.projects,
+        )
+        cur.execute(
+            "SELECT name FROM characters WHERE name = ANY(%s) ORDER BY name",
+            ([accepted_target, dropped_target],),
+        )
+        created_names = [str(row[0]) for row in cur.fetchall()]
+
+    project_stub_rows = [
+        row
+        for row in manifest["entity_stub_rows"]
+        if any(
+            source["plan"] == "project_plan" and source["role"] == "target"
+            for source in row["sources"]
+        )
+    ]
+    assert [(row["entity_ref"], row["status"]) for row in project_stub_rows] == [
+        (accepted_target, "inserted")
+    ]
+    assert dropped_target not in {
+        row["entity_ref"] for row in manifest["entity_stub_rows"]
+    }
+    assert created_names == [accepted_target]
+
+
 def test_seek_redemption_requires_target_to_actor_negative_valence(
     project_db: dict[str, Any],
 ) -> None:
@@ -314,6 +414,16 @@ def test_wizard_genesis_checkpoint_carries_seeded_project_through_replay(
         )
         base_id = manifest["genesis_checkpoint"]["id"]
         prologue_chunk = manifest["genesis_checkpoint"]["chunk_id"]
+        with pytest.raises(
+            RuntimeError,
+            match=rf"checkpoint {base_id} already exists at prologue chunk "
+            rf"{prologue_chunk}",
+        ):
+            persist_retrograde_history(
+                cur,
+                bundle=bundle,
+                settings=settings,
+            )
         cur.execute(
             """
             SELECT state -> 'character_project_states'

--- a/tests/test_orrery/test_retrograde_projects_live.py
+++ b/tests/test_orrery/test_retrograde_projects_live.py
@@ -1,0 +1,574 @@
+"""Live rollback-only coverage for wizard-time Retrograde project seeding."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import json
+import logging
+from typing import Any, Iterator, Mapping, Sequence
+from uuid import uuid4
+
+import psycopg2
+import pytest
+
+from nexus.agents.orrery.events import _apply_state_delta_sync
+from nexus.agents.orrery.needs import load_need_tuning
+from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
+from nexus.agents.orrery.replay import verify_checkpoints_sync
+from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.retrograde_expansion import (
+    RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION,
+)
+from nexus.agents.orrery.retrograde_orchestrator import (
+    RetrogradeGenerationBundle,
+    persist_retrograde_history,
+)
+from nexus.agents.orrery.retrograde_persistence import (
+    PROJECT_FIRST_STAGES,
+    PROJECT_STARTED_EVENT_TYPES,
+    build_retrograde_persistence_plan,
+)
+from nexus.agents.orrery.retrograde_seed_candidates import (
+    SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION,
+)
+from nexus.agents.orrery.retrograde_vocabulary import (
+    SeedEligibleVocabulary,
+    enumerate_seed_eligible_vocabulary,
+)
+from nexus.agents.orrery.substrate import coerce_project_policy
+from nexus.api.slot_utils import get_slot_db_url
+from nexus.config import load_settings
+
+pytestmark = pytest.mark.requires_postgres
+
+PROJECT_TYPES = tuple(PROJECT_FIRST_STAGES)
+
+
+@pytest.fixture()
+def project_db() -> Iterator[dict[str, Any]]:
+    """Open save_02 only inside an always-rolled-back transaction."""
+
+    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT c.entity_id, c.name
+                FROM characters c
+                WHERE c.entity_id IS NOT NULL
+                ORDER BY c.id
+                LIMIT 12
+                """
+            )
+            characters = [(int(row[0]), str(row[1])) for row in cur.fetchall()]
+            assert len(characters) >= 12
+            cur.execute("SELECT id, name FROM places ORDER BY id LIMIT 2")
+            places = [(int(row[0]), str(row[1])) for row in cur.fetchall()]
+            assert len(places) >= 2
+            actor_ids = [entity_id for entity_id, _name in characters[:8]]
+            character_ids = [entity_id for entity_id, _name in characters]
+            cur.execute(
+                """
+                DELETE FROM character_project_states
+                WHERE character_entity_id = ANY(%s)
+                """,
+                (actor_ids,),
+            )
+            cur.execute(
+                """
+                DELETE FROM character_relationships cr
+                USING characters c1, characters c2
+                WHERE cr.character1_id = c1.id
+                  AND cr.character2_id = c2.id
+                  AND c1.entity_id = ANY(%s)
+                  AND c2.entity_id = ANY(%s)
+                """,
+                (character_ids, character_ids),
+            )
+        yield {
+            "conn": conn,
+            "characters": characters,
+            "places": places,
+            "vocabulary": enumerate_seed_eligible_vocabulary(dbname="save_02"),
+        }
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_writer_inserts_all_types_and_started_events(
+    project_db: dict[str, Any],
+) -> None:
+    db = project_db
+    specs = _all_type_specs(db)
+    packet, seeds, expansion = _contracts(db["vocabulary"], specs)
+    with db["conn"].cursor() as cur:
+        manifest = build_retrograde_persistence_plan(
+            cur,
+            packet=packet,
+            seed_candidate_response=seeds,
+            expansion_plan_payload=expansion,
+            slot=2,
+            dbname="save_02",
+            dry_run=False,
+            project_seeding_enabled=True,
+            max_seeded_projects=6,
+            project_settings=load_settings().orrery.projects,
+        )
+        assert manifest["counters"]["projects_inserted"] == 6
+        assert all(row["status"] == "inserted" for row in manifest["project_rows"])
+
+        project_ids = [row["project_id"] for row in manifest["project_rows"]]
+        cur.execute(
+            """
+            SELECT cps.id, cps.project_type, cps.status, cps.stage,
+                   cps.target_place_id, cps.target_character_entity_id,
+                   cps.target_faction_entity_id, cps.progress, cps.stall_count,
+                   cps.next_eligible_at_world_time, cps.source_chunk_id
+            FROM character_project_states cps
+            WHERE cps.id = ANY(%s)
+            ORDER BY cps.id
+            """,
+            (project_ids,),
+        )
+        persisted = cur.fetchall()
+        assert len(persisted) == 6
+        cur.execute("SELECT base_timestamp FROM global_variables WHERE id = true")
+        base_timestamp = cur.fetchone()[0]
+        assert base_timestamp is not None
+        for row in persisted:
+            project_type = str(row[1])
+            assert row[2] == "active"
+            assert row[3] == PROJECT_FIRST_STAGES[project_type]
+            assert row[6] is None
+            assert float(row[7]) == 0.0
+            assert row[8] == 0
+            assert row[9] == base_timestamp + timedelta(hours=24)
+            assert row[10] == manifest["prologue_anchor"]["chunk_id"]
+            if project_type == "build_venture":
+                assert row[4] is None and row[5] is None
+
+        event_ids = [row["started_event_id"] for row in manifest["project_rows"]]
+        cur.execute(
+            """
+            SELECT event_type, source::text, tick_chunk_id, payload
+            FROM world_events
+            WHERE id = ANY(%s)
+            ORDER BY id
+            """,
+            (event_ids,),
+        )
+        events = cur.fetchall()
+        assert {row[0] for row in events} == set(PROJECT_STARTED_EVENT_TYPES.values())
+        assert all(row[1] == "retrograde" for row in events)
+        assert all(row[2] == manifest["prologue_anchor"]["chunk_id"] for row in events)
+        for _event_type, _source, _chunk, payload in events:
+            assert set(payload) == {"seed_ids", "project_intent", "actor", "target"}
+            assert payload["project_intent"] is True
+
+
+def test_writer_dedup_cap_disabled_and_unresolvable_are_loud(
+    project_db: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    db = project_db
+    actor = db["characters"][0][1]
+    target = db["characters"][8][1]
+    specs = [
+        ("seed_first", "build_venture", actor, None),
+        ("seed_second", "recruit_ally", actor, target),
+        ("seed_cap_1", "build_venture", db["characters"][1][1], None),
+        ("seed_cap_2", "build_venture", db["characters"][2][1], None),
+        ("seed_cap_3", "build_venture", db["characters"][3][1], None),
+    ]
+    packet, seeds, expansion = _contracts(db["vocabulary"], specs)
+    caplog.set_level(logging.WARNING)
+    with db["conn"].cursor() as cur:
+        manifest = build_retrograde_persistence_plan(
+            cur,
+            packet=packet,
+            seed_candidate_response=seeds,
+            expansion_plan_payload=expansion,
+            slot=2,
+            dbname="save_02",
+            dry_run=True,
+            project_seeding_enabled=True,
+            max_seeded_projects=3,
+            project_settings=load_settings().orrery.projects,
+        )
+        assert [row["status"] for row in manifest["project_rows"]] == [
+            "would_insert",
+            "dropped_duplicate_actor",
+            "would_insert",
+            "would_insert",
+            "dropped_cap",
+        ]
+        assert "seed_second" in caplog.text and "seed_first" in caplog.text
+        assert "cast-wide cap 3" in caplog.text
+
+        caplog.clear()
+        disabled = build_retrograde_persistence_plan(
+            cur,
+            packet=packet,
+            seed_candidate_response=seeds,
+            expansion_plan_payload=expansion,
+            slot=2,
+            dbname="save_02",
+            dry_run=True,
+            project_seeding_enabled=False,
+        )
+        assert disabled["counters"]["projects_would_insert"] == 0
+        assert disabled["counters"]["projects_dropped_disabled"] == len(specs)
+        assert "project seeding is disabled" in caplog.text
+
+    broken_specs = [("seed_broken", "recruit_ally", actor, "No Such Person")]
+    packet, seeds, expansion = _contracts(db["vocabulary"], broken_specs)
+    with db["conn"].cursor() as cur:
+        with pytest.raises(ValueError, match="seed_broken.*unresolvable target"):
+            build_retrograde_persistence_plan(
+                cur,
+                packet=packet,
+                seed_candidate_response=seeds,
+                expansion_plan_payload=expansion,
+                slot=2,
+                dbname="save_02",
+                dry_run=True,
+                project_seeding_enabled=True,
+                project_settings=load_settings().orrery.projects,
+            )
+
+
+def test_seek_redemption_requires_target_to_actor_negative_valence(
+    project_db: dict[str, Any],
+) -> None:
+    db = project_db
+    actor_id, actor = db["characters"][0]
+    target_id, target = db["characters"][8]
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            """
+            DELETE FROM character_relationships cr
+            USING characters target_c, characters actor_c
+            WHERE cr.character1_id = target_c.id
+              AND cr.character2_id = actor_c.id
+              AND target_c.entity_id = %s
+              AND actor_c.entity_id = %s
+            """,
+            (target_id, actor_id),
+        )
+        specs = [("seed_redemption", "seek_redemption", actor, target)]
+        packet, seeds, expansion = _contracts(
+            db["vocabulary"],
+            specs,
+            include_redemption_wrong=False,
+        )
+        with pytest.raises(ValueError, match="wary-or-worse"):
+            build_retrograde_persistence_plan(
+                cur,
+                packet=packet,
+                seed_candidate_response=seeds,
+                expansion_plan_payload=expansion,
+                slot=2,
+                dbname="save_02",
+                dry_run=True,
+                project_seeding_enabled=True,
+                project_settings=load_settings().orrery.projects,
+            )
+
+
+def test_wizard_genesis_checkpoint_carries_seeded_project_through_replay(
+    project_db: dict[str, Any],
+) -> None:
+    db = project_db
+    actor_id, actor = db["characters"][0]
+    specs = [("seed_replay", "build_venture", actor, None)]
+    packet, seeds, expansion = _contracts(db["vocabulary"], specs)
+    settings = load_settings()
+    assert settings.orrery is not None
+    bundle = RetrogradeGenerationBundle(
+        slot=2,
+        dbname="save_02",
+        model="test",
+        weird={"level": "medium"},
+        packet=packet,
+        seed_candidate_response=seeds,
+        expansion_plan=expansion,
+        timings=[],
+    )
+    with db["conn"].cursor() as cur:
+        # Force this rollback-only run to create a fresh highest-id prologue,
+        # so its genesis checkpoint is a truthful chronological replay base.
+        cur.execute(
+            """
+            UPDATE narrative_chunks
+            SET authorial_directives = '[]'::jsonb
+            WHERE COALESCE(authorial_directives, '[]'::jsonb)
+                  @> '["retrograde_prologue"]'::jsonb
+            """
+        )
+        cur.execute("DELETE FROM state_checkpoints WHERE label = 'genesis'")
+        manifest = persist_retrograde_history(
+            cur,
+            bundle=bundle,
+            settings=settings,
+        )
+        base_id = manifest["genesis_checkpoint"]["id"]
+        prologue_chunk = manifest["genesis_checkpoint"]["chunk_id"]
+        cur.execute(
+            """
+            SELECT state -> 'character_project_states'
+            FROM state_checkpoints WHERE id = %s
+            """,
+            (base_id,),
+        )
+        project_rows = cur.fetchone()[0]
+        assert any(row["character_entity_id"] == actor_id for row in project_rows)
+
+        cur.execute(
+            """
+            SELECT next_eligible_at_world_time
+            FROM character_project_states
+            WHERE character_entity_id = %s AND status = 'active'
+            """,
+            (actor_id,),
+        )
+        advance_time = cur.fetchone()[0]
+        advance_chunk = _fabricate_chunk(cur, advance_time)
+        _apply_project_advance(
+            cur,
+            chunk_id=advance_chunk,
+            actor_entity_id=actor_id,
+            project_settings=settings.orrery.projects,
+        )
+        target_id = capture_state_checkpoint_sync(
+            cur,
+            chunk_id=advance_chunk,
+            label="manual",
+        )
+        assert target_id is not None
+        pair = [
+            verdict
+            for verdict in verify_checkpoints_sync(cur)
+            if verdict.base_checkpoint_id == base_id
+            and verdict.target_checkpoint_id == target_id
+        ]
+        assert len(pair) == 1
+        assert pair[0].base_chunk_id == prologue_chunk
+        assert pair[0].drifts == []
+
+
+def _all_type_specs(db: Mapping[str, Any]) -> list[tuple[str, str, str, str | None]]:
+    characters = db["characters"]
+    places = db["places"]
+    return [
+        ("seed_relocation", "plan_relocation", characters[0][1], places[0][1]),
+        ("seed_recruit", "recruit_ally", characters[1][1], characters[8][1]),
+        ("seed_venture", "build_venture", characters[2][1], None),
+        ("seed_romance", "pursue_romance", characters[3][1], characters[9][1]),
+        ("seed_patron", "court_patron", characters[4][1], characters[10][1]),
+        ("seed_redemption", "seek_redemption", characters[5][1], characters[11][1]),
+    ]
+
+
+def _contracts(
+    vocabulary: SeedEligibleVocabulary,
+    specs: Sequence[tuple[str, str, str, str | None]],
+    *,
+    include_redemption_wrong: bool = True,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    nonce = uuid4().hex[:10]
+    coverage = [
+        {"id": "unresolved_ledger"},
+        {"id": "trait_bound_hook"},
+        {"id": "opening_pressure"},
+    ]
+    packet = {
+        "seed_generation_request": {
+            "budget": {
+                "generate_candidates": max(12, len(specs)),
+                "select_target": max(12, len(specs)),
+            },
+            "coverage_functions": coverage,
+            "candidate_graph": {},
+            "prompt_sections": [],
+        },
+        "seed_eligible_vocabulary": vocabulary,
+    }
+    candidates = []
+    events = []
+    threads = []
+    projects = []
+    selected = []
+    event_type = str(vocabulary["event_types"][0])
+    for index, (seed_id, project_type, actor_ref, target_ref) in enumerate(specs):
+        seed_key = f"{seed_id}_{nonce}"
+        event_ref = f"project_event_{nonce}_{index}"
+        selected.append(seed_key)
+        candidates.append(
+            {
+                "seed_id": seed_key,
+                "summary": f"{actor_ref} carries an unfinished long-arc intent.",
+                "origin_friction": "medium",
+                "present_leaf_anchor": "The intent remains active at story start.",
+                "coverage_functions": ["unresolved_ledger"],
+                "mechanical_hints": {},
+                "defer_or_reject_if": [],
+                "claimed_edges": [],
+                "project_intent": {
+                    "project_type": project_type,
+                    "target_ref": target_ref,
+                    "rationale": "Generated history creates a live project.",
+                },
+            }
+        )
+        events.append(
+            {
+                "event_ref": event_ref,
+                "seed_ids": [seed_key],
+                "event_type": event_type,
+                "summary": f"An old record left {actor_ref} with unfinished work.",
+                "chronology": "recent_past",
+                "participants": [
+                    {
+                        "entity_ref": actor_ref,
+                        "entity_kind": "character",
+                        "role": "actor",
+                    }
+                ],
+                "changed_fields": [],
+                "payload": [],
+            }
+        )
+        threads.append(
+            {
+                "seed_id": seed_key,
+                "status": "woven",
+                "event_refs": [event_ref],
+                "present_leaf_anchor": "The project is active at story start.",
+            }
+        )
+        projects.append(
+            {
+                "seed_id": seed_key,
+                "project_type": project_type,
+                "actor_ref": actor_ref,
+                "target_ref": target_ref,
+                "rationale": "Begin at the first stage without skipped milestones.",
+            }
+        )
+
+    relationships = []
+    if include_redemption_wrong:
+        negative_type = next(
+            relationship_type
+            for relationship_type in ("enemy", "rival", "captor")
+            if relationship_type in vocabulary["relationship_types"]
+        )
+        for seed_id, project_type, actor_ref, target_ref in specs:
+            if project_type != "seek_redemption":
+                continue
+            relationships.append(
+                {
+                    "subject_ref": target_ref,
+                    "subject_kind": "character",
+                    "relationship_type": negative_type,
+                    "object_ref": actor_ref,
+                    "object_kind": "character",
+                    "rationale": f"{seed_id} names the wrong being amended.",
+                }
+            )
+    seed_response = {
+        "schema_version": SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION,
+        "candidates": candidates,
+        "selected_seed_ids": selected,
+        "rejected_seed_ids": [],
+    }
+    expansion = {
+        "schema_version": RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION,
+        "selected_seed_ids": selected,
+        "event_plan": events,
+        "entity_tag_plan": [],
+        "pair_tag_plan": [],
+        "relationship_plan": relationships,
+        "death_plan": [],
+        "project_plan": projects,
+        "thread_plan": threads,
+        "coverage_notes": [],
+        "commit_readiness": {
+            "writes": "none",
+            "planned_source": "retrograde",
+            "blocked_by": [
+                "pre_game_tick_chunk_id",
+                "event_source_kind_retrograde",
+            ],
+            "explanation": "Dry-run plan only.",
+        },
+    }
+    return packet, seed_response, expansion
+
+
+def _fabricate_chunk(cur: Any, world_time: datetime) -> int:
+    cur.execute(
+        """
+        INSERT INTO narrative_chunks (id, raw_text, created_at)
+        SELECT max(id) + 1, 'retrograde project replay probe', now()
+        FROM narrative_chunks
+        RETURNING id
+        """
+    )
+    chunk_id = int(cur.fetchone()[0])
+    cur.execute(
+        "INSERT INTO chunk_metadata (chunk_id, world_time) VALUES (%s, %s)",
+        (chunk_id, world_time),
+    )
+    cur.execute(
+        "UPDATE chunk_metadata SET world_time = %s WHERE chunk_id = %s",
+        (world_time, chunk_id),
+    )
+    return chunk_id
+
+
+def _apply_project_advance(
+    cur: Any,
+    *,
+    chunk_id: int,
+    actor_entity_id: int,
+    project_settings: Any,
+) -> None:
+    state_delta = {"project.advance": {"progress_delta": 0.25}}
+    cur.execute(
+        """
+        INSERT INTO orrery_resolutions (
+            tick_chunk_id, template_id, binding_hash, actor_entity_id,
+            priority, magnitude, state_delta
+        ) VALUES (%s, 'retrograde_replay_probe', %s, %s, 50, 0.4, %s::jsonb)
+        RETURNING id
+        """,
+        (
+            chunk_id,
+            f"retrograde-project-{chunk_id}",
+            actor_entity_id,
+            json.dumps(state_delta),
+        ),
+    )
+    resolution_id = int(cur.fetchone()[0])
+    draft = OrreryResolutionDraft(
+        template_id="retrograde_replay_probe",
+        priority=50,
+        binding_hash=f"retrograde-project-{chunk_id}",
+        bindings={"actor": actor_entity_id},
+        branch_label="project progress",
+        narrative_stub="project progress",
+        state_delta=state_delta,
+        magnitude=0.4,
+    )
+    _apply_state_delta_sync(
+        cur,
+        draft,
+        resolution_id=resolution_id,
+        actor_entity_id=actor_entity_id,
+        target_entity_id=None,
+        source_chunk_id=chunk_id,
+        need_tuning=load_need_tuning(),
+        project_policy=coerce_project_policy(project_settings),
+    )

--- a/tests/test_orrery/test_retrograde_seed_candidates.py
+++ b/tests/test_orrery/test_retrograde_seed_candidates.py
@@ -14,6 +14,7 @@ from nexus.agents.orrery.retrograde_seed_candidates import (
     SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION,
     RetrogradeSeedCandidateResponse,
     RetrogradeSeedCandidateValidationError,
+    RetrogradeProjectIntent,
     coerce_seed_candidate_response_payload,
     render_seed_generation_prompt,
     render_seed_selection_prompt,
@@ -66,6 +67,42 @@ def test_seed_candidate_prompt_embeds_schema_and_allowed_vocabulary() -> None:
     assert "knows_location" in prompt
     assert "single_entity_tag_refs" in prompt
     assert "character|scholar" in prompt
+    assert "project_intent_policy" in prompt
+    assert "at most two candidates" in prompt
+
+
+@pytest.mark.parametrize(
+    ("project_type", "target_ref"),
+    [
+        ("build_venture", "Vale"),
+        ("pursue_romance", None),
+        ("court_patron", None),
+        ("seek_redemption", None),
+        ("recruit_ally", None),
+    ],
+)
+def test_project_intent_rejects_migration_incompatible_targets(
+    project_type: str,
+    target_ref: str | None,
+) -> None:
+    with pytest.raises(ValidationError):
+        RetrogradeProjectIntent.model_validate(
+            {
+                "project_type": project_type,
+                "target_ref": target_ref,
+                "rationale": "Long-arc pressure.",
+            }
+        )
+
+
+def test_project_intent_rejects_unknown_type() -> None:
+    with pytest.raises(ValidationError):
+        RetrogradeProjectIntent.model_validate(
+            {
+                "project_type": "conquer_world",
+                "rationale": "Not in the closed vocabulary.",
+            }
+        )
 
 
 def test_seed_candidate_wire_schema_constrains_kind_tag_refs() -> None:


### PR DESCRIPTION
Stage A of #531 (Stage B — maturation-time sourcing for declared entities — comes later and shares this stage's writer).

## What This Ships

Retrograde seeds become project generators so mature casts start mid-arc:

- **R4**: `RetrogradeSeedCandidate` gains optional `project_intent` (`project_type` from the six, compact `target_ref`, `rationale`), with a short prompt-policy section — intents are optional and rare, unresolved-ledger seeds may propose court_patron/seek_redemption, trait-bound-hook seeds the venture/romance/ally types.
- **R6**: `RetrogradeExpansionPlanResponse` gains `project_plan` (+ wire twin using the empty-string-for-None convention); the prompt instructs carrying a woven seed's intent forward or dropping it with the thread noted. Target-shape validation is **one shared validator** used by both the R4 intent model and the R6 plan model, mirroring the migration-087 CHECK arms exactly.
- **Persistence**: a dedicated writer step (the `coordinates` structural template) inserts `character_project_states` rows after entity stubs and relationships exist. All validation precedes any INSERT and raises with the seed id named: unresolvable refs, per-type target shapes, seek_redemption's TARGET→ACTOR wary-or-worse signal (checked against this plan's own relationship rows *and* the DB), and an existing-open-project guard so the one-open-project unique index can never fire. Stage-one starts only; deterministic first-wins per-character dedup with loud logs; cast-wide cap; per-type `<type>_started` events with `{seed_ids, project_intent, actor, target}` payloads — zero new event types.

## Genesis-Checkpoint Finding (the Load-Bearing Requirement)

The new-story flow captured **no checkpoint at wizard completion** — wizard-born projection rows had no honest replay base. `persist_retrograde_history` now captures a `genesis` checkpoint at the synthetic prologue as its **final in-transaction write** (whole-world rollback semantics preserved), and the manifest surfaces it. The live seam test seeds a project through the wizard path, applies a real synthetic transition, captures a later checkpoint, and verifies **zero drift**. `_replay_project` is unmodified.

## Config

`[orrery.retrograde.projects]`: `enabled` (model default **false**, shipped on), `max_seeded_projects = 3` (validated positive). Disabled means intents drop with a loud log — the feature is off, not the seeds invalid.

## Evidence

- `NEXUS_RUN_POSTGRES=1 pytest tests/test_orrery/ -q` → **1234 passed, 5 skipped, 0 failed** (rerun independently after the build)
- Full suite: 1602 passed, 406 skipped
- `replay_state.py --slot 5 --verify` → all checkpoint intervals ok
- flake8/black/validate-config clean; pre-commit hooks passed

No migrations. Known pre-existing mypy debt in `retrograde_seed_candidates.py` (18 errors around dynamic `create_model` types) is untouched — that's #528's territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)