### PR TITLE
Let Matured Entities Arrive Mid-Arc (#531 Stage B)

### DIFF
--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -113,6 +113,15 @@ MATURATION_PROJECT_STARTED_TYPES = {
     "seek_redemption_started": "seek_redemption",
 }
 
+# Step 8.55 captures the checkpoint before Step 8.6 persists maturation
+# starts in the same accepted-chunk transaction. A base-chunk maturation
+# start is therefore absent from the base checkpoint and must replay, while a
+# target-chunk start is absent from the target checkpoint and must not replay.
+# Ordinary Skald/resolution writes precede Step 8.55, so they use the opposite
+# edges: base-exclusive and target-inclusive.
+CHECKPOINTED_WRITE_WINDOW_SQL = "{column} > %(base)s AND {column} <= %(target)s"
+MATURATION_PROJECT_START_WINDOW_SQL = "{column} >= %(base)s AND {column} < %(target)s"
+
 # Composite natural keys, verbatim column order (faction_relationships
 # enforces faction1_id < faction2_id; character_relationships only c1 <> c2
 # — never re-canonicalize when re-inserting delete pre-images).
@@ -527,12 +536,18 @@ class _Replayer:
 
         if base_chunk < self.target_chunk_id:
             for chunk_id in self._window_chunks(base_chunk):
-                self._apply_skald_rows(chunk_id, characters, places, result)
-                self._apply_orrery_resolutions(
-                    chunk_id, characters, needs, travel, projects, result
-                )
+                if base_chunk < chunk_id <= self.target_chunk_id:
+                    self._apply_skald_rows(chunk_id, characters, places, result)
+                    self._apply_orrery_resolutions(
+                        chunk_id, characters, needs, travel, projects, result
+                    )
                 self._apply_maturation_project_starts(
-                    chunk_id, characters, projects, travel, result
+                    chunk_id,
+                    base_chunk,
+                    characters,
+                    projects,
+                    travel,
+                    result,
                 )
 
         tag_workings, tag_touched_entities = self._replay_tags(
@@ -936,17 +951,26 @@ class _Replayer:
         )
 
     def _window_chunks(self, base_chunk: int) -> list[int]:
+        checkpointed_state_window = CHECKPOINTED_WRITE_WINDOW_SQL.format(
+            column="source_chunk_id"
+        )
+        checkpointed_resolution_window = CHECKPOINTED_WRITE_WINDOW_SQL.format(
+            column="tick_chunk_id"
+        )
+        maturation_start_window = MATURATION_PROJECT_START_WINDOW_SQL.format(
+            column="tick_chunk_id"
+        )
         self.cur.execute(
-            """
+            f"""
             SELECT DISTINCT chunk_id FROM (
                 SELECT source_chunk_id AS chunk_id FROM state_delta_log
-                WHERE source_chunk_id > %(base)s AND source_chunk_id <= %(n)s
+                WHERE {checkpointed_state_window}
                 UNION
                 SELECT tick_chunk_id FROM orrery_resolutions
-                WHERE tick_chunk_id > %(base)s AND tick_chunk_id <= %(n)s
+                WHERE {checkpointed_resolution_window}
                 UNION
                 SELECT tick_chunk_id FROM world_events
-                WHERE tick_chunk_id > %(base)s AND tick_chunk_id <= %(n)s
+                WHERE {maturation_start_window}
                   AND event_type = ANY(%(started_types)s)
                   AND (
                         source::text = 'maturation'
@@ -961,7 +985,7 @@ class _Replayer:
             """,
             {
                 "base": base_chunk,
-                "n": self.target_chunk_id,
+                "target": self.target_chunk_id,
                 "started_types": list(MATURATION_PROJECT_STARTED_TYPES),
             },
         )
@@ -1179,6 +1203,7 @@ class _Replayer:
     def _apply_maturation_project_starts(
         self,
         chunk_id: int,
+        base_chunk: int,
         characters: dict[int, dict[str, Any]],
         projects: dict[Any, dict[str, Any]],
         travel: dict[int, dict[str, Any]],
@@ -1186,12 +1211,16 @@ class _Replayer:
     ) -> None:
         """Replay only runtime maturation's applied project-start snapshots."""
 
+        maturation_start_window = MATURATION_PROJECT_START_WINDOW_SQL.format(
+            column="tick_chunk_id"
+        )
         self.cur.execute(
-            """
+            f"""
             SELECT id, event_type, actor_entity_id, payload
             FROM world_events
-            WHERE tick_chunk_id = %s
-              AND event_type = ANY(%s)
+            WHERE tick_chunk_id = %(chunk)s
+              AND {maturation_start_window}
+              AND event_type = ANY(%(started_types)s)
               AND (
                     source::text = 'maturation'
                     OR (
@@ -1203,7 +1232,12 @@ class _Replayer:
                   )
             ORDER BY id
             """,
-            (chunk_id, list(MATURATION_PROJECT_STARTED_TYPES)),
+            {
+                "chunk": chunk_id,
+                "base": base_chunk,
+                "target": self.target_chunk_id,
+                "started_types": list(MATURATION_PROJECT_STARTED_TYPES),
+            },
         )
         event_rows = self.cur.fetchall()
         by_entity = {row["entity_id"]: row for row in characters.values()}

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -39,6 +39,8 @@ produces. Sections and their replay sources:
   transitions. Every transition carries the exact applied project projection,
   so cadence and applier-derived values are independent of current tuning;
   project.complete also replays its explicit-destination travel.start handoff.
+  Runtime maturation starts are replayed from their ``*_started`` world event's
+  applied projection; wizard-time Retrograde starts remain checkpoint-only.
 - ``character_routine_anchors`` — checkpoint pass-through (no runtime
   writer; offline seed scripts mutate it invisibly between checkpoints).
 - ``claim_awareness`` — append-only participant/witness/granted/deliberate-
@@ -100,6 +102,15 @@ PROJECT_STAGE_LADDERS = {
         "making_amends",
         "earning_forgiveness",
     ),
+}
+
+MATURATION_PROJECT_STARTED_TYPES = {
+    "relocation_plan_started": "plan_relocation",
+    "recruit_ally_started": "recruit_ally",
+    "build_venture_started": "build_venture",
+    "pursue_romance_started": "pursue_romance",
+    "court_patron_started": "court_patron",
+    "seek_redemption_started": "seek_redemption",
 }
 
 # Composite natural keys, verbatim column order (faction_relationships
@@ -520,6 +531,9 @@ class _Replayer:
                 self._apply_orrery_resolutions(
                     chunk_id, characters, needs, travel, projects, result
                 )
+                self._apply_maturation_project_starts(
+                    chunk_id, characters, projects, travel, result
+                )
 
         tag_workings, tag_touched_entities = self._replay_tags(
             base_chunk, base_created_at, base_state, result
@@ -930,9 +944,26 @@ class _Replayer:
                 UNION
                 SELECT tick_chunk_id FROM orrery_resolutions
                 WHERE tick_chunk_id > %(base)s AND tick_chunk_id <= %(n)s
+                UNION
+                SELECT tick_chunk_id FROM world_events
+                WHERE tick_chunk_id > %(base)s AND tick_chunk_id <= %(n)s
+                  AND event_type = ANY(%(started_types)s)
+                  AND (
+                        source::text = 'maturation'
+                        OR (
+                            source::text = 'retrograde'
+                            AND payload ->> 'source' = 'maturation'
+                            AND payload ->> 'retrograde_event_ref'
+                                LIKE 'maturation_job_%%'
+                        )
+                      )
             ) w ORDER BY chunk_id
             """,
-            {"base": base_chunk, "n": self.target_chunk_id},
+            {
+                "base": base_chunk,
+                "n": self.target_chunk_id,
+                "started_types": list(MATURATION_PROJECT_STARTED_TYPES),
+            },
         )
         return [_row_value(row, 0) for row in self.cur.fetchall()]
 
@@ -1144,6 +1175,73 @@ class _Replayer:
                 f"type {row['project_type']!r}"
             )
         return key, row
+
+    def _apply_maturation_project_starts(
+        self,
+        chunk_id: int,
+        characters: dict[int, dict[str, Any]],
+        projects: dict[Any, dict[str, Any]],
+        travel: dict[int, dict[str, Any]],
+        result: ReplayResult,
+    ) -> None:
+        """Replay only runtime maturation's applied project-start snapshots."""
+
+        self.cur.execute(
+            """
+            SELECT id, event_type, actor_entity_id, payload
+            FROM world_events
+            WHERE tick_chunk_id = %s
+              AND event_type = ANY(%s)
+              AND (
+                    source::text = 'maturation'
+                    OR (
+                        source::text = 'retrograde'
+                        AND payload ->> 'source' = 'maturation'
+                        AND payload ->> 'retrograde_event_ref'
+                            LIKE 'maturation_job_%%'
+                    )
+                  )
+            ORDER BY id
+            """,
+            (chunk_id, list(MATURATION_PROJECT_STARTED_TYPES)),
+        )
+        event_rows = self.cur.fetchall()
+        by_entity = {row["entity_id"]: row for row in characters.values()}
+        world_time = _fetch_world_time(self.cur, chunk_id)
+        for event_id, event_type, actor_entity_id, raw_payload in event_rows:
+            if actor_entity_id is None:
+                raise ValueError(
+                    f"Maturation project-start event {event_id} has no actor"
+                )
+            payload = _as_document(raw_payload)
+            if not isinstance(payload, dict):
+                raise ValueError(
+                    f"Maturation project-start event {event_id} payload is not "
+                    "an object"
+                )
+            applied = payload.get("applied")
+            if not isinstance(applied, dict):
+                raise ValueError(
+                    f"Maturation project-start event {event_id} at chunk "
+                    f"{chunk_id} is missing its required applied project projection"
+                )
+            expected_type = MATURATION_PROJECT_STARTED_TYPES[str(event_type)]
+            if applied.get("project_type") != expected_type:
+                raise ValueError(
+                    f"Maturation project-start event {event_id} type {event_type!r} "
+                    f"requires project_type {expected_type!r}"
+                )
+            self._replay_project(
+                "project.start",
+                chunk_id,
+                int(actor_entity_id),
+                payload,
+                world_time,
+                projects,
+                travel,
+                by_entity,
+                result,
+            )
 
     def _replay_project(
         self,

--- a/nexus/agents/orrery/retrograde_maturation.py
+++ b/nexus/agents/orrery/retrograde_maturation.py
@@ -750,25 +750,19 @@ def _mature_one(
         )
         return manifest
 
-    from nexus.agents.orrery.retrograde_persistence import (
-        build_retrograde_persistence_plan,
-    )
-
     persistence_started = time.monotonic()
     with conn:
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
-            persistence = build_retrograde_persistence_plan(
+            persistence = _persist_maturation_expansion(
                 cur,
                 packet=packet,
-                seed_candidate_response=seed_response,
-                expansion_plan_payload=expansion_payload,
+                seed_response=seed_response,
+                expansion_payload=expansion_payload,
+                row=row,
                 slot=_slot_int(slot, row.get("slot")),
                 dbname=dbname,
-                dry_run=False,
-                create_missing_entities=True,
                 summaries_enabled=retrieval.summaries_enabled,
-                recorded_at_chunk_id=int(row["requesting_chunk_id"]),
-                epistemics_settings=settings.orrery.epistemics,
+                settings=settings,
             )
             _apply_maturation_coordinates(
                 cur,
@@ -991,6 +985,19 @@ def build_runtime_maturation_packet(
             1, round(cfg.generate_candidates / cfg.select_target)
         ),
     }
+    request["project_intent_policy"] = {
+        "optional": True,
+        "rarity": "The maturation target may propose at most one project.",
+        "actor_rule": (
+            f"actor_ref must name the maturation target exactly: "
+            f"{row['entity_name']}"
+        ),
+        "target_rule": (
+            "Use the existing per-type Retrograde target shapes. COURT_PATRON "
+            "must target a character; faction patronage is deliberately not "
+            "seeded here."
+        ),
+    }
     request["prompt_sections"] = list(request["prompt_sections"]) + [
         {
             "heading": "Maturation directive",
@@ -1007,6 +1014,11 @@ def build_runtime_maturation_packet(
                 (
                     "Implied entities get minimum viable mechanical weight "
                     "only; never recursive histories."
+                ),
+                (
+                    "The maturation target may propose AT MOST ONE project. "
+                    "Its actor_ref MUST be the maturation target; no other "
+                    "entity may receive a runtime-maturation project."
                 ),
             ],
         }
@@ -1031,6 +1043,52 @@ def build_runtime_maturation_packet(
         "seed_generation_request": request,
         "seed_generation_prompt": prompt,
     }
+
+
+def _persist_maturation_expansion(
+    cur: Any,
+    *,
+    packet: Mapping[str, Any],
+    seed_response: Mapping[str, Any],
+    expansion_payload: Mapping[str, Any],
+    row: Mapping[str, Any],
+    slot: int,
+    dbname: str,
+    settings: Settings,
+    summaries_enabled: bool,
+) -> dict[str, Any]:
+    """Apply one maturation expansion through the shared Retrograde writer."""
+
+    if settings.orrery is None:
+        raise ValueError("settings.orrery is required for Retrograde maturation")
+    from nexus.agents.orrery.retrograde_persistence import (
+        build_retrograde_persistence_plan,
+    )
+
+    return build_retrograde_persistence_plan(
+        cur,
+        packet=packet,
+        seed_candidate_response=seed_response,
+        expansion_plan_payload=expansion_payload,
+        slot=slot,
+        dbname=dbname,
+        dry_run=False,
+        create_missing_entities=True,
+        summaries_enabled=summaries_enabled,
+        recorded_at_chunk_id=int(row["requesting_chunk_id"]),
+        epistemics_settings=settings.orrery.epistemics,
+        project_seeding_enabled=settings.orrery.retrograde.projects.enabled,
+        max_seeded_projects=1,
+        project_settings=settings.orrery.projects,
+        project_start_chunk_id=int(row["requesting_chunk_id"]),
+        project_event_origin="maturation",
+        project_event_ref_prefix=(
+            f"{MATURATION_EVENT_REF_PREFIX}_{int(row['job_id'])}"
+        ),
+        expected_project_actor_entity_id=int(row["entity_id"]),
+        project_actor_allowed=(row.get("entity_kind", "character") == "character"),
+        project_log_context=f"Maturation job {int(row['job_id'])}",
+    )
 
 
 def namespace_expansion_event_refs(

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -118,6 +118,12 @@ def build_retrograde_persistence_plan(
     project_seeding_enabled: bool = False,
     max_seeded_projects: int = 3,
     project_settings: Optional[Any] = None,
+    project_start_chunk_id: Optional[int] = None,
+    project_event_origin: str = RETROGRADE_SOURCE_KIND,
+    project_event_ref_prefix: Optional[str] = None,
+    expected_project_actor_entity_id: Optional[int] = None,
+    project_actor_allowed: bool = True,
+    project_log_context: Optional[str] = None,
 ) -> dict[str, Any]:
     """Build or apply a canonical persistence plan for a Retrograde expansion.
 
@@ -141,26 +147,40 @@ def build_retrograde_persistence_plan(
     )
     if max_seeded_projects <= 0:
         raise ValueError("max_seeded_projects must be positive")
+    if project_event_origin != RETROGRADE_SOURCE_KIND:
+        if not project_event_ref_prefix:
+            raise ValueError(
+                "Runtime Retrograde project starts require an event-ref prefix"
+            )
+        if expected_project_actor_entity_id is None:
+            raise ValueError(
+                "Runtime Retrograde project starts require an expected actor"
+            )
+    existing_prologue_id = _find_prologue_chunk_id(cur)
+    entity_index = _load_entity_index(cur)
     project_ref_decisions = (
         _arbitrate_project_refs(
             expansion,
             max_seeded_projects=max_seeded_projects,
+            entity_index=entity_index,
+            expected_actor_entity_id=expected_project_actor_entity_id,
+            expected_actor_allowed=project_actor_allowed,
         )
         if project_seeding_enabled
         else {}
     )
-    existing_prologue_id = _find_prologue_chunk_id(cur)
-    entity_index = _load_entity_index(cur)
     event_types = _load_event_types(cur)
     tag_records = _load_tag_records(cur)
     pair_tag_ids = _load_pair_tag_ids(cur)
     source_blockers = _source_kind_blockers(cur)
     world_time = _load_world_time(cur)
-    base_timestamp = (
-        _load_base_timestamp(cur)
-        if project_seeding_enabled and expansion.project_plan
-        else None
-    )
+    base_timestamp = None
+    if project_seeding_enabled and expansion.project_plan:
+        base_timestamp = (
+            _load_chunk_world_time(cur, project_start_chunk_id)
+            if project_start_chunk_id is not None
+            else _load_base_timestamp(cur)
+        )
     project_policy = coerce_project_policy(project_settings)
 
     manifest = _build_plan(
@@ -188,6 +208,10 @@ def build_retrograde_persistence_plan(
         project_ref_decisions=project_ref_decisions,
         project_policy=project_policy,
         base_timestamp=base_timestamp,
+        project_start_chunk_id=project_start_chunk_id,
+        project_event_origin=project_event_origin,
+        project_event_ref_prefix=project_event_ref_prefix,
+        project_log_context=project_log_context,
     )
     if dry_run:
         return manifest
@@ -234,6 +258,10 @@ def build_retrograde_persistence_plan(
         project_ref_decisions=project_ref_decisions,
         project_policy=project_policy,
         base_timestamp=base_timestamp,
+        project_start_chunk_id=project_start_chunk_id,
+        project_event_origin=project_event_origin,
+        project_event_ref_prefix=project_event_ref_prefix,
+        project_log_context=project_log_context,
     )
 
 
@@ -263,6 +291,10 @@ def _build_plan(
     project_ref_decisions: Mapping[str, _ProjectRefDecision],
     project_policy: ProjectPolicy,
     base_timestamp: Any,
+    project_start_chunk_id: Optional[int],
+    project_event_origin: str,
+    project_event_ref_prefix: Optional[str],
+    project_log_context: Optional[str],
 ) -> dict[str, Any]:
     counters: Counter[str] = Counter()
     reference_issues: list[dict[str, Any]] = []
@@ -368,10 +400,13 @@ def _build_plan(
         project_ref_decisions=project_ref_decisions,
         project_policy=project_policy,
         base_timestamp=base_timestamp,
-        prologue_chunk_id=prologue_chunk_id,
         entity_index=entity_index,
         creatable_refs=creatable_refs,
         event_types=event_types,
+        source_chunk_id=project_start_chunk_id or prologue_chunk_id,
+        event_origin=project_event_origin,
+        event_ref_prefix=project_event_ref_prefix,
+        log_context=project_log_context,
     )
     for project_row in project_rows:
         counters[f"projects_{project_row['status']}"] += 1
@@ -444,6 +479,7 @@ def _build_plan(
         "projects_dropped_disabled",
         "projects_dropped_duplicate_actor",
         "projects_dropped_cap",
+        "projects_dropped_foreign_actor",
         "entity_stubs_would_insert",
         "entity_stubs_inserted",
         "entity_stubs_already_present",
@@ -1014,10 +1050,13 @@ def _plan_project_rows(
     project_ref_decisions: Mapping[str, _ProjectRefDecision],
     project_policy: ProjectPolicy,
     base_timestamp: Any,
-    prologue_chunk_id: Optional[int],
     entity_index: Mapping[tuple[str, str], Sequence[_EntityRecord]],
     creatable_refs: frozenset[tuple[str, str]],
     event_types: set[str],
+    source_chunk_id: Optional[int],
+    event_origin: str,
+    event_ref_prefix: Optional[str],
+    log_context: Optional[str],
 ) -> list[dict[str, Any]]:
     """Plan or insert typed stage-one projects after relationship persistence."""
 
@@ -1027,7 +1066,8 @@ def _plan_project_rows(
         disabled_rows = []
         for project in expansion.project_plan:
             logger.warning(
-                "Retrograde project seed %s dropped: project seeding is disabled",
+                "%s project seed %s dropped: project seeding is disabled",
+                log_context or "Retrograde",
                 project.seed_id,
             )
             disabled_rows.append(
@@ -1061,6 +1101,27 @@ def _plan_project_rows(
             raise AssertionError(
                 f"Missing ref-level arbitration for project seed {project.seed_id!r}"
             )
+        if decision.status == "invalid_actor":
+            raise ValueError(
+                f"Retrograde project seed {project.seed_id!r} has unresolvable "
+                f"actor ref {project.actor_ref!r} at maturation arbitration"
+            )
+        if decision.status == "dropped_foreign_actor":
+            logger.warning(
+                "%s project seed %s dropped: actor %s resolves outside the "
+                "maturation target",
+                log_context or "Retrograde",
+                project.seed_id,
+                project.actor_ref,
+            )
+            rows.append(
+                _dropped_project_row(
+                    project,
+                    status="dropped_foreign_actor",
+                    actor=actor,
+                )
+            )
+            continue
         if decision.status == "dropped_duplicate_actor":
             logger.warning(
                 "Retrograde project seed %s dropped for actor %s; seed %s won "
@@ -1079,11 +1140,19 @@ def _plan_project_rows(
             )
             continue
         if decision.status == "dropped_cap":
-            logger.warning(
-                "Retrograde project seed %s dropped: cast-wide cap %s already met",
-                project.seed_id,
-                max_seeded_projects,
-            )
+            if log_context:
+                logger.warning(
+                    "%s project seed %s dropped: maturation accepts at most one "
+                    "project",
+                    log_context,
+                    project.seed_id,
+                )
+            else:
+                logger.warning(
+                    "Retrograde project seed %s dropped: cast-wide cap %s already met",
+                    project.seed_id,
+                    max_seeded_projects,
+                )
             rows.append(
                 _dropped_project_row(
                     project,
@@ -1165,7 +1234,7 @@ def _plan_project_rows(
             "progress": 0,
             "stall_count": 0,
             "next_eligible_at_world_time": next_eligible,
-            "source_chunk_id": prologue_chunk_id,
+            "source_chunk_id": source_chunk_id,
             "started_event_type": started_event_type,
         }
         if dry_run:
@@ -1178,9 +1247,9 @@ def _plan_project_rows(
                 }
             )
         else:
-            if prologue_chunk_id is None or actor["resolution"] != "resolved":
+            if source_chunk_id is None or actor["resolution"] != "resolved":
                 raise AssertionError(
-                    "project refs and prologue must resolve on execute"
+                    "project refs and source chunk must resolve on execute"
                 )
             if target is not None and target["resolution"] != "resolved":
                 raise AssertionError("project target must resolve on execute")
@@ -1191,7 +1260,7 @@ def _plan_project_rows(
                 target=target,
                 stage=PROJECT_FIRST_STAGES[project.project_type],
                 next_eligible=next_eligible,
-                prologue_chunk_id=prologue_chunk_id,
+                source_chunk_id=source_chunk_id,
             )
             started_event_id = _insert_project_started_event(
                 cur,
@@ -1199,7 +1268,14 @@ def _plan_project_rows(
                 actor=actor,
                 target=target,
                 event_type=started_event_type,
-                prologue_chunk_id=prologue_chunk_id,
+                source_chunk_id=source_chunk_id,
+                event_origin=event_origin,
+                event_ref=(
+                    f"{event_ref_prefix}_project_{project.seed_id}"
+                    if event_ref_prefix
+                    else None
+                ),
+                next_eligible=next_eligible,
             )
             rows.append(
                 {
@@ -1218,6 +1294,9 @@ def _arbitrate_project_refs(
     expansion: RetrogradeExpansionPlanResponse,
     *,
     max_seeded_projects: int,
+    entity_index: Optional[Mapping[tuple[str, str], Sequence[_EntityRecord]]] = None,
+    expected_actor_entity_id: Optional[int] = None,
+    expected_actor_allowed: bool = True,
 ) -> dict[str, _ProjectRefDecision]:
     """Choose project seeds by normalized actor ref, then cast-wide cap."""
 
@@ -1225,6 +1304,32 @@ def _arbitrate_project_refs(
     accepted_by_actor_ref: dict[str, str] = {}
     accepted_count = 0
     for project in expansion.project_plan:
+        if expected_actor_entity_id is not None:
+            if not expected_actor_allowed:
+                decisions[project.seed_id] = _ProjectRefDecision(
+                    status="dropped_foreign_actor"
+                )
+                continue
+            if entity_index is None:
+                raise AssertionError("maturation arbitration requires entity index")
+            actor = _resolve_entity(
+                project.actor_ref,
+                "character",
+                entity_index,
+                role="project_actor",
+                creatable_refs=frozenset(),
+            )
+            if actor["resolution"] != "resolved":
+                decisions[project.seed_id] = _ProjectRefDecision(status="invalid_actor")
+                continue
+            if int(actor["entity_id"]) != expected_actor_entity_id:
+                decisions[project.seed_id] = _ProjectRefDecision(
+                    status="dropped_foreign_actor"
+                )
+                continue
+            if accepted_count >= max_seeded_projects:
+                decisions[project.seed_id] = _ProjectRefDecision(status="dropped_cap")
+                continue
         actor_key = normalize_entity_ref(project.actor_ref)
         winning_seed = accepted_by_actor_ref.get(actor_key)
         if winning_seed is not None:
@@ -1398,7 +1503,7 @@ def _insert_seeded_project(
     target: Optional[Mapping[str, Any]],
     stage: str,
     next_eligible: Any,
-    prologue_chunk_id: int,
+    source_chunk_id: int,
 ) -> int:
     target_place_id = target.get("place_id") if target else None
     target_character_entity_id = (
@@ -1424,7 +1529,7 @@ def _insert_seeded_project(
             target_place_id,
             target_character_entity_id,
             next_eligible,
-            prologue_chunk_id,
+            source_chunk_id,
         ),
     )
     return int(_row_value(cur.fetchone(), "id", 0))
@@ -1437,7 +1542,10 @@ def _insert_project_started_event(
     actor: Mapping[str, Any],
     target: Optional[Mapping[str, Any]],
     event_type: str,
-    prologue_chunk_id: int,
+    source_chunk_id: int,
+    event_origin: str,
+    event_ref: Optional[str],
+    next_eligible: Any,
 ) -> int:
     target_character_entity_id = (
         target.get("entity_id")
@@ -1455,6 +1563,29 @@ def _insert_project_started_event(
         "actor": project.actor_ref,
         "target": project.target_ref,
     }
+    if event_origin != RETROGRADE_SOURCE_KIND:
+        payload.update(
+            {
+                "source": event_origin,
+                "retrograde_event_ref": event_ref,
+                "applied": {
+                    "project_type": project.project_type,
+                    "status": "active",
+                    "stage": PROJECT_FIRST_STAGES[project.project_type],
+                    "target_place_id": location_id,
+                    "target_character_entity_id": target_character_entity_id,
+                    "target_faction_entity_id": None,
+                    "progress": 0.0,
+                    "stall_count": 0,
+                    "next_eligible_at_world_time": next_eligible.isoformat(),
+                    "source_chunk_id": source_chunk_id,
+                },
+            }
+        )
+    # Migration 060 registers only the canonical ``retrograde`` enum label.
+    # Runtime maturation is therefore distinguished by the applied payload's
+    # source plus namespaced event ref; adding a new enum label would require
+    # the migration/catalog change that Stage B explicitly excludes.
     cur.execute(
         """
         /* orrery:retrograde:insert_project_started_event */
@@ -1468,7 +1599,7 @@ def _insert_project_started_event(
         """,
         (
             event_type,
-            prologue_chunk_id,
+            source_chunk_id,
             actor["entity_id"],
             target_character_entity_id,
             location_id,
@@ -2491,6 +2622,22 @@ def _load_base_timestamp(cur: Any) -> Any:
     if row is None:
         return None
     return _row_value(row, "base_timestamp", 0)
+
+
+def _load_chunk_world_time(cur: Any, chunk_id: int) -> Any:
+    """Load the accepted story time that anchors a runtime project start."""
+
+    cur.execute(
+        """
+        /* orrery:retrograde:project_start_world_time */
+        SELECT world_time FROM chunk_metadata WHERE chunk_id = %s
+        """,
+        (chunk_id,),
+    )
+    row = cur.fetchone()
+    if row is None or _row_value(row, "world_time", 0) is None:
+        raise ValueError(f"Retrograde project start chunk {chunk_id} has no world_time")
+    return _row_value(row, "world_time", 0)
 
 
 def _plan_entity_stubs(

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -1966,8 +1966,13 @@ def _load_persisted_retrograde_event_sources(cur: Any) -> list[dict[str, Any]]:
         FROM world_events AS we
         LEFT JOIN retrograde_summaries AS rs ON rs.world_event_id = we.id
         WHERE we.source = 'retrograde'::event_source_kind
+          -- Project-start events are mechanical projection provenance, not
+          -- generated history prose. Wizard and maturation starts share this
+          -- exclusion; neither carries canonical summary/chronology fields.
+          AND we.event_type <> ALL(%s)
         ORDER BY we.id
-        """
+        """,
+        (list(PROJECT_STARTED_EVENT_TYPES.values()),),
     )
     sources = []
     for row in cur.fetchall():

--- a/nexus/agents/orrery/retrograde_seed_candidates.py
+++ b/nexus/agents/orrery/retrograde_seed_candidates.py
@@ -541,19 +541,22 @@ def render_seed_generation_prompt(
         "coverage_functions": seed_generation_request.get("coverage_functions", []),
         "candidate_graph": seed_generation_request.get("candidate_graph", {}),
         "selection_rubric": seed_generation_request.get("selection_rubric", {}),
-        "project_intent_policy": {
-            "optional": True,
-            "rarity": "At most two candidates per cast should carry an intent.",
-            "unresolved_ledger": ["court_patron", "seek_redemption"],
-            "trait_bound_hook": [
-                "build_venture",
-                "pursue_romance",
-                "recruit_ally",
-            ],
-            "target_refs": (
-                "Use the same compact entity-ref language as mechanical_hints."
-            ),
-        },
+        "project_intent_policy": seed_generation_request.get(
+            "project_intent_policy",
+            {
+                "optional": True,
+                "rarity": "At most two candidates per cast should carry an intent.",
+                "unresolved_ledger": ["court_patron", "seek_redemption"],
+                "trait_bound_hook": [
+                    "build_venture",
+                    "pursue_romance",
+                    "recruit_ally",
+                ],
+                "target_refs": (
+                    "Use the same compact entity-ref language as mechanical_hints."
+                ),
+            },
+        ),
         "prompt_sections": seed_generation_request.get("prompt_sections", []),
         "response_contract": _prompt_response_contract(),
     }

--- a/tests/test_orrery/test_retrograde_graph.py
+++ b/tests/test_orrery/test_retrograde_graph.py
@@ -360,6 +360,12 @@ def test_runtime_maturation_packet_sizes_graph_from_its_own_budget() -> None:
     )
     request = packet["seed_generation_request"]
     assert request["budget"]["generate_candidates"] == cfg.generate_candidates
+    assert request["project_intent_policy"]["rarity"] == (
+        "The maturation target may propose at most one project."
+    )
+    assert "Test Subject" in request["project_intent_policy"]["actor_rule"]
+    assert "AT MOST ONE project" in packet["seed_generation_prompt"]
+    assert "MUST be the maturation target" in packet["seed_generation_prompt"]
     edges = request["candidate_graph"]["dangling_edges"]
     expected_max = max(2, ceil(cfg.generate_candidates * 1.5))
     assert len(edges) <= expected_max

--- a/tests/test_orrery/test_retrograde_projects_live.py
+++ b/tests/test_orrery/test_retrograde_projects_live.py
@@ -8,18 +8,22 @@ import logging
 from typing import Any, Iterator, Mapping, Sequence
 from uuid import uuid4
 
-import psycopg2
 import pytest
 from pydantic import ValidationError
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
 
-from nexus.agents.orrery.events import _apply_state_delta_sync
+from nexus.agents.orrery.events import (
+    _apply_state_delta_sync,
+    commit_orrery_tick_sync,
+)
 from nexus.agents.orrery.needs import load_need_tuning
 from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
 from nexus.agents.orrery.replay import (
     reconstruct_state_at_sync,
     verify_checkpoints_sync,
 )
-from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.resolver import OrreryResolutionDraft, resolve_dry_run
 from nexus.agents.orrery.retrograde_expansion import (
     RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION,
     RetrogradeExpansionPlanResponse,
@@ -35,6 +39,7 @@ from nexus.agents.orrery.retrograde_persistence import (
     PROJECT_STARTED_EVENT_TYPES,
     _validate_project_start_dependencies,
     build_retrograde_persistence_plan,
+    plan_retrograde_summaries,
 )
 from nexus.agents.orrery.retrograde_seed_candidates import (
     SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION,
@@ -43,12 +48,7 @@ from nexus.agents.orrery.retrograde_vocabulary import (
     SeedEligibleVocabulary,
     enumerate_seed_eligible_vocabulary,
 )
-from nexus.agents.orrery.substrate import (
-    ProjectState,
-    Slot,
-    WorldState,
-    coerce_project_policy,
-)
+from nexus.agents.orrery.substrate import coerce_project_policy
 from nexus.agents.orrery.templates import ADVANCE_BUILD_VENTURE
 from nexus.api.slot_utils import get_slot_db_url
 from nexus.config import load_settings
@@ -62,7 +62,11 @@ PROJECT_TYPES = tuple(PROJECT_FIRST_STAGES)
 def project_db() -> Iterator[dict[str, Any]]:
     """Open save_02 only inside an always-rolled-back transaction."""
 
-    conn = psycopg2.connect(get_slot_db_url(slot=2))
+    engine = create_engine(get_slot_db_url(slot=2))
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+    conn = connection.connection.driver_connection
     try:
         with conn.cursor() as cur:
             cur.execute(
@@ -101,13 +105,16 @@ def project_db() -> Iterator[dict[str, Any]]:
             )
         yield {
             "conn": conn,
+            "session": session,
             "characters": characters,
             "places": places,
             "vocabulary": enumerate_seed_eligible_vocabulary(dbname="save_02"),
         }
     finally:
-        conn.rollback()
-        conn.close()
+        session.close()
+        transaction.rollback()
+        connection.close()
+        engine.dispose()
 
 
 def test_writer_inserts_all_types_and_started_events(
@@ -748,6 +755,77 @@ def test_maturation_disabled_config_drops_intent_loudly(
     assert "project seeding is disabled" in caplog.text
 
 
+def test_summary_backfill_excludes_wizard_and_maturation_project_starts(
+    project_db: dict[str, Any],
+) -> None:
+    """Mechanical started events share one exclusion from prose summaries."""
+
+    db = project_db
+    settings = load_settings()
+    assert settings.orrery is not None
+    _wizard_id, wizard_actor = db["characters"][0]
+    maturation_id, maturation_actor = db["characters"][1]
+    wizard_packet, wizard_seeds, wizard_expansion = _contracts(
+        db["vocabulary"],
+        [("seed_wizard_summary", "build_venture", wizard_actor, None)],
+    )
+    maturation_packet, maturation_seeds, maturation_expansion = _contracts(
+        db["vocabulary"],
+        [("seed_maturation_summary", "build_venture", maturation_actor, None)],
+    )
+
+    with db["conn"].cursor() as cur:
+        wizard_manifest = build_retrograde_persistence_plan(
+            cur,
+            packet=wizard_packet,
+            seed_candidate_response=wizard_seeds,
+            expansion_plan_payload=wizard_expansion,
+            slot=2,
+            dbname="save_02",
+            dry_run=False,
+            project_seeding_enabled=True,
+            project_settings=settings.orrery.projects,
+        )
+        assert wizard_manifest["counters"]["projects_inserted"] == 1
+
+        request_chunk = _fabricate_chunk(cur, _next_world_time(cur))
+        maturation_manifest = _persist_maturation_expansion(
+            cur,
+            packet=maturation_packet,
+            seed_response=maturation_seeds,
+            expansion_payload=maturation_expansion,
+            row={
+                "job_id": 531008,
+                "entity_id": maturation_id,
+                "requesting_chunk_id": request_chunk,
+            },
+            slot=2,
+            dbname="save_02",
+            settings=settings,
+            summaries_enabled=True,
+        )
+        assert maturation_manifest["counters"]["projects_inserted"] == 1
+
+        started_event_ids = {
+            int(wizard_manifest["project_rows"][0]["started_event_id"]),
+            int(maturation_manifest["project_rows"][0]["started_event_id"]),
+        }
+        rows = plan_retrograde_summaries(cur, dry_run=False)
+        assert started_event_ids.isdisjoint(
+            int(row["world_event_id"])
+            for row in rows
+            if row["world_event_id"] is not None
+        )
+        cur.execute(
+            """
+            SELECT count(*) FROM retrograde_summaries
+            WHERE world_event_id = ANY(%s)
+            """,
+            (list(started_event_ids),),
+        )
+        assert cur.fetchone()[0] == 0
+
+
 def test_maturation_project_replays_exactly_and_hydrates_continuation(
     project_db: dict[str, Any],
 ) -> None:
@@ -762,6 +840,21 @@ def test_maturation_project_replays_exactly_and_hydrates_continuation(
     assert settings.orrery is not None
     with db["conn"].cursor() as cur:
         base_time = _next_world_time(cur)
+        expected_due_time = base_time + timedelta(
+            hours=1 + settings.orrery.projects.advance_interval_hours
+        )
+        cur.execute(
+            "DELETE FROM character_travel_states WHERE character_entity_id = %s",
+            (actor_id,),
+        )
+        cur.execute(
+            """
+            UPDATE character_need_states
+            SET debt_score = 0, last_evaluated_at = %s
+            WHERE character_entity_id = %s
+            """,
+            (expected_due_time, actor_id),
+        )
         base_chunk = _fabricate_chunk(cur, base_time)
         base_id = capture_state_checkpoint_sync(
             cur, chunk_id=base_chunk, label="manual"
@@ -788,38 +881,38 @@ def test_maturation_project_replays_exactly_and_hydrates_continuation(
             row for row in manifest["project_rows"] if row["status"] == "inserted"
         )
         due_time = project_row["next_eligible_at_world_time"]
-
-        state = WorldState(
-            is_active={actor_id: True},
-            project_states={
-                actor_id: ProjectState(
-                    id=int(project_row["project_id"]),
-                    project_type="build_venture",
-                    status="active",
-                    stage="laying_groundwork",
-                    progress=0.0,
-                    stall_count=0,
-                    next_eligible_at_world_time=due_time,
-                    source_chunk_id=request_chunk,
-                )
-            },
-            project_policy=coerce_project_policy(settings.orrery.projects),
-            world_time=due_time,
-        )
-        bindings = {Slot.ACTOR: actor_id}
-        assert ADVANCE_BUILD_VENTURE.package_gate(state, bindings)
-        assert any(
-            branch.label == "Make the venture legible"
-            and branch.conditions(state, bindings)
-            for branch in ADVANCE_BUILD_VENTURE.branches
-        )
-
+        assert due_time == expected_due_time
         advance_chunk = _fabricate_chunk(cur, due_time)
-        _apply_project_advance(
-            cur,
-            chunk_id=advance_chunk,
-            actor_entity_id=actor_id,
+        proposal = resolve_dry_run(
+            db["session"],
+            (ADVANCE_BUILD_VENTURE,),
+            anchor_chunk_id=advance_chunk,
+            window_chunks=30,
             project_settings=settings.orrery.projects,
+        )
+        continuation = next(
+            draft
+            for draft in proposal.resolutions
+            if draft.template_id == ADVANCE_BUILD_VENTURE.id
+            and draft.bindings.get("actor") == actor_id
+        )
+        assert continuation.branch_label == "Make the venture legible"
+        assert "project.advance" in continuation.state_delta
+
+        commit_orrery_tick_sync(
+            db["conn"],
+            proposal,
+            tick_chunk_id=advance_chunk,
+            project_settings=settings.orrery.projects,
+            adjudications=[
+                {
+                    "proposal_id": draft.proposal_id,
+                    "action": "defer",
+                    "note": "isolate the maturation continuation seam",
+                }
+                for draft in proposal.resolutions
+                if draft.proposal_id != continuation.proposal_id
+            ],
         )
         target_id = capture_state_checkpoint_sync(
             cur, chunk_id=advance_chunk, label="manual"
@@ -832,6 +925,124 @@ def test_maturation_project_replays_exactly_and_hydrates_continuation(
         assert not any(
             section == "character_project_states"
             for section, _row_id in replayed.uncertain_rows
+        )
+        pair = [
+            verdict
+            for verdict in verify_checkpoints_sync(cur)
+            if verdict.base_checkpoint_id == base_id
+            and verdict.target_checkpoint_id == target_id
+        ]
+        assert len(pair) == 1
+        assert pair[0].drifts == []
+
+
+def test_maturation_start_at_base_chunk_replays_without_drift(
+    project_db: dict[str, Any],
+) -> None:
+    """Step 8.6 base starts are newer than their Step 8.55 checkpoint."""
+
+    db = project_db
+    actor_id, actor = db["characters"][0]
+    packet, seeds, expansion = _contracts(
+        db["vocabulary"], [("seed_base_edge", "build_venture", actor, None)]
+    )
+    settings = load_settings()
+    with db["conn"].cursor() as cur:
+        base_time = _next_world_time(cur)
+        base_chunk = _fabricate_chunk(cur, base_time)
+        base_id = capture_state_checkpoint_sync(
+            cur, chunk_id=base_chunk, label="manual"
+        )
+        assert base_id is not None
+
+        manifest = _persist_maturation_expansion(
+            cur,
+            packet=packet,
+            seed_response=seeds,
+            expansion_payload=expansion,
+            row={
+                "job_id": 531006,
+                "entity_id": actor_id,
+                "requesting_chunk_id": base_chunk,
+            },
+            slot=2,
+            dbname="save_02",
+            settings=settings,
+            summaries_enabled=False,
+        )
+        assert any(row["status"] == "inserted" for row in manifest["project_rows"])
+        target_chunk = _fabricate_chunk(cur, base_time + timedelta(hours=1))
+        target_id = capture_state_checkpoint_sync(
+            cur, chunk_id=target_chunk, label="manual"
+        )
+        assert target_id is not None
+
+        replayed = reconstruct_state_at_sync(
+            cur, target_chunk, base_checkpoint_id=base_id
+        )
+        assert any(
+            row["character_entity_id"] == actor_id
+            and row["project_type"] == "build_venture"
+            for row in replayed.state["character_project_states"]
+        )
+        pair = [
+            verdict
+            for verdict in verify_checkpoints_sync(cur)
+            if verdict.base_checkpoint_id == base_id
+            and verdict.target_checkpoint_id == target_id
+        ]
+        assert len(pair) == 1
+        assert pair[0].drifts == []
+
+
+def test_maturation_start_at_target_chunk_is_absent_without_drift(
+    project_db: dict[str, Any],
+) -> None:
+    """Step 8.6 target starts are newer than their Step 8.55 checkpoint."""
+
+    db = project_db
+    actor_id, actor = db["characters"][0]
+    packet, seeds, expansion = _contracts(
+        db["vocabulary"], [("seed_target_edge", "build_venture", actor, None)]
+    )
+    settings = load_settings()
+    with db["conn"].cursor() as cur:
+        base_time = _next_world_time(cur)
+        base_chunk = _fabricate_chunk(cur, base_time)
+        base_id = capture_state_checkpoint_sync(
+            cur, chunk_id=base_chunk, label="manual"
+        )
+        assert base_id is not None
+        target_chunk = _fabricate_chunk(cur, base_time + timedelta(hours=1))
+        target_id = capture_state_checkpoint_sync(
+            cur, chunk_id=target_chunk, label="manual"
+        )
+        assert target_id is not None
+
+        manifest = _persist_maturation_expansion(
+            cur,
+            packet=packet,
+            seed_response=seeds,
+            expansion_payload=expansion,
+            row={
+                "job_id": 531007,
+                "entity_id": actor_id,
+                "requesting_chunk_id": target_chunk,
+            },
+            slot=2,
+            dbname="save_02",
+            settings=settings,
+            summaries_enabled=False,
+        )
+        assert any(row["status"] == "inserted" for row in manifest["project_rows"])
+
+        replayed = reconstruct_state_at_sync(
+            cur, target_chunk, base_checkpoint_id=base_id
+        )
+        assert not any(
+            row["character_entity_id"] == actor_id
+            and row["project_type"] == "build_venture"
+            for row in replayed.state["character_project_states"]
         )
         pair = [
             verdict
@@ -882,8 +1093,9 @@ def test_maturation_started_event_requires_applied_projection_in_replay(
                 ),
             ),
         )
+        target_chunk = _fabricate_chunk(cur, base_time + timedelta(hours=2))
         with pytest.raises(ValueError, match="missing its required applied"):
-            reconstruct_state_at_sync(cur, event_chunk, base_checkpoint_id=base_id)
+            reconstruct_state_at_sync(cur, target_chunk, base_checkpoint_id=base_id)
 
 
 def _next_world_time(cur: Any) -> datetime:

--- a/tests/test_orrery/test_retrograde_projects_live.py
+++ b/tests/test_orrery/test_retrograde_projects_live.py
@@ -10,11 +10,15 @@ from uuid import uuid4
 
 import psycopg2
 import pytest
+from pydantic import ValidationError
 
 from nexus.agents.orrery.events import _apply_state_delta_sync
 from nexus.agents.orrery.needs import load_need_tuning
 from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
-from nexus.agents.orrery.replay import verify_checkpoints_sync
+from nexus.agents.orrery.replay import (
+    reconstruct_state_at_sync,
+    verify_checkpoints_sync,
+)
 from nexus.agents.orrery.resolver import OrreryResolutionDraft
 from nexus.agents.orrery.retrograde_expansion import (
     RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION,
@@ -25,6 +29,7 @@ from nexus.agents.orrery.retrograde_orchestrator import (
     RetrogradeGenerationBundle,
     persist_retrograde_history,
 )
+from nexus.agents.orrery.retrograde_maturation import _persist_maturation_expansion
 from nexus.agents.orrery.retrograde_persistence import (
     PROJECT_FIRST_STAGES,
     PROJECT_STARTED_EVENT_TYPES,
@@ -38,7 +43,13 @@ from nexus.agents.orrery.retrograde_vocabulary import (
     SeedEligibleVocabulary,
     enumerate_seed_eligible_vocabulary,
 )
-from nexus.agents.orrery.substrate import coerce_project_policy
+from nexus.agents.orrery.substrate import (
+    ProjectState,
+    Slot,
+    WorldState,
+    coerce_project_policy,
+)
+from nexus.agents.orrery.templates import ADVANCE_BUILD_VENTURE
 from nexus.api.slot_utils import get_slot_db_url
 from nexus.config import load_settings
 
@@ -541,6 +552,345 @@ def test_wizard_genesis_checkpoint_carries_seeded_project_through_replay(
         assert len(pair) == 1
         assert pair[0].base_chunk_id == prologue_chunk
         assert pair[0].drifts == []
+
+
+def test_maturation_seeds_only_target_actor_and_logs_advisory_drops(
+    project_db: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Runtime arbitration admits one target-owned project and nothing else."""
+
+    db = project_db
+    actor_id, actor = db["characters"][0]
+    foreign = db["characters"][1][1]
+    specs = [
+        ("seed_foreign", "build_venture", foreign, None),
+        ("seed_target", "build_venture", actor, None),
+        ("seed_second", "build_venture", actor, None),
+    ]
+    packet, seeds, expansion = _contracts(db["vocabulary"], specs)
+    with db["conn"].cursor() as cur:
+        request_chunk = _fabricate_chunk(cur, _next_world_time(cur))
+        caplog.set_level(logging.WARNING)
+        manifest = _persist_maturation_expansion(
+            cur,
+            packet=packet,
+            seed_response=seeds,
+            expansion_payload=expansion,
+            row={
+                "job_id": 531001,
+                "entity_id": actor_id,
+                "requesting_chunk_id": request_chunk,
+            },
+            slot=2,
+            dbname="save_02",
+            settings=load_settings(),
+            summaries_enabled=False,
+        )
+
+        assert [row["status"] for row in manifest["project_rows"]] == [
+            "dropped_foreign_actor",
+            "inserted",
+            "dropped_cap",
+        ]
+        assert manifest["counters"]["projects_inserted"] == 1
+        assert "Maturation job 531001" in caplog.text
+        assert "seed_foreign" in caplog.text
+        assert "seed_second" in caplog.text
+
+        inserted = manifest["project_rows"][1]
+        cur.execute(
+            """
+            SELECT event_type, source::text, tick_chunk_id, payload
+            FROM world_events WHERE id = %s
+            """,
+            (inserted["started_event_id"],),
+        )
+        event_type, source, tick_chunk_id, payload = cur.fetchone()
+        assert event_type == "build_venture_started"
+        # event_source_kind has no maturation label; payload provenance is the
+        # bounded discriminator while canonical Retrograde storage stays valid.
+        assert source == "retrograde"
+        assert tick_chunk_id == request_chunk
+        assert payload["source"] == "maturation"
+        assert payload["retrograde_event_ref"].startswith("maturation_job_531001_")
+        assert set(payload["applied"]) == {
+            "project_type",
+            "status",
+            "stage",
+            "target_place_id",
+            "target_character_entity_id",
+            "target_faction_entity_id",
+            "progress",
+            "stall_count",
+            "next_eligible_at_world_time",
+            "source_chunk_id",
+        }
+        assert payload["applied"]["source_chunk_id"] == request_chunk
+
+
+def test_maturation_shared_writer_validation_raises(
+    project_db: dict[str, Any],
+) -> None:
+    """Target shape, dead participant, and unresolved actor stay fail-fast."""
+
+    db = project_db
+    actor_id, actor = db["characters"][0]
+    target = db["characters"][8][1]
+    settings = load_settings()
+
+    cases: list[tuple[str, dict[str, Any], dict[str, Any], str]] = []
+
+    packet, seeds, expansion = _contracts(
+        db["vocabulary"], [("seed_bad_shape", "build_venture", actor, None)]
+    )
+    seeds["candidates"][0]["project_intent"]["target_ref"] = target
+    expansion["project_plan"][0]["target_ref"] = target
+    cases.append(("bad shape", seeds, expansion, "build_venture.*target"))
+
+    packet_dead, seeds_dead, expansion_dead = _contracts(
+        db["vocabulary"], [("seed_dead", "build_venture", actor, None)]
+    )
+    expansion_dead["death_plan"] = [
+        {
+            "entity_ref": actor,
+            "entity_kind": "character",
+            "cause_event_ref": expansion_dead["event_plan"][0]["event_ref"],
+        }
+    ]
+    cases.append(("dead actor", seeds_dead, expansion_dead, "death_plan"))
+
+    packet_missing, seeds_missing, expansion_missing = _contracts(
+        db["vocabulary"],
+        [("seed_missing_actor", "build_venture", "No Such Actor", None)],
+    )
+    cases.append(
+        (
+            "missing actor",
+            seeds_missing,
+            expansion_missing,
+            "unresolvable actor",
+        )
+    )
+
+    with db["conn"].cursor() as cur:
+        request_chunk = _fabricate_chunk(cur, _next_world_time(cur))
+        for label, case_seeds, case_expansion, match in cases:
+            case_packet = {
+                "bad shape": packet,
+                "dead actor": packet_dead,
+                "missing actor": packet_missing,
+            }[label]
+            with pytest.raises((ValueError, ValidationError), match=match):
+                _persist_maturation_expansion(
+                    cur,
+                    packet=case_packet,
+                    seed_response=case_seeds,
+                    expansion_payload=case_expansion,
+                    row={
+                        "job_id": 531002,
+                        "entity_id": actor_id,
+                        "requesting_chunk_id": request_chunk,
+                    },
+                    slot=2,
+                    dbname="save_02",
+                    settings=settings,
+                    summaries_enabled=False,
+                )
+
+
+def test_maturation_disabled_config_drops_intent_loudly(
+    project_db: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    db = project_db
+    actor_id, actor = db["characters"][0]
+    packet, seeds, expansion = _contracts(
+        db["vocabulary"], [("seed_disabled", "build_venture", actor, None)]
+    )
+    settings = load_settings()
+    assert settings.orrery is not None
+    disabled_retrograde = settings.orrery.retrograde.model_copy(
+        update={
+            "projects": settings.orrery.retrograde.projects.model_copy(
+                update={"enabled": False}
+            )
+        }
+    )
+    disabled_settings = settings.model_copy(
+        update={
+            "orrery": settings.orrery.model_copy(
+                update={"retrograde": disabled_retrograde}
+            )
+        }
+    )
+    with db["conn"].cursor() as cur:
+        request_chunk = _fabricate_chunk(cur, _next_world_time(cur))
+        caplog.set_level(logging.WARNING)
+        manifest = _persist_maturation_expansion(
+            cur,
+            packet=packet,
+            seed_response=seeds,
+            expansion_payload=expansion,
+            row={
+                "job_id": 531003,
+                "entity_id": actor_id,
+                "requesting_chunk_id": request_chunk,
+            },
+            slot=2,
+            dbname="save_02",
+            settings=disabled_settings,
+            summaries_enabled=False,
+        )
+    assert manifest["counters"]["projects_dropped_disabled"] == 1
+    assert "Maturation job 531003" in caplog.text
+    assert "seed_disabled" in caplog.text
+    assert "project seeding is disabled" in caplog.text
+
+
+def test_maturation_project_replays_exactly_and_hydrates_continuation(
+    project_db: dict[str, Any],
+) -> None:
+    """A mid-arc start survives a later checkpoint with no project drift."""
+
+    db = project_db
+    actor_id, actor = db["characters"][0]
+    packet, seeds, expansion = _contracts(
+        db["vocabulary"], [("seed_mid_arc", "build_venture", actor, None)]
+    )
+    settings = load_settings()
+    assert settings.orrery is not None
+    with db["conn"].cursor() as cur:
+        base_time = _next_world_time(cur)
+        base_chunk = _fabricate_chunk(cur, base_time)
+        base_id = capture_state_checkpoint_sync(
+            cur, chunk_id=base_chunk, label="manual"
+        )
+        assert base_id is not None
+
+        request_chunk = _fabricate_chunk(cur, base_time + timedelta(hours=1))
+        manifest = _persist_maturation_expansion(
+            cur,
+            packet=packet,
+            seed_response=seeds,
+            expansion_payload=expansion,
+            row={
+                "job_id": 531004,
+                "entity_id": actor_id,
+                "requesting_chunk_id": request_chunk,
+            },
+            slot=2,
+            dbname="save_02",
+            settings=settings,
+            summaries_enabled=False,
+        )
+        project_row = next(
+            row for row in manifest["project_rows"] if row["status"] == "inserted"
+        )
+        due_time = project_row["next_eligible_at_world_time"]
+
+        state = WorldState(
+            is_active={actor_id: True},
+            project_states={
+                actor_id: ProjectState(
+                    id=int(project_row["project_id"]),
+                    project_type="build_venture",
+                    status="active",
+                    stage="laying_groundwork",
+                    progress=0.0,
+                    stall_count=0,
+                    next_eligible_at_world_time=due_time,
+                    source_chunk_id=request_chunk,
+                )
+            },
+            project_policy=coerce_project_policy(settings.orrery.projects),
+            world_time=due_time,
+        )
+        bindings = {Slot.ACTOR: actor_id}
+        assert ADVANCE_BUILD_VENTURE.package_gate(state, bindings)
+        assert any(
+            branch.label == "Make the venture legible"
+            and branch.conditions(state, bindings)
+            for branch in ADVANCE_BUILD_VENTURE.branches
+        )
+
+        advance_chunk = _fabricate_chunk(cur, due_time)
+        _apply_project_advance(
+            cur,
+            chunk_id=advance_chunk,
+            actor_entity_id=actor_id,
+            project_settings=settings.orrery.projects,
+        )
+        target_id = capture_state_checkpoint_sync(
+            cur, chunk_id=advance_chunk, label="manual"
+        )
+        assert target_id is not None
+
+        replayed = reconstruct_state_at_sync(
+            cur, advance_chunk, base_checkpoint_id=base_id
+        )
+        assert not any(
+            section == "character_project_states"
+            for section, _row_id in replayed.uncertain_rows
+        )
+        pair = [
+            verdict
+            for verdict in verify_checkpoints_sync(cur)
+            if verdict.base_checkpoint_id == base_id
+            and verdict.target_checkpoint_id == target_id
+        ]
+        assert len(pair) == 1
+        assert pair[0].drifts == []
+
+
+def test_maturation_started_event_requires_applied_projection_in_replay(
+    project_db: dict[str, Any],
+) -> None:
+    db = project_db
+    actor_id, _actor = db["characters"][0]
+    with db["conn"].cursor() as cur:
+        base_time = _next_world_time(cur)
+        base_chunk = _fabricate_chunk(cur, base_time)
+        base_id = capture_state_checkpoint_sync(
+            cur, chunk_id=base_chunk, label="manual"
+        )
+        assert base_id is not None
+        event_chunk = _fabricate_chunk(cur, base_time + timedelta(hours=1))
+        cur.execute(
+            """
+            INSERT INTO world_events (
+                event_type, tick_chunk_id, actor_entity_id, world_layer,
+                source, changed_fields, payload
+            ) VALUES (
+                'build_venture_started', %s, %s,
+                'primary'::world_layer_type,
+                'retrograde'::event_source_kind,
+                ARRAY['character_project_states'],
+                %s::jsonb
+            )
+            """,
+            (
+                event_chunk,
+                actor_id,
+                json.dumps(
+                    {
+                        "source": "maturation",
+                        "retrograde_event_ref": (
+                            "maturation_job_531005_project_missing_applied"
+                        ),
+                    }
+                ),
+            ),
+        )
+        with pytest.raises(ValueError, match="missing its required applied"):
+            reconstruct_state_at_sync(cur, event_chunk, base_checkpoint_id=base_id)
+
+
+def _next_world_time(cur: Any) -> datetime:
+    cur.execute("SELECT max(world_time) FROM chunk_metadata")
+    value = cur.fetchone()[0]
+    assert value is not None
+    return value + timedelta(hours=24)
 
 
 def _all_type_specs(db: Mapping[str, Any]) -> list[tuple[str, str, str, str | None]]:


### PR DESCRIPTION
Closes #531 (Stage A = #544; this is the maturation-time half).

## What This Ships

When a declared entity matures mid-story (`drain_maturation_jobs_sync` → `_mature_one`), its scoped R4/R5 output may propose **at most one project whose actor is the maturation target** — enforced in code, not prompt: foreign-actor or surplus proposals drop with loud logs naming the job and seed. The insert is **Stage A's writer, refactored for a second caller** (identical validation semantics: per-type CHECK-mirroring target shapes, unresolvable refs raise, redemption's TARGET→ACTOR signal, existing-open-project guard, dead-participant rejection, stage-one starts, policy-derived `next_eligible`), with maturation provenance and the same `[orrery.retrograde.projects]` gating. Character-only targets, deliberately — migration 096 relaxing the DB does not change retrograde seeding discipline.

## The Replay Mechanism (the Load-Bearing Piece)

Maturation-born rows land *between* interval checkpoints, so neither Stage A's genesis-checkpoint answer nor the resolution ledger covers them. The ruled mechanism: the maturation insert emits the type's `<type>_started` world_event whose payload carries Stage A's provenance **plus a complete `applied` projection matching `_replay_project`'s exact contract**. Replay gains one bounded arm — maturation-provenance started events replay through the *same validation path* as resolution-sourced transitions (ladder membership, active status, quantization). Wizard-born `source='retrograde'` starts remain checkpoint-only with a regression test proving they cannot double-insert.

The live seam test: checkpoint → mature → seed → the real aspiration continuation template accepts the project when due → advance on a later tick → later checkpoint → reconstruct from the earlier one → **zero drift, no `uncertain_rows` exemption**.

## Deviation (Recorded, Judged Sound)

The `event_source_kind` enum has no `maturation` label and this PR ships no migration, so rows stay `source='retrograde'` discriminated by `payload.source='maturation'` + the `maturation_job_*` event-ref namespace — both writer-controlled and validated. Replay already accepts a future literal `source='maturation'` label if the enum ever grows one.

## Evidence

- `NEXUS_RUN_POSTGRES=1 pytest tests/test_orrery/ -q` → **1274 passed, 5 skipped, 0 failed** (rerun independently after the build)
- Full suite: **1621 passed, 427 skipped**
- `replay_state.py --slot 5 --verify` → all intervals ok
- flake8 / black / validate-config clean; pre-commit hooks passed

No migrations. No new settings. No template/catalog changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)