### PR TITLE
Index Orrery WorldState predicate reads

### DIFF
--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -9,6 +9,7 @@ from hashlib import sha256
 import json
 import math
 import random
+from types import MappingProxyType
 from typing import Any, Callable, Dict, Iterable, Literal, Mapping, Optional, Tuple
 
 from nexus.agents.orrery.communication import CommunicationGraph
@@ -384,23 +385,97 @@ class WorldState:
     localized_weather_enabled: bool = False
     mood_enabled: bool = False
     current_tick: int = 0
+    _recent_events_by_type: Mapping[str, Tuple[EventRecord, ...]] = field(
+        init=False, repr=False, compare=False
+    )
+    _recent_events_by_actor: Mapping[int, Tuple[EventRecord, ...]] = field(
+        init=False, repr=False, compare=False
+    )
+    _recent_events_by_target: Mapping[int, Tuple[EventRecord, ...]] = field(
+        init=False, repr=False, compare=False
+    )
+    _outbound_pair_tags_by_entity: Mapping[int, frozenset[str]] = field(
+        init=False, repr=False, compare=False
+    )
+    _inbound_pair_tags_by_entity: Mapping[int, frozenset[str]] = field(
+        init=False, repr=False, compare=False
+    )
 
     def __post_init__(self) -> None:
-        """Premerge common possession for directly constructed test states."""
+        """Build immutable derived reads for one canonical state snapshot."""
 
-        if self.possessed_claim_knowledge_by_entity:
-            return
-        common_by_claim_id = {
-            record.claim_id: record for record in self.common_claim_knowledge
-        }
-        possessed: dict[int, Tuple[ClaimKnowledge, ...]] = {}
-        for entity_id, explicit_records in self.claim_knowledge_by_entity.items():
-            by_claim_id = dict(common_by_claim_id)
-            by_claim_id.update({record.claim_id: record for record in explicit_records})
-            possessed[entity_id] = tuple(
-                by_claim_id[claim_id] for claim_id in sorted(by_claim_id)
-            )
-        object.__setattr__(self, "possessed_claim_knowledge_by_entity", possessed)
+        if not self.possessed_claim_knowledge_by_entity:
+            common_by_claim_id = {
+                record.claim_id: record for record in self.common_claim_knowledge
+            }
+            possessed: dict[int, Tuple[ClaimKnowledge, ...]] = {}
+            for entity_id, explicit_records in self.claim_knowledge_by_entity.items():
+                by_claim_id = dict(common_by_claim_id)
+                by_claim_id.update(
+                    {record.claim_id: record for record in explicit_records}
+                )
+                possessed[entity_id] = tuple(
+                    by_claim_id[claim_id] for claim_id in sorted(by_claim_id)
+                )
+            object.__setattr__(self, "possessed_claim_knowledge_by_entity", possessed)
+
+        events_by_type: dict[str, list[EventRecord]] = {}
+        events_by_actor: dict[int, list[EventRecord]] = {}
+        events_by_target: dict[int, list[EventRecord]] = {}
+        for event in self.recent_events:
+            events_by_type.setdefault(event.event_type, []).append(event)
+            if event.actor_entity_id is not None:
+                events_by_actor.setdefault(event.actor_entity_id, []).append(event)
+            if event.target_entity_id is not None:
+                events_by_target.setdefault(event.target_entity_id, []).append(event)
+
+        outbound_pair_tags: dict[int, set[str]] = {}
+        inbound_pair_tags: dict[int, set[str]] = {}
+        for (subject_id, object_id), tags in self.pair_tags.items():
+            outbound_pair_tags.setdefault(subject_id, set()).update(tags)
+            inbound_pair_tags.setdefault(object_id, set()).update(tags)
+
+        object.__setattr__(
+            self,
+            "_recent_events_by_type",
+            MappingProxyType(
+                {key: tuple(events) for key, events in events_by_type.items()}
+            ),
+        )
+        object.__setattr__(
+            self,
+            "_recent_events_by_actor",
+            MappingProxyType(
+                {key: tuple(events) for key, events in events_by_actor.items()}
+            ),
+        )
+        object.__setattr__(
+            self,
+            "_recent_events_by_target",
+            MappingProxyType(
+                {key: tuple(events) for key, events in events_by_target.items()}
+            ),
+        )
+        object.__setattr__(
+            self,
+            "_outbound_pair_tags_by_entity",
+            MappingProxyType(
+                {
+                    entity_id: frozenset(tags)
+                    for entity_id, tags in outbound_pair_tags.items()
+                }
+            ),
+        )
+        object.__setattr__(
+            self,
+            "_inbound_pair_tags_by_entity",
+            MappingProxyType(
+                {
+                    entity_id: frozenset(tags)
+                    for entity_id, tags in inbound_pair_tags.items()
+                }
+            ),
+        )
 
 
 def _slot_entity(bindings: Bindings, slot: Slot) -> Optional[int]:
@@ -419,17 +494,36 @@ def _is_in_transit(state: WorldState, entity_id: int) -> bool:
 
 
 def _has_outbound_pair_tag(state: WorldState, entity_id: int, pair_tag: str) -> bool:
-    return any(
-        subject_id == entity_id and pair_tag in tags
-        for (subject_id, _object_id), tags in state.pair_tags.items()
-    )
+    return pair_tag in state._outbound_pair_tags_by_entity.get(entity_id, frozenset())
 
 
 def _has_inbound_pair_tag(state: WorldState, entity_id: int, pair_tag: str) -> bool:
-    return any(
-        object_id == entity_id and pair_tag in tags
-        for (_subject_id, object_id), tags in state.pair_tags.items()
-    )
+    return pair_tag in state._inbound_pair_tags_by_entity.get(entity_id, frozenset())
+
+
+def _recent_event_candidates(
+    state: WorldState,
+    *,
+    event_type: Optional[str] = None,
+    actor_id: Optional[int] = None,
+    target_id: Optional[int] = None,
+) -> Tuple[EventRecord, ...]:
+    """Return the smallest applicable event bucket, preserving source order."""
+
+    candidates = state.recent_events
+    if event_type is not None:
+        typed = state._recent_events_by_type.get(event_type, ())
+        if len(typed) < len(candidates):
+            candidates = typed
+    if actor_id is not None:
+        acted = state._recent_events_by_actor.get(actor_id, ())
+        if len(acted) < len(candidates):
+            candidates = acted
+    if target_id is not None:
+        targeted = state._recent_events_by_target.get(target_id, ())
+        if len(targeted) < len(candidates):
+            candidates = targeted
+    return candidates
 
 
 def _possessed_claim_knowledge(
@@ -2161,7 +2255,12 @@ def recent_event(
         if target_slot is not None and target_id is None:
             return False
         cutoff = state.current_tick - within_ticks
-        for event in state.recent_events:
+        for event in _recent_event_candidates(
+            state,
+            event_type=event_type,
+            actor_id=actor_id,
+            target_id=target_id,
+        ):
             if event.tick < cutoff:
                 continue
             if event_type is not None and event.event_type != event_type:
@@ -2217,7 +2316,12 @@ def knows_recent_event(
         known_events: frozenset[int] = frozenset()
         if knower_id is not None:
             known_events = state.awareness_by_entity.get(knower_id, frozenset())
-        for event in state.recent_events:
+        for event in _recent_event_candidates(
+            state,
+            event_type=event_type,
+            actor_id=actor_id,
+            target_id=target_id,
+        ):
             if event.tick < cutoff:
                 continue
             if event_type is not None and event.event_type != event_type:
@@ -2276,7 +2380,12 @@ def since_last_event_at_least(
         if target_slot is not None and target_id is None:
             return False
         latest_tick: Optional[int] = None
-        for event in state.recent_events:
+        for event in _recent_event_candidates(
+            state,
+            event_type=event_type,
+            actor_id=actor_id,
+            target_id=target_id,
+        ):
             if event.event_type != event_type:
                 continue
             if event.actor_entity_id != actor_id:
@@ -2325,7 +2434,12 @@ def count_recent_events_at_least(
             return False
         cutoff = state.current_tick - within_ticks
         count = 0
-        for event in state.recent_events:
+        for event in _recent_event_candidates(
+            state,
+            event_type=event_type,
+            actor_id=actor_id,
+            target_id=target_id,
+        ):
             if event.tick < cutoff:
                 continue
             if event.event_type != event_type:

--- a/tests/test_orrery/test_substrate.py
+++ b/tests/test_orrery/test_substrate.py
@@ -1,5 +1,6 @@
 """Tests for the Orrery pure-Python behavior substrate."""
 
+from dataclasses import replace
 from datetime import datetime, timezone
 import re
 from typing import Any
@@ -12,6 +13,7 @@ from nexus.agents.orrery.substrate import (
     Branch,
     CompoundCondition,
     DriveBand,
+    EventRecord,
     PresentTargetPolicy,
     RoutineAnchor,
     Slot,
@@ -45,6 +47,7 @@ from nexus.agents.orrery.substrate import (
     in_location_class,
     is_constrained,
     is_hidden,
+    knows_recent_event,
     lacks_pair_tag,
     recent_event,
     relationship_is_asymmetric,
@@ -332,6 +335,31 @@ def test_contact_kind_predicate_reads_outbound_kind_specific_edges() -> None:
     assert has_contact_of_kind("lodging")(state, {Slot.ACTOR: 2})
     assert not has_contact_of_kind("intimate")(state, {Slot.ACTOR: 1})
     assert not has_contact_of_kind("social")(state, {Slot.TARGET: 1})
+
+
+def test_pair_tag_indexes_preserve_direction_and_rebuild_on_replace() -> None:
+    """Aggregate indexes dedupe tags without changing directed semantics."""
+
+    state = WorldState(
+        pair_tags={
+            (1, 2): frozenset({"contact:social", "ally"}),
+            (1, 3): frozenset({"contact:social"}),
+            (4, 2): frozenset({"hunting"}),
+        }
+    )
+
+    assert has_contact_of_kind("social")(state, {Slot.ACTOR: 1})
+    assert not has_contact_of_kind("social")(state, {Slot.ACTOR: 2})
+    assert has_inbound_pair_tag("hunting")(state, {Slot.ACTOR: 2})
+    assert not has_inbound_pair_tag("hunting")(state, {Slot.ACTOR: 4})
+
+    replaced = replace(
+        state,
+        pair_tags={(5, 1): frozenset({"contact:intimate"})},
+    )
+    assert not has_contact_of_kind("social")(replaced, {Slot.ACTOR: 1})
+    assert has_contact_of_kind("intimate")(replaced, {Slot.ACTOR: 5})
+    assert has_inbound_pair_tag("contact:intimate")(replaced, {Slot.ACTOR: 1})
 
 
 def test_contact_pair_tag_for_kind_rejects_unknown_kind() -> None:
@@ -842,6 +870,138 @@ def test_recent_event_can_filter_by_changed_fields() -> None:
         changed_fields_any_of=("character.emotional_state",),
         actor_slot=Slot.ACTOR,
     )(state, {Slot.ACTOR: 1})
+
+
+def test_indexed_event_predicates_preserve_semantics() -> None:
+    """Narrowed buckets retain windows, roles, counts, and awareness gates."""
+
+    bindings = {Slot.ACTOR: 99, Slot.FACTION: 1, Slot.TARGET: 2}
+    empty = WorldState(current_tick=10)
+    assert not recent_event("signal")(empty, bindings)
+    assert since_last_event_at_least("signal", 5)(empty, bindings)
+    assert not count_recent_events_at_least("signal", within_ticks=5, min_count=1)(
+        empty, bindings
+    )
+
+    state = WorldState(
+        recent_events=(
+            EventRecord(
+                event_id=1,
+                event_type="signal",
+                tick=4,
+                actor_entity_id=1,
+                target_entity_id=2,
+                changed_fields=("character.current_location",),
+            ),
+            EventRecord(
+                event_id=2,
+                event_type="signal",
+                tick=5,
+                actor_entity_id=1,
+                target_entity_id=2,
+                changed_fields=("character.current_location",),
+            ),
+            EventRecord(
+                event_id=3,
+                event_type="signal",
+                tick=7,
+                actor_entity_id=1,
+                target_entity_id=2,
+                changed_fields=("character.current_activity",),
+            ),
+            EventRecord(
+                event_id=4,
+                event_type="signal",
+                tick=9,
+                actor_entity_id=3,
+                target_entity_id=2,
+                changed_fields=("character.current_location",),
+            ),
+            EventRecord(
+                event_id=5,
+                event_type="other",
+                tick=10,
+                actor_entity_id=1,
+                target_entity_id=2,
+                changed_fields=("character.current_location",),
+            ),
+        ),
+        claimed_event_scopes={1: "private", 2: "private", 3: "private"},
+        awareness_by_entity={99: frozenset({2})},
+        epistemics_enabled=True,
+        current_tick=10,
+    )
+
+    location_signal = recent_event(
+        "signal",
+        within_ticks=5,
+        actor_slot=Slot.FACTION,
+        target_slot=Slot.TARGET,
+        changed_fields_any_of=("character.current_location",),
+    )
+    assert location_signal(state, bindings), "the cutoff tick is inclusive"
+    assert not recent_event(
+        "signal",
+        within_ticks=4,
+        actor_slot=Slot.FACTION,
+        target_slot=Slot.TARGET,
+        changed_fields_any_of=("character.current_location",),
+    )(state, bindings)
+    assert not location_signal(state, {**bindings, Slot.FACTION: 4})
+
+    known_location_signal = knows_recent_event(
+        "signal",
+        within_ticks=5,
+        actor_slot=Slot.FACTION,
+        target_slot=Slot.TARGET,
+        changed_fields_any_of=("character.current_location",),
+    )
+    assert known_location_signal(state, bindings)
+    assert not known_location_signal(
+        replace(state, awareness_by_entity={99: frozenset()}), bindings
+    )
+    assert not knows_recent_event(
+        "signal",
+        within_ticks=5,
+        actor_slot=Slot.FACTION,
+        target_slot=Slot.TARGET,
+        changed_fields_any_of=("character.current_activity",),
+    )(state, bindings)
+
+    assert count_recent_events_at_least(
+        "signal",
+        within_ticks=6,
+        min_count=3,
+        actor_slot=Slot.FACTION,
+        target_slot=Slot.TARGET,
+    )(state, bindings)
+    assert not count_recent_events_at_least(
+        "signal",
+        within_ticks=5,
+        min_count=3,
+        actor_slot=Slot.FACTION,
+        target_slot=Slot.TARGET,
+    )(state, bindings)
+    assert since_last_event_at_least(
+        "signal", 3, actor_slot=Slot.FACTION, target_slot=Slot.TARGET
+    )(state, bindings)
+    assert not since_last_event_at_least(
+        "signal", 4, actor_slot=Slot.FACTION, target_slot=Slot.TARGET
+    )(state, bindings)
+
+    replacement = replace(
+        state,
+        recent_events=(
+            EventRecord(
+                event_type="replacement",
+                tick=10,
+                actor_entity_id=1,
+                target_entity_id=2,
+            ),
+        ),
+    )
+    assert not recent_event("signal")(replacement, bindings)
+    assert recent_event("replacement")(replacement, bindings)
 
 
 def test_recent_event_preserves_actor_target_roles() -> None:


### PR DESCRIPTION
## Summary

- build immutable derived event buckets and aggregate directed pair-tag indexes in `WorldState.__post_init__`
- choose the smallest applicable event bucket while reapplying every existing semantic filter
- preserve canonical constructor data, equality, hydration, and `dataclasses.replace` behavior
- cover empty history, inclusive cutoffs, actor/target roles, repeated events/tags, changed fields, awareness, and directed pair tags

No public constructor, CLI, configuration, schema, migration, or canonical state-data changes.

## Benchmark

Re-ran the issue #523 deterministic dense ring-and-chords resolver harness with production built-in templates/current settings and the resolver `FakeSession`. The adapted execution-only harness added current orbit rows and `valence_current`, used 8 repetitions per shape, and was intentionally not committed:

```console
poetry run python temp/benchmark_orrery_indexes.py
```

| Dense shape | Supplied baseline median | Indexed median | Indexed p95 | Speedup |
| --- | ---: | ---: | ---: | ---: |
| 100 actors / 1,000 events | 111.56 ms | 87.90 ms | 96.42 ms | 1.27x |
| 500 actors / 5,000 events | 1,025.16 ms | 500.83 ms | 512.68 ms | 2.05x |

A second independent run measured 87.39 ms and 498.97 ms medians, respectively. The largest-shape result clears the required 2x gate.

The slot-5 latest-anchor probe at anchor 147 / 167 window events improved from the supplied 41.24 ms median / 53.17 ms p95 to 24.02 ms median / 41.86 ms p95. Its result remained 15 actors, 8 resolutions, 12 pressures, and 31 communication edges.

## Verification

- `poetry run pytest tests/test_orrery -q` — 976 passed, 310 skipped
- `poetry run mypy nexus/agents/orrery/` — zero errors in 50 files
- `poetry run black --check nexus/agents/orrery/substrate.py tests/test_orrery/test_substrate.py`
- `poetry run flake8 nexus/agents/orrery/substrate.py tests/test_orrery/test_substrate.py`
- `poetry run python scripts/replay_state.py --slot 5 --verify` — four windows clean

Closes #523

Codex — GPT-5.6-Sol
