### PR TITLE
Checkpoint entity activity

### DIFF
--- a/migrations/065_reconstructability.sql
+++ b/migrations/065_reconstructability.sql
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS state_checkpoints (
 );
 
 COMMENT ON TABLE state_checkpoints IS
-    'Point-in-time JSONB snapshots of the mutable world-state surface (tags, pair tags, character scalars, relationships, needs, travel, routine anchors, faction memberships). Auto-taken every [orrery.reconstruction] checkpoint_interval_chunks accepted chunks; "genesis" marks the instrumentation-era boundary for slots older than migration 065.';
+    'Point-in-time JSONB snapshots of the mutable world-state surface (entity activity, tags, pair tags, character scalars, relationships, needs, travel, routine anchors, faction memberships). Auto-taken every [orrery.reconstruction] checkpoint_interval_chunks accepted chunks; "genesis" marks the instrumentation-era boundary for slots older than migration 065.';
 COMMENT ON COLUMN state_checkpoints.chunk_id IS
     'Head chunk at snapshot time; NULL only for empty slots checkpointed before any chunk exists.';
 
@@ -142,6 +142,7 @@ SELECT
     (SELECT max(id) FROM narrative_chunks),
     'genesis',
     jsonb_build_object(
+        'entities', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM (SELECT id, is_active FROM entities) t),
         'entity_tags', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM (SELECT * FROM entity_tags WHERE cleared_at IS NULL) t),
         'entity_pair_tags', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM (SELECT * FROM entity_pair_tags WHERE cleared_at IS NULL) t),
         'characters', (SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) FROM (SELECT id, entity_id, current_location, current_activity, emotional_state FROM characters) t),

--- a/nexus/agents/orrery/reconstruction.py
+++ b/nexus/agents/orrery/reconstruction.py
@@ -91,6 +91,10 @@ def interval_checkpoint_due(*, playable_ordinal: int, interval: int) -> bool:
 # Order is presentation-only; each section is captured atomically inside the
 # caller's transaction.
 CHECKPOINT_SECTIONS: dict[str, str] = {
+    "entities": (
+        "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
+        "FROM (SELECT id, is_active FROM entities) t"
+    ),
     "entity_tags": (
         "SELECT coalesce(jsonb_agg(to_jsonb(t)), '[]'::jsonb) "
         "FROM (SELECT * FROM entity_tags WHERE cleared_at IS NULL) t"

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -4,6 +4,10 @@ Reconstructs the mutable world-state surface at an arbitrary chunk N from
 the artifacts the write side (migrations 064/065, ``reconstruction.py``)
 produces. Sections and their replay sources:
 
+- ``entities`` activity — forward from the base checkpoint. Entity rows born
+  inside the window are seeded with the schema's ``is_active=true`` default;
+  any later activity change without replayable provenance deliberately
+  surfaces as verification drift.
 - ``characters`` / ``places`` scalars — forward from the base checkpoint:
   ``state_delta_log`` rows (Skald, applied first within a chunk), then
   ``orrery_resolutions.state_delta`` keys ``character.current_activity``
@@ -458,6 +462,7 @@ class _Replayer:
             )
         missing = set(CHECKPOINT_SECTIONS) - set(state)
         allowed_missing = {
+            "entities",
             "character_project_states",
             "claim_awareness",
             "backstory_secrets",
@@ -468,6 +473,9 @@ class _Replayer:
                 f"Checkpoint {checkpoint_id} lacks sections "
                 f"{sorted(unexpected_missing)}"
             )
+        if "entities" in missing:
+            state["entities"] = []
+            self.missing_base_sections.add("entities")
         if "character_project_states" in missing:
             state["character_project_states"] = []
             self.missing_base_sections.add("character_project_states")
@@ -491,6 +499,13 @@ class _Replayer:
             base_checkpoint_chunk_id=base_chunk,
             state={},
         )
+        if "entities" in self.missing_base_sections:
+            result.add_note(
+                "entities",
+                "base checkpoint predates the entity-activity checkpoint "
+                "section; pre-checkpoint activity is unreproducible",
+                approximate=True,
+            )
         if "character_project_states" in self.missing_base_sections:
             result.add_note(
                 "character_project_states",
@@ -515,6 +530,7 @@ class _Replayer:
                 approximate=True,
             )
 
+        entities = {row["id"]: dict(row) for row in base_state["entities"]}
         characters = {row["id"]: dict(row) for row in base_state["characters"]}
         places = {row["id"]: dict(row) for row in base_state["places"]}
         needs = {
@@ -532,6 +548,8 @@ class _Replayer:
             project.setdefault("target_character_entity_id", None)
             project.setdefault("target_faction_entity_id", None)
 
+        if "entities" not in self.missing_base_sections:
+            self._seed_window_entity_births(entities, result)
         born_entities = self._seed_window_births(characters, places, result)
         character_entities = {
             row["entity_id"]
@@ -580,6 +598,14 @@ class _Replayer:
         for section, working in tag_workings.items():
             result.state[section] = sorted(working.values(), key=lambda r: r["id"])
 
+        result.state["entities"] = sorted(entities.values(), key=lambda r: r["id"])
+        if "entities" not in self.missing_base_sections:
+            result.add_note(
+                "entities",
+                "checkpoint-forward activity; an unledgered is_active change "
+                "surfaces as verification drift",
+                approximate=False,
+            )
         result.state["characters"] = sorted(characters.values(), key=lambda r: r["id"])
         result.state["places"] = sorted(places.values(), key=lambda r: r["id"])
         result.state["character_need_states"] = [
@@ -1005,6 +1031,40 @@ class _Replayer:
             },
         )
         return [_row_value(row, 0) for row in self.cur.fetchall()]
+
+    def _seed_window_entity_births(
+        self,
+        entities: dict[int, dict[str, Any]],
+        result: ReplayResult,
+    ) -> None:
+        """Seed entity-spine rows born after the base checkpoint.
+
+        ``entities.is_active`` has a NOT NULL ``true`` schema default, and
+        every in-repo entity creator relies on it. Starting window-born rows
+        at that value preserves their exact initial activity without copying
+        a possibly later live value. A deactivation with no replay evidence
+        therefore remains visible to checkpoint verification.
+        """
+
+        self.cur.execute(
+            "SELECT id, created_at FROM entities WHERE created_at <= %s",
+            (self.target_created_at,),
+        )
+        births = 0
+        for entity_id, created_at in self.cur.fetchall():
+            if entity_id in entities:
+                continue
+            entities[entity_id] = {"id": entity_id, "is_active": True}
+            births += 1
+            if created_at == self.target_created_at:
+                result.uncertain_rows.add(("entities", str(entity_id)))
+        if births:
+            result.add_note(
+                "entities",
+                f"{births} row(s) born in the window; activity seeded from "
+                "the entities.is_active=true schema default",
+                approximate=False,
+            )
 
     def _seed_window_births(
         self,
@@ -2431,6 +2491,7 @@ def _section_key_fn(section: str) -> Any:
 def _load_checkpoint_state(cur: Any, checkpoint_id: int) -> dict[str, Any]:
     cur.execute("SELECT state FROM state_checkpoints WHERE id = %s", (checkpoint_id,))
     state = _as_document(_row_value(cur.fetchone(), 0))
+    state.setdefault("entities", [])
     state.setdefault("character_project_states", [])
     state.setdefault("claim_awareness", [])
     state.setdefault("backstory_secrets", [])
@@ -2508,6 +2569,16 @@ def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:
                             "same-chunk captures compared directly "
                             "(stored vs stored)"
                         ],
+                        **(
+                            {
+                                "entities": [
+                                    "checkpoint predates the entity-activity "
+                                    "section; comparison skipped"
+                                ]
+                            }
+                            if "entities" in missing_sections
+                            else {}
+                        ),
                         **(
                             {
                                 "claim_awareness": [

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -6,8 +6,9 @@ produces. Sections and their replay sources:
 
 - ``entities`` activity — forward from the base checkpoint. Entity rows born
   inside the window are seeded with the schema's ``is_active=true`` default;
-  any later activity change without replayable provenance deliberately
-  surfaces as verification drift.
+  runtime maturation deaths replay their exact projection from the causing
+  world event, while any activity change without replayable provenance
+  deliberately surfaces as verification drift.
 - ``characters`` / ``places`` scalars — forward from the base checkpoint:
   ``state_delta_log`` rows (Skald, applied first within a chunk), then
   ``orrery_resolutions.state_delta`` keys ``character.current_activity``
@@ -574,6 +575,13 @@ class _Replayer:
                         made_applicable_at,
                         result,
                     )
+                if "entities" not in self.missing_base_sections:
+                    self._apply_maturation_entity_activity(
+                        chunk_id,
+                        base_chunk,
+                        entities,
+                        result,
+                    )
                 self._apply_maturation_project_starts(
                     chunk_id,
                     base_chunk,
@@ -602,8 +610,9 @@ class _Replayer:
         if "entities" not in self.missing_base_sections:
             result.add_note(
                 "entities",
-                "checkpoint-forward activity; an unledgered is_active change "
-                "surfaces as verification drift",
+                "checkpoint-forward activity with exact runtime-maturation "
+                "death projections; an unledgered is_active change surfaces "
+                "as verification drift",
                 approximate=False,
             )
         result.state["characters"] = sorted(characters.values(), key=lambda r: r["id"])
@@ -1001,6 +1010,9 @@ class _Replayer:
         maturation_start_window = MATURATION_PROJECT_START_WINDOW_SQL.format(
             column="tick_chunk_id"
         )
+        maturation_activity_window = MATURATION_PROJECT_START_WINDOW_SQL.format(
+            column="(activity.row ->> 'source_chunk_id')::bigint"
+        )
         self.cur.execute(
             f"""
             SELECT DISTINCT chunk_id FROM (
@@ -1022,6 +1034,16 @@ class _Replayer:
                                 LIKE 'maturation_job_%%'
                         )
                       )
+                UNION
+                SELECT (activity.row ->> 'source_chunk_id')::bigint
+                FROM world_events
+                CROSS JOIN LATERAL jsonb_array_elements(
+                    payload -> 'applied_entity_activity'
+                ) WITH ORDINALITY AS activity(row, ordinal)
+                WHERE source::text = 'retrograde'
+                  AND payload ->> 'retrograde_event_ref'
+                        LIKE 'maturation_job_%%'
+                  AND {maturation_activity_window}
             ) w ORDER BY chunk_id
             """,
             {
@@ -1031,6 +1053,92 @@ class _Replayer:
             },
         )
         return [_row_value(row, 0) for row in self.cur.fetchall()]
+
+    def _apply_maturation_entity_activity(
+        self,
+        chunk_id: int,
+        base_chunk: int,
+        entities: dict[int, dict[str, Any]],
+        result: ReplayResult,
+    ) -> None:
+        """Replay exact activity flips applied by runtime maturation."""
+
+        maturation_activity_window = MATURATION_PROJECT_START_WINDOW_SQL.format(
+            column="(activity.row ->> 'source_chunk_id')::bigint"
+        )
+        self.cur.execute(
+            f"""
+            SELECT
+                world_events.id,
+                activity.row,
+                EXISTS (
+                    SELECT 1
+                    FROM world_event_entities
+                    WHERE event_id = world_events.id
+                      AND entity_id =
+                            (activity.row ->> 'entity_id')::bigint
+                ) AS entity_is_participant
+            FROM world_events
+            CROSS JOIN LATERAL jsonb_array_elements(
+                payload -> 'applied_entity_activity'
+            ) WITH ORDINALITY AS activity(row, ordinal)
+            WHERE source::text = 'retrograde'
+              AND payload ->> 'retrograde_event_ref'
+                    LIKE 'maturation_job_%%'
+              AND (activity.row ->> 'source_chunk_id')::bigint = %(chunk)s
+              AND {maturation_activity_window}
+            ORDER BY world_events.id, activity.ordinal
+            """,
+            {
+                "chunk": chunk_id,
+                "base": base_chunk,
+                "target": self.target_chunk_id,
+            },
+        )
+        applied_count = 0
+        for event_id, raw_projection, entity_is_participant in self.cur.fetchall():
+            projection = _as_document(raw_projection)
+            required = {"entity_id", "is_active", "source_chunk_id"}
+            if not isinstance(projection, dict) or set(projection) != required:
+                raise ValueError(
+                    f"Maturation world event {event_id} has an invalid applied "
+                    "entity-activity projection"
+                )
+            entity_id = projection["entity_id"]
+            source_chunk_id = projection["source_chunk_id"]
+            if type(entity_id) is not int or type(source_chunk_id) is not int:
+                raise ValueError(
+                    f"Maturation world event {event_id} activity ids must be integers"
+                )
+            if projection["is_active"] is not False:
+                raise ValueError(
+                    f"Maturation world event {event_id} activity projection "
+                    "must record is_active=false"
+                )
+            if source_chunk_id != chunk_id:
+                raise ValueError(
+                    f"Maturation world event {event_id} activity projection "
+                    f"belongs to chunk {source_chunk_id}, not {chunk_id}"
+                )
+            if not entity_is_participant:
+                raise ValueError(
+                    f"Maturation world event {event_id} activity entity "
+                    f"{entity_id} is not an event participant"
+                )
+            if entity_id not in entities:
+                raise ValueError(
+                    f"Maturation world event {event_id} deactivates missing "
+                    f"entity {entity_id}"
+                )
+            entities[entity_id]["is_active"] = False
+            applied_count += 1
+        if applied_count:
+            result.add_note(
+                "entities",
+                f"replayed {applied_count} ledgered runtime-maturation "
+                "activity projection(s)",
+                approximate=False,
+            )
 
     def _seed_window_entity_births(
         self,

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -424,6 +424,7 @@ def _build_plan(
             event_ref_to_id=event_ref_to_id,
             creatable_refs=creatable_refs,
             inserted_stub_keys=inserted_stub_keys,
+            recorded_at_chunk_id=recorded_at_chunk_id,
         )
         death_rows.append(planned)
         counters[f"deaths_{planned['status']}"] += 1
@@ -1632,6 +1633,7 @@ def _plan_death_row(
     event_ref_to_id: Mapping[str, int],
     creatable_refs: frozenset[tuple[str, str]],
     inserted_stub_keys: frozenset[tuple[str, str]],
+    recorded_at_chunk_id: Optional[int],
 ) -> dict[str, Any]:
     """Plan or execute one entities.is_active=false flip for an asserted death.
 
@@ -1696,7 +1698,18 @@ def _plan_death_row(
         return {**base, "status": "blocked"}
     if dry_run:
         return {**base, "status": "would_deactivate"}
+    cause_world_event_id = base["cause_world_event_id"]
+    if cause_world_event_id is None:
+        raise AssertionError("executed death must resolve its cause world event")
+    if recorded_at_chunk_id is None:
+        raise AssertionError("executed death must have a recording boundary")
     _deactivate_entity(cur, entity_id)
+    _record_entity_activity_projection(
+        cur,
+        world_event_id=int(cause_world_event_id),
+        entity_id=entity_id,
+        source_chunk_id=int(recorded_at_chunk_id),
+    )
     return {**base, "status": "deactivated"}
 
 
@@ -1724,6 +1737,67 @@ def _deactivate_entity(cur: Any, entity_id: int) -> None:
         """,
         (entity_id,),
     )
+
+
+def _record_entity_activity_projection(
+    cur: Any,
+    *,
+    world_event_id: int,
+    entity_id: int,
+    source_chunk_id: int,
+) -> None:
+    """Attach an exact death projection to its durable cause event.
+
+    Runtime maturation history events retain their backstory chronology at the
+    synthetic prologue tick, so ``source_chunk_id`` records when the activity
+    flip was actually applied. Replay uses that boundary with the same
+    base-inclusive/target-exclusive semantics as maturation project starts.
+    """
+
+    cur.execute(
+        """
+        /* orrery:retrograde:record_entity_activity */
+        WITH projection AS (
+            SELECT jsonb_build_object(
+                'entity_id', %s,
+                'is_active', false,
+                'source_chunk_id', %s
+            ) AS value
+        )
+        UPDATE world_events
+        SET changed_fields = CASE
+                WHEN 'entities.is_active' = ANY(changed_fields)
+                THEN changed_fields
+                ELSE array_append(changed_fields, 'entities.is_active')
+            END,
+            payload = jsonb_set(
+                payload,
+                '{applied_entity_activity}',
+                COALESCE(
+                    payload -> 'applied_entity_activity',
+                    '[]'::jsonb
+                ) ||
+                    CASE
+                        WHEN COALESCE(
+                            payload -> 'applied_entity_activity',
+                            '[]'::jsonb
+                        ) @> jsonb_build_array(projection.value)
+                        THEN '[]'::jsonb
+                        ELSE jsonb_build_array(projection.value)
+                    END,
+                true
+            )
+        FROM projection
+        WHERE id = %s
+        RETURNING world_events.id
+        """,
+        (entity_id, source_chunk_id, world_event_id),
+    )
+    if cur.fetchone() is None:
+        raise RuntimeError(
+            f"Cause world event {world_event_id} disappeared before entity "
+            "activity could be recorded"
+        )
 
 
 def plan_retrograde_summaries(

--- a/tests/test_orrery/test_reconstruction.py
+++ b/tests/test_orrery/test_reconstruction.py
@@ -76,6 +76,9 @@ def test_checkpoint_captures_every_section_and_is_idempotent() -> None:
             assert len(state["entity_tags"]) == active_tags
             assert active_tags > 0, "save_05 must carry active tags"
             assert state["characters"], "character scalars must be captured"
+            cur.execute("SELECT count(*) FROM entities")
+            assert len(state["entities"]) == cur.fetchone()[0]
+            assert all(set(row) == {"id", "is_active"} for row in state["entities"])
 
             # Idempotent per (chunk, label): re-commit of the same tick
             # cannot duplicate the snapshot.

--- a/tests/test_orrery/test_replay.py
+++ b/tests/test_orrery/test_replay.py
@@ -48,6 +48,10 @@ from nexus.agents.orrery.replay import (
     verify_checkpoints_sync,
 )
 from nexus.agents.orrery.resolver import OrreryResolutionDraft
+from nexus.agents.orrery.retrograde_persistence import (
+    _deactivate_entity,
+    _record_entity_activity_projection,
+)
 from nexus.agents.orrery.substrate import ProjectPolicy
 from nexus.api.commit_handler_sync import apply_state_updates_sync
 
@@ -769,6 +773,117 @@ def test_verify_catches_unledgered_entity_deactivation() -> None:
         conn.close()
 
 
+def test_runtime_maturation_death_replays_without_drift() -> None:
+    """A ledgered maturation death is exact, not a false-positive drift."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            base_id = capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            assert base_id is not None
+            source_chunk = _fabricate_chunk(
+                cur,
+                None,
+                created_offset_minutes=1,
+            )
+            target_chunk = _fabricate_chunk(
+                cur,
+                None,
+                created_offset_minutes=2,
+            )
+
+            cur.execute("INSERT INTO entities (kind) VALUES ('character') RETURNING id")
+            entity_id = int(cur.fetchone()[0])
+            cur.execute("SELECT type FROM event_types ORDER BY type LIMIT 1")
+            event_type = str(cur.fetchone()[0])
+            projection = {
+                "entity_id": entity_id,
+                "is_active": False,
+                "source_chunk_id": source_chunk,
+            }
+            cur.execute(
+                """
+                INSERT INTO world_events (
+                    event_type, tick_chunk_id, source, payload
+                ) VALUES (
+                    %s, %s, 'retrograde', %s::jsonb
+                )
+                RETURNING id
+                """,
+                (
+                    event_type,
+                    head,
+                    json.dumps(
+                        {
+                            "source": "retrograde",
+                            "retrograde_event_ref": (
+                                "maturation_job_545001_death_probe"
+                            ),
+                        }
+                    ),
+                ),
+            )
+            cause_world_event_id = int(cur.fetchone()[0])
+            cur.execute(
+                """
+                INSERT INTO world_event_entities (event_id, role, entity_id)
+                VALUES (%s, 'observer', %s)
+                """,
+                (cause_world_event_id, entity_id),
+            )
+            _deactivate_entity(cur, entity_id)
+            _record_entity_activity_projection(
+                cur,
+                world_event_id=cause_world_event_id,
+                entity_id=entity_id,
+                source_chunk_id=source_chunk,
+            )
+            # The append is idempotent for a retried entity/boundary pair.
+            _record_entity_activity_projection(
+                cur,
+                world_event_id=cause_world_event_id,
+                entity_id=entity_id,
+                source_chunk_id=source_chunk,
+            )
+            cur.execute(
+                "SELECT changed_fields, payload FROM world_events WHERE id = %s",
+                (cause_world_event_id,),
+            )
+            changed_fields, cause_payload = cur.fetchone()
+            assert changed_fields == ["entities.is_active"]
+            assert cause_payload["applied_entity_activity"] == [projection]
+            target_id = capture_state_checkpoint_sync(
+                cur, chunk_id=target_chunk, label="manual"
+            )
+            assert target_id is not None
+
+            at_target = reconstruct_state_at_sync(
+                cur, target_chunk, base_checkpoint_id=base_id
+            )
+            assert _section_row(
+                at_target.state["entities"],
+                id=entity_id,
+                is_active=False,
+            )
+
+            verdicts = verify_checkpoints_sync(cur)
+            verdict = next(
+                item
+                for item in verdicts
+                if item.base_checkpoint_id == base_id
+                and item.target_checkpoint_id == target_id
+            )
+            assert verdict.drifts == []
+            assert any(
+                "ledgered runtime-maturation" in note
+                for note in verdict.notes.get("entities", [])
+            )
+    finally:
+        conn.rollback()
+        conn.close()
+
+
 def test_verify_skips_legacy_checkpoint_without_entity_activity() -> None:
     """Pre-section checkpoint documents remain an explicit skip boundary."""
 
@@ -783,13 +898,50 @@ def test_verify_skips_legacy_checkpoint_without_entity_activity() -> None:
                 "WHERE id = %s",
                 (base_id,),
             )
-            probe_chunk = _fabricate_chunk(
+            death_chunk = _fabricate_chunk(
                 cur,
                 None,
                 created_offset_minutes=1,
             )
+            target_chunk = _fabricate_chunk(
+                cur,
+                None,
+                created_offset_minutes=2,
+            )
+            cur.execute("INSERT INTO entities (kind) VALUES ('character') RETURNING id")
+            entity_id = int(cur.fetchone()[0])
+            cur.execute("SELECT type FROM event_types ORDER BY type LIMIT 1")
+            event_type = str(cur.fetchone()[0])
+            cur.execute(
+                """
+                INSERT INTO world_events (
+                    event_type, tick_chunk_id, source, payload
+                ) VALUES (%s, %s, 'retrograde', %s::jsonb)
+                RETURNING id
+                """,
+                (
+                    event_type,
+                    head,
+                    json.dumps(
+                        {
+                            "source": "retrograde",
+                            "retrograde_event_ref": (
+                                "maturation_job_545002_legacy_probe"
+                            ),
+                        }
+                    ),
+                ),
+            )
+            cause_world_event_id = int(cur.fetchone()[0])
+            _deactivate_entity(cur, entity_id)
+            _record_entity_activity_projection(
+                cur,
+                world_event_id=cause_world_event_id,
+                entity_id=entity_id,
+                source_chunk_id=death_chunk,
+            )
             target_id = capture_state_checkpoint_sync(
-                cur, chunk_id=probe_chunk, label="manual"
+                cur, chunk_id=target_chunk, label="manual"
             )
             assert target_id is not None
 

--- a/tests/test_orrery/test_replay.py
+++ b/tests/test_orrery/test_replay.py
@@ -723,6 +723,96 @@ def test_verify_catches_unledgered_scalar_drift() -> None:
         conn.close()
 
 
+def test_verify_catches_unledgered_entity_deactivation() -> None:
+    """A missed activity replay produces an exact entity-section drift."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            _, entity_id, _, _ = _probe_character(cur)
+            base_id = capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            assert base_id is not None
+            probe_chunk = _fabricate_chunk(
+                cur,
+                None,
+                created_offset_minutes=1,
+            )
+
+            cur.execute(
+                "UPDATE entities SET is_active = false WHERE id = %s",
+                (entity_id,),
+            )
+            target_id = capture_state_checkpoint_sync(
+                cur, chunk_id=probe_chunk, label="manual"
+            )
+            assert target_id is not None
+
+            verdicts = verify_checkpoints_sync(cur)
+            verdict = next(
+                item
+                for item in verdicts
+                if item.base_checkpoint_id == base_id
+                and item.target_checkpoint_id == target_id
+            )
+            assert any(
+                drift.section == "entities"
+                and drift.row_key == str(entity_id)
+                and drift.column == "is_active"
+                and drift.kind == "value"
+                and drift.expected is False
+                and drift.actual is True
+                for drift in verdict.drifts
+            ), f"verify must catch the un-ledgered deactivation; got {verdict.drifts}"
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_verify_skips_legacy_checkpoint_without_entity_activity() -> None:
+    """Pre-section checkpoint documents remain an explicit skip boundary."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            base_id = capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
+            assert base_id is not None
+            cur.execute(
+                "UPDATE state_checkpoints SET state = state - 'entities' "
+                "WHERE id = %s",
+                (base_id,),
+            )
+            probe_chunk = _fabricate_chunk(
+                cur,
+                None,
+                created_offset_minutes=1,
+            )
+            target_id = capture_state_checkpoint_sync(
+                cur, chunk_id=probe_chunk, label="manual"
+            )
+            assert target_id is not None
+
+            verdicts = verify_checkpoints_sync(cur)
+            verdict = next(
+                item
+                for item in verdicts
+                if item.base_checkpoint_id == base_id
+                and item.target_checkpoint_id == target_id
+            )
+            assert not [
+                drift for drift in verdict.drifts if drift.section == "entities"
+            ]
+            assert verdict.skipped_unreproducible >= 1
+            assert any(
+                "comparison skipped" in note
+                for note in verdict.notes.get("entities", [])
+            )
+    finally:
+        conn.rollback()
+        conn.close()
+
+
 def test_reconstruction_refuses_pre_instrumentation_chunks() -> None:
     conn = _connect()
     try:

--- a/tests/test_orrery/test_retrograde_persistence.py
+++ b/tests/test_orrery/test_retrograde_persistence.py
@@ -595,6 +595,13 @@ def test_persistence_execute_deactivates_staged_stub() -> None:
     assert death_row["status"] == "deactivated"
     assert death_row["cause_world_event_id"] == 901
     assert cur.deactivated_entity_ids == [300]
+    assert cur.entity_activity_projections == [
+        {
+            "entity_id": 300,
+            "source_chunk_id": 900,
+            "world_event_id": 901,
+        }
+    ]
 
 
 def test_persistence_death_already_inactive_is_idempotent() -> None:
@@ -731,6 +738,7 @@ class FakeRetrogradePersistenceCursor:
         }
         self.inactive_entity_ids = set(inactive_entity_ids or set())
         self.deactivated_entity_ids: list[int] = []
+        self.entity_activity_projections: list[dict[str, int]] = []
         self.inserted_character_stubs: list[str] = []
         self.statements: list[str] = []
         self.params: list[Any] = []
@@ -885,6 +893,16 @@ class FakeRetrogradePersistenceCursor:
             self.deactivated_entity_ids.append(entity_id)
             self.inactive_entity_ids.add(entity_id)
             self._result = []
+        elif "orrery:retrograde:record_entity_activity" in sql:
+            assert params is not None
+            self.entity_activity_projections.append(
+                {
+                    "entity_id": int(params[0]),
+                    "source_chunk_id": int(params[1]),
+                    "world_event_id": int(params[2]),
+                }
+            )
+            self._result = [{"id": int(params[2])}]
         elif "SELECT to_regclass" in sql:
             self._result = [{"checkpoint_table": "backstory_secrets"}]
         elif "jsonb_agg(to_jsonb(t))" in sql:


### PR DESCRIPTION
## Summary

- add an entities checkpoint section containing exactly id and is_active
- reconstruct in-window entity births from the schema default without copying later live activity
- persist each successful Retrograde death as an exact, idempotent applied_entity_activity projection on its mandatory cause event
- replay namespaced runtime-maturation deaths at the established base-inclusive/target-exclusive maturation boundary, validating the entity is an event participant
- keep raw unledgered deactivation visible as exact drift
- treat a missing entity section as an explicit legacy comparison boundary, including windows containing a maturation death
- update migration 065 genesis shape for fresh installs without rewriting historical checkpoint JSON

There is no numbered/data migration or historical backfill because current activity cannot truthfully reconstruct an old checkpoint.

## Review fix

Claude correctly identified that runtime maturation can create and deactivate a stub inside a replay window. Commit 730f5920 threads the effective recording boundary into the shared death writer, stores the exact false projection on the cause world event in the same transaction, and replays only writer-authored maturation projections. The JSONB append is idempotent and fails if the cause event disappears.

The broader inherited race where a detached maturation worker can finish after an intervening checkpoint is tracked separately in #552.

## Regression proof

- unledgered deactivation still reports entities / entity id / is_active with expected false and replayed true
- a ledgered runtime-maturation death persists one exact projection and verifies with zero drift
- replay rejects a projection whose entity is not a cause-event participant
- a legacy base carrying a later maturation death skips entity comparison without crashing or false drift
- existing window-born entity and need replay remains clean

## Verification

- NEXUS_RUN_POSTGRES=1 poetry run pytest tests/test_orrery/test_reconstruction.py tests/test_orrery/test_replay.py -q — 29 passed
- poetry run pytest tests/test_orrery/test_retrograde_persistence.py -q — 24 passed
- NEXUS_RUN_POSTGRES=1 poetry run pytest tests/test_orrery -q — 1,284 passed, 5 skipped
- poetry run mypy nexus/agents/orrery/ — zero errors in 50 files
- changed-file Black and flake8 — clean
- poetry run python scripts/replay_state.py --slot 4 --verify — six checkpoint windows clean
- poetry run python scripts/replay_state.py --slot 5 --verify — four checkpoint windows clean

Closes #545

Codex — GPT-5.6-Sol