### PR TITLE
Move live vocabulary catalogs out of the storyteller wire schemas (#553)

### DIFF
--- a/nexus/agents/logon/orrery_tag_schema.py
+++ b/nexus/agents/logon/orrery_tag_schema.py
@@ -1,66 +1,30 @@
-"""Runtime JSON Schema constraints for storyteller Orrery tag bestowals."""
+"""Compact native JSON Schema constraints for storyteller responses."""
 
 from __future__ import annotations
 
-from copy import deepcopy
-import logging
-from typing import Any, Dict, Mapping, Optional, Sequence, Type
+from typing import Any, Dict, Mapping, Optional, Type
 
 from pydantic import BaseModel
 
-from nexus.agents.orrery.tag_library import (
-    read_event_types,
-    read_pair_tag_library,
-    read_tag_library,
-)
 from nexus.api.native_structured_output import (
     anthropic_output_config,
-    openai_response_text_format,
     strict_json_schema,
 )
-
-logger = logging.getLogger("nexus.logon.orrery_tag_schema")
-
-_KIND_DEF_NAMES = {
-    "character": "OrreryTagBestowalCharacter",
-    "place": "OrreryTagBestowalPlace",
-    "faction": "OrreryTagBestowalFaction",
-}
-
-_OWNER_KINDS = {
-    "CharacterStateUpdate": "character",
-    "NewCharacter": "character",
-    "LocationStateUpdate": "place",
-    "NewPlace": "place",
-    "FactionStateUpdate": "faction",
-    "NewFaction": "faction",
-}
-
-
-def storyteller_openai_text_format(
-    schema_model: Type[BaseModel], dbname: Optional[str]
-) -> Optional[Dict[str, Any]]:
-    """Build an OpenAI text.format with live tag enums for LOGON responses."""
-
-    schema = storyteller_schema_with_runtime_tag_enums(schema_model, dbname)
-    if schema is None:
-        return None
-    return openai_response_text_format(schema_model, schema=schema)
 
 
 def storyteller_anthropic_output_config(
     schema_model: Type[BaseModel], dbname: Optional[str]
 ) -> Optional[Dict[str, Any]]:
-    """Build an Anthropic output_config with live tag enums for LOGON responses."""
+    """Build an Anthropic output_config without live vocabulary catalogs."""
 
     compact_schema = storyteller_anthropic_compact_schema(schema_model, dbname)
     if compact_schema is not None:
         return anthropic_output_config(schema_model, schema=compact_schema)
 
-    schema = storyteller_schema_with_runtime_tag_enums(schema_model, dbname)
-    if schema is None:
-        return None
-    return anthropic_output_config(schema_model, schema=schema)
+    return anthropic_output_config(
+        schema_model,
+        schema=strict_json_schema(schema_model),
+    )
 
 
 def storyteller_anthropic_compact_schema(
@@ -69,9 +33,9 @@ def storyteller_anthropic_compact_schema(
 ) -> Optional[Dict[str, Any]]:
     """Return a compact Anthropic wire schema for extended storyteller turns."""
 
+    del dbname  # The wire contract must remain stable as live registries grow.
     if schema_model.__name__ != "StorytellerResponseExtended":
         return None
-    tag_names, pair_tag_names, event_types = _compact_storyteller_vocabulary(dbname)
 
     return {
         "type": "object",
@@ -94,12 +58,12 @@ def storyteller_anthropic_compact_schema(
             "operations": _empty_object_schema("No operations."),
             "orrery_adjudications": {
                 "type": "array",
-                "items": _compact_orrery_adjudication_schema(event_types),
+                "items": _compact_orrery_adjudication_schema(),
                 "description": "Optional defer/replace/void rulings.",
             },
             "new_entities": {
                 "type": "array",
-                "items": _compact_new_entity_schema(tag_names, pair_tag_names),
+                "items": _compact_new_entity_schema(),
                 "description": (
                     "Sparing declarations for newly introduced persistent entities."
                 ),
@@ -120,81 +84,12 @@ def storyteller_anthropic_compact_schema(
     }
 
 
-def storyteller_schema_with_runtime_tag_enums(
-    schema_model: Type[BaseModel], dbname: Optional[str]
-) -> Optional[Dict[str, Any]]:
-    """Specialize LOGON's JSON Schema with slot-specific Orrery tag enums."""
-
-    if not dbname:
-        return None
-    try:
-        tags_by_kind = _read_tags_by_kind(dbname)
-    except Exception as exc:
-        logger.warning(
-            "Failed to load runtime Orrery tag enums for storyteller schema: %s",
-            exc,
-        )
-        return None
-    if not any(tags_by_kind.values()):
-        return None
-
-    schema = deepcopy(strict_json_schema(schema_model))
-    defs = schema.get("$defs")
-    if not isinstance(defs, dict) or "OrreryTagBestowal" not in defs:
-        return None
-
-    base_bestowal = defs["OrreryTagBestowal"]
-    for entity_kind, tags in tags_by_kind.items():
-        if not tags:
-            continue
-        def_name = _KIND_DEF_NAMES[entity_kind]
-        defs[def_name] = _bestowal_def_with_tag_enum(
-            base_bestowal,
-            tags,
-            entity_kind=entity_kind,
-        )
-
-    replaced = False
-    for owner_def, entity_kind in _OWNER_KINDS.items():
-        if not tags_by_kind.get(entity_kind):
-            continue
-        if _replace_owner_bestowal_ref(
-            defs,
-            owner_def=owner_def,
-            target_def=_KIND_DEF_NAMES[entity_kind],
-        ):
-            replaced = True
-
-    return schema if replaced else None
-
-
 def _string_array_schema(description: str) -> Dict[str, Any]:
     return {
         "type": "array",
         "items": {"type": "string"},
         "description": description,
     }
-
-
-def _enum_string_array_schema(
-    description: str,
-    values: Sequence[str],
-) -> Dict[str, Any]:
-    items: Dict[str, Any] = {"type": "string"}
-    if values:
-        items["enum"] = list(values)
-    return {
-        "type": "array",
-        "items": items,
-        "description": description,
-    }
-
-
-def _enum_string_schema(values: Sequence[str]) -> Dict[str, Any]:
-    schema: Dict[str, Any] = {"type": "string"}
-    if values:
-        schema["enum"] = list(values)
-    return schema
 
 
 def _optional_string_schema(description: str) -> Dict[str, Any]:
@@ -249,10 +144,7 @@ def _compact_state_update_entry_schema() -> Dict[str, Any]:
     }
 
 
-def _compact_new_entity_schema(
-    tag_names: Sequence[str],
-    pair_tag_names: Sequence[str],
-) -> Dict[str, Any]:
+def _compact_new_entity_schema() -> Dict[str, Any]:
     return {
         "type": "object",
         "additionalProperties": False,
@@ -260,13 +152,12 @@ def _compact_new_entity_schema(
             "kind": {"type": "string", "enum": ["character", "place", "faction"]},
             "name": {"type": "string"},
             "summary": {"type": "string"},
-            "tag_hints": _enum_string_array_schema(
+            "tag_hints": _string_array_schema(
                 "Registered single-entity tag names.",
-                tag_names,
             ),
             "pair_tag_hints": {
                 "type": "array",
-                "items": _compact_pair_tag_hint_schema(pair_tag_names),
+                "items": _compact_pair_tag_hint_schema(),
             },
         },
         "required": [
@@ -279,12 +170,12 @@ def _compact_new_entity_schema(
     }
 
 
-def _compact_pair_tag_hint_schema(pair_tag_names: Sequence[str]) -> Dict[str, Any]:
+def _compact_pair_tag_hint_schema() -> Dict[str, Any]:
     return {
         "type": "object",
         "additionalProperties": False,
         "properties": {
-            "tag": _enum_string_schema(pair_tag_names),
+            "tag": {"type": "string"},
             "other_entity_name": {"type": "string"},
             "declared_entity_role": {
                 "type": "string",
@@ -295,16 +186,13 @@ def _compact_pair_tag_hint_schema(pair_tag_names: Sequence[str]) -> Dict[str, An
     }
 
 
-def _compact_orrery_adjudication_schema(
-    event_types: Sequence[str],
-) -> Dict[str, Any]:
+def _compact_orrery_adjudication_schema() -> Dict[str, Any]:
     properties: Dict[str, Any] = {
         "proposal_id": {"type": "string"},
         "action": {"type": "string", "enum": ["defer", "replace", "void"]},
         "note": {"type": "string"},
+        "replacement_event_type": {"type": "string"},
     }
-    if event_types:
-        properties["replacement_event_type"] = _enum_string_schema(event_types)
 
     return {
         "type": "object",
@@ -315,94 +203,3 @@ def _compact_orrery_adjudication_schema(
             "action",
         ],
     }
-
-
-def _compact_storyteller_vocabulary(
-    dbname: Optional[str],
-) -> tuple[list[str], list[str], list[str]]:
-    if not dbname:
-        return [], [], []
-    try:
-        tags_by_kind = _read_tags_by_kind(dbname)
-        tag_names = sorted({tag for tags in tags_by_kind.values() for tag in tags})
-        pair_tag_names = _read_pair_tags(dbname)
-        event_types = _read_event_types(dbname)
-    except Exception as exc:
-        logger.warning(
-            "Failed to load compact Anthropic storyteller vocab enums: %s",
-            exc,
-        )
-        return [], [], []
-    return tag_names, pair_tag_names, event_types
-
-
-def _read_tags_by_kind(dbname: str) -> dict[str, list[str]]:
-    tags_by_kind = {kind: [] for kind in _KIND_DEF_NAMES}
-    for entry in read_tag_library(dbname):
-        tags_by_kind.setdefault(entry.entity_kind, []).append(entry.tag)
-    return {
-        kind: sorted(dict.fromkeys(tags))
-        for kind, tags in tags_by_kind.items()
-        if kind in _KIND_DEF_NAMES
-    }
-
-
-def _read_pair_tags(dbname: str) -> list[str]:
-    return read_pair_tag_library(dbname)
-
-
-def _read_event_types(dbname: str) -> list[str]:
-    return read_event_types(dbname)
-
-
-def _bestowal_def_with_tag_enum(
-    base_bestowal: Mapping[str, Any], tags: list[str], *, entity_kind: str
-) -> Dict[str, Any]:
-    bestowal = deepcopy(dict(base_bestowal))
-    bestowal["title"] = _KIND_DEF_NAMES[entity_kind]
-    bestowal["description"] = (
-        f"{base_bestowal.get('description', '')}\n\n"
-        f"Runtime constraint: tag names must be registered {entity_kind} tags "
-        "from this slot."
-    ).strip()
-    properties = bestowal.get("properties", {})
-    if isinstance(properties, dict):
-        for field_name in ("applied_tags", "tags_to_clear"):
-            field_schema = properties.get(field_name)
-            if isinstance(field_schema, dict):
-                items = field_schema.setdefault("items", {})
-                if isinstance(items, dict):
-                    items["type"] = "string"
-                    items["enum"] = tags
-    return bestowal
-
-
-def _replace_owner_bestowal_ref(
-    defs: Dict[str, Any], *, owner_def: str, target_def: str
-) -> bool:
-    owner_schema = defs.get(owner_def)
-    if not isinstance(owner_schema, dict):
-        return False
-    properties = owner_schema.get("properties")
-    if not isinstance(properties, dict):
-        return False
-    bestowal_field = properties.get("orrery_tags")
-    if not isinstance(bestowal_field, dict):
-        return False
-    return _replace_bestowal_ref(bestowal_field, target_def=target_def)
-
-
-def _replace_bestowal_ref(schema: Any, *, target_def: str) -> bool:
-    if isinstance(schema, dict):
-        if schema.get("$ref") == "#/$defs/OrreryTagBestowal":
-            schema["$ref"] = f"#/$defs/{target_def}"
-            return True
-        return any(
-            _replace_bestowal_ref(value, target_def=target_def)
-            for value in schema.values()
-        )
-    if isinstance(schema, list):
-        return any(
-            _replace_bestowal_ref(item, target_def=target_def) for item in schema
-        )
-    return False

--- a/nexus/agents/logon/orrery_tag_validation.py
+++ b/nexus/agents/logon/orrery_tag_validation.py
@@ -14,16 +14,51 @@ retry while the model still owns the turn.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
-from typing import Any, List, Optional, Tuple
+from typing import Any, FrozenSet, List, Mapping, Optional, Tuple
 
 from nexus.agents.orrery.declaration_validation import (
     collect_new_entity_declaration_vocabulary_issues,
+)
+from nexus.agents.orrery.tag_library import (
+    read_event_types,
+    read_pair_tag_library,
+    read_tag_library,
 )
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
 from nexus.agents.orrery.tag_writer import validate_tag_bestowal
 
 logger = logging.getLogger("nexus.logon.orrery_tag_validation")
+
+
+@dataclass(frozen=True)
+class StorytellerVocabulary:
+    """One validation pass's immutable snapshot of live storyteller catalogs."""
+
+    tag_names_by_kind: Mapping[str, FrozenSet[str]]
+    pair_tag_names: FrozenSet[str]
+    event_types: FrozenSet[str]
+
+
+def read_storyteller_vocabulary(dbname: str) -> StorytellerVocabulary:
+    """Load each live vocabulary catalog once for one validation attempt."""
+
+    tags_by_kind: dict[str, set[str]] = {
+        "character": set(),
+        "place": set(),
+        "faction": set(),
+    }
+    for entry in read_tag_library(dbname):
+        if entry.entity_kind in tags_by_kind:
+            tags_by_kind[entry.entity_kind].add(entry.tag)
+    return StorytellerVocabulary(
+        tag_names_by_kind={
+            kind: frozenset(tag_names) for kind, tag_names in tags_by_kind.items()
+        },
+        pair_tag_names=frozenset(read_pair_tag_library(dbname)),
+        event_types=frozenset(read_event_types(dbname)),
+    )
 
 
 def _bestowal_sites(response: Any) -> List[Tuple[str, str, OrreryTagBestowal]]:
@@ -87,20 +122,76 @@ def _bestowal_sites(response: Any) -> List[Tuple[str, str, OrreryTagBestowal]]:
     return sites
 
 
-def collect_orrery_tag_issues(response: Any, cur: Any) -> List[str]:
+def _validate_bestowal_against_vocabulary(
+    *,
+    entity_kind: str,
+    bestowal: OrreryTagBestowal,
+    vocabulary: StorytellerVocabulary,
+) -> List[str]:
+    """Return field-qualified issues from the cached per-kind tag catalog."""
+
+    allowed_tags = vocabulary.tag_names_by_kind.get(entity_kind, frozenset())
+    issues: List[str] = []
+    for field_name in ("applied_tags", "tags_to_clear"):
+        for tag_name in getattr(bestowal, field_name):
+            if tag_name not in allowed_tags:
+                issues.append(
+                    f"{field_name}: Unknown or entity-kind-incompatible tag "
+                    f"{tag_name!r} for {entity_kind!r}"
+                )
+    return issues
+
+
+def collect_orrery_tag_issues(
+    response: Any,
+    cur: Any,
+    *,
+    vocabulary: Optional[StorytellerVocabulary] = None,
+) -> List[str]:
     """Validate every bestowal and declaration against the live registry."""
 
     issues: List[str] = []
     for path, entity_kind, bestowal in _bestowal_sites(response):
-        for issue in validate_tag_bestowal(
-            cur, entity_kind=entity_kind, bestowal=bestowal
-        ):
+        if vocabulary is None:
+            bestowal_issues = validate_tag_bestowal(
+                cur,
+                entity_kind=entity_kind,
+                bestowal=bestowal,
+            )
+        else:
+            bestowal_issues = _validate_bestowal_against_vocabulary(
+                entity_kind=entity_kind,
+                bestowal=bestowal,
+                vocabulary=vocabulary,
+            )
+        for issue in bestowal_issues:
             issues.append(f"{path}: {issue}")
     issues.extend(
         collect_new_entity_declaration_vocabulary_issues(
-            cur, getattr(response, "new_entities", None) or []
+            cur,
+            getattr(response, "new_entities", None) or [],
+            tag_names_by_kind=(
+                vocabulary.tag_names_by_kind if vocabulary is not None else None
+            ),
+            pair_tag_names=(
+                vocabulary.pair_tag_names if vocabulary is not None else None
+            ),
         )
     )
+    for index, adjudication in enumerate(
+        getattr(response, "orrery_adjudications", None) or []
+    ):
+        event_type = getattr(adjudication, "replacement_event_type", None)
+        if (
+            event_type is not None
+            and vocabulary is not None
+            and event_type not in vocabulary.event_types
+        ):
+            issues.append(
+                "orrery_adjudications"
+                f"[{index}].replacement_event_type: Unknown or deprecated "
+                f"event type {event_type!r}"
+            )
     return issues
 
 
@@ -121,9 +212,14 @@ def build_storyteller_tag_validator(dbname: Optional[str]) -> Optional[Any]:
 
         from nexus.api.db_pool import get_connection
 
+        vocabulary = read_storyteller_vocabulary(dbname)
         with get_connection(dbname) as conn:
             with conn.cursor() as cur:
-                issues = collect_orrery_tag_issues(output, cur)
+                issues = collect_orrery_tag_issues(
+                    output,
+                    cur,
+                    vocabulary=vocabulary,
+                )
         if issues:
             formatted = "\n".join(f"- {issue}" for issue in issues)
             logger.info(
@@ -132,13 +228,14 @@ def build_storyteller_tag_validator(dbname: Optional[str]) -> Optional[Any]:
                 len(issues),
             )
             raise ModelRetry(
-                "Your Orrery tags or new-entity declaration hints failed "
-                "closed-registry validation. For applied_tags and tag_hints, "
-                "use bare registered tag names only (e.g. 'comfortable'), never "
-                "'category:name' composites. For pair_tag_hints, use the exact "
-                "registered pair-tag name; pair tags may contain colons (e.g. "
-                "'contact:social'). Drop any tag with no registered equivalent. "
-                "Fix every listed "
+                "Your Orrery tags, new-entity declaration hints, or replacement "
+                "event types failed closed-registry validation. For applied_tags, "
+                "tags_to_clear, and tag_hints, use bare registered tag names only "
+                "(e.g. 'comfortable'), never 'category:name' composites. For "
+                "pair_tag_hints, use the exact registered pair-tag name; pair tags "
+                "may contain colons (e.g. 'contact:social'). For "
+                "replacement_event_type, use an exact registered event type. Drop "
+                "any value with no registered equivalent. Fix every listed "
                 f"path and resubmit the complete response:\n{formatted}"
             )
         return output

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -8,7 +8,7 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Literal, Mapping, Optional, cast
 
 import psycopg2
 
@@ -117,7 +117,7 @@ class LogonUtility:
         self.dbname = dbname
         self.model_override = model_override
         self.bootstrap_mode = bootstrap_mode
-        self.provider: Optional[object] = None
+        self.provider: Optional[OpenAIProvider | AnthropicProvider] = None
         self._system_prompt: Optional[str] = None
         self._provider_bootstrap_mode: Optional[bool] = None
         self._provider_wire_type: Optional[str] = None
@@ -302,8 +302,9 @@ class LogonUtility:
         endpoint = get_openai_compatible_endpoint(model)
         base_url = endpoint["base_url"] if endpoint else None
         api_key = endpoint["api_key"] if endpoint else None
-        structured_transport = (
-            endpoint["structured_transport"] if endpoint else "responses"
+        structured_transport = cast(
+            Literal["responses", "chat_completions"],
+            endpoint["structured_transport"] if endpoint else "responses",
         )
         request_timeout = endpoint["request_timeout_seconds"] if endpoint else None
         if base_url:
@@ -418,6 +419,7 @@ class LogonUtility:
     def generate_narrative(self, context_payload: Dict[str, Any]) -> StoryTurnResponse:
         """Generate narrative from context payload with structured output."""
         self._ensure_provider(context_payload)
+        assert self.provider is not None
         # Format the context into a prompt
         prompt = self._format_context_prompt(context_payload)
         schema_model = self._select_response_schema(context_payload)
@@ -445,6 +447,7 @@ class LogonUtility:
     ) -> StoryTurnResponse:
         """Generate narrative from context payload without blocking the event loop."""
         self._ensure_provider(context_payload)
+        assert self.provider is not None
         prompt = self._format_context_prompt(context_payload)
         schema_model = self._select_response_schema(context_payload)
         schema_kwargs = self._schema_format_kwargs(schema_model)
@@ -478,35 +481,22 @@ class LogonUtility:
     def _schema_format_kwargs(self, schema_model: type) -> Dict[str, Any]:
         """Return provider-specific native schema overrides for LOGON."""
 
-        if not self._validation_dbname or not self._provider_wire_type:
+        if not self._provider_wire_type:
             return {}
         if schema_model in self._schema_format_cache:
             return self._schema_format_cache[schema_model]
 
         kwargs: Dict[str, Any] = {}
-        try:
+        if self._provider_wire_type == "anthropic":
             from nexus.agents.logon.orrery_tag_schema import (
                 storyteller_anthropic_output_config,
-                storyteller_openai_text_format,
             )
 
-            if self._provider_wire_type == "anthropic":
-                output_config = storyteller_anthropic_output_config(
-                    schema_model, self._validation_dbname
-                )
-                if output_config is not None:
-                    kwargs = {"output_config": output_config}
-            else:
-                text_format = storyteller_openai_text_format(
-                    schema_model, self._validation_dbname
-                )
-                if text_format is not None:
-                    kwargs = {"text_format": text_format}
-        except Exception as exc:
-            logger.warning(
-                "Failed to build runtime storyteller schema constraints: %s",
-                exc,
+            output_config = storyteller_anthropic_output_config(
+                schema_model, self._validation_dbname
             )
+            if output_config is not None:
+                kwargs = {"output_config": output_config}
 
         self._schema_format_cache[schema_model] = kwargs
         return kwargs

--- a/nexus/agents/orrery/declaration_validation.py
+++ b/nexus/agents/orrery/declaration_validation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, Sequence
+from typing import AbstractSet, Any, Literal, Mapping, Optional, Sequence
 
 from nexus.agents.logon.apex_schema import NewEntityDeclaration
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
@@ -15,6 +15,9 @@ from nexus.agents.orrery.tag_writer import (
 def collect_new_entity_declaration_vocabulary_issues(
     cur: Any,
     declarations: Sequence[NewEntityDeclaration],
+    *,
+    tag_names_by_kind: Optional[Mapping[str, AbstractSet[str]]] = None,
+    pair_tag_names: Optional[AbstractSet[str]] = None,
 ) -> list[str]:
     """Return path-qualified vocabulary issues without mutating the database.
 
@@ -28,28 +31,45 @@ def collect_new_entity_declaration_vocabulary_issues(
         path = f"new_entities[{declaration_index}]"
 
         if declaration.tag_hints:
-            bestowal = OrreryTagBestowal(applied_tags=list(declaration.tag_hints))
-            for issue in validate_tag_bestowal(
-                cur,
-                entity_kind=declaration.kind,
-                bestowal=bestowal,
-            ):
-                detail = issue.removeprefix("applied_tags: ")
-                issues.append(f"{path}.tag_hints: {detail}")
+            if tag_names_by_kind is None:
+                bestowal = OrreryTagBestowal(applied_tags=list(declaration.tag_hints))
+                tag_issues = validate_tag_bestowal(
+                    cur,
+                    entity_kind=declaration.kind,
+                    bestowal=bestowal,
+                )
+                for issue in tag_issues:
+                    detail = issue.removeprefix("applied_tags: ")
+                    issues.append(f"{path}.tag_hints: {detail}")
+            else:
+                allowed_tags = tag_names_by_kind.get(declaration.kind, set())
+                for tag_name in declaration.tag_hints:
+                    if tag_name not in allowed_tags:
+                        issues.append(
+                            f"{path}.tag_hints: Unknown or "
+                            f"entity-kind-incompatible tag {tag_name!r} for "
+                            f"{declaration.kind!r}"
+                        )
 
         for hint_index, hint in enumerate(declaration.pair_tag_hints):
             hint_path = f"{path}.pair_tag_hints[{hint_index}]"
             tag_is_valid = True
-            try:
-                validate_pair_tag_endpoint(
-                    cur,
-                    tag=hint.tag,
-                    entity_kind=declaration.kind,
-                    role=hint.declared_entity_role,
-                )
-            except ValueError as exc:
+            if pair_tag_names is not None and hint.tag not in pair_tag_names:
                 tag_is_valid = False
-                issues.append(f"{hint_path}.tag: {exc}")
+                issues.append(
+                    f"{hint_path}.tag: Unknown or deprecated pair_tag {hint.tag!r}"
+                )
+            else:
+                try:
+                    validate_pair_tag_endpoint(
+                        cur,
+                        tag=hint.tag,
+                        entity_kind=declaration.kind,
+                        role=hint.declared_entity_role,
+                    )
+                except ValueError as exc:
+                    tag_is_valid = False
+                    issues.append(f"{hint_path}.tag: {exc}")
 
             endpoint_kind, endpoint_issue = _resolve_hint_endpoint_kind(
                 cur,

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
-from typing import Any, List, Optional, Tuple
+from typing import Any, cast, List, Literal, Optional, Tuple
 
 import pytest
 from pydantic_ai import ModelRetry
@@ -21,16 +22,17 @@ from nexus.agents.logon.apex_schema import (
     StorytellerResponseExtended,
 )
 from nexus.agents.logon.orrery_tag_schema import (
+    storyteller_anthropic_compact_schema,
     storyteller_anthropic_output_config,
-    storyteller_openai_text_format,
-    storyteller_schema_with_runtime_tag_enums,
 )
 from nexus.agents.logon.orrery_tag_validation import (
+    StorytellerVocabulary,
     build_storyteller_tag_validator,
     collect_orrery_tag_issues,
 )
 from nexus.agents.orrery.tag_library import TagLibraryEntry
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
+from nexus.api.native_structured_output import strict_json_schema
 from scripts.api_openai import OpenAIProvider
 
 
@@ -74,7 +76,7 @@ class FakeRegistryCursor:
     def __enter__(self) -> "FakeRegistryCursor":
         return self
 
-    def __exit__(self, *_args: Any) -> bool:
+    def __exit__(self, *_args: Any) -> Literal[False]:
         return False
 
     def execute(self, sql: str, params: Tuple[Any, ...] = ()) -> None:
@@ -90,13 +92,13 @@ class FakeRegistryCursor:
             ]
             self._one = None
         elif "FROM tags" in sql:
-            row = self.tags.get(params[0])
-            self._one = row
-            self._result = [row] if row else []
+            tag_row: Optional[Tuple[Any, ...]] = self.tags.get(params[0])
+            self._one = tag_row
+            self._result = [tag_row] if tag_row else []
         elif "FROM pair_tags" in sql:
-            row = self.pair_tags.get(params[0])
-            self._one = row
-            self._result = [row] if row else []
+            pair_tag_row: Optional[Tuple[Any, ...]] = self.pair_tags.get(params[0])
+            self._one = pair_tag_row
+            self._result = [pair_tag_row] if pair_tag_row else []
         else:
             raise AssertionError(f"Unexpected query: {sql}")
 
@@ -125,17 +127,61 @@ class FakeRegistryConnection:
     def __enter__(self) -> "FakeRegistryConnection":
         return self
 
-    def __exit__(self, *_args: Any) -> bool:
+    def __exit__(self, *_args: Any) -> Literal[False]:
         return False
 
     def cursor(self) -> FakeRegistryCursor:
         return self._cursor
 
 
+def _test_vocabulary() -> StorytellerVocabulary:
+    return StorytellerVocabulary(
+        tag_names_by_kind={
+            "character": frozenset({"human", "perceptive"}),
+            "place": frozenset({"haven"}),
+            "faction": frozenset({"loyalist"}),
+        },
+        pair_tag_names=frozenset({"protects", "contact:social", "status:junior"}),
+        event_types=frozenset({"evade_pursuit", "slept"}),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_storyteller_vocabulary_readers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep generation-validator tests offline with deterministic catalogs."""
+
+    from nexus.agents.logon import orrery_tag_validation
+
+    monkeypatch.setattr(
+        orrery_tag_validation,
+        "read_tag_library",
+        lambda _dbname: [
+            _tag_entry("character", "bodyform", "human"),
+            _tag_entry("character", "disposition", "perceptive"),
+            _tag_entry("place", "place_class", "haven"),
+            _tag_entry("faction", "ideology", "loyalist"),
+        ],
+    )
+    monkeypatch.setattr(
+        orrery_tag_validation,
+        "read_pair_tag_library",
+        lambda _dbname: ["protects", "contact:social", "status:junior"],
+    )
+    monkeypatch.setattr(
+        orrery_tag_validation,
+        "read_event_types",
+        lambda _dbname: ["evade_pursuit", "slept"],
+    )
+
+
 def _storyteller_response(
     *,
     tag_hints: Optional[List[str]] = None,
     pair_tag_hints: Optional[List[dict[str, str]]] = None,
+    state_updates: Optional[dict[str, Any]] = None,
+    orrery_adjudications: Optional[List[dict[str, Any]]] = None,
 ) -> StorytellerResponseExtended:
     return StorytellerResponseExtended.model_validate(
         {
@@ -143,9 +189,9 @@ def _storyteller_response(
             "choices": ["Question Marra.", "Keep walking."],
             "chunk_metadata": {},
             "referenced_entities": {},
-            "state_updates": {},
+            "state_updates": state_updates or {},
             "operations": None,
-            "orrery_adjudications": [],
+            "orrery_adjudications": orrery_adjudications or [],
             "new_entities": [
                 {
                     "kind": "character",
@@ -227,6 +273,70 @@ def test_kind_incompatible_tags_are_flagged() -> None:
     assert "haven" in issues[0]
 
 
+@pytest.mark.parametrize(
+    ("kind", "valid_tag", "invalid_tag"),
+    [
+        ("character", "human", "haven"),
+        ("place", "haven", "human"),
+        ("faction", "loyalist", "perceptive"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("wire_field", "canonical_field"),
+    [
+        ("tag_add", "applied_tags"),
+        ("tag_clear", "tags_to_clear"),
+    ],
+)
+def test_cached_catalog_validates_single_tags_per_kind_and_field(
+    kind: str,
+    valid_tag: str,
+    invalid_tag: str,
+    wire_field: str,
+    canonical_field: str,
+) -> None:
+    valid = _storyteller_response(
+        state_updates={
+            "updates": [
+                {
+                    "kind": kind,
+                    "name": f"Known {kind}",
+                    wire_field: valid_tag,
+                }
+            ]
+        }
+    )
+    invalid = _storyteller_response(
+        state_updates={
+            "updates": [
+                {
+                    "kind": kind,
+                    "name": f"Known {kind}",
+                    wire_field: invalid_tag,
+                }
+            ]
+        }
+    )
+
+    assert (
+        collect_orrery_tag_issues(
+            valid,
+            FakeRegistryCursor(),
+            vocabulary=_test_vocabulary(),
+        )
+        == []
+    )
+    issues = collect_orrery_tag_issues(
+        invalid,
+        FakeRegistryCursor(),
+        vocabulary=_test_vocabulary(),
+    )
+    assert len(issues) == 1
+    assert canonical_field in issues[0]
+    assert invalid_tag in issues[0]
+    assert kind in issues[0]
+
+
 def test_new_entity_hint_issues_are_path_qualified_and_aggregated() -> None:
     response = _response(
         new_entities=[
@@ -253,7 +363,11 @@ def test_new_entity_hint_issues_are_path_qualified_and_aggregated() -> None:
         ]
     )
 
-    issues = collect_orrery_tag_issues(response, FakeRegistryCursor())
+    issues = collect_orrery_tag_issues(
+        response,
+        FakeRegistryCursor(),
+        vocabulary=_test_vocabulary(),
+    )
 
     assert len(issues) == 3
     assert issues[0].startswith("new_entities[0].tag_hints:")
@@ -274,7 +388,53 @@ def test_registered_new_entity_hints_produce_no_issues() -> None:
         ],
     )
 
-    assert collect_orrery_tag_issues(response, FakeRegistryCursor()) == []
+    assert (
+        collect_orrery_tag_issues(
+            response,
+            FakeRegistryCursor(),
+            vocabulary=_test_vocabulary(),
+        )
+        == []
+    )
+
+
+def test_replacement_event_type_uses_cached_catalog() -> None:
+    valid = _storyteller_response(
+        orrery_adjudications=[
+            {
+                "proposal_id": "proposal-valid",
+                "action": "replace",
+                "replacement_event_type": "slept",
+            }
+        ]
+    )
+    invalid = _storyteller_response(
+        orrery_adjudications=[
+            {
+                "proposal_id": "proposal-invalid",
+                "action": "replace",
+                "replacement_event_type": "invented_event",
+            }
+        ]
+    )
+
+    assert (
+        collect_orrery_tag_issues(
+            valid,
+            FakeRegistryCursor(),
+            vocabulary=_test_vocabulary(),
+        )
+        == []
+    )
+    issues = collect_orrery_tag_issues(
+        invalid,
+        FakeRegistryCursor(),
+        vocabulary=_test_vocabulary(),
+    )
+    assert issues == [
+        "orrery_adjudications[0].replacement_event_type: Unknown or "
+        "deprecated event type 'invented_event'"
+    ]
 
 
 @pytest.mark.parametrize(
@@ -442,10 +602,84 @@ async def test_storyteller_validator_attributes_declaration_failure_to_model_ret
         )
 
     assert "new_entities[0].tag_hints" in exc_info.value.message
-    assert "For applied_tags and tag_hints" in exc_info.value.message
+    assert "For applied_tags, tags_to_clear, and tag_hints" in exc_info.value.message
     assert "pair tags may contain colons" in exc_info.value.message
     assert "'contact:social'" in exc_info.value.message
     assert "resubmit the complete response" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_storyteller_validator_reads_each_catalog_once_per_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nexus.agents.logon import orrery_tag_validation
+    from nexus.api import db_pool
+
+    read_counts = {"tags": 0, "pair_tags": 0, "event_types": 0}
+
+    def read_tags(_dbname: str) -> list[TagLibraryEntry]:
+        read_counts["tags"] += 1
+        return [
+            _tag_entry("character", "bodyform", "human"),
+            _tag_entry("character", "disposition", "perceptive"),
+        ]
+
+    def read_pair_tags(_dbname: str) -> list[str]:
+        read_counts["pair_tags"] += 1
+        return ["protects"]
+
+    def read_registered_event_types(_dbname: str) -> list[str]:
+        read_counts["event_types"] += 1
+        return ["slept"]
+
+    monkeypatch.setattr(orrery_tag_validation, "read_tag_library", read_tags)
+    monkeypatch.setattr(
+        orrery_tag_validation,
+        "read_pair_tag_library",
+        read_pair_tags,
+    )
+    monkeypatch.setattr(
+        orrery_tag_validation,
+        "read_event_types",
+        read_registered_event_types,
+    )
+    monkeypatch.setattr(
+        db_pool,
+        "get_connection",
+        lambda _dbname: FakeRegistryConnection(FakeRegistryCursor()),
+    )
+    validator = build_storyteller_tag_validator("test_slot")
+    assert validator is not None
+    response = _storyteller_response(
+        tag_hints=["human", "perceptive"],
+        pair_tag_hints=[
+            {
+                "tag": "protects",
+                "other_entity_name": "The Lower Sluice",
+                "declared_entity_role": "subject",
+            }
+        ],
+        state_updates={
+            "updates": [
+                {
+                    "kind": "character",
+                    "name": "Brena Tideloft",
+                    "tag_add": "human",
+                    "tag_clear": "perceptive",
+                }
+            ]
+        },
+        orrery_adjudications=[
+            {
+                "proposal_id": "proposal-1",
+                "action": "replace",
+                "replacement_event_type": "slept",
+            }
+        ],
+    )
+
+    assert await validator(SimpleNamespace(retry=0), response) is response
+    assert read_counts == {"tags": 1, "pair_tags": 1, "event_types": 1}
 
 
 def test_provider_repairs_invalid_declaration_inside_structured_retry_budget(
@@ -483,7 +717,7 @@ def test_provider_repairs_invalid_declaration_inside_structured_retry_budget(
         structured_output_retries=1,
         output_validator=build_storyteller_tag_validator("test_slot"),
     )
-    provider.client = SimpleNamespace(responses=FakeResponses())
+    provider.client = cast(Any, SimpleNamespace(responses=FakeResponses()))
 
     parsed, _llm_response = provider.get_structured_completion(
         "Continue the story.", StorytellerResponseExtended
@@ -494,6 +728,136 @@ def test_provider_repairs_invalid_declaration_inside_structured_retry_budget(
     assert len(prompts) == 2
     assert "=== STRUCTURED OUTPUT RETRY ===" in prompts[1]
     assert "new_entities[0].tag_hints" in prompts[1]
+
+
+def _retry_boundary_response(
+    boundary: str,
+    *,
+    valid: bool,
+) -> StorytellerResponseExtended:
+    if boundary == "character_applied_tags":
+        return _storyteller_response(
+            state_updates={
+                "updates": [
+                    {
+                        "kind": "character",
+                        "name": "Brena Tideloft",
+                        "tag_add": "human" if valid else "haven",
+                    }
+                ]
+            }
+        )
+    if boundary == "place_tags_to_clear":
+        return _storyteller_response(
+            state_updates={
+                "updates": [
+                    {
+                        "kind": "place",
+                        "name": "The Lower Sluice",
+                        "tag_clear": "haven" if valid else "human",
+                    }
+                ]
+            }
+        )
+    if boundary == "faction_applied_tags":
+        return _storyteller_response(
+            state_updates={
+                "updates": [
+                    {
+                        "kind": "faction",
+                        "name": "The Sluice Guild",
+                        "tag_add": "loyalist" if valid else "perceptive",
+                    }
+                ]
+            }
+        )
+    if boundary == "tag_hints":
+        return _storyteller_response(tag_hints=["human" if valid else "invented:tag"])
+    if boundary == "pair_tag_hints":
+        return _storyteller_response(
+            pair_tag_hints=[
+                {
+                    "tag": "protects" if valid else "invented_pair_tag",
+                    "other_entity_name": "The Lower Sluice",
+                    "declared_entity_role": "subject",
+                }
+            ]
+        )
+    if boundary == "replacement_event_type":
+        return _storyteller_response(
+            orrery_adjudications=[
+                {
+                    "proposal_id": "proposal-1",
+                    "action": "replace",
+                    "replacement_event_type": ("slept" if valid else "invented_event"),
+                }
+            ]
+        )
+    raise AssertionError(f"Unknown retry boundary {boundary!r}")
+
+
+@pytest.mark.parametrize(
+    ("boundary", "failure_path"),
+    [
+        ("character_applied_tags", "state_updates.characters[0]"),
+        ("place_tags_to_clear", "state_updates.locations[0]"),
+        ("faction_applied_tags", "state_updates.factions[0]"),
+        ("tag_hints", "new_entities[0].tag_hints"),
+        ("pair_tag_hints", "new_entities[0].pair_tag_hints[0].tag"),
+        (
+            "replacement_event_type",
+            "orrery_adjudications[0].replacement_event_type",
+        ),
+    ],
+)
+def test_each_catalog_boundary_consumes_retry_and_returns_valid_output_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+    failure_path: str,
+) -> None:
+    """Every moved catalog is enforced inside the bounded provider retry."""
+
+    from nexus.api import db_pool
+
+    cursor = FakeRegistryCursor()
+    monkeypatch.setattr(
+        db_pool,
+        "get_connection",
+        lambda _dbname: FakeRegistryConnection(cursor),
+    )
+    invalid = _retry_boundary_response(boundary, valid=False)
+    valid = _retry_boundary_response(boundary, valid=True)
+    outputs = [invalid, valid]
+    prompts: list[str] = []
+
+    class FakeResponses:
+        def parse(self, **kwargs: Any) -> Any:
+            prompts.append(kwargs["input"][-1]["content"])
+            output = outputs.pop(0)
+            return SimpleNamespace(
+                output_parsed=output,
+                output_text=output.model_dump_json(),
+                usage=SimpleNamespace(input_tokens=11, output_tokens=22),
+            )
+
+    provider = OpenAIProvider(
+        model="gpt-4.1",
+        api_key="test-key",
+        structured_output_retries=1,
+        output_validator=build_storyteller_tag_validator("test_slot"),
+    )
+    provider.client = cast(Any, SimpleNamespace(responses=FakeResponses()))
+
+    parsed, _llm_response = provider.get_structured_completion(
+        "Continue the story.",
+        StorytellerResponseExtended,
+    )
+
+    assert parsed is valid
+    assert outputs == []
+    assert len(prompts) == 2
+    assert "=== STRUCTURED OUTPUT RETRY ===" in prompts[1]
+    assert failure_path in prompts[1]
 
 
 @pytest.mark.asyncio
@@ -512,6 +876,7 @@ async def test_exhausted_declaration_validation_never_reaches_incubator(
     )
     validator = build_storyteller_tag_validator("test_slot")
     assert validator is not None
+    storyteller_validator = validator
 
     class InvalidDeclarationLore:
         def __init__(self, *_args: Any, **_kwargs: Any) -> None:
@@ -524,7 +889,7 @@ async def test_exhausted_declaration_validation_never_reaches_incubator(
             note: Optional[str] = None,
         ) -> Any:
             del parent_chunk_id, note
-            return await validator(
+            return await storyteller_validator(
                 SimpleNamespace(retry=1),
                 _storyteller_response(tag_hints=["invented:tag"]),
             )
@@ -587,109 +952,47 @@ def test_validator_skipped_without_slot_database() -> None:
     assert build_storyteller_tag_validator("save_05") is not None
 
 
-def test_storyteller_schema_uses_runtime_tag_enums(monkeypatch) -> None:
-    """Native LOGON schema constrains Orrery tags by live entity kind."""
+def test_logon_schema_kwargs_keep_openai_plain_and_anthropic_compact() -> None:
+    from nexus.agents.lore.logon_utility import LogonUtility
 
-    from nexus.agents.logon import orrery_tag_schema
-    from nexus.agents.logon.apex_schema import StorytellerResponseExtended
+    utility = LogonUtility({}, dbname="save_05")
+    utility._validation_dbname = "save_05"
+    utility._provider_wire_type = "openai"
+    assert utility._schema_format_kwargs(StorytellerResponseExtended) == {}
 
-    entries = [
-        _tag_entry("character", "bodyform", "human"),
-        _tag_entry("character", "disposition", "perceptive"),
-        _tag_entry("place", "place_class", "haven"),
-        _tag_entry("faction", "ideology", "loyalist"),
-    ]
-    monkeypatch.setattr(
-        orrery_tag_schema,
-        "read_tag_library",
-        lambda _dbname: entries,
-    )
-
-    schema = storyteller_schema_with_runtime_tag_enums(
+    utility._provider_wire_type = "anthropic"
+    utility._validation_dbname = None
+    utility._schema_format_cache = {}
+    kwargs = utility._schema_format_kwargs(StorytellerResponseExtended)
+    assert set(kwargs) == {"output_config"}
+    schema = kwargs["output_config"]["format"]["schema"]
+    assert schema == storyteller_anthropic_compact_schema(
         StorytellerResponseExtended,
-        "save_05",
+        None,
     )
 
-    assert schema is not None
+
+def test_openai_strict_schema_uses_plain_strings_for_live_catalogs() -> None:
+    """The canonical strict wire schema contains no live vocabulary enums."""
+
+    schema = strict_json_schema(StorytellerResponseExtended)
     defs = schema["$defs"]
-    character_tags = defs["OrreryTagBestowalCharacter"]["properties"]["applied_tags"][
-        "items"
-    ]["enum"]
-    place_tags = defs["OrreryTagBestowalPlace"]["properties"]["applied_tags"]["items"][
-        "enum"
+    bestowal_properties = defs["OrreryTagBestowal"]["properties"]
+    assert bestowal_properties["applied_tags"]["items"] == {"type": "string"}
+    assert bestowal_properties["tags_to_clear"]["items"] == {"type": "string"}
+    declaration_properties = defs["NewEntityDeclaration"]["properties"]
+    assert declaration_properties["tag_hints"]["items"] == {"type": "string"}
+    pair_hint_properties = defs["NewEntityPairTagHint"]["properties"]
+    assert "enum" not in pair_hint_properties["tag"]
+    adjudication_properties = defs["OrreryAdjudication"]["properties"]
+    assert adjudication_properties["replacement_event_type"]["anyOf"] == [
+        {"type": "string"},
+        {"type": "null"},
     ]
-    faction_tags = defs["OrreryTagBestowalFaction"]["properties"]["tags_to_clear"][
-        "items"
-    ]["enum"]
-    assert character_tags == ["human", "perceptive"]
-    assert place_tags == ["haven"]
-    assert faction_tags == ["loyalist"]
-    assert (
-        defs["NewCharacter"]["properties"]["orrery_tags"]["anyOf"][0]["$ref"]
-        == "#/$defs/OrreryTagBestowalCharacter"
-    )
-    assert (
-        defs["LocationStateUpdate"]["properties"]["orrery_tags"]["anyOf"][0]["$ref"]
-        == "#/$defs/OrreryTagBestowalPlace"
-    )
-    assert (
-        defs["FactionStateUpdate"]["properties"]["orrery_tags"]["anyOf"][0]["$ref"]
-        == "#/$defs/OrreryTagBestowalFaction"
-    )
 
 
-def test_storyteller_openai_text_format_wraps_runtime_schema(monkeypatch) -> None:
-    from nexus.agents.logon import orrery_tag_schema
-    from nexus.agents.logon.apex_schema import StorytellerResponseExtended
-
-    monkeypatch.setattr(
-        orrery_tag_schema,
-        "read_tag_library",
-        lambda _dbname: [_tag_entry("character", "bodyform", "human")],
-    )
-
-    text_format = storyteller_openai_text_format(
-        StorytellerResponseExtended,
-        "save_05",
-    )
-
-    assert text_format is not None
-    assert text_format["type"] == "json_schema"
-    assert text_format["strict"] is True
-    assert text_format["schema"]["$defs"]["OrreryTagBestowalCharacter"]["properties"][
-        "applied_tags"
-    ]["items"]["enum"] == ["human"]
-
-
-def test_storyteller_anthropic_output_config_uses_compact_extended_schema(
-    monkeypatch,
-) -> None:
+def test_storyteller_anthropic_output_config_uses_compact_extended_schema() -> None:
     """Anthropic extended turns avoid the full DB-mirroring grammar."""
-
-    from nexus.agents.logon import orrery_tag_schema
-    from nexus.agents.logon.apex_schema import StorytellerResponseExtended
-
-    entries = [
-        _tag_entry("character", "bodyform", "human"),
-        _tag_entry("character", "disposition", "perceptive"),
-        _tag_entry("place", "place_class", "haven"),
-        _tag_entry("faction", "ideology", "loyalist"),
-    ]
-    monkeypatch.setattr(
-        orrery_tag_schema,
-        "read_tag_library",
-        lambda _dbname: entries,
-    )
-    monkeypatch.setattr(
-        orrery_tag_schema,
-        "_read_pair_tags",
-        lambda _dbname: ["hiding", "shelters"],
-    )
-    monkeypatch.setattr(
-        orrery_tag_schema,
-        "_read_event_types",
-        lambda _dbname: ["evade_pursuit", "slept"],
-    )
 
     output_config = storyteller_anthropic_output_config(
         StorytellerResponseExtended,
@@ -725,19 +1028,13 @@ def test_storyteller_anthropic_output_config_uses_compact_extended_schema(
         "description": "Registered tag name to apply.",
     }
     entity_schema = schema["properties"]["new_entities"]["items"]
-    assert entity_schema["properties"]["tag_hints"]["items"]["enum"] == [
-        "haven",
-        "human",
-        "loyalist",
-        "perceptive",
-    ]
+    assert entity_schema["properties"]["tag_hints"]["items"] == {"type": "string"}
     pair_tag_schema = entity_schema["properties"]["pair_tag_hints"]["items"]
-    assert pair_tag_schema["properties"]["tag"]["enum"] == ["hiding", "shelters"]
+    assert pair_tag_schema["properties"]["tag"] == {"type": "string"}
     adjudication_schema = schema["properties"]["orrery_adjudications"]["items"]
-    assert adjudication_schema["properties"]["replacement_event_type"]["enum"] == [
-        "evade_pursuit",
-        "slept",
-    ]
+    assert adjudication_schema["properties"]["replacement_event_type"] == {
+        "type": "string"
+    }
 
     response = StorytellerResponseExtended.model_validate(
         {
@@ -780,6 +1077,62 @@ def test_storyteller_anthropic_output_config_uses_compact_extended_schema(
         "perceptive"
     ]
     assert response.new_entities[0].name == "Marra Kest"
+
+
+def _enum_paths(value: Any, path: str = "$") -> dict[str, list[str]]:
+    enums: dict[str, list[str]] = {}
+    if isinstance(value, dict):
+        if "enum" in value:
+            enums[path] = value["enum"]
+        for key, item in value.items():
+            enums.update(_enum_paths(item, f"{path}.{key}"))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            enums.update(_enum_paths(item, f"{path}[{index}]"))
+    return enums
+
+
+def test_compact_schema_is_small_structural_and_registry_stable() -> None:
+    """Registry identity cannot affect the vocabulary-free compact wire bytes."""
+
+    schema_a = storyteller_anthropic_compact_schema(
+        StorytellerResponseExtended,
+        "fake_registry_a",
+    )
+    schema_b = storyteller_anthropic_compact_schema(
+        StorytellerResponseExtended,
+        "fake_registry_b",
+    )
+    schema_none = storyteller_anthropic_compact_schema(
+        StorytellerResponseExtended,
+        None,
+    )
+    assert schema_a is not None
+    assert schema_a == schema_b == schema_none
+
+    serialized = json.dumps(schema_a, separators=(",", ":"), sort_keys=True)
+    assert len(serialized.encode("utf-8")) <= 3500
+    assert _enum_paths(schema_a) == {
+        "$.properties.state_updates.properties.updates.items.properties.kind": [
+            "character",
+            "place",
+            "faction",
+        ],
+        "$.properties.orrery_adjudications.items.properties.action": [
+            "defer",
+            "replace",
+            "void",
+        ],
+        "$.properties.new_entities.items.properties.kind": [
+            "character",
+            "place",
+            "faction",
+        ],
+        (
+            "$.properties.new_entities.items.properties.pair_tag_hints.items."
+            "properties.declared_entity_role"
+        ): ["subject", "object"],
+    }
 
 
 def _tag_entry(entity_kind: str, category: str, tag: str) -> TagLibraryEntry:

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -33,6 +33,7 @@ from nexus.agents.logon.orrery_tag_validation import (
 from nexus.agents.orrery.tag_library import TagLibraryEntry
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
 from nexus.api.native_structured_output import strict_json_schema
+from scripts.api_anthropic import AnthropicProvider
 from scripts.api_openai import OpenAIProvider
 
 
@@ -730,6 +731,178 @@ def test_provider_repairs_invalid_declaration_inside_structured_retry_budget(
     assert "new_entities[0].tag_hints" in prompts[1]
 
 
+def test_openai_chat_transport_repairs_invalid_declaration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The local-model Chat transport enforces catalog validation and repair."""
+
+    from nexus.api import db_pool
+
+    monkeypatch.setattr(
+        db_pool,
+        "get_connection",
+        lambda _dbname: FakeRegistryConnection(FakeRegistryCursor()),
+    )
+    invalid = _storyteller_response(tag_hints=["invented:tag"])
+    repaired = _storyteller_response(tag_hints=["human"])
+    outputs = [invalid, repaired]
+    prompts: list[str] = []
+
+    class FakeChatCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            prompts.append(kwargs["messages"][-1]["content"])
+            output = outputs.pop(0)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content=output.model_dump_json())
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=11, completion_tokens=22),
+            )
+
+    provider = OpenAIProvider(
+        model="local-test-model",
+        api_key="test-key",
+        base_url="http://127.0.0.1:8012/v1",
+        structured_transport="chat_completions",
+        structured_output_retries=1,
+        output_validator=build_storyteller_tag_validator("test_slot"),
+    )
+    provider.client = cast(
+        Any,
+        SimpleNamespace(
+            chat=SimpleNamespace(completions=FakeChatCompletions()),
+        ),
+    )
+
+    parsed, llm_response = provider.get_structured_completion(
+        "Continue the story.",
+        StorytellerResponseExtended,
+    )
+
+    assert parsed == repaired
+    assert llm_response.content == repaired.model_dump_json()
+    assert llm_response.content != invalid.model_dump_json()
+    assert outputs == []
+    assert len(prompts) == 2
+    assert "=== STRUCTURED OUTPUT RETRY ===" in prompts[1]
+    assert "new_entities[0].tag_hints" in prompts[1]
+
+
+def test_anthropic_transport_repairs_invalid_declaration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anthropic Messages enforces catalog validation inside its retry loop."""
+
+    from nexus.api import db_pool
+
+    monkeypatch.setattr(
+        db_pool,
+        "get_connection",
+        lambda _dbname: FakeRegistryConnection(FakeRegistryCursor()),
+    )
+    invalid = _storyteller_response(tag_hints=["invented:tag"])
+    repaired = _storyteller_response(tag_hints=["human"])
+    outputs = [invalid, repaired]
+    prompts: list[str] = []
+
+    class FakeMessages:
+        def create(self, **kwargs: Any) -> Any:
+            prompts.append(kwargs["messages"][-1]["content"])
+            output = outputs.pop(0)
+            return SimpleNamespace(
+                content=[
+                    SimpleNamespace(type="text", text=output.model_dump_json()),
+                ],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        structured_output_retries=1,
+        output_validator=build_storyteller_tag_validator("test_slot"),
+    )
+    provider.client = cast(
+        Any,
+        SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages())),
+    )
+
+    parsed, llm_response = provider.get_structured_completion(
+        "Continue the story.",
+        StorytellerResponseExtended,
+    )
+
+    assert parsed == repaired
+    assert llm_response.content == repaired.model_dump_json()
+    assert llm_response.content != invalid.model_dump_json()
+    assert outputs == []
+    assert len(prompts) == 2
+    assert "=== STRUCTURED OUTPUT RETRY ===" in prompts[1]
+    assert "new_entities[0].tag_hints" in prompts[1]
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_transport_async_repairs_invalid_declaration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real async Chat entry point reaches the same catalog validator."""
+
+    from nexus.api import db_pool
+
+    monkeypatch.setattr(
+        db_pool,
+        "get_connection",
+        lambda _dbname: FakeRegistryConnection(FakeRegistryCursor()),
+    )
+    invalid = _storyteller_response(tag_hints=["invented:tag"])
+    repaired = _storyteller_response(tag_hints=["human"])
+    outputs = [invalid, repaired]
+    prompts: list[str] = []
+
+    class FakeChatCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            prompts.append(kwargs["messages"][-1]["content"])
+            output = outputs.pop(0)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content=output.model_dump_json())
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=11, completion_tokens=22),
+            )
+
+    provider = OpenAIProvider(
+        model="local-test-model",
+        api_key="test-key",
+        base_url="http://127.0.0.1:8012/v1",
+        structured_transport="chat_completions",
+        structured_output_retries=1,
+        output_validator=build_storyteller_tag_validator("test_slot"),
+    )
+    provider.client = cast(
+        Any,
+        SimpleNamespace(
+            chat=SimpleNamespace(completions=FakeChatCompletions()),
+        ),
+    )
+
+    parsed, llm_response = await provider.get_structured_completion_async(
+        "Continue the story.",
+        StorytellerResponseExtended,
+    )
+
+    assert parsed == repaired
+    assert llm_response.content == repaired.model_dump_json()
+    assert llm_response.content != invalid.model_dump_json()
+    assert outputs == []
+    assert len(prompts) == 2
+    assert "=== STRUCTURED OUTPUT RETRY ===" in prompts[1]
+    assert "new_entities[0].tag_hints" in prompts[1]
+
+
 def _retry_boundary_response(
     boundary: str,
     *,
@@ -1092,6 +1265,12 @@ def _enum_paths(value: Any, path: str = "$") -> dict[str, list[str]]:
     return enums
 
 
+def _compact_schema_bytes(schema: dict[str, Any]) -> bytes:
+    """Serialize a compact schema using the canonical wire comparison form."""
+
+    return json.dumps(schema, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
 def test_compact_schema_is_small_structural_and_registry_stable() -> None:
     """Registry identity cannot affect the vocabulary-free compact wire bytes."""
 
@@ -1108,11 +1287,79 @@ def test_compact_schema_is_small_structural_and_registry_stable() -> None:
         None,
     )
     assert schema_a is not None
+    assert schema_b is not None
+    assert schema_none is not None
     assert schema_a == schema_b == schema_none
 
-    serialized = json.dumps(schema_a, separators=(",", ":"), sort_keys=True)
-    assert len(serialized.encode("utf-8")) <= 3500
+    serialized_a = _compact_schema_bytes(schema_a)
+    serialized_b = _compact_schema_bytes(schema_b)
+    serialized_none = _compact_schema_bytes(schema_none)
+    assert serialized_a == serialized_b == serialized_none
+    assert len(serialized_a) <= 3500
     assert _enum_paths(schema_a) == {
+        "$.properties.state_updates.properties.updates.items.properties.kind": [
+            "character",
+            "place",
+            "faction",
+        ],
+        "$.properties.orrery_adjudications.items.properties.action": [
+            "defer",
+            "replace",
+            "void",
+        ],
+        "$.properties.new_entities.items.properties.kind": [
+            "character",
+            "place",
+            "faction",
+        ],
+        (
+            "$.properties.new_entities.items.properties.pair_tag_hints.items."
+            "properties.declared_entity_role"
+        ): ["subject", "object"],
+    }
+
+
+@pytest.mark.requires_postgres
+def test_compact_schema_matches_populated_slot_registry_live() -> None:
+    """A populated save_05 registry cannot alter compact schema wire bytes."""
+
+    import psycopg2
+
+    from nexus.api.slot_utils import get_slot_db_url
+
+    with psycopg2.connect(get_slot_db_url(slot=5)) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    (SELECT count(*) FROM tags
+                     WHERE deprecated = FALSE AND synonym_for IS NULL),
+                    (SELECT count(*) FROM pair_tags WHERE deprecated = FALSE),
+                    (SELECT count(*) FROM event_types WHERE deprecated = FALSE)
+                """
+            )
+            registry_counts = cur.fetchone()
+            assert registry_counts is not None
+            tag_count, pair_tag_count, event_type_count = (
+                int(value) for value in registry_counts
+            )
+
+    assert tag_count > 0, "save_05 must have registered entity tags"
+    assert pair_tag_count > 0, "save_05 must have registered pair tags"
+    assert event_type_count > 0, "save_05 must have registered event types"
+
+    schema_live = storyteller_anthropic_compact_schema(
+        StorytellerResponseExtended,
+        "save_05",
+    )
+    schema_none = storyteller_anthropic_compact_schema(
+        StorytellerResponseExtended,
+        None,
+    )
+    assert schema_live is not None
+    assert schema_none is not None
+    assert _compact_schema_bytes(schema_live) == _compact_schema_bytes(schema_none)
+    assert _enum_paths(schema_live) == {
         "$.properties.state_updates.properties.updates.items.properties.kind": [
             "character",
             "place",


### PR DESCRIPTION
Closes #553. Stage 1 of the schema-weight campaign (Arachne ruling seq 7, relayed on the issue).

## What Changed

- **No live-registry enums on the wire.** `storyteller_schema_with_runtime_tag_enums` and the vocabulary plumbing in the compact builder are gone; catalog-valued fields (`applied_tags`, `tags_to_clear`, `tag_hints`, `pair_tag_hints[].tag`, `replacement_event_type`) are plain strings on both provider paths.
- **Generation-time semantic validation covers every moved boundary.** `orrery_tag_validation` now takes a per-attempt `StorytellerVocabulary` snapshot (one registry read per validation pass), enforces per-kind tag compatibility, and adds the previously uncovered `replacement_event_type` check. Failures raise `ModelRetry` into the existing bounded repair loop with field-qualified paths.
- **Schema stability across registry growth.** The compact extended-turn schema is byte-identical for any `dbname` (including `None`), enforced by a regression test with a 3.5 KB budget and an explicit structural-enum allowlist.
- **Loud errors.** The `try/except -> logger.warning` wrapper around schema construction is removed per repo doctrine.
- A latent hole fixed en route: `replacement_event_type` was silently absent from the compact schema whenever the event-type registry was empty; it is now always present as a plain string.

## Measurements (o200k, save_05)

| Wire schema | Before | After |
|---|---:|---:|
| OpenAI Extended | 13,585 tok | 9,033 tok |
| Compact Extended | 3,088 tok | 583 tok |

## Verification

- `tests/test_orrery_tag_validation.py`: 34 passed (rewritten — covers all six moved boundaries valid+invalid through the real `OpenAIProvider.get_structured_completion` retry loop, per-attempt catalog caching, incubator-gate integration via the real `generate_narrative_async` entry point, and the stability/budget test).
- Full import blast radius (`test_narrative_generation`, `test_logon_lazy_init`, `test_logon_prompt_formatting`, `test_typed_memory_identity`, + the new file): 66 passed, 2 skipped.
- Commit-time ring (`-k "declaration or maturation"`): 36 passed, 23 skipped (live-gated).
- black / mypy / flake8 clean on all five touched files.

## Descoped (tracked on #553)

Live provider A/B (first-pass validity, retry rate, latency on Anthropic + local Hermes) belongs to the campaign's measurement stage per the ruling — the optimized schema is the first configuration local models get a fair trial on.

Implemented by Codex (GPT-5) from a frozen work order; reviewed, gated, and verified by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ