### PR TITLE
Rebuild the wire updates block as a per-kind namespace (#566)

### DIFF
--- a/nexus/agents/logon/orrery_tag_validation.py
+++ b/nexus/agents/logon/orrery_tag_validation.py
@@ -66,23 +66,24 @@ def _bestowal_sites(response: Any) -> List[Tuple[str, str, OrreryTagBestowal]]:
 
     sites: List[Tuple[str, str, OrreryTagBestowal]] = []
 
-    for index, update in enumerate(getattr(response, "updates", None) or []):
-        entity_kind = getattr(update, "kind", None)
-        if entity_kind not in {"character", "place", "faction"}:
-            continue
-        tags_add = getattr(update, "tags_add", None)
-        tags_clear = getattr(update, "tags_clear", None)
-        if tags_add is not None or tags_clear is not None:
-            sites.append(
-                (
-                    f"updates[{index}]",
-                    entity_kind,
-                    OrreryTagBestowal(
-                        applied_tags=tags_add or [],
-                        tags_to_clear=tags_clear or [],
-                    ),
-                )
-            )
+    updates = getattr(response, "updates", None)
+    if updates is not None:
+        for array_name in ("characters", "places", "factions", "relationships"):
+            entity_kind = array_name.removesuffix("s")
+            for index, update in enumerate(getattr(updates, array_name)):
+                tags_add = getattr(update, "tags_add", None)
+                tags_clear = getattr(update, "tags_clear", None)
+                if tags_add is not None or tags_clear is not None:
+                    sites.append(
+                        (
+                            f"updates.{array_name}[{index}]",
+                            entity_kind,
+                            OrreryTagBestowal(
+                                applied_tags=tags_add or [],
+                                tags_to_clear=tags_clear or [],
+                            ),
+                        )
+                    )
 
     state_updates = getattr(response, "state_updates", None)
     if state_updates is not None:

--- a/nexus/agents/logon/skald_wire.py
+++ b/nexus/agents/logon/skald_wire.py
@@ -6,7 +6,7 @@ per-chunk mentions, never members of the carried scene roster.
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -179,7 +179,6 @@ class PresenceBaseline(BaseModel):
 class CharacterUpdateDelta(BaseModel):
     """Sparse character state changes."""
 
-    kind: Literal["character"] = Field(description="Character update.")
     name: str = Field(min_length=1, description="Canonical character name.")
     id: Optional[int] = Field(default=None, description="Canonical ID when known.")
     activity: Optional[str] = Field(default=None, description="Current activity.")
@@ -224,7 +223,6 @@ class CharacterUpdateDelta(BaseModel):
 class PlaceUpdateDelta(BaseModel):
     """Sparse place state changes."""
 
-    kind: Literal["place"] = Field(description="Place update.")
     name: str = Field(min_length=1, description="Canonical place name.")
     id: Optional[int] = Field(default=None, description="Canonical ID when known.")
     condition: Optional[str] = Field(default=None, description="Current conditions.")
@@ -262,7 +260,6 @@ class PlaceUpdateDelta(BaseModel):
 class FactionUpdateDelta(BaseModel):
     """Sparse faction state changes."""
 
-    kind: Literal["faction"] = Field(description="Faction update.")
     name: str = Field(min_length=1, description="Canonical faction name.")
     id: Optional[int] = Field(default=None, description="Canonical ID when known.")
     action: Optional[str] = Field(default=None, description="One recent action.")
@@ -303,7 +300,6 @@ class FactionUpdateDelta(BaseModel):
 class RelationshipUpdateDelta(BaseModel):
     """Sparse relationship state changes."""
 
-    kind: Literal["relationship"] = Field(description="Relationship update.")
     name: str = Field(min_length=1, description="First character name.")
     other_name: str = Field(min_length=1, description="Second character name.")
     id: Optional[int] = Field(default=None, description="First character ID.")
@@ -344,15 +340,19 @@ class RelationshipUpdateDelta(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
 
-UpdateDelta = Annotated[
-    Union[
-        CharacterUpdateDelta,
-        PlaceUpdateDelta,
-        FactionUpdateDelta,
-        RelationshipUpdateDelta,
-    ],
-    Field(discriminator="kind"),
-]
+class UpdatesBlock(BaseModel):
+    """Namespaced semantic state changes."""
+
+    characters: List[CharacterUpdateDelta] = Field(
+        description="Character state changes."
+    )
+    places: List[PlaceUpdateDelta] = Field(description="Place state changes.")
+    factions: List[FactionUpdateDelta] = Field(description="Faction state changes.")
+    relationships: List[RelationshipUpdateDelta] = Field(
+        description="Relationship state changes."
+    )
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class SkaldTurnWire(BaseModel):
@@ -372,8 +372,8 @@ class SkaldTurnWire(BaseModel):
         default=None,
         description="Scene presence and reference changes.",
     )
-    updates: List[UpdateDelta] = Field(
-        default_factory=list,
+    updates: Optional[UpdatesBlock] = Field(
+        default=None,
         description="Durable semantic state changes.",
     )
     operations: Optional[Operations] = Field(
@@ -557,83 +557,87 @@ def _hydrate_tags(
     )
 
 
-def _hydrate_updates(updates: List[UpdateDelta]) -> StateUpdates:
-    """Map semantic update arms to canonical nested state lists."""
+def _hydrate_updates(updates: Optional[UpdatesBlock]) -> StateUpdates:
+    """Map namespaced semantic updates to canonical nested state lists."""
+
+    if updates is None:
+        return StateUpdates()
 
     characters: List[CharacterStateUpdate] = []
     locations: List[LocationStateUpdate] = []
     factions: List[FactionStateUpdate] = []
     relationships: List[RelationshipUpdate] = []
 
-    for update in updates:
-        if isinstance(update, CharacterUpdateDelta):
-            characters.append(
-                CharacterStateUpdate(
-                    character_id=update.id,
-                    character_name=update.name,
-                    current_location=update.location,
-                    current_activity=update.activity,
-                    emotional_state=update.emotional_state,
-                    extra_observations=update.observations or [],
-                    orrery_tags=_hydrate_tags(
-                        update.tags_add,
-                        update.tags_clear,
-                    ),
-                )
+    for character_update in updates.characters:
+        characters.append(
+            CharacterStateUpdate(
+                character_id=character_update.id,
+                character_name=character_update.name,
+                current_location=character_update.location,
+                current_activity=character_update.activity,
+                emotional_state=character_update.emotional_state,
+                extra_observations=character_update.observations or [],
+                orrery_tags=_hydrate_tags(
+                    character_update.tags_add,
+                    character_update.tags_clear,
+                ),
             )
-        elif isinstance(update, PlaceUpdateDelta):
-            locations.append(
-                LocationStateUpdate(
-                    place_id=update.id,
-                    place_name=update.name,
-                    current_conditions=update.condition,
-                    notable_changes=(
-                        [update.notable_change]
-                        if update.notable_change is not None
-                        else []
-                    ),
-                    orrery_tags=_hydrate_tags(
-                        update.tags_add,
-                        update.tags_clear,
-                    ),
-                )
+        )
+    for place_update in updates.places:
+        locations.append(
+            LocationStateUpdate(
+                place_id=place_update.id,
+                place_name=place_update.name,
+                current_conditions=place_update.condition,
+                notable_changes=(
+                    [place_update.notable_change]
+                    if place_update.notable_change is not None
+                    else []
+                ),
+                orrery_tags=_hydrate_tags(
+                    place_update.tags_add,
+                    place_update.tags_clear,
+                ),
             )
-        elif isinstance(update, FactionUpdateDelta):
-            factions.append(
-                FactionStateUpdate(
-                    faction_id=update.id,
-                    faction_name=update.name,
-                    recent_actions=[update.action] if update.action is not None else [],
-                    stance_changes=(
-                        [
-                            FactionStanceChange(
-                                target=update.stance_toward,
-                                stance=update.stance,
-                            )
-                        ]
-                        if update.stance_toward is not None
-                        and update.stance is not None
-                        else []
-                    ),
-                    orrery_tags=_hydrate_tags(
-                        update.tags_add,
-                        update.tags_clear,
-                    ),
-                )
+        )
+    for faction_update in updates.factions:
+        factions.append(
+            FactionStateUpdate(
+                faction_id=faction_update.id,
+                faction_name=faction_update.name,
+                recent_actions=(
+                    [faction_update.action] if faction_update.action is not None else []
+                ),
+                stance_changes=(
+                    [
+                        FactionStanceChange(
+                            target=faction_update.stance_toward,
+                            stance=faction_update.stance,
+                        )
+                    ]
+                    if faction_update.stance_toward is not None
+                    and faction_update.stance is not None
+                    else []
+                ),
+                orrery_tags=_hydrate_tags(
+                    faction_update.tags_add,
+                    faction_update.tags_clear,
+                ),
             )
-        else:
-            relationships.append(
-                RelationshipUpdate(
-                    character1_id=update.id,
-                    character1_name=update.name,
-                    character2_id=update.other_id,
-                    character2_name=update.other_name,
-                    relationship_type=update.type,
-                    emotional_valence=update.valence,
-                    dynamic=update.dynamic,
-                    recent_events=update.recent_events,
-                )
+        )
+    for relationship_update in updates.relationships:
+        relationships.append(
+            RelationshipUpdate(
+                character1_id=relationship_update.id,
+                character1_name=relationship_update.name,
+                character2_id=relationship_update.other_id,
+                character2_name=relationship_update.other_name,
+                relationship_type=relationship_update.type,
+                emotional_valence=relationship_update.valence,
+                dynamic=relationship_update.dynamic,
+                recent_events=relationship_update.recent_events,
             )
+        )
 
     return StateUpdates(
         characters=characters,

--- a/nexus/api/mock_openai.py
+++ b/nexus/api/mock_openai.py
@@ -1096,7 +1096,7 @@ async def responses_create(request: ResponsesRequest):
 
     # Exact routing: the structured-output tool's schema says which
     # Storyteller response the caller validates against. Turn requests
-    # (SkaldTurnWire) carry updates; bootstrap requests
+    # (SkaldTurnWire) expose the optional updates namespace; bootstrap requests
     # (StorytellerResponseBootstrap) do not.
     output_fields = _requested_output_properties(request)
     if output_fields:

--- a/nexus/api/native_structured_output.py
+++ b/nexus/api/native_structured_output.py
@@ -120,10 +120,9 @@ def _rewrite_anthropic_schema(value: Any) -> Any:
         return value
     return {
         # Anthropic's native format rejects oneOf (Pydantic emits it for
-        # discriminated unions, e.g. SkaldTurnWire.updates). anyOf is the
-        # accepted, semantically-wider spelling; app-side Pydantic still
-        # enforces the discriminator after parse. Found live on the first
-        # universal-wire Anthropic turn (measurement stage).
+        # discriminated unions). anyOf is the accepted, semantically-wider
+        # spelling; app-side Pydantic still enforces the discriminator after
+        # parse. Found live during the universal-wire measurement stage.
         ("anyOf" if key == "oneOf" else key): _rewrite_anthropic_schema(item)
         for key, item in value.items()
         if key not in ANTHROPIC_UNSUPPORTED_SCHEMA_KEYS

--- a/prompts/storyteller_core.md
+++ b/prompts/storyteller_core.md
@@ -107,7 +107,7 @@ Design heritage: Bethesda's Creation Engine (radiant routines, faction state) cr
 **When to apply tags.**
 
 - **New entities** — when declaring a new character / place / faction via `new_entities[].tag_hints`. Apply registered tags by name.
-- **Existing entities** — when an existing character, place, or faction changes, use its matching `updates[]` arm:
+- **Existing entities** — when an existing character, place, or faction changes, use its matching `updates.characters`, `updates.places`, or `updates.factions` array:
   - `tags_add` — add a registered tag that newly applies (the apprentice just bound her first geas → `geas_caster`)
   - `tags_clear` — retire an ephemeral that no longer applies (the pursuers gave up → clear `under_active_pursuit`)
 
@@ -167,7 +167,7 @@ Structured output uses `StorytellerResponseBootstrap` for chunk 1 and `SkaldTurn
 
 - `scene` — only changed chronology or scene attributes. Omit it when nothing changed.
 - `presence` — character `enter` / `exit`, absent-entity `mentions`, and place `transit`. Silence carries the roster and setting forward. On relocation or a scene cut, use `scene_reset` with the new setting place and complete present-character roster; on a reset, list the full roster instead of `enter` / `exit`. Factions appear only in `mentions`.
-- `updates` — semantic deltas for characters, places, factions, and relationships. Record only durable changes, never unchanged state.
+- `updates` — optional object for durable semantic changes. When present, include all four arrays: `characters`, `places`, `factions`, and `relationships`; each array may be empty. Omit the whole block when there are no updates.
 - `new_entities` — persistent declarations under the doctrine below.
 
 **Off-screen updates.** Use `updates` for a few background characters or places when their state genuinely advances. Prioritize narrative pull: consequences, parallel plots, thematic echoes, or future convergence. Small mundane changes can maintain the world's pulse; do not emit unchanged-state filler.

--- a/tests/test_logon_mock_integration.py
+++ b/tests/test_logon_mock_integration.py
@@ -77,5 +77,6 @@ def test_provider_routes_to_mock_server():
         len(response.choices) == 3
     ), f"Expected 3 choices, got {len(response.choices)}"
     assert response.narrative.startswith("[TEST MODE]")
+    assert response.updates is None
     assert response.orrery_adjudications == []
     assert "deterministic mock control" in response.narrative

--- a/tests/test_mock_openai.py
+++ b/tests/test_mock_openai.py
@@ -42,6 +42,7 @@ def test_mock_non_bootstrap_payload_is_sparse_skald_wire() -> None:
     wire = SkaldTurnWire.model_validate(payload)
 
     assert set(payload) == {"narrative", "choices"}
+    assert wire.updates is None
     assert wire.model_dump(exclude_unset=True, mode="json") == payload
 
 
@@ -184,6 +185,7 @@ async def test_mock_responses_routes_turn_schema_without_orrery_proposals() -> N
     assert json.loads(tool_call["arguments"]) == payload
     parsed = SkaldTurnWire.model_validate(payload)
     assert parsed.narrative.startswith("[TEST MODE]")
+    assert parsed.updates is None
     assert parsed.orrery_adjudications == []
 
 
@@ -205,6 +207,7 @@ async def test_mock_responses_routes_turn_schema_as_native_text_format() -> None
     payload = json.loads(response["output_text"])
     parsed = SkaldTurnWire.model_validate(payload)
     assert parsed.narrative.startswith("[TEST MODE]")
+    assert parsed.updates is None
     assert parsed.orrery_adjudications == []
 
 

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -179,24 +179,31 @@ def test_de_null_schema_is_total_for_arbitrary_json_shapes(value: object) -> Non
     de_null_schema(value)
 
 
-def test_anthropic_rewrites_representative_pydantic_discriminated_union() -> None:
+def test_anthropic_preserves_wire_updates_namespace_after_lenient_transform() -> None:
     raw_schema = SkaldTurnWire.model_json_schema()
-    raw_items = raw_schema["properties"]["updates"]["items"]
+    assert raw_schema["properties"]["updates"]["anyOf"] == [
+        {"$ref": "#/$defs/UpdatesBlock"},
+        {"type": "null"},
+    ]
 
-    # Pydantic emits oneOf, never a simultaneous oneOf/anyOf collision here.
-    assert "oneOf" in raw_items
-    assert "anyOf" not in raw_items
-    assert "discriminator" in raw_items
-
+    lenient_schema = skald_wire_lenient_schema()
     transformed = anthropic_output_format(
         SkaldTurnWire,
-        schema=raw_schema,
+        schema=lenient_schema,
     )["schema"]
-    transformed_items = transformed["properties"]["updates"]["items"]
-
-    assert "oneOf" not in transformed_items
-    assert "discriminator" not in transformed_items
-    assert transformed_items["anyOf"] == raw_items["oneOf"]
+    assert transformed["properties"]["updates"] == {
+        "$ref": "#/$defs/UpdatesBlock",
+        "description": "Durable semantic state changes.",
+    }
+    assert transformed["$defs"]["UpdatesBlock"]["required"] == [
+        "characters",
+        "places",
+        "factions",
+        "relationships",
+    ]
+    assert not _contains_key(transformed, "oneOf")
+    assert not _contains_key(transformed, "discriminator")
+    assert not _contains_key(transformed, "anyOf")
 
 
 def test_anthropic_one_of_rewrite_recurses_through_lists_and_dicts() -> None:

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -171,41 +171,63 @@ def _storyteller_response(
     *,
     tag_hints: Optional[List[str]] = None,
     pair_tag_hints: Optional[List[dict[str, str]]] = None,
-    updates: Optional[List[dict[str, Any]]] = None,
+    updates: Optional[dict[str, List[dict[str, Any]]]] = None,
     orrery_adjudications: Optional[List[dict[str, Any]]] = None,
 ) -> SkaldTurnWire:
-    return SkaldTurnWire.model_validate(
-        {
-            "narrative": "Marra Kest steps out from behind the sluice gate.",
-            "choices": ["Question Marra.", "Keep walking."],
-            "updates": updates or [],
-            "orrery_adjudications": orrery_adjudications or [],
-            "new_entities": [
-                {
-                    "kind": "character",
-                    "name": "Marra Kest",
-                    "summary": "A sluice keeper with divided loyalties.",
-                    "tag_hints": tag_hints or [],
-                    "pair_tag_hints": pair_tag_hints or [],
-                }
-            ],
-        }
-    )
+    payload: dict[str, Any] = {
+        "narrative": "Marra Kest steps out from behind the sluice gate.",
+        "choices": ["Question Marra.", "Keep walking."],
+        "orrery_adjudications": orrery_adjudications or [],
+        "new_entities": [
+            {
+                "kind": "character",
+                "name": "Marra Kest",
+                "summary": "A sluice keeper with divided loyalties.",
+                "tag_hints": tag_hints or [],
+                "pair_tag_hints": pair_tag_hints or [],
+            }
+        ],
+    }
+    if updates is not None:
+        payload["updates"] = updates
+    return SkaldTurnWire.model_validate(payload)
 
 
-def _state_updates_with_tag(
+def _updates_block(
+    *,
+    characters: Optional[List[dict[str, Any]]] = None,
+    places: Optional[List[dict[str, Any]]] = None,
+    factions: Optional[List[dict[str, Any]]] = None,
+    relationships: Optional[List[dict[str, Any]]] = None,
+) -> dict[str, List[dict[str, Any]]]:
+    """Build the complete provider-facing updates namespace."""
+
+    return {
+        "characters": characters or [],
+        "places": places or [],
+        "factions": factions or [],
+        "relationships": relationships or [],
+    }
+
+
+def _updates_block_with_tag(
     kind: str,
     name: str,
     field_name: str,
     tag_name: str,
-) -> List[dict[str, Any]]:
+) -> dict[str, List[dict[str, Any]]]:
     """Build one semantic update with an Orrery tag delta."""
 
     wire_field = {
         "applied_tags": "tags_add",
         "tags_to_clear": "tags_clear",
     }[field_name]
-    return [{"kind": kind, "name": name, wire_field: [tag_name]}]
+    array_name = {
+        "character": "characters",
+        "place": "places",
+        "faction": "factions",
+    }[kind]
+    return _updates_block(**{array_name: [{"name": name, wire_field: [tag_name]}]})
 
 
 def test_valid_bestowals_produce_no_issues() -> None:
@@ -292,7 +314,7 @@ def test_cached_catalog_validates_single_tags_per_kind_and_field(
     canonical_field: str,
 ) -> None:
     valid = _storyteller_response(
-        updates=_state_updates_with_tag(
+        updates=_updates_block_with_tag(
             kind,
             f"Known {kind}",
             canonical_field,
@@ -300,7 +322,7 @@ def test_cached_catalog_validates_single_tags_per_kind_and_field(
         )
     )
     invalid = _storyteller_response(
-        updates=_state_updates_with_tag(
+        updates=_updates_block_with_tag(
             kind,
             f"Known {kind}",
             canonical_field,
@@ -666,14 +688,15 @@ async def test_storyteller_validator_reads_each_catalog_once_per_attempt(
                 "declared_entity_role": "subject",
             }
         ],
-        updates=[
-            {
-                "kind": "character",
-                "name": "Brena Tideloft",
-                "tags_add": ["human"],
-                "tags_clear": ["perceptive"],
-            }
-        ],
+        updates=_updates_block(
+            characters=[
+                {
+                    "name": "Brena Tideloft",
+                    "tags_add": ["human"],
+                    "tags_clear": ["perceptive"],
+                }
+            ]
+        ),
         orrery_adjudications=[
             {
                 "proposal_id": "proposal-1",
@@ -914,7 +937,7 @@ def _retry_boundary_response(
 ) -> SkaldTurnWire:
     if boundary == "character_applied_tags":
         return _storyteller_response(
-            updates=_state_updates_with_tag(
+            updates=_updates_block_with_tag(
                 "character",
                 "Brena Tideloft",
                 "applied_tags",
@@ -923,7 +946,7 @@ def _retry_boundary_response(
         )
     if boundary == "place_tags_to_clear":
         return _storyteller_response(
-            updates=_state_updates_with_tag(
+            updates=_updates_block_with_tag(
                 "place",
                 "The Lower Sluice",
                 "tags_to_clear",
@@ -932,7 +955,7 @@ def _retry_boundary_response(
         )
     if boundary == "faction_applied_tags":
         return _storyteller_response(
-            updates=_state_updates_with_tag(
+            updates=_updates_block_with_tag(
                 "faction",
                 "The Sluice Guild",
                 "applied_tags",
@@ -967,9 +990,9 @@ def _retry_boundary_response(
 @pytest.mark.parametrize(
     ("boundary", "failure_path", "expected_suggestion"),
     [
-        ("character_applied_tags", "updates[0]", "human"),
-        ("place_tags_to_clear", "updates[0]", None),
-        ("faction_applied_tags", "updates[0]", None),
+        ("character_applied_tags", "updates.characters[0]", "human"),
+        ("place_tags_to_clear", "updates.places[0]", None),
+        ("faction_applied_tags", "updates.factions[0]", None),
         ("tag_hints", "new_entities[0].tag_hints", "human"),
         ("pair_tag_hints", "new_entities[0].pair_tag_hints[0].tag", "protects"),
         (

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -92,6 +92,24 @@ BASELINE = PresenceBaseline(
     setting=PresenceRef(kind="place", name="The Lower Sluice", id=41),
 )
 
+
+def _updates_payload(
+    *,
+    characters: list[dict[str, Any]] | None = None,
+    places: list[dict[str, Any]] | None = None,
+    factions: list[dict[str, Any]] | None = None,
+    relationships: list[dict[str, Any]] | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Build the complete provider-facing updates namespace."""
+
+    return {
+        "characters": characters or [],
+        "places": places or [],
+        "factions": factions or [],
+        "relationships": relationships or [],
+    }
+
+
 RICH_WIRE_PAYLOAD: dict[str, Any] = {
     "narrative": "Brena follows the bell-sound through the flooded stacks.",
     "choices": [
@@ -114,49 +132,53 @@ RICH_WIRE_PAYLOAD: dict[str, Any] = {
         ],
         "transit": [{"kind": "place", "name": "The East Lock", "id": 43}],
     },
-    "updates": [
-        {
-            "kind": "character",
-            "name": "Brena Tideloft",
-            "id": 7,
-            "activity": "tracking the drowned clerk",
-            "location": 41,
-            "emotional_state": "alert but composed",
-            "observations": [{"key": "clue", "value": "heard the drowned bell"}],
-            "tags_add": ["perceptive", "alert"],
-            "tags_clear": ["resting"],
-        },
-        {
-            "kind": "place",
-            "name": "The Lower Sluice",
-            "id": 41,
-            "condition": "Floodwater rising between the stacks.",
-            "notable_change": "The archive bell is ringing underwater.",
-            "tags_add": ["hazardous"],
-            "tags_clear": ["sheltered"],
-        },
-        {
-            "kind": "faction",
-            "name": "The Sluice Guild",
-            "id": 12,
-            "action": "Sealed the eastern lock.",
-            "stance_toward": "Brena Tideloft",
-            "stance": "watchful cooperation",
-            "tags_add": ["mobilized"],
-            "tags_clear": ["dormant"],
-        },
-        {
-            "kind": "relationship",
-            "name": "Brena Tideloft",
-            "other_name": "Odile",
-            "id": 7,
-            "other_id": 8,
-            "type": "ally",
-            "valence": "+2|friendly",
-            "dynamic": "Trust sharpened by shared danger.",
-            "recent_events": "Odile stayed behind at the eastern lock.",
-        },
-    ],
+    "updates": _updates_payload(
+        characters=[
+            {
+                "name": "Brena Tideloft",
+                "id": 7,
+                "activity": "tracking the drowned clerk",
+                "location": 41,
+                "emotional_state": "alert but composed",
+                "observations": [{"key": "clue", "value": "heard the drowned bell"}],
+                "tags_add": ["perceptive", "alert"],
+                "tags_clear": ["resting"],
+            }
+        ],
+        places=[
+            {
+                "name": "The Lower Sluice",
+                "id": 41,
+                "condition": "Floodwater rising between the stacks.",
+                "notable_change": "The archive bell is ringing underwater.",
+                "tags_add": ["hazardous"],
+                "tags_clear": ["sheltered"],
+            }
+        ],
+        factions=[
+            {
+                "name": "The Sluice Guild",
+                "id": 12,
+                "action": "Sealed the eastern lock.",
+                "stance_toward": "Brena Tideloft",
+                "stance": "watchful cooperation",
+                "tags_add": ["mobilized"],
+                "tags_clear": ["dormant"],
+            }
+        ],
+        relationships=[
+            {
+                "name": "Brena Tideloft",
+                "other_name": "Odile",
+                "id": 7,
+                "other_id": 8,
+                "type": "ally",
+                "valence": "+2|friendly",
+                "dynamic": "Trust sharpened by shared danger.",
+                "recent_events": "Odile stayed behind at the eastern lock.",
+            }
+        ],
+    ),
     "operations": {
         "request_summary": {
             "summary_type": "episode",
@@ -333,14 +355,15 @@ def _rich_canonical_expectation(wire: SkaldTurnWire) -> StorytellerResponseExten
     )
 
 
-def test_rich_wire_hydrates_every_block_field_by_field() -> None:
+def test_rich_wire_hydrates_mixed_update_namespaces_field_by_field() -> None:
     wire = SkaldTurnWire.model_validate(RICH_WIRE_PAYLOAD)
     actual = hydrate_skald_turn(wire, presence_baseline=BASELINE)
     _assert_canonical_fields_equal(actual, _rich_canonical_expectation(wire))
 
 
 def test_sparse_prose_only_wire_needs_no_baseline() -> None:
-    hydrated = hydrate_skald_turn(SkaldTurnWire.model_validate(SPARSE_WIRE_PAYLOAD))
+    wire = SkaldTurnWire.model_validate(SPARSE_WIRE_PAYLOAD)
+    hydrated = hydrate_skald_turn(wire)
     expected = StorytellerResponseExtended(
         narrative=str(SPARSE_WIRE_PAYLOAD["narrative"]),
         choices=list(SPARSE_WIRE_PAYLOAD["choices"]),
@@ -352,7 +375,87 @@ def test_sparse_prose_only_wire_needs_no_baseline() -> None:
         new_entities=[],
         reasoning=None,
     )
+    assert wire.updates is None
     _assert_canonical_fields_equal(hydrated, expected)
+
+
+def test_present_empty_updates_block_hydrates_to_empty_state_updates() -> None:
+    wire = SkaldTurnWire.model_validate(
+        {**SPARSE_WIRE_PAYLOAD, "updates": _updates_payload()}
+    )
+
+    assert wire.updates is not None
+    assert hydrate_skald_turn(wire).state_updates == StateUpdates()
+
+
+@pytest.mark.parametrize(
+    ("namespace", "item", "state_field", "expected"),
+    [
+        (
+            "characters",
+            {"name": "Brena Tideloft", "activity": "keeping watch"},
+            "characters",
+            CharacterStateUpdate(
+                character_name="Brena Tideloft",
+                current_activity="keeping watch",
+            ),
+        ),
+        (
+            "places",
+            {"name": "The Lower Sluice", "condition": "The lock is sealed."},
+            "locations",
+            LocationStateUpdate(
+                place_name="The Lower Sluice",
+                current_conditions="The lock is sealed.",
+            ),
+        ),
+        (
+            "factions",
+            {"name": "The Sluice Guild", "action": "Sealed the eastern lock."},
+            "factions",
+            FactionStateUpdate(
+                faction_name="The Sluice Guild",
+                recent_actions=["Sealed the eastern lock."],
+            ),
+        ),
+        (
+            "relationships",
+            {
+                "name": "Brena Tideloft",
+                "other_name": "Odile",
+                "dynamic": "Wary cooperation.",
+            },
+            "relationships",
+            RelationshipUpdate(
+                character1_name="Brena Tideloft",
+                character2_name="Odile",
+                dynamic="Wary cooperation.",
+            ),
+        ),
+    ],
+)
+def test_each_update_namespace_hydrates_its_canonical_list(
+    namespace: str,
+    item: dict[str, Any],
+    state_field: str,
+    expected: BaseModel,
+) -> None:
+    wire = SkaldTurnWire.model_validate(
+        {
+            **SPARSE_WIRE_PAYLOAD,
+            "updates": _updates_payload(**{namespace: [item]}),
+        }
+    )
+
+    state_updates = hydrate_skald_turn(wire).state_updates
+    assert getattr(state_updates, state_field) == [expected]
+    assert (
+        sum(
+            bool(getattr(state_updates, field_name))
+            for field_name in ("characters", "locations", "factions", "relationships")
+        )
+        == 1
+    )
 
 
 def test_explicit_null_scene_still_validates_and_hydrates_to_defaults() -> None:
@@ -537,23 +640,26 @@ def test_presence_rejects_same_name_in_enter_and_exit_casefolded() -> None:
 
 
 @pytest.mark.parametrize(
-    ("update", "message"),
+    ("namespace", "update", "message"),
     [
         (
-            {"kind": "character", "name": "Brena Tideloft"},
+            "characters",
+            {"name": "Brena Tideloft"},
             "character update requires a substantive field",
         ),
         (
-            {"kind": "place", "name": "The Lower Sluice"},
+            "places",
+            {"name": "The Lower Sluice"},
             "place update requires a substantive field",
         ),
         (
-            {"kind": "faction", "name": "The Sluice Guild"},
+            "factions",
+            {"name": "The Sluice Guild"},
             "faction update requires a substantive field",
         ),
         (
+            "relationships",
             {
-                "kind": "relationship",
                 "name": "Brena Tideloft",
                 "other_name": "Odile",
             },
@@ -562,11 +668,49 @@ def test_presence_rejects_same_name_in_enter_and_exit_casefolded() -> None:
     ],
 )
 def test_update_arms_require_substantive_fields(
+    namespace: str,
     update: dict[str, Any],
     message: str,
 ) -> None:
     with pytest.raises(ValidationError, match=message):
-        SkaldTurnWire.model_validate({**SPARSE_WIRE_PAYLOAD, "updates": [update]})
+        SkaldTurnWire.model_validate(
+            {
+                **SPARSE_WIRE_PAYLOAD,
+                "updates": _updates_payload(**{namespace: [update]}),
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "missing_namespace",
+    ["characters", "places", "factions", "relationships"],
+)
+def test_present_updates_block_requires_every_namespace(
+    missing_namespace: str,
+) -> None:
+    updates = _updates_payload()
+    del updates[missing_namespace]
+
+    with pytest.raises(ValidationError, match="Field required"):
+        SkaldTurnWire.model_validate({**SPARSE_WIRE_PAYLOAD, "updates": updates})
+
+
+def test_update_items_reject_removed_kind_discriminator() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        SkaldTurnWire.model_validate(
+            {
+                **SPARSE_WIRE_PAYLOAD,
+                "updates": _updates_payload(
+                    characters=[
+                        {
+                            "kind": "character",
+                            "name": "Brena Tideloft",
+                            "activity": "keeping watch",
+                        }
+                    ]
+                ),
+            }
+        )
 
 
 def test_faction_stance_fields_must_travel_together() -> None:
@@ -577,13 +721,14 @@ def test_faction_stance_fields_must_travel_together() -> None:
         SkaldTurnWire.model_validate(
             {
                 **SPARSE_WIRE_PAYLOAD,
-                "updates": [
-                    {
-                        "kind": "faction",
-                        "name": "Guild",
-                        "stance_toward": "Brena",
-                    }
-                ],
+                "updates": _updates_payload(
+                    factions=[
+                        {
+                            "name": "Guild",
+                            "stance_toward": "Brena",
+                        }
+                    ]
+                ),
             }
         )
 
@@ -626,14 +771,18 @@ def test_lenient_sparse_round_trip_has_no_scaffold_keys() -> None:
         "default": None,
         "description": "Changed chronology or scene attributes.",
     }
-    update_items = schema["properties"]["updates"]["items"]
-    assert update_items["discriminator"]["propertyName"] == "kind"
-    assert set(update_items["discriminator"]["mapping"]) == {
-        "character",
-        "place",
-        "faction",
-        "relationship",
+    assert schema["properties"]["updates"] == {
+        "$ref": "#/$defs/UpdatesBlock",
+        "default": None,
+        "description": "Durable semantic state changes.",
     }
+    assert schema["$defs"]["UpdatesBlock"]["required"] == [
+        "characters",
+        "places",
+        "factions",
+        "relationships",
+    ]
+    assert "anyOf" not in schema["properties"]["updates"]
 
     serialized = json.dumps(SPARSE_WIRE_PAYLOAD, separators=(",", ":"))
     wire = SkaldTurnWire.model_validate_json(serialized)
@@ -645,6 +794,17 @@ def test_openai_strict_wire_keeps_required_nullable_spelling() -> None:
 
     assert "scene" in schema["required"]
     assert {"type": "null"} in schema["properties"]["scene"]["anyOf"]
+    assert "updates" in schema["required"]
+    assert schema["properties"]["updates"]["anyOf"] == [
+        {"$ref": "#/$defs/UpdatesBlock"},
+        {"type": "null"},
+    ]
+    assert schema["$defs"]["UpdatesBlock"]["required"] == [
+        "characters",
+        "places",
+        "factions",
+        "relationships",
+    ]
 
 
 def _compact_schema_json(schema: dict[str, Any]) -> str:
@@ -728,15 +888,14 @@ def test_lenient_wire_closes_every_object_schema_node() -> None:
     assert open_object_nodes == []
 
 
-def test_anthropic_wire_stays_within_union_parameter_budget() -> None:
+def test_shipped_anthropic_wire_has_no_union_typed_schema_nodes() -> None:
     utility = LogonUtility({})
     utility._provider_wire_type = "anthropic"
     schema = utility._schema_format_kwargs(SkaldTurnWire)["output_config"]["format"][
         "schema"
     ]
 
-    # Anthropic's live #566 error: "20 parameters with union types... limit: 16".
-    assert _count_union_typed_parameters(schema) <= 16
+    assert _count_union_typed_parameters(schema) == 0
 
 
 def test_wire_schema_size_and_description_budget() -> None:
@@ -888,6 +1047,9 @@ async def test_async_non_bootstrap_logon_requires_parent_chunk_id() -> None:
 def test_storyteller_prompt_defines_reset_and_world_layer_semantics() -> None:
     prompt = (Path(__file__).parents[1] / "prompts" / "storyteller_core.md").read_text()
     assert "on a reset, list the full roster instead of `enter` / `exit`" in prompt
+    assert "When present, include all four arrays" in prompt
+    assert "Omit the whole block when there are no updates" in prompt
+    assert "`updates[]`" not in prompt
     assert "A flashback is a scene set in the past" in prompt
     assert "atemporal means dreams or time-abnormal realms" in prompt
     assert "extradiegetic means the user addressing out-of-game" in prompt


### PR DESCRIPTION
## Summary

Implements Arachne ruling seq 8 (relayed on #566): `SkaldTurnWire.updates` becomes **one optional namespace holding four required per-kind arrays** — `characters`, `places`, `factions`, `relationships` — and the `kind` discriminator is removed (the array an item sits in encodes its type). The block is omitted entirely when a turn carries no updates; when present, all four arrays are required and may be empty.

## Why

The 4-arm `UpdateDelta` discriminated union was the last union-typed node in the de-nulled Anthropic wire (#568 took it 44→1). Live compile probes (full table on #566) showed the ruled namespace shape compiles cleanly on its own (5,354 B, PASS) where the flat union failed alone (6,029 B). The shape also pays off transport-independently: the shipped Anthropic transform now carries **zero union-typed schema nodes**, the lenient wire drops **4,212 → 3,809 o200k tokens (−10%)**, local GBNF shrinks, and the prompt contract simplifies.

## Changes

- `skald_wire.py` — `UpdatesBlock` replaces the union; `kind` stripped from all four arm models (validators and configs untouched); `updates: Optional[UpdatesBlock]`; hydration maps the four arrays through the same per-kind canonical mappings, absent block → empty `StateUpdates`.
- `orrery_tag_validation.py` — traversal walks the namespace with qualified paths (`updates.characters[0]`) for kind-correct repair messages.
- `prompts/storyteller_core.md` — Output section documents the namespace contract.
- `mock_openai.py` / `native_structured_output.py` — comment accuracy only.
- Tests reworked across six files; the zero-union regression drives `LogonUtility._schema_format_kwargs` (the real shipped path, not a fixture).

## Test Results

```
266 passed, 18 skipped (postgres-gated) in 1.57s
mypy: Success (4 source files) · black --check: clean · flake8: clean
```

## Sequencing

The Anthropic transport decision this shape feeds into (prompted-schema default; convergent Sol consult; totalization probed dead) is recorded on #566 and ships as the next PR — both touch `logon_utility`, so they are deliberately sequential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ