### PR TITLE
Add provider-profile payload budgets for storyteller turns (#566)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -209,6 +209,11 @@ max_deep_queries = 5
 apex_context_window = 75_000  # Total tokens available for APEX (includes prompt + context)
 system_prompt_tokens = 5000  # Reserved tokens for system prompt
 
+[lore.token_budget.provider_overrides]
+# Effective apex_context_window per storyteller provider class. Absent key =
+# base value. Local models need a smaller assembled payload (see #566).
+local = 24_000
+
 [lore.payload_percent_budget.structured_summaries]
 # Percentage allocation for entity summaries, relationships, events
 min = 70  # Minimum % for structured data

--- a/nexus.toml
+++ b/nexus.toml
@@ -209,6 +209,9 @@ max_deep_queries = 5
 # Context window limits for APEX generation
 apex_context_window = 75_000  # Total tokens available for APEX (includes prompt + context)
 system_prompt_tokens = 5000  # Reserved tokens for system prompt
+# Reserve for LOGON's tag library and formatting after Phase 5; live chunk
+# 1369 measured +2,999 tokens. Keep headroom above that observed overhead.
+prompt_overhead_tokens = 4_000
 
 [lore.token_budget.provider_overrides]
 # Effective apex_context_window per storyteller provider class. Absent key =

--- a/nexus.toml
+++ b/nexus.toml
@@ -124,7 +124,8 @@ theme = "veil"
 [ui.lore_budget_slider]
 # Bounds, step, and preset ladder stops for the LORE budget slider in the
 # settings pane. Values are token counts for lore.token_budget.apex_context_window.
-min = 10_000
+# Keep this floor aligned with the largest committed provider override below.
+min = 24_000
 max = 200_000
 step = 1000
 stops = [75_000, 100_000, 150_000, 200_000]

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -274,7 +274,9 @@ class LogonUtility:
         self.provider: Optional[OpenAIProvider | AnthropicProvider] = None
         self._system_prompt: Optional[str] = None
         self._provider_bootstrap_mode: Optional[bool] = None
-        self._provider_wire_type: Optional[str] = None
+        self._provider_wire_type: Optional[Literal["openai", "anthropic", "local"]] = (
+            None
+        )
         self._validation_dbname: Optional[str] = None
         self._schema_format_cache: Dict[type, Dict[str, Any]] = {}
 
@@ -466,14 +468,35 @@ class LogonUtility:
         """Return LOGON's wire classification without constructing a provider."""
         return self._resolve_storyteller_route()[3]
 
-    def _initialize_provider(self, is_bootstrap: Optional[bool] = None) -> None:
+    def resolve_storyteller_route(
+        self,
+    ) -> tuple[str, Literal["openai", "anthropic", "local"]]:
+        """Return the concrete storyteller model and its wire class."""
+        model, _provider_type, _endpoint, provider_wire_type = (
+            self._resolve_storyteller_route()
+        )
+        return model, provider_wire_type
+
+    def _initialize_provider(
+        self,
+        is_bootstrap: Optional[bool] = None,
+        *,
+        resolved_route: Optional[
+            tuple[
+                str,
+                str,
+                Optional[Dict[str, Any]],
+                Literal["openai", "anthropic", "local"],
+            ]
+        ] = None,
+    ) -> None:
         """Initialize the appropriate API provider based on settings and slot config."""
         apex_settings = self.settings.get("API Settings", {}).get("apex", {})
         provider_bootstrap_mode = (
             self.bootstrap_mode if is_bootstrap is None else is_bootstrap
         )
 
-        model, provider_type, endpoint, provider_wire_type = (
+        model, provider_type, endpoint, provider_wire_type = resolved_route or (
             self._resolve_storyteller_route()
         )
         base_url = endpoint["base_url"] if endpoint else None
@@ -567,7 +590,11 @@ class LogonUtility:
         logger.info(f"System prompt loaded: {len(system_prompt)} chars")
 
     def _ensure_provider(
-        self, context_payload: Optional[Dict[str, Any]] = None
+        self,
+        context_payload: Optional[Dict[str, Any]] = None,
+        *,
+        expected_model: Optional[str] = None,
+        expected_wire_type: Optional[Literal["openai", "anthropic", "local"]] = None,
     ) -> None:
         """Ensure the provider is initialized before use."""
         desired_bootstrap_mode = (
@@ -576,25 +603,66 @@ class LogonUtility:
             else self.bootstrap_mode
         )
 
+        resolved_route = None
+        if (expected_model is None) != (expected_wire_type is None):
+            raise RuntimeError(
+                "Expected storyteller model and wire class must be supplied together"
+            )
+        if expected_model is not None and expected_wire_type is not None:
+            resolved_route = self._resolve_storyteller_route()
+            resolved_model = resolved_route[0]
+            resolved_wire_type = resolved_route[3]
+            if (
+                resolved_model != expected_model
+                or resolved_wire_type != expected_wire_type
+            ):
+                raise RuntimeError(
+                    "slot model changed mid-turn; aborting the turn: "
+                    f"expected model={expected_model!r}, "
+                    f"wire_class={expected_wire_type!r}; "
+                    f"found model={resolved_model!r}, "
+                    f"wire_class={resolved_wire_type!r}"
+                )
+
         if self.provider is None:
-            self._initialize_provider(desired_bootstrap_mode)
+            if resolved_route is None:
+                self._initialize_provider(desired_bootstrap_mode)
+            else:
+                self._initialize_provider(
+                    desired_bootstrap_mode,
+                    resolved_route=resolved_route,
+                )
             return
 
-        resolved_model = self.model_override or self._get_slot_model()
-        if resolved_model:
-            resolved_model = self._resolve_generation_model(resolved_model)
+        if resolved_route is not None:
+            active_model: Optional[str] = resolved_route[0]
+            active_wire_type: Optional[Literal["openai", "anthropic", "local"]] = (
+                resolved_route[3]
+            )
+        else:
+            active_model = self.model_override or self._get_slot_model()
+            if active_model:
+                active_model = self._resolve_generation_model(active_model)
+            active_wire_type = self._provider_wire_type
         model_changed = bool(
-            resolved_model and getattr(self.provider, "model", None) != resolved_model
+            active_model and getattr(self.provider, "model", None) != active_model
         )
+        wire_type_changed = self._provider_wire_type != active_wire_type
         bootstrap_changed = self._provider_bootstrap_mode != desired_bootstrap_mode
-        if model_changed or bootstrap_changed:
+        if model_changed or wire_type_changed or bootstrap_changed:
             logger.info(
                 "LOGON provider context changed. Reinitializing provider for model %s "
                 "(bootstrap=%s)",
-                resolved_model or getattr(self.provider, "model", None),
+                active_model or getattr(self.provider, "model", None),
                 desired_bootstrap_mode,
             )
-            self._initialize_provider(desired_bootstrap_mode)
+            if resolved_route is None:
+                self._initialize_provider(desired_bootstrap_mode)
+            else:
+                self._initialize_provider(
+                    desired_bootstrap_mode,
+                    resolved_route=resolved_route,
+                )
 
     def ensure_provider(self) -> None:
         """Public wrapper for provider initialization."""
@@ -649,10 +717,18 @@ class LogonUtility:
             raise
 
     async def generate_narrative_async(
-        self, context_payload: Dict[str, Any]
+        self,
+        context_payload: Dict[str, Any],
+        *,
+        expected_model: Optional[str] = None,
+        expected_wire_type: Optional[Literal["openai", "anthropic", "local"]] = None,
     ) -> StoryTurnResponse:
         """Generate narrative from context payload without blocking the event loop."""
-        self._ensure_provider(context_payload)
+        self._ensure_provider(
+            context_payload,
+            expected_model=expected_model,
+            expected_wire_type=expected_wire_type,
+        )
         assert self.provider is not None
         schema_model = self._select_response_schema(context_payload)
         presence_baseline = await self._read_presence_baseline_for_context_async(

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -418,12 +418,16 @@ class LogonUtility:
         """Resolve a runtime roster reference before constructing the provider."""
         return resolve_model_ref(model) if model.startswith("@") else model
 
-    def _initialize_provider(self, is_bootstrap: Optional[bool] = None) -> None:
-        """Initialize the appropriate API provider based on settings and slot config."""
+    def _resolve_storyteller_route(
+        self,
+    ) -> tuple[
+        str,
+        str,
+        Optional[Dict[str, Any]],
+        Literal["openai", "anthropic", "local"],
+    ]:
+        """Resolve the active model, endpoint, and storyteller wire class."""
         apex_settings = self.settings.get("API Settings", {}).get("apex", {})
-        provider_bootstrap_mode = (
-            self.bootstrap_mode if is_bootstrap is None else is_bootstrap
-        )
 
         # Model priority: override > slot config > settings
         model = self.model_override
@@ -440,10 +444,38 @@ class LogonUtility:
         )
 
         # OpenAI-compatible base_url routing (mock TEST server, local servers):
-        # the endpoint lives in the [global.model.api_models] registry (#401).
+        # the endpoint lives in [global.model.api_models] (#401).
         from nexus.config import get_openai_compatible_endpoint
 
         endpoint = get_openai_compatible_endpoint(model)
+        base_url = endpoint["base_url"] if endpoint else None
+
+        provider_wire_type: Literal["openai", "anthropic", "local"]
+        if provider_type == "anthropic":
+            provider_wire_type = "anthropic"
+        elif provider_type == "openai" or base_url:
+            provider_wire_type = "local" if base_url else "openai"
+        else:
+            raise ValueError(f"Unsupported provider type: {provider_type}")
+
+        return model, provider_type, endpoint, provider_wire_type
+
+    def resolve_provider_wire_type(
+        self,
+    ) -> Literal["openai", "anthropic", "local"]:
+        """Return LOGON's wire classification without constructing a provider."""
+        return self._resolve_storyteller_route()[3]
+
+    def _initialize_provider(self, is_bootstrap: Optional[bool] = None) -> None:
+        """Initialize the appropriate API provider based on settings and slot config."""
+        apex_settings = self.settings.get("API Settings", {}).get("apex", {})
+        provider_bootstrap_mode = (
+            self.bootstrap_mode if is_bootstrap is None else is_bootstrap
+        )
+
+        model, provider_type, endpoint, provider_wire_type = (
+            self._resolve_storyteller_route()
+        )
         base_url = endpoint["base_url"] if endpoint else None
         api_key = endpoint["api_key"] if endpoint else None
         structured_transport = cast(
@@ -499,8 +531,8 @@ class LogonUtility:
         self._validation_dbname = validation_dbname
         self._schema_format_cache = {}
 
-        if provider_type == "anthropic":
-            self._provider_wire_type = "anthropic"
+        self._provider_wire_type = provider_wire_type
+        if provider_wire_type == "anthropic":
             self.provider = AnthropicProvider(
                 model=model,
                 max_tokens=apex_settings.get(
@@ -512,10 +544,9 @@ class LogonUtility:
                 structured_output_retries=structured_output_retries,
                 output_validator=output_validator,
             )
-        elif provider_type == "openai" or base_url:
+        else:
             # Native OpenAI, or any OpenAI-compatible server registered with a
             # base_url in [global.model.api_models] (mock TEST, Ollama, vLLM).
-            self._provider_wire_type = "local" if base_url else "openai"
             self.provider = OpenAIProvider(
                 model=model,
                 temperature=apex_settings.get("temperature", 0.7),
@@ -529,8 +560,6 @@ class LogonUtility:
                 structured_output_retries=structured_output_retries,
                 output_validator=output_validator,
             )
-        else:
-            raise ValueError(f"Unsupported provider type: {provider_type}")
 
         logger.info(
             f"LOGON initialized with {provider_type} provider using model {model}"

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -32,6 +32,9 @@ from nexus.agents.logon.skald_wire import (  # noqa: E402
     skald_wire_prompt_guide,
     skald_wire_strict_text_format,
 )
+from nexus.agents.lore.utils.chunk_operations import (  # noqa: E402
+    calculate_chunk_tokens,
+)
 from nexus.agents.orrery.tag_library import (  # noqa: E402
     EntityRowReference,
     TagLibraryContext,
@@ -40,6 +43,9 @@ from nexus.agents.orrery.tag_library import (  # noqa: E402
 )
 from nexus.config.loader import get_provider_for_model, resolve_model_ref  # noqa: E402
 from nexus.memory.context_state import is_retrograde_summary  # noqa: E402
+from nexus.memory.manager import (  # noqa: E402
+    resolve_storyteller_context_window,
+)
 from nexus.memory.retrieval_coverage import coerce_chunk_id  # noqa: E402
 
 logger = logging.getLogger("nexus.lore.logon")
@@ -678,9 +684,20 @@ class LogonUtility:
         response.generation_model = generation_model
         return response
 
-    def generate_narrative(self, context_payload: Dict[str, Any]) -> StoryTurnResponse:
+    def generate_narrative(
+        self,
+        context_payload: Dict[str, Any],
+        *,
+        expected_model: Optional[str] = None,
+        expected_wire_type: Optional[Literal["openai", "anthropic", "local"]] = None,
+        effective_context_window: Optional[int] = None,
+    ) -> StoryTurnResponse:
         """Generate narrative from context payload with structured output."""
-        self._ensure_provider(context_payload)
+        self._ensure_provider(
+            context_payload,
+            expected_model=expected_model,
+            expected_wire_type=expected_wire_type,
+        )
         assert self.provider is not None
         schema_model = self._select_response_schema(context_payload)
         presence_baseline = self._read_presence_baseline_for_context(
@@ -691,6 +708,10 @@ class LogonUtility:
         prompt = self._format_context_prompt(
             context_payload,
             presence_baseline=presence_baseline,
+        )
+        self._enforce_final_prompt_window(
+            prompt,
+            effective_context_window=effective_context_window,
         )
         schema_kwargs = self._schema_format_kwargs(schema_model)
 
@@ -722,6 +743,7 @@ class LogonUtility:
         *,
         expected_model: Optional[str] = None,
         expected_wire_type: Optional[Literal["openai", "anthropic", "local"]] = None,
+        effective_context_window: Optional[int] = None,
     ) -> StoryTurnResponse:
         """Generate narrative from context payload without blocking the event loop."""
         self._ensure_provider(
@@ -738,6 +760,10 @@ class LogonUtility:
         prompt = self._format_context_prompt(
             context_payload,
             presence_baseline=presence_baseline,
+        )
+        self._enforce_final_prompt_window(
+            prompt,
+            effective_context_window=effective_context_window,
         )
         schema_kwargs = self._schema_format_kwargs(schema_model)
 
@@ -762,6 +788,50 @@ class LogonUtility:
         except Exception:
             logger.exception("Failed to get structured response")
             raise
+
+    def _enforce_final_prompt_window(
+        self,
+        prompt: str,
+        *,
+        effective_context_window: Optional[int],
+    ) -> int:
+        """Fail before generation when LOGON formatting exceeds the turn window."""
+        provider_wire_type = self._provider_wire_type
+        if provider_wire_type is None:
+            raise RuntimeError(
+                "Final storyteller prompt sizing requires an active provider "
+                "wire class"
+            )
+        if effective_context_window is None:
+            effective_context_window = resolve_storyteller_context_window(
+                self.settings,
+                provider_wire_type,
+            )
+        if isinstance(effective_context_window, bool) or not isinstance(
+            effective_context_window, int
+        ):
+            raise TypeError("Effective storyteller context window must be an integer")
+        if effective_context_window < 1000:
+            raise ValueError(
+                "Effective storyteller context window must be at least 1000 tokens"
+            )
+
+        prompt_tokens = calculate_chunk_tokens(prompt)
+        logger.debug(
+            "Final storyteller prompt size: wire_class=%s tokens=%s "
+            "effective_window=%s",
+            provider_wire_type,
+            prompt_tokens,
+            effective_context_window,
+        )
+        if prompt_tokens > effective_context_window:
+            raise ValueError(
+                "Final storyteller prompt exceeds the effective context window: "
+                f"wire_class={provider_wire_type!r}, "
+                f"prompt_tokens={prompt_tokens}, "
+                f"effective_window={effective_context_window}"
+            )
+        return prompt_tokens
 
     def _select_response_schema(
         self, context_payload: Dict[str, Any]

--- a/nexus/agents/lore/utils/context_validation.py
+++ b/nexus/agents/lore/utils/context_validation.py
@@ -8,157 +8,191 @@ All validation is done in tokens and percentages, not chunk counts.
 import logging
 from typing import Dict, Any, Tuple, List
 
+from nexus.memory.manager import resolve_storyteller_context_window
+
 logger = logging.getLogger("nexus.lore.context_validation")
 
 
-def validate_context(context: Dict[str, Any], settings: Dict[str, Any]) -> Tuple[bool, List[str]]:
+def validate_context(
+    context: Dict[str, Any],
+    settings: Dict[str, Any],
+    provider_wire_type: str,
+) -> Tuple[bool, List[str]]:
     """
     Validate context payload against constraints from settings.
-    
+
     Args:
         context: Context payload to validate
         settings: Settings dictionary
-        
+        provider_wire_type: Active LOGON storyteller wire class
+
     Returns:
         Tuple of (is_valid, list_of_errors)
     """
     errors = []
-    
+
     # Get LORE settings
     lore_settings = settings.get("Agent Settings", {}).get("LORE", {})
-    
-    # Get token budget settings - apex_context_window is required
-    token_budget = lore_settings.get("token_budget", {})
-    if "apex_context_window" not in token_budget:
-        raise ValueError(
-            "apex_context_window must be configured in the configuration file under "
-            "Agent Settings > LORE > token_budget > apex_context_window"
-        )
-    apex_window = token_budget["apex_context_window"]
-    logger.debug(f"Context validation using apex_context_window: {apex_window} tokens")
-    
+
+    apex_window = resolve_storyteller_context_window(settings, provider_wire_type)
+
     # Get the percentage ranges
     ranges = lore_settings.get("payload_percent_budget", {})
     warm_range = ranges.get("warm_slice", {"min": 40, "max": 70})
     struct_range = ranges.get("structured_summaries", {"min": 10, "max": 25})
     augment_range = ranges.get("contextual_augmentation", {"min": 25, "max": 40})
-    
+
     # Check token limits and allocations
     metadata = context.get("metadata", {})
     token_counts = metadata.get("token_counts", {})
-    
+
     if token_counts:
         total_tokens = sum(token_counts.values())
         if total_tokens > apex_window:
             errors.append(f"Token limit exceeded: {total_tokens:,} > {apex_window:,}")
-        
+
         # Check if each component meets its percentage requirements
         total_context_tokens = (
-            token_counts.get("warm_slice", 0) +
-            token_counts.get("structured", 0) +
-            token_counts.get("augmentation", 0)
+            token_counts.get("warm_slice", 0)
+            + token_counts.get("structured", 0)
+            + token_counts.get("augmentation", 0)
         )
-        
+
         if total_context_tokens > 0:
             # Calculate actual percentages
             warm_pct = (token_counts.get("warm_slice", 0) / total_context_tokens) * 100
-            struct_pct = (token_counts.get("structured", 0) / total_context_tokens) * 100
-            augment_pct = (token_counts.get("augmentation", 0) / total_context_tokens) * 100
-            
+            struct_pct = (
+                token_counts.get("structured", 0) / total_context_tokens
+            ) * 100
+            augment_pct = (
+                token_counts.get("augmentation", 0) / total_context_tokens
+            ) * 100
+
             # Validate warm slice percentage
             if warm_pct < warm_range["min"]:
-                errors.append(f"Warm slice below minimum: {warm_pct:.1f}% < {warm_range['min']}%")
+                errors.append(
+                    f"Warm slice below minimum: {warm_pct:.1f}% < {warm_range['min']}%"
+                )
             elif warm_pct > warm_range["max"]:
-                errors.append(f"Warm slice above maximum: {warm_pct:.1f}% > {warm_range['max']}%")
-            
+                errors.append(
+                    f"Warm slice above maximum: {warm_pct:.1f}% > {warm_range['max']}%"
+                )
+
             # Validate structured data percentage
             if struct_pct < struct_range["min"]:
-                errors.append(f"Structured data below minimum: {struct_pct:.1f}% < {struct_range['min']}%")
+                errors.append(
+                    f"Structured data below minimum: {struct_pct:.1f}% "
+                    f"< {struct_range['min']}%"
+                )
             elif struct_pct > struct_range["max"]:
-                errors.append(f"Structured data above maximum: {struct_pct:.1f}% > {struct_range['max']}%")
-            
+                errors.append(
+                    f"Structured data above maximum: {struct_pct:.1f}% "
+                    f"> {struct_range['max']}%"
+                )
+
             # Validate augmentation percentage
             if augment_pct < augment_range["min"]:
-                errors.append(f"Augmentation below minimum: {augment_pct:.1f}% < {augment_range['min']}%")
+                errors.append(
+                    f"Augmentation below minimum: {augment_pct:.1f}% "
+                    f"< {augment_range['min']}%"
+                )
             elif augment_pct > augment_range["max"]:
-                errors.append(f"Augmentation above maximum: {augment_pct:.1f}% > {augment_range['max']}%")
-    
+                errors.append(
+                    f"Augmentation above maximum: {augment_pct:.1f}% "
+                    f"> {augment_range['max']}%"
+                )
+
     # Check required fields exist
     if not context.get("user_input"):
         errors.append("Missing user_input")
-    
+
     if not context.get("narrative_context"):
         errors.append("Missing narrative_context")
-    
+
     # Validate warm slice exists and has content
     warm_slice = context.get("narrative_context", {}).get("warm_slice", [])
     if not warm_slice:
         errors.append("Empty or missing warm_slice in narrative_context")
-    
+
     return (len(errors) == 0, errors)
 
 
-def validate_token_allocation(allocations: Dict[str, int], total_budget: int, settings: Dict[str, Any]) -> Tuple[bool, List[str]]:
+def validate_token_allocation(
+    allocations: Dict[str, int], total_budget: int, settings: Dict[str, Any]
+) -> Tuple[bool, List[str]]:
     """
     Validate that token allocations meet percentage constraints from settings.
-    
+
     Args:
         allocations: Proposed token allocations
         total_budget: Total available token budget
         settings: Settings dictionary
-        
+
     Returns:
         Tuple of (is_valid, list_of_errors)
     """
     errors = []
-    
+
     # Get allocation ranges from settings
     lore_settings = settings.get("Agent Settings", {}).get("LORE", {})
     ranges = lore_settings.get("payload_percent_budget", {})
-    
+
     # Check warm slice constraints
     warm_tokens = allocations.get("warm_slice", 0)
     warm_range = ranges.get("warm_slice", {"min": 40, "max": 70})
     warm_min_tokens = int(total_budget * warm_range["min"] / 100)
     warm_max_tokens = int(total_budget * warm_range["max"] / 100)
-    
+
     if not (warm_min_tokens <= warm_tokens <= warm_max_tokens):
-        errors.append(f"Warm slice allocation {warm_tokens:,} tokens outside bounds [{warm_min_tokens:,}, {warm_max_tokens:,}]")
-    
+        errors.append(
+            f"Warm slice allocation {warm_tokens:,} tokens outside bounds "
+            f"[{warm_min_tokens:,}, {warm_max_tokens:,}]"
+        )
+
     # Check structured data constraints
     structured_tokens = allocations.get("structured_data", 0)
     struct_range = ranges.get("structured_summaries", {"min": 10, "max": 25})
     struct_min_tokens = int(total_budget * struct_range["min"] / 100)
     struct_max_tokens = int(total_budget * struct_range["max"] / 100)
-    
+
     if not (struct_min_tokens <= structured_tokens <= struct_max_tokens):
-        errors.append(f"Structured data allocation {structured_tokens:,} tokens outside bounds [{struct_min_tokens:,}, {struct_max_tokens:,}]")
-    
+        errors.append(
+            f"Structured data allocation {structured_tokens:,} tokens outside "
+            f"bounds [{struct_min_tokens:,}, {struct_max_tokens:,}]"
+        )
+
     # Check augmentation constraints
     augment_tokens = allocations.get("contextual_augmentation", 0)
     augment_range = ranges.get("contextual_augmentation", {"min": 25, "max": 40})
     augment_min_tokens = int(total_budget * augment_range["min"] / 100)
     augment_max_tokens = int(total_budget * augment_range["max"] / 100)
-    
+
     if not (augment_min_tokens <= augment_tokens <= augment_max_tokens):
-        errors.append(f"Augmentation allocation {augment_tokens:,} tokens outside bounds [{augment_min_tokens:,}, {augment_max_tokens:,}]")
-    
+        errors.append(
+            f"Augmentation allocation {augment_tokens:,} tokens outside bounds "
+            f"[{augment_min_tokens:,}, {augment_max_tokens:,}]"
+        )
+
     # Check that total doesn't exceed budget
     total_allocated = warm_tokens + structured_tokens + augment_tokens
     if total_allocated > total_budget:
-        errors.append(f"Total allocation {total_allocated:,} exceeds budget {total_budget:,}")
-    
+        errors.append(
+            f"Total allocation {total_allocated:,} exceeds budget {total_budget:,}"
+        )
+
     return (len(errors) == 0, errors)
 
 
-def check_utilization(token_counts: Dict[str, int], settings: Dict[str, Any]) -> Tuple[float, bool, str]:
+def check_utilization(
+    token_counts: Dict[str, int], settings: Dict[str, Any]
+) -> Tuple[float, bool, str]:
     """
     Check token utilization against target thresholds.
-    
+
     Args:
         token_counts: Dictionary with actual token usage
         settings: Settings dictionary
-        
+
     Returns:
         Tuple of (utilization_percentage, is_within_target, message)
     """
@@ -166,56 +200,74 @@ def check_utilization(token_counts: Dict[str, int], settings: Dict[str, Any]) ->
     lore_settings = settings.get("Agent Settings", {}).get("LORE", {})
     token_budget = lore_settings.get("token_budget", {})
     utilization_config = token_budget.get("utilization", {})
-    
+
     target = utilization_config.get("target", 95)
     minimum = utilization_config.get("minimum", 90)
     maximum = utilization_config.get("maximum", 98)
-    
+
     # Calculate actual utilization
     total_available = token_counts.get("total_available", 1)
-    total_used = sum([
-        token_counts.get("user_input", 0),
-        token_counts.get("warm_slice", 0),
-        token_counts.get("structured", 0),
-        token_counts.get("augmentation", 0)
-    ])
-    
+    total_used = sum(
+        [
+            token_counts.get("user_input", 0),
+            token_counts.get("warm_slice", 0),
+            token_counts.get("structured", 0),
+            token_counts.get("augmentation", 0),
+        ]
+    )
+
     utilization = (total_used / total_available * 100) if total_available > 0 else 0
-    
+
     # Check against thresholds
     if utilization < minimum:
-        return (utilization, False, f"Underutilized: {utilization:.1f}% < {minimum}% minimum")
+        return (
+            utilization,
+            False,
+            f"Underutilized: {utilization:.1f}% < {minimum}% minimum",
+        )
     elif utilization > maximum:
-        return (utilization, False, f"Overutilized: {utilization:.1f}% > {maximum}% maximum")
+        return (
+            utilization,
+            False,
+            f"Overutilized: {utilization:.1f}% > {maximum}% maximum",
+        )
     else:
         distance_from_target = abs(utilization - target)
         if distance_from_target < 5:
-            return (utilization, True, f"Optimal: {utilization:.1f}% (target: {target}%)")
+            return (
+                utilization,
+                True,
+                f"Optimal: {utilization:.1f}% (target: {target}%)",
+            )
         else:
-            return (utilization, True, f"Acceptable: {utilization:.1f}% (target: {target}%)")
+            return (
+                utilization,
+                True,
+                f"Acceptable: {utilization:.1f}% (target: {target}%)",
+            )
 
 
 def validate_phase_completion(turn_context: Any) -> Tuple[bool, List[str]]:
     """
     Validate that all required phases have been completed.
-    
+
     Args:
         turn_context: TurnContext object
-        
+
     Returns:
         Tuple of (all_completed, list_of_incomplete_phases)
     """
     required_phases = [
         "user_input",
-        "warm_analysis", 
+        "warm_analysis",
         "entity_state",
         "deep_queries",
-        "payload_assembly"
+        "payload_assembly",
     ]
-    
+
     incomplete = []
     for phase in required_phases:
         if phase not in turn_context.phase_states:
             incomplete.append(phase)
-    
+
     return (len(incomplete) == 0, incomplete)

--- a/nexus/agents/lore/utils/token_budget.py
+++ b/nexus/agents/lore/utils/token_budget.py
@@ -27,7 +27,7 @@ class TokenBudgetManager:
     def calculate_budget(
         self,
         user_input: str,
-        apex_model: str = None,
+        apex_model: Optional[str] = None,
         *,
         apex_context_window: Optional[int] = None,
     ) -> Dict[str, int]:
@@ -64,7 +64,13 @@ class TokenBudgetManager:
         # Check if we're using a reasoning model
         if not apex_model:
             apex_settings = self.settings.get("API Settings", {}).get("apex", {})
-            apex_model = apex_settings.get("model", "gpt-4o")
+            configured_model = apex_settings.get("model", "gpt-4o")
+            if not isinstance(configured_model, str) or not configured_model.strip():
+                raise RuntimeError(
+                    "Storyteller model must be configured before calculating its "
+                    "token budget"
+                )
+            apex_model = configured_model
 
         using_reasoning_model = (
             apex_model.startswith("o")
@@ -83,6 +89,16 @@ class TokenBudgetManager:
             - reasoning_reserve
             - response_reserve
         )
+        if available_context < 1000:
+            raise ValueError(
+                "Storyteller payload budget must leave at least 1000 context "
+                "tokens: "
+                f"window={apex_window} - system_prompt={system_prompt} - "
+                f"user_input={user_input_tokens} - "
+                f"reasoning_reserve={reasoning_reserve} - "
+                f"response_reserve={response_reserve} = "
+                f"available_context={available_context}; model={apex_model}"
+            )
 
         # Calculate component allocations using minimum percentages initially
         warm_slice_min = self.allocation_config.get("warm_slice", {}).get("min", 40)
@@ -508,7 +524,7 @@ class TokenBudgetManager:
                 max_tokens,
             )
             # Keep baseline, remove all featured
-            trimmed_data = {
+            trimmed_data: Dict[str, Any] = {
                 "characters": {
                     "baseline": entity_data.get("characters", {}).get("baseline", []),
                     "featured": [],
@@ -572,7 +588,7 @@ class TokenBudgetManager:
 
         # Keep items until budget exhausted
         current_tokens = 0
-        kept_items = {
+        kept_items: Dict[str, List[Dict[str, Any]]] = {
             "characters": [],
             "locations": [],
             "factions": [],

--- a/nexus/agents/lore/utils/token_budget.py
+++ b/nexus/agents/lore/utils/token_budget.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("nexus.lore.token_budget")
 
 class TokenBudgetManager:
     """Manages token budget allocation for context assembly"""
-    
+
     def __init__(self, settings: Dict[str, Any]):
         """Initialize with LORE settings"""
         self.settings = settings
@@ -23,56 +23,81 @@ class TokenBudgetManager:
         if not allocation:
             allocation = lore_settings.get("payload_percent_budget", {})
         self.allocation_config = allocation or {}
-    
-    def calculate_budget(self, user_input: str, apex_model: str = None) -> Dict[str, int]:
+
+    def calculate_budget(
+        self,
+        user_input: str,
+        apex_model: str = None,
+        *,
+        apex_context_window: Optional[int] = None,
+    ) -> Dict[str, int]:
         """
         Calculate dynamic token budget for current turn.
-        
+
         Args:
             user_input: The user's input text
             apex_model: Optional model name to check for reasoning models
-            
+            apex_context_window: Effective window resolved for the active
+                storyteller provider class.
+
         Returns:
             Dictionary with token allocations
         """
-        # Get base values - apex_context_window is required
-        if "apex_context_window" not in self.token_budget_config:
-            raise ValueError(
-                "apex_context_window must be configured in the configuration file under "
-                "Agent Settings > LORE > token_budget > apex_context_window"
+        if apex_context_window is None:
+            raise RuntimeError(
+                "Effective storyteller apex_context_window must be resolved before "
+                "calculating the payload budget"
             )
-        apex_window = self.token_budget_config["apex_context_window"]
-        logger.debug(f"Using apex_context_window: {apex_window} tokens")
+        if not isinstance(apex_context_window, int):
+            raise TypeError("Resolved apex_context_window must be an integer")
+        if apex_context_window < 1000:
+            raise ValueError(
+                "Resolved apex_context_window must be greater than or equal to 1000"
+            )
+        apex_window = apex_context_window
 
         system_prompt = self.token_budget_config.get("system_prompt_tokens", 5000)
-        
+
         # Calculate user input tokens using tiktoken
         user_input_tokens = calculate_chunk_tokens(user_input)
-        
+
         # Check if we're using a reasoning model
         if not apex_model:
             apex_settings = self.settings.get("API Settings", {}).get("apex", {})
             apex_model = apex_settings.get("model", "gpt-4o")
-        
-        using_reasoning_model = apex_model.startswith("o") or "gpt-5" in apex_model  # pin: family-prefix feature detection
-        
+
+        using_reasoning_model = (
+            apex_model.startswith("o")
+            or "gpt-5" in apex_model  # pin: family-prefix feature detection
+        )
+
         # Reserve tokens for reasoning if needed (up to 30k for high-effort reasoning)
         reasoning_reserve = 30000 if using_reasoning_model else 0
         response_reserve = 4000
-        
+
         # Calculate available context
-        available_context = apex_window - system_prompt - user_input_tokens - reasoning_reserve - response_reserve
-        
+        available_context = (
+            apex_window
+            - system_prompt
+            - user_input_tokens
+            - reasoning_reserve
+            - response_reserve
+        )
+
         # Calculate component allocations using minimum percentages initially
         warm_slice_min = self.allocation_config.get("warm_slice", {}).get("min", 40)
-        structured_min = self.allocation_config.get("structured_summaries", {}).get("min", 10)
-        augmentation_min = self.allocation_config.get("contextual_augmentation", {}).get("min", 25)
-        
+        structured_min = self.allocation_config.get("structured_summaries", {}).get(
+            "min", 10
+        )
+        augmentation_min = self.allocation_config.get(
+            "contextual_augmentation", {}
+        ).get("min", 25)
+
         # Start with minimum allocations
         warm_slice_tokens = int(available_context * warm_slice_min / 100)
         structured_tokens = int(available_context * structured_min / 100)
         augmentation_tokens = int(available_context * augmentation_min / 100)
-        
+
         budget = {
             "total_available": available_context,
             "user_input": user_input_tokens,
@@ -83,132 +108,150 @@ class TokenBudgetManager:
             "response_reserve": response_reserve,
             "using_reasoning_model": using_reasoning_model,
             "apex_window": apex_window,
-            "system_prompt": system_prompt
+            "system_prompt": system_prompt,
         }
-        
+
         logger.debug(f"Token budget calculated: {budget}")
         return budget
-    
+
     def calculate_utilization(self, token_counts: Dict[str, int]) -> float:
         """
         Calculate the utilization percentage of the token budget.
-        
+
         Args:
             token_counts: Dictionary with actual token usage
-            
+
         Returns:
             Utilization percentage (0-100)
         """
-        total_used = sum([
-            token_counts.get("user_input", 0),
-            token_counts.get("warm_slice", 0),
-            token_counts.get("structured", 0),
-            token_counts.get("augmentation", 0)
-        ])
-        
+        total_used = sum(
+            [
+                token_counts.get("user_input", 0),
+                token_counts.get("warm_slice", 0),
+                token_counts.get("structured", 0),
+                token_counts.get("augmentation", 0),
+            ]
+        )
+
         total_available = token_counts.get("total_available", 1)
         utilization = (total_used / total_available) * 100 if total_available > 0 else 0
-        
+
         return utilization
-    
-    def optimize_allocation(self, 
-                           current_counts: Dict[str, int],
-                           available_content: Dict[str, int]) -> Dict[str, int]:
+
+    def optimize_allocation(
+        self, current_counts: Dict[str, int], available_content: Dict[str, int]
+    ) -> Dict[str, int]:
         """
         Optimize token allocation to reach target utilization.
-        
+
         Args:
             current_counts: Current token usage
             available_content: Available content that could be added
-            
+
         Returns:
             Optimized token allocation
         """
         current_utilization = self.calculate_utilization(current_counts)
-        target_utilization = self.token_budget_config.get("utilization", {}).get("target", 95)
-        
+        target_utilization = self.token_budget_config.get("utilization", {}).get(
+            "target", 95
+        )
+
         if current_utilization >= target_utilization:
             return current_counts
-        
+
         # Calculate remaining tokens
         total_available = current_counts.get("total_available", 0)
-        current_used = sum([
-            current_counts.get("user_input", 0),
-            current_counts.get("warm_slice", 0),
-            current_counts.get("structured", 0),
-            current_counts.get("augmentation", 0)
-        ])
-        
-        remaining = total_available - current_used
-        target_additional = int((target_utilization / 100) * total_available - current_used)
-        
+        current_used = sum(
+            [
+                current_counts.get("user_input", 0),
+                current_counts.get("warm_slice", 0),
+                current_counts.get("structured", 0),
+                current_counts.get("augmentation", 0),
+            ]
+        )
+
+        target_additional = int(
+            (target_utilization / 100) * total_available - current_used
+        )
+
         # Get max allocation percentages
         warm_slice_max = self.allocation_config.get("warm_slice", {}).get("max", 70)
-        structured_max = self.allocation_config.get("structured_summaries", {}).get("max", 25)
-        augmentation_max = self.allocation_config.get("contextual_augmentation", {}).get("max", 40)
-        
+        structured_max = self.allocation_config.get("structured_summaries", {}).get(
+            "max", 25
+        )
+        augmentation_max = self.allocation_config.get(
+            "contextual_augmentation", {}
+        ).get("max", 40)
+
         # Calculate max tokens for each component
         max_warm = int(total_available * warm_slice_max / 100)
         max_structured = int(total_available * structured_max / 100)
         max_augmentation = int(total_available * augmentation_max / 100)
-        
+
         # Distribute remaining tokens proportionally
         optimized = current_counts.copy()
-        
+
         # Priority order: warm slice, augmentation, structured
         if available_content.get("warm_slice", 0) > 0:
             additional_warm = min(
                 target_additional // 2,
                 max_warm - current_counts.get("warm_slice", 0),
-                available_content.get("warm_slice", 0)
+                available_content.get("warm_slice", 0),
             )
             optimized["warm_slice"] += additional_warm
             target_additional -= additional_warm
-        
+
         if available_content.get("augmentation", 0) > 0 and target_additional > 0:
             additional_aug = min(
                 target_additional,
                 max_augmentation - current_counts.get("augmentation", 0),
-                available_content.get("augmentation", 0)
+                available_content.get("augmentation", 0),
             )
             optimized["augmentation"] += additional_aug
             target_additional -= additional_aug
-        
+
         if available_content.get("structured", 0) > 0 and target_additional > 0:
             additional_struct = min(
                 target_additional,
                 max_structured - current_counts.get("structured", 0),
-                available_content.get("structured", 0)
+                available_content.get("structured", 0),
             )
             optimized["structured"] += additional_struct
-        
-        logger.debug(f"Optimized allocation from {current_utilization:.1f}% to {self.calculate_utilization(optimized):.1f}%")
+
+        logger.debug(
+            "Optimized allocation from %.1f%% to %.1f%%",
+            current_utilization,
+            self.calculate_utilization(optimized),
+        )
         return optimized
-    
-    def calculate_token_budget(self, tpm: int, system_tokens: int, user_tokens: int) -> int:
+
+    def calculate_token_budget(
+        self, tpm: int, system_tokens: int, user_tokens: int
+    ) -> int:
         """
         Simple arithmetic: Calculate available tokens for context.
         NO LLM NEEDED - just subtraction!
-        
+
         Args:
             tpm: Total tokens per message (model context window)
             system_tokens: Tokens used by system prompt
             user_tokens: Tokens used by user input
-            
+
         Returns:
             Available tokens for context
         """
         return tpm - system_tokens - user_tokens
-    
+
     def allocate_percentages(self, narrative_state: str, budget: int) -> Dict[str, int]:
         """
         Programmatic percentage allocation based on narrative state.
         NO LLM NEEDED - just a lookup table!
-        
+
         Args:
-            narrative_state: Type of narrative moment (dialogue_heavy, action_sequence, etc.)
+            narrative_state: Type of narrative moment (dialogue_heavy,
+                action_sequence, etc.)
             budget: Total token budget available
-            
+
         Returns:
             Token allocations for each component
         """
@@ -226,68 +269,101 @@ class TokenBudgetManager:
             "planning": {"warm": 50, "augment": 30, "structured": 20},
             "investigation": {"warm": 40, "augment": 45, "structured": 15},
             "combat": {"warm": 75, "augment": 15, "structured": 10},
-            "default": {"warm": 50, "augment": 30, "structured": 20}
+            "default": {"warm": 50, "augment": 30, "structured": 20},
         }
-        
+
         # Get percentages for the narrative state (with fallback to default)
         percentages = allocations.get(narrative_state.lower(), allocations["default"])
-        
+
         # Calculate actual token amounts
         result = {
             "warm_slice": int(budget * percentages["warm"] / 100),
             "contextual_augmentation": int(budget * percentages["augment"] / 100),
-            "structured_data": int(budget * percentages["structured"] / 100)
+            "structured_data": int(budget * percentages["structured"] / 100),
         }
-        
+
         # Log the allocation for debugging
-        logger.debug(f"Allocated tokens for '{narrative_state}' state: warm={result['warm_slice']}, augment={result['contextual_augmentation']}, structured={result['structured_data']}")
-        
+        logger.debug(
+            "Allocated tokens for '%s' state: warm=%s, augment=%s, structured=%s",
+            narrative_state,
+            result["warm_slice"],
+            result["contextual_augmentation"],
+            result["structured_data"],
+        )
+
         return result
-    
-    def validate_budget_constraints(self, allocations: Dict[str, int], constraints: Optional[Dict[str, Dict[str, int]]] = None) -> bool:
+
+    def validate_budget_constraints(
+        self,
+        allocations: Dict[str, int],
+        constraints: Optional[Dict[str, Dict[str, int]]] = None,
+    ) -> bool:
         """
         Validate that allocations meet min/max constraints.
         NO LLM NEEDED - just comparison operators!
-        
+
         Args:
             allocations: Proposed token allocations
             constraints: Optional override constraints (defaults to config)
-            
+
         Returns:
             True if allocations are valid, False otherwise
         """
         if not constraints:
             constraints = self.allocation_config
-        
+
         total = sum(allocations.values())
-        
+
         # Check warm slice constraints
         warm_tokens = allocations.get("warm_slice", 0)
         warm_min = int(total * constraints.get("warm_slice", {}).get("min", 40) / 100)
         warm_max = int(total * constraints.get("warm_slice", {}).get("max", 70) / 100)
-        
+
         if not (warm_min <= warm_tokens <= warm_max):
-            logger.warning(f"Warm slice allocation {warm_tokens} outside bounds [{warm_min}, {warm_max}]")
+            logger.warning(
+                "Warm slice allocation %s outside bounds [%s, %s]",
+                warm_tokens,
+                warm_min,
+                warm_max,
+            )
             return False
-        
+
         # Check structured data constraints
         structured_tokens = allocations.get("structured_data", 0)
-        structured_min = int(total * constraints.get("structured_summaries", {}).get("min", 10) / 100)
-        structured_max = int(total * constraints.get("structured_summaries", {}).get("max", 25) / 100)
-        
+        structured_min = int(
+            total * constraints.get("structured_summaries", {}).get("min", 10) / 100
+        )
+        structured_max = int(
+            total * constraints.get("structured_summaries", {}).get("max", 25) / 100
+        )
+
         if not (structured_min <= structured_tokens <= structured_max):
-            logger.warning(f"Structured data allocation {structured_tokens} outside bounds [{structured_min}, {structured_max}]")
+            logger.warning(
+                "Structured data allocation %s outside bounds [%s, %s]",
+                structured_tokens,
+                structured_min,
+                structured_max,
+            )
             return False
-        
-        # Check augmentation constraints  
+
+        # Check augmentation constraints
         augment_tokens = allocations.get("contextual_augmentation", 0)
-        augment_min = int(total * constraints.get("contextual_augmentation", {}).get("min", 25) / 100)
-        augment_max = int(total * constraints.get("contextual_augmentation", {}).get("max", 40) / 100)
-        
+        augment_min = int(
+            total * constraints.get("contextual_augmentation", {}).get("min", 25) / 100
+        )
+        augment_max = int(
+            total * constraints.get("contextual_augmentation", {}).get("max", 40) / 100
+        )
+
         if not (augment_min <= augment_tokens <= augment_max):
-            logger.warning(f"Augmentation allocation {augment_tokens} outside bounds [{augment_min}, {augment_max}]")
+            logger.warning(
+                "Augmentation allocation %s outside bounds [%s, %s]",
+                augment_tokens,
+                augment_min,
+                augment_max,
+            )
             return False
-        
+
         return True
 
     def estimate_entity_tokens(self, entity: Dict[str, Any]) -> int:
@@ -306,7 +382,15 @@ class TokenBudgetManager:
 
         # Collect all text content from entity
         text_candidates = []
-        for key in ("summary", "details", "text", "content", "description", "background", "personality"):
+        for key in (
+            "summary",
+            "details",
+            "text",
+            "content",
+            "description",
+            "background",
+            "personality",
+        ):
             value = entity.get(key)
             if isinstance(value, str) and value.strip():
                 text_candidates.append(value)
@@ -322,8 +406,7 @@ class TokenBudgetManager:
         return tokens
 
     def calculate_structured_tokens_by_tier(
-        self,
-        entity_data: Dict[str, Any]
+        self, entity_data: Dict[str, Any]
     ) -> Tuple[int, int]:
         """
         Calculate token counts separately for baseline and featured entities.
@@ -362,13 +445,15 @@ class TokenBudgetManager:
         for threat in entity_data.get("threats", []):
             featured_tokens += self.estimate_entity_tokens(threat)
 
-        logger.debug(f"Structured tokens: {baseline_tokens} baseline (protected), {featured_tokens} featured (trimmable)")
+        logger.debug(
+            "Structured tokens: %s baseline (protected), %s featured (trimmable)",
+            baseline_tokens,
+            featured_tokens,
+        )
         return baseline_tokens, featured_tokens
 
     def trim_structured_with_baseline_protection(
-        self,
-        entity_data: Dict[str, Any],
-        max_tokens: int
+        self, entity_data: Dict[str, Any], max_tokens: int
     ) -> Dict[str, Any]:
         """
         Trim structured entity data to fit budget while PROTECTING baseline entities.
@@ -392,7 +477,9 @@ class TokenBudgetManager:
         Returns:
             Trimmed entity data
         """
-        baseline_tokens, featured_tokens = self.calculate_structured_tokens_by_tier(entity_data)
+        baseline_tokens, featured_tokens = self.calculate_structured_tokens_by_tier(
+            entity_data
+        )
         total_tokens = baseline_tokens + featured_tokens
 
         if total_tokens <= max_tokens:
@@ -400,8 +487,12 @@ class TokenBudgetManager:
             return entity_data
 
         logger.info(
-            f"Structured data ({total_tokens} tokens) exceeds budget ({max_tokens} tokens). "
-            f"Baseline: {baseline_tokens} tokens (protected), Featured: {featured_tokens} tokens (trimmable)"
+            "Structured data (%s tokens) exceeds budget (%s tokens). "
+            "Baseline: %s tokens (protected), Featured: %s tokens (trimmable)",
+            total_tokens,
+            max_tokens,
+            baseline_tokens,
+            featured_tokens,
         )
 
         # Calculate available budget for featured entities
@@ -409,32 +500,37 @@ class TokenBudgetManager:
 
         if available_for_featured <= 0:
             logger.warning(
-                f"Baseline entities ({baseline_tokens} tokens) exceed structured budget ({max_tokens} tokens)! "
-                f"Consider increasing apex_context_window or structured_summaries max%. "
-                f"Removing ALL featured entities to stay within budget."
+                "Baseline entities (%s tokens) exceed structured budget "
+                "(%s tokens)! Consider increasing apex_context_window or "
+                "structured_summaries max%%. Removing ALL featured entities "
+                "to stay within budget.",
+                baseline_tokens,
+                max_tokens,
             )
             # Keep baseline, remove all featured
             trimmed_data = {
                 "characters": {
                     "baseline": entity_data.get("characters", {}).get("baseline", []),
-                    "featured": []
+                    "featured": [],
                 },
                 "locations": {
                     "baseline": entity_data.get("locations", {}).get("baseline", []),
-                    "featured": []
+                    "featured": [],
                 },
                 "factions": {
                     "baseline": entity_data.get("factions", {}).get("baseline", []),
-                    "featured": []
+                    "featured": [],
                 },
                 "relationships": [],
                 "events": [],
-                "threats": []
+                "threats": [],
             }
             return trimmed_data
 
         # Collect all trimmable items with priorities
-        trimmable_items: List[Tuple[str, str, Any, int, int]] = []  # (category, type, entity, tokens, priority)
+        trimmable_items: List[Tuple[str, str, Any, int, int]] = (
+            []
+        )  # (category, type, entity, tokens, priority)
 
         # Characters
         for char in entity_data.get("characters", {}).get("featured", []):
@@ -470,7 +566,8 @@ class TokenBudgetManager:
             tokens = self.estimate_entity_tokens(threat)
             trimmable_items.append(("threats", "threat", threat, tokens, 8))
 
-        # Sort by priority (lower is better), then by token count (larger first to maximize utilization)
+        # Sort by priority (lower is better), then by token count (larger
+        # first to maximize utilization).
         trimmable_items.sort(key=lambda x: (x[4], -x[3]))
 
         # Keep items until budget exhausted
@@ -481,7 +578,7 @@ class TokenBudgetManager:
             "factions": [],
             "relationships": [],
             "events": [],
-            "threats": []
+            "threats": [],
         }
 
         for category, item_type, entity, tokens, priority in trimmable_items:
@@ -493,26 +590,29 @@ class TokenBudgetManager:
         trimmed_data = {
             "characters": {
                 "baseline": entity_data.get("characters", {}).get("baseline", []),
-                "featured": kept_items["characters"]
+                "featured": kept_items["characters"],
             },
             "locations": {
                 "baseline": entity_data.get("locations", {}).get("baseline", []),
-                "featured": kept_items["locations"]
+                "featured": kept_items["locations"],
             },
             "factions": {
                 "baseline": entity_data.get("factions", {}).get("baseline", []),
-                "featured": kept_items["factions"]
+                "featured": kept_items["factions"],
             },
             "relationships": kept_items["relationships"],
             "events": kept_items["events"],
-            "threats": kept_items["threats"]
+            "threats": kept_items["threats"],
         }
 
-        trimmed_count = len(trimmable_items) - sum(len(items) for items in kept_items.values())
+        trimmed_count = len(trimmable_items) - sum(
+            len(items) for items in kept_items.values()
+        )
         trimmed_tokens = featured_tokens - current_tokens
+        kept_count = sum(len(items) for items in kept_items.values())
         logger.info(
             f"Trimmed {trimmed_count} featured items ({trimmed_tokens} tokens). "
-            f"Kept {sum(len(items) for items in kept_items.values())} items ({current_tokens} tokens)"
+            f"Kept {kept_count} items ({current_tokens} tokens)"
         )
 
         return trimmed_data

--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -42,6 +42,7 @@ class TurnContext:
     error_log: List[str] = field(default_factory=list)
     token_counts: Dict[str, int] = field(default_factory=dict)
     provider_wire_type: Optional[str] = None
+    apex_model: Optional[str] = None
     memory_state: Dict[str, Any] = field(default_factory=dict)
     target_chunk_id: Optional[int] = None
     # Soft author's note / suggestion for the storyteller.

--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -41,6 +41,7 @@ class TurnContext:
     apex_response: Optional[str] = None
     error_log: List[str] = field(default_factory=list)
     token_counts: Dict[str, int] = field(default_factory=dict)
+    provider_wire_type: Optional[str] = None
     memory_state: Dict[str, Any] = field(default_factory=dict)
     target_chunk_id: Optional[int] = None
     # Soft author's note / suggestion for the storyteller.

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -208,8 +208,25 @@ class TurnCycleManager:
 
         # Calculate token budget
         if self.lore.token_manager:
+            memory_manager = getattr(self.lore, "memory_manager", None)
+            if memory_manager is None:
+                raise RuntimeError(
+                    "Storyteller payload sizing requires the memory manager"
+                )
+            self.lore.ensure_logon()
+            logon = getattr(self.lore, "logon", None)
+            if logon is None:
+                raise RuntimeError(
+                    "Active LOGON provider is required for storyteller payload sizing"
+                )
+            provider_wire_type = logon.resolve_provider_wire_type()
+            turn_context.provider_wire_type = provider_wire_type
+            apex_context_window = memory_manager.configure_storyteller_budget(
+                provider_wire_type
+            )
             turn_context.token_counts = self.lore.token_manager.calculate_budget(
-                turn_context.user_input
+                turn_context.user_input,
+                apex_context_window=apex_context_window,
             )
 
         # Store processed input

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Iterable, List, Optional, Union
 
 from nexus.agents.lore.utils.chunk_operations import calculate_chunk_tokens
 from nexus.memory.context_state import memory_identity
+from nexus.memory.manager import resolve_storyteller_prompt_overhead_tokens
 from nexus.memory.retrieval_coverage import coerce_chunk_id
 
 logger = logging.getLogger("nexus.lore.turn_cycle")
@@ -1011,6 +1012,9 @@ class TurnCycleManager:
             "tokens_before_trimming": payload_budget["tokens_before"],
             "warm_chunks_dropped": payload_budget["warm_chunks_dropped"],
             "retrieved_passages_dropped": payload_budget["retrieved_passages_dropped"],
+            "memory_budget_refunded": payload_budget["memory_budget_refunded"],
+            "payload_ceiling": payload_budget["payload_ceiling"],
+            "prompt_overhead_tokens": payload_budget["prompt_overhead_tokens"],
             "utilization_percentage": utilization,
         }
 
@@ -1025,12 +1029,22 @@ class TurnCycleManager:
                 "Storyteller payload assembly requires a total_available token "
                 "ceiling"
             )
-        ceiling = turn_context.token_counts["total_available"]
-        if not isinstance(ceiling, int):
+        total_available = turn_context.token_counts["total_available"]
+        if not isinstance(total_available, int):
             raise TypeError("Storyteller total_available token ceiling must be an int")
-        if ceiling < 1000:
+        if total_available < 1000:
             raise ValueError(
                 "Storyteller total_available token ceiling must be at least 1000"
+            )
+        prompt_overhead_tokens = resolve_storyteller_prompt_overhead_tokens(
+            self.settings
+        )
+        ceiling = total_available - prompt_overhead_tokens
+        if ceiling < 0:
+            raise ValueError(
+                "Storyteller prompt overhead exceeds the available payload "
+                f"ceiling: total_available={total_available}, "
+                f"prompt_overhead_tokens={prompt_overhead_tokens}"
             )
 
         payload = turn_context.context_payload
@@ -1038,6 +1052,7 @@ class TurnCycleManager:
         tokens_after = tokens_before
         warm_chunks_dropped = 0
         retrieved_passages_dropped = 0
+        memory_budget_refunded = 0
 
         if tokens_after <= ceiling:
             return {
@@ -1045,6 +1060,9 @@ class TurnCycleManager:
                 "tokens_after": tokens_after,
                 "warm_chunks_dropped": 0,
                 "retrieved_passages_dropped": 0,
+                "memory_budget_refunded": 0,
+                "payload_ceiling": ceiling,
+                "prompt_overhead_tokens": prompt_overhead_tokens,
             }
 
         warm_section = payload.get("warm_slice")
@@ -1062,22 +1080,46 @@ class TurnCycleManager:
         retrieved_passages = list(retrieved_section["results"])
         warm_section["chunks"] = warm_chunks
         retrieved_section["results"] = retrieved_passages
+        dropped_chunks: List[Dict[str, Any]] = []
 
         protected_chunk = _protected_warm_chunk(warm_chunks) if warm_chunks else None
         while tokens_after > ceiling and protected_chunk is not None:
             oldest_index = _oldest_droppable_warm_index(warm_chunks, protected_chunk)
             if oldest_index is None:
                 break
-            warm_chunks.pop(oldest_index)
+            dropped_chunks.append(warm_chunks.pop(oldest_index))
             warm_chunks_dropped += 1
             tokens_after = _context_component_token_count(payload)
 
         while tokens_after > ceiling and retrieved_passages:
-            retrieved_passages.pop()
+            dropped_chunks.append(retrieved_passages.pop())
             retrieved_passages_dropped += 1
             tokens_after = _context_component_token_count(payload)
 
         if warm_chunks_dropped or retrieved_passages_dropped:
+            memory_manager = getattr(self.lore, "memory_manager", None)
+            dropped_identities = {
+                identity
+                for chunk in dropped_chunks
+                for identity in [memory_identity(chunk)]
+                if identity is not None
+            }
+            if memory_manager is None and dropped_identities:
+                raise RuntimeError(
+                    "Storyteller payload trimming cannot synchronize chunk state "
+                    "without the memory manager"
+                )
+            unregistered_identities = set()
+            if memory_manager is not None:
+                (
+                    unregistered_identities,
+                    memory_budget_refunded,
+                ) = memory_manager.unregister_payload_chunks(dropped_chunks)
+            self._synchronize_trimmed_memory_snapshot(
+                turn_context,
+                unregistered_identities,
+                memory_budget_refunded,
+            )
             logger.info(
                 "Storyteller payload trimmed: wire_class=%s tokens=%s -> %s "
                 "warm_chunks_dropped=%s retrieved_passages_dropped=%s",
@@ -1102,7 +1144,52 @@ class TurnCycleManager:
             "tokens_after": tokens_after,
             "warm_chunks_dropped": warm_chunks_dropped,
             "retrieved_passages_dropped": retrieved_passages_dropped,
+            "memory_budget_refunded": memory_budget_refunded,
+            "payload_ceiling": ceiling,
+            "prompt_overhead_tokens": prompt_overhead_tokens,
         }
+
+    @staticmethod
+    def _synchronize_trimmed_memory_snapshot(
+        turn_context: TurnContext,
+        removed_identities: set[Union[int, str]],
+        refunded_tokens: int,
+    ) -> None:
+        """Remove dropped retrievals from the turn's diagnostic memory snapshot."""
+        if not removed_identities:
+            return
+
+        pass2_snapshots: List[Dict[str, Any]] = []
+        memory_snapshot = turn_context.memory_state.get("pass2")
+        if isinstance(memory_snapshot, dict):
+            pass2_snapshots.append(memory_snapshot)
+        user_input_state = turn_context.phase_states.get("user_input")
+        if isinstance(user_input_state, dict):
+            phase_snapshot = user_input_state.get("memory_pass2")
+            if isinstance(phase_snapshot, dict) and all(
+                phase_snapshot is not snapshot for snapshot in pass2_snapshots
+            ):
+                pass2_snapshots.append(phase_snapshot)
+
+        narrative_ids = {
+            identity for identity in removed_identities if isinstance(identity, int)
+        }
+        for snapshot in pass2_snapshots:
+            memory_ids = snapshot.get("retrieved_memory_ids")
+            if isinstance(memory_ids, list):
+                snapshot["retrieved_memory_ids"] = [
+                    identity
+                    for identity in memory_ids
+                    if identity not in removed_identities
+                ]
+            chunk_ids = snapshot.get("retrieved_chunk_ids")
+            if isinstance(chunk_ids, list):
+                snapshot["retrieved_chunk_ids"] = [
+                    chunk_id for chunk_id in chunk_ids if chunk_id not in narrative_ids
+                ]
+            tokens_used = snapshot.get("tokens_used")
+            if isinstance(tokens_used, int):
+                snapshot["tokens_used"] = max(0, tokens_used - refunded_tokens)
 
     def _build_world_knowledge(self, turn_context: TurnContext) -> list[dict[str, Any]]:
         """Load optional spoiler-limited knowledge for the current scene."""
@@ -1291,10 +1378,19 @@ class TurnCycleManager:
                     "Storyteller route must be resolved during Phase 1 before "
                     "provider initialization"
                 )
+            effective_context_window = turn_context.token_counts.get("apex_window")
+            if isinstance(effective_context_window, bool) or not isinstance(
+                effective_context_window, int
+            ):
+                raise RuntimeError(
+                    "Storyteller effective context window must be resolved during "
+                    "Phase 1 before provider initialization"
+                )
             story_response = await self.lore.logon.generate_narrative_async(
                 turn_context.context_payload,
                 expected_model=turn_context.apex_model,
                 expected_wire_type=turn_context.provider_wire_type,
+                effective_context_window=effective_context_window,
             )
 
             # Store the full structured response
@@ -1370,10 +1466,27 @@ class TurnCycleManager:
 
         if getattr(self.lore, "memory_manager", None):
             try:
+                warm_section = turn_context.context_payload.get("warm_slice")
+                retrieved_section = turn_context.context_payload.get(
+                    "retrieved_passages"
+                )
+                if not isinstance(warm_section, dict) or not isinstance(
+                    warm_section.get("chunks"), list
+                ):
+                    raise RuntimeError(
+                        "Integrated storyteller payload is missing warm_slice.chunks"
+                    )
+                if not isinstance(retrieved_section, dict) or not isinstance(
+                    retrieved_section.get("results"), list
+                ):
+                    raise RuntimeError(
+                        "Integrated storyteller payload is missing "
+                        "retrieved_passages.results"
+                    )
                 baseline = self.lore.memory_manager.handle_storyteller_response(
                     narrative=narrative_text,
-                    warm_slice=turn_context.warm_slice,
-                    retrieved_passages=turn_context.retrieved_passages,
+                    warm_slice=warm_section["chunks"],
+                    retrieved_passages=retrieved_section["results"],
                     token_usage=turn_context.token_counts,
                     assembled_context=turn_context.context_payload,
                 )

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -4,10 +4,12 @@ Turn Cycle Phase Implementations for LORE
 Handles the execution of individual turn cycle phases.
 """
 
+import json
 import logging
-from typing import Dict, List, Any, Optional, Union, Iterable
 from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional, Union
 
+from nexus.agents.lore.utils.chunk_operations import calculate_chunk_tokens
 from nexus.memory.context_state import memory_identity
 from nexus.memory.retrieval_coverage import coerce_chunk_id
 
@@ -142,6 +144,75 @@ def _deduplicate_retrieval_results(
     )[:limit]
 
 
+def _context_component_token_count(payload: Dict[str, Any]) -> int:
+    """Count assembled context components after separately reserved user input."""
+    context_components = {
+        key: value for key, value in payload.items() if key != "user_input"
+    }
+    try:
+        serialized = json.dumps(
+            context_components,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            "Storyteller context payload must be JSON-serializable for token "
+            "budget enforcement"
+        ) from exc
+    return calculate_chunk_tokens(serialized)
+
+
+def _warm_chunk_recency_id(chunk: Dict[str, Any]) -> Optional[int]:
+    """Resolve narrative or Retrograde chronology for warm-slice ordering."""
+    chunk_id = coerce_chunk_id(chunk)
+    if chunk_id is not None:
+        return chunk_id
+    metadata = chunk.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    recorded_at_chunk_id = metadata.get("recorded_at_chunk_id")
+    try:
+        return int(recorded_at_chunk_id) if recorded_at_chunk_id is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _protected_warm_chunk(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return the load-bearing parent, or the most recent identifiable chunk."""
+    target_chunks = [chunk for chunk in chunks if chunk.get("is_target")]
+    candidates = target_chunks or chunks
+    identified: List[tuple[int, Dict[str, Any]]] = []
+    for chunk in candidates:
+        chunk_id = _warm_chunk_recency_id(chunk)
+        if chunk_id is not None:
+            identified.append((chunk_id, chunk))
+    if identified:
+        return max(identified, key=lambda item: item[0])[1]
+    return candidates[-1]
+
+
+def _oldest_droppable_warm_index(
+    chunks: List[Dict[str, Any]], protected_chunk: Dict[str, Any]
+) -> Optional[int]:
+    """Locate the oldest warm chunk other than the protected parent."""
+    droppable = [
+        (index, _warm_chunk_recency_id(chunk))
+        for index, chunk in enumerate(chunks)
+        if chunk is not protected_chunk
+    ]
+    if not droppable:
+        return None
+
+    def age_key(item: tuple[int, Optional[int]]) -> tuple[int, int]:
+        index, chunk_id = item
+        if chunk_id is not None:
+            return (1, chunk_id)
+        return (0, -index)
+
+    return min(droppable, key=age_key)[0]
+
+
 class TurnCycleManager:
     """Manages the execution of turn cycle phases"""
 
@@ -213,24 +284,34 @@ class TurnCycleManager:
                 raise RuntimeError(
                     "Storyteller payload sizing requires the memory manager"
                 )
-            self.lore.ensure_logon()
-            logon = getattr(self.lore, "logon", None)
-            if logon is None:
-                raise RuntimeError(
-                    "Active LOGON provider is required for storyteller payload sizing"
+            if not getattr(self.lore, "enable_logon", True):
+                apex_context_window = memory_manager.configure_base_storyteller_budget()
+                turn_context.token_counts = self.lore.token_manager.calculate_budget(
+                    turn_context.user_input,
+                    apex_context_window=apex_context_window,
                 )
-            provider_wire_type = logon.resolve_provider_wire_type()
-            turn_context.provider_wire_type = provider_wire_type
-            apex_context_window = memory_manager.configure_storyteller_budget(
-                provider_wire_type
-            )
-            turn_context.token_counts = self.lore.token_manager.calculate_budget(
-                turn_context.user_input,
-                apex_context_window=apex_context_window,
-            )
+            else:
+                self.lore.ensure_logon()
+                logon = getattr(self.lore, "logon", None)
+                if logon is None:
+                    raise RuntimeError(
+                        "Active LOGON provider is required for storyteller payload "
+                        "sizing"
+                    )
+                apex_model, provider_wire_type = logon.resolve_storyteller_route()
+                turn_context.apex_model = apex_model
+                turn_context.provider_wire_type = provider_wire_type
+                apex_context_window = memory_manager.configure_storyteller_budget(
+                    provider_wire_type
+                )
+                turn_context.token_counts = self.lore.token_manager.calculate_budget(
+                    turn_context.user_input,
+                    apex_model=apex_model,
+                    apex_context_window=apex_context_window,
+                )
 
         # Store processed input
-        phase_state = {
+        phase_state: Dict[str, Any] = {
             "processed": True,
             "token_count": turn_context.token_counts.get("user_input", 0),
         }
@@ -238,7 +319,7 @@ class TurnCycleManager:
             phase_state["target_chunk_id"] = turn_context.target_chunk_id
         turn_context.phase_states["user_input"] = phase_state
 
-        memory_update = {}
+        memory_update: Dict[str, Any] = {}
         if getattr(self.lore, "memory_manager", None):
             try:
                 pass2_update = self.lore.memory_manager.handle_user_input(
@@ -396,7 +477,10 @@ class TurnCycleManager:
             warm_chunk_ids = []
 
         # Query characters with baseline + featured structure
-        characters_data = {"baseline": [], "featured": []}
+        characters_data: Dict[str, List[Dict[str, Any]]] = {
+            "baseline": [],
+            "featured": [],
+        }
         try:
             from sqlalchemy import text
 
@@ -413,14 +497,17 @@ class TurnCycleManager:
 
         # Query places with baseline + featured structure
         # Include places that are current_location of featured characters
-        featured_place_ids = set()
+        featured_place_ids: set[int] = set()
         for char in characters_data.get("featured", []):
             loc_name = char.get("current_location")
             if loc_name:
                 # Get place ID from name (we'll query by name in the function)
                 pass  # fetch_all_places_with_references handles this
 
-        places_data = {"baseline": [], "featured": []}
+        places_data: Dict[str, List[Dict[str, Any]]] = {
+            "baseline": [],
+            "featured": [],
+        }
         try:
             with self.lore.memnon.Session() as session:
                 places_data = fetch_all_places_with_references(
@@ -434,7 +521,10 @@ class TurnCycleManager:
             logger.error(f"Failed to query places: {e}")
 
         # Query factions with baseline + featured structure
-        factions_data = {"baseline": [], "featured": []}
+        factions_data: Dict[str, List[Dict[str, Any]]] = {
+            "baseline": [],
+            "featured": [],
+        }
         try:
             with self.lore.memnon.Session() as session:
                 factions_data = fetch_all_factions_with_references(
@@ -608,8 +698,8 @@ class TurnCycleManager:
             return
 
         # Execute queries with proper SearchManager configuration
-        all_results = []
-        query_type_counts = {}
+        all_results: List[Dict[str, Any]] = []
+        query_type_counts: Dict[str, int] = {}
         max_deep_queries = self._max_deep_queries()
 
         for query_obj in queries[:max_deep_queries]:
@@ -906,6 +996,8 @@ class TurnCycleManager:
                 "target_chunk_id"
             ] = turn_context.target_chunk_id
 
+        payload_budget = self._enforce_context_payload_budget(turn_context)
+
         # Calculate utilization
         if self.lore.token_manager:
             utilization = self.lore.token_manager.calculate_utilization(
@@ -915,18 +1007,102 @@ class TurnCycleManager:
             utilization = 0
 
         turn_context.phase_states["payload_assembly"] = {
-            "total_tokens_used": sum(
-                [
-                    turn_context.token_counts.get("user_input", 0),
-                    turn_context.token_counts.get("warm_slice", 0),
-                    turn_context.token_counts.get("structured", 0),
-                    turn_context.token_counts.get("augmentation", 0),
-                ]
-            ),
+            "total_tokens_used": payload_budget["tokens_after"],
+            "tokens_before_trimming": payload_budget["tokens_before"],
+            "warm_chunks_dropped": payload_budget["warm_chunks_dropped"],
+            "retrieved_passages_dropped": payload_budget["retrieved_passages_dropped"],
             "utilization_percentage": utilization,
         }
 
         logger.info(f"Context payload assembled: {utilization:.1f}% budget utilization")
+
+    def _enforce_context_payload_budget(
+        self, turn_context: TurnContext
+    ) -> Dict[str, int]:
+        """Trim expendable context until the assembled payload fits its ceiling."""
+        if "total_available" not in turn_context.token_counts:
+            raise RuntimeError(
+                "Storyteller payload assembly requires a total_available token "
+                "ceiling"
+            )
+        ceiling = turn_context.token_counts["total_available"]
+        if not isinstance(ceiling, int):
+            raise TypeError("Storyteller total_available token ceiling must be an int")
+        if ceiling < 1000:
+            raise ValueError(
+                "Storyteller total_available token ceiling must be at least 1000"
+            )
+
+        payload = turn_context.context_payload
+        tokens_before = _context_component_token_count(payload)
+        tokens_after = tokens_before
+        warm_chunks_dropped = 0
+        retrieved_passages_dropped = 0
+
+        if tokens_after <= ceiling:
+            return {
+                "tokens_before": tokens_before,
+                "tokens_after": tokens_after,
+                "warm_chunks_dropped": 0,
+                "retrieved_passages_dropped": 0,
+            }
+
+        warm_section = payload.get("warm_slice")
+        retrieved_section = payload.get("retrieved_passages")
+        if not isinstance(warm_section, dict) or not isinstance(
+            warm_section.get("chunks"), list
+        ):
+            raise TypeError("Storyteller warm_slice.chunks must be a list")
+        if not isinstance(retrieved_section, dict) or not isinstance(
+            retrieved_section.get("results"), list
+        ):
+            raise TypeError("Storyteller retrieved_passages.results must be a list")
+
+        warm_chunks = list(warm_section["chunks"])
+        retrieved_passages = list(retrieved_section["results"])
+        warm_section["chunks"] = warm_chunks
+        retrieved_section["results"] = retrieved_passages
+
+        protected_chunk = _protected_warm_chunk(warm_chunks) if warm_chunks else None
+        while tokens_after > ceiling and protected_chunk is not None:
+            oldest_index = _oldest_droppable_warm_index(warm_chunks, protected_chunk)
+            if oldest_index is None:
+                break
+            warm_chunks.pop(oldest_index)
+            warm_chunks_dropped += 1
+            tokens_after = _context_component_token_count(payload)
+
+        while tokens_after > ceiling and retrieved_passages:
+            retrieved_passages.pop()
+            retrieved_passages_dropped += 1
+            tokens_after = _context_component_token_count(payload)
+
+        if warm_chunks_dropped or retrieved_passages_dropped:
+            logger.info(
+                "Storyteller payload trimmed: wire_class=%s tokens=%s -> %s "
+                "warm_chunks_dropped=%s retrieved_passages_dropped=%s",
+                turn_context.provider_wire_type,
+                tokens_before,
+                tokens_after,
+                warm_chunks_dropped,
+                retrieved_passages_dropped,
+            )
+
+        if tokens_after > ceiling:
+            raise ValueError(
+                "Structured storyteller context exceeds the configured payload "
+                "window after all trimmable context was removed: "
+                f"wire_class={turn_context.provider_wire_type!r}, "
+                f"tokens={tokens_after}, ceiling={ceiling}. "
+                "The structured core is a configuration error."
+            )
+
+        return {
+            "tokens_before": tokens_before,
+            "tokens_after": tokens_after,
+            "warm_chunks_dropped": warm_chunks_dropped,
+            "retrieved_passages_dropped": retrieved_passages_dropped,
+        }
 
     def _build_world_knowledge(self, turn_context: TurnContext) -> list[dict[str, Any]]:
         """Load optional spoiler-limited knowledge for the current scene."""
@@ -1107,8 +1283,18 @@ class TurnCycleManager:
 
         try:
             # Generate narrative with structured output
+            if (
+                turn_context.apex_model is None
+                or turn_context.provider_wire_type is None
+            ):
+                raise RuntimeError(
+                    "Storyteller route must be resolved during Phase 1 before "
+                    "provider initialization"
+                )
             story_response = await self.lore.logon.generate_narrative_async(
-                turn_context.context_payload
+                turn_context.context_payload,
+                expected_model=turn_context.apex_model,
+                expected_wire_type=turn_context.provider_wire_type,
             )
 
             # Store the full structured response

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -601,6 +601,36 @@ class TokenBudgetConfig(BaseModel):
     system_prompt_tokens: int = Field(
         ..., ge=100, description="Reserved for system prompt"
     )
+    provider_overrides: Dict[str, int] = Field(
+        default_factory=dict,
+        description="Smaller APEX context windows by storyteller provider class",
+    )
+
+    @model_validator(mode="after")
+    def _validate_provider_overrides(self) -> "TokenBudgetConfig":
+        """Provider overrides are closed-keyed reductions of the base window."""
+        legal_provider_classes = {"openai", "anthropic", "local"}
+        unknown_provider_classes = set(self.provider_overrides) - legal_provider_classes
+        if unknown_provider_classes:
+            raise ValueError(
+                "token budget provider_overrides contains unknown provider "
+                f"classes: {sorted(unknown_provider_classes)}; legal keys are "
+                f"{sorted(legal_provider_classes)}"
+            )
+
+        for provider_class, override in self.provider_overrides.items():
+            if override < 1000:
+                raise ValueError(
+                    f"token budget provider override for '{provider_class}' must "
+                    "be greater than or equal to 1000"
+                )
+            if override > self.apex_context_window:
+                raise ValueError(
+                    "token budget provider overrides may only shrink "
+                    f"apex_context_window; '{provider_class}' override {override} "
+                    f"exceeds base {self.apex_context_window}"
+                )
+        return self
 
 
 class PayloadBudgetRange(BaseModel):

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -601,6 +601,11 @@ class TokenBudgetConfig(BaseModel):
     system_prompt_tokens: int = Field(
         ..., ge=100, description="Reserved for system prompt"
     )
+    prompt_overhead_tokens: int = Field(
+        default=4000,
+        ge=0,
+        description="Reserve for LOGON formatting added after payload assembly",
+    )
     provider_overrides: Dict[str, int] = Field(
         default_factory=dict,
         description="Smaller APEX context windows by storyteller provider class",

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -2803,7 +2803,7 @@ class UILoreBudgetSlider(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    min: int = Field(default=10_000, ge=1000, description="Slider lower bound (tok)")
+    min: int = Field(default=24_000, ge=1000, description="Slider lower bound (tok)")
     max: int = Field(default=200_000, ge=1000, description="Slider upper bound (tok)")
     step: int = Field(default=1000, ge=1, description="Slider step size (tok)")
     stops: List[int] = Field(

--- a/nexus/memory/context_state.py
+++ b/nexus/memory/context_state.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Optional, Set, Union
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Union
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +93,7 @@ class ContextStateManager:
         self._context: Optional[ContextPackage] = None
         self._transition: Optional[PassTransition] = None
         self._chunk_cache: Dict[MemoryIdentity, Dict[str, Any]] = {}
+        self._additional_chunk_token_costs: Dict[MemoryIdentity, int] = {}
 
     # ------------------------------------------------------------------
     # Baseline context management
@@ -119,6 +120,7 @@ class ContextStateManager:
         self._context = package
         self._transition = transition
         self._chunk_cache = {}
+        self._additional_chunk_token_costs = {}
 
         if chunk_details:
             self.register_chunks(chunk_details)
@@ -171,9 +173,12 @@ class ContextStateManager:
         )
 
     def register_additional_chunks(
-        self, chunks: Iterable[Dict[str, Any]]
+        self,
+        chunks: Iterable[Dict[str, Any]],
+        *,
+        token_costs: Optional[Mapping[MemoryIdentity, int]] = None,
     ) -> List[Dict[str, Any]]:
-        """Register additional chunks and return only the truly new entries."""
+        """Register new chunks and optionally charge their exact Pass-2 costs."""
 
         if not self._context:
             logger.debug(
@@ -182,14 +187,101 @@ class ContextStateManager:
             return []
 
         new_chunks: List[Dict[str, Any]] = []
+        new_identities: Set[MemoryIdentity] = set()
         for chunk in chunks:
             identity = memory_identity(chunk)
-            if identity is None or self.is_chunk_known(identity):
+            if (
+                identity is None
+                or identity in new_identities
+                or self.is_chunk_known(identity)
+            ):
                 continue
+            new_chunks.append(chunk)
+            new_identities.add(identity)
+
+        tracked_costs: Dict[MemoryIdentity, int] = {}
+        if token_costs is not None:
+            for identity in new_identities:
+                if identity not in token_costs:
+                    raise RuntimeError(
+                        "Pass-2 token accounting is missing a cost for newly "
+                        f"registered memory {identity!r}"
+                    )
+                cost = token_costs[identity]
+                if isinstance(cost, bool) or not isinstance(cost, int):
+                    raise TypeError(
+                        f"Pass-2 token cost for memory {identity!r} must be an int"
+                    )
+                if cost < 0:
+                    raise ValueError(
+                        f"Pass-2 token cost for memory {identity!r} cannot be negative"
+                    )
+                tracked_costs[identity] = cost
+
+            total_cost = sum(tracked_costs.values())
+            if total_cost > self.get_remaining_budget():
+                raise RuntimeError(
+                    "Pass-2 chunk registration exceeds the remaining budget: "
+                    f"cost={total_cost}, remaining={self.get_remaining_budget()}"
+                )
+
+        for chunk in new_chunks:
+            identity = memory_identity(chunk)
+            assert identity is not None
             self._context.additional_chunks.add(identity)
             self._chunk_cache[identity] = chunk
-            new_chunks.append(chunk)
+
+        if tracked_costs:
+            consumed = self.consume_budget(sum(tracked_costs.values()))
+            if consumed != sum(tracked_costs.values()):
+                raise RuntimeError(
+                    "Pass-2 chunk registration failed to consume its full token cost"
+                )
+            self._additional_chunk_token_costs.update(tracked_costs)
         return new_chunks
+
+    def unregister_chunks(
+        self, chunks: Iterable[Dict[str, Any]]
+    ) -> tuple[Set[MemoryIdentity], int]:
+        """Forget dropped payload chunks and refund tracked Pass-2 token costs."""
+
+        if not self._context:
+            return set(), 0
+
+        identities = {
+            identity
+            for chunk in chunks
+            for identity in [memory_identity(chunk)]
+            if identity is not None
+        }
+        removed: Set[MemoryIdentity] = set()
+        refunded_tokens = 0
+        for identity in identities:
+            was_known = (
+                identity in self._context.baseline_chunks
+                or identity in self._context.additional_chunks
+            )
+            if not was_known:
+                continue
+            self._context.baseline_chunks.discard(identity)
+            self._context.additional_chunks.discard(identity)
+            self._chunk_cache.pop(identity, None)
+            refunded_tokens += self._additional_chunk_token_costs.pop(identity, 0)
+            removed.add(identity)
+
+        if refunded_tokens:
+            if not self._transition:
+                raise RuntimeError(
+                    "Cannot refund dropped Pass-2 chunks without transition state"
+                )
+            self._transition.remaining_budget += refunded_tokens
+            logger.debug(
+                "Refunded %s tokens from dropped Pass-2 chunks (now %s)",
+                refunded_tokens,
+                self._transition.remaining_budget,
+            )
+
+        return removed, refunded_tokens
 
     def get_all_chunks(self) -> List[Dict[str, Any]]:
         if not self._context:

--- a/nexus/memory/manager.py
+++ b/nexus/memory/manager.py
@@ -39,17 +39,8 @@ logger = logging.getLogger(__name__)
 _STORYTELLER_WIRE_CLASSES = frozenset({"openai", "anthropic", "local"})
 
 
-def resolve_storyteller_context_window(
-    settings: Mapping[str, Any], provider_wire_type: Optional[str]
-) -> int:
-    """Resolve the assembled-context ceiling for one storyteller provider class."""
-    if provider_wire_type not in _STORYTELLER_WIRE_CLASSES:
-        raise RuntimeError(
-            "Cannot resolve the storyteller context budget without a valid active "
-            "provider wire class; expected one of "
-            f"{sorted(_STORYTELLER_WIRE_CLASSES)}, got {provider_wire_type!r}"
-        )
-
+def _storyteller_token_budget(settings: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the validated LORE token-budget mapping."""
     legacy_agent_settings = settings.get("Agent Settings")
     legacy_lore_settings = (
         legacy_agent_settings.get("LORE")
@@ -73,10 +64,32 @@ def resolve_storyteller_context_window(
         raise ValueError(
             "apex_context_window must be configured under LORE token_budget"
         )
+    return token_budget
+
+
+def resolve_base_storyteller_context_window(settings: Mapping[str, Any]) -> int:
+    """Resolve the base context ceiling used when LOGON is explicitly disabled."""
+    token_budget = _storyteller_token_budget(settings)
 
     apex_context_window = token_budget["apex_context_window"]
     if not isinstance(apex_context_window, int):
         raise TypeError("apex_context_window must be an integer")
+    return apex_context_window
+
+
+def resolve_storyteller_context_window(
+    settings: Mapping[str, Any], provider_wire_type: Optional[str]
+) -> int:
+    """Resolve the assembled-context ceiling for one storyteller provider class."""
+    if provider_wire_type not in _STORYTELLER_WIRE_CLASSES:
+        raise RuntimeError(
+            "Cannot resolve the storyteller context budget without a valid active "
+            "provider wire class; expected one of "
+            f"{sorted(_STORYTELLER_WIRE_CLASSES)}, got {provider_wire_type!r}"
+        )
+
+    token_budget = _storyteller_token_budget(settings)
+    apex_context_window = resolve_base_storyteller_context_window(settings)
 
     provider_overrides = token_budget.get("provider_overrides", {})
     if not isinstance(provider_overrides, Mapping):
@@ -226,6 +239,7 @@ class ContextMemoryManager:
         # change models while a LORE instance remains alive.
         self.provider_wire_type: Optional[str] = None
         self.phase2_budget: Optional[int] = None
+        self._storyteller_budget_configured = False
         if provider_wire_type is not None:
             self.configure_storyteller_budget(provider_wire_type)
 
@@ -281,6 +295,20 @@ class ContextMemoryManager:
             self.settings, provider_wire_type
         )
         self.provider_wire_type = provider_wire_type
+        self._storyteller_budget_configured = True
+        self._configure_phase2_budget(apex_context_window)
+        return apex_context_window
+
+    def configure_base_storyteller_budget(self) -> int:
+        """Use the base window for a turn where LOGON is explicitly disabled."""
+        apex_context_window = resolve_base_storyteller_context_window(self.settings)
+        self.provider_wire_type = None
+        self._storyteller_budget_configured = True
+        self._configure_phase2_budget(apex_context_window)
+        return apex_context_window
+
+    def _configure_phase2_budget(self, apex_context_window: int) -> None:
+        """Apply one resolved context window to the Phase 2 reserve."""
         self.phase2_budget = int(apex_context_window * self.phase2_fraction)
         logger.info(
             "Phase 2 budget: %s tokens (%.0f%% of %s)",
@@ -288,7 +316,6 @@ class ContextMemoryManager:
             self.phase2_fraction * 100,
             apex_context_window,
         )
-        return apex_context_window
 
     def get_memory_summary(self) -> Dict[str, Any]:
         """Get a summary of the current memory state for status reporting."""
@@ -513,10 +540,10 @@ class ContextMemoryManager:
         """Determine the usable Phase 2 budget for this turn."""
 
         phase2_budget = self.phase2_budget
-        if phase2_budget is None or self.provider_wire_type is None:
+        if phase2_budget is None or not self._storyteller_budget_configured:
             raise RuntimeError(
-                "Storyteller provider wire class must be configured before "
-                "resolving the Phase 2 payload budget"
+                "Storyteller context budget must be configured before resolving "
+                "the Phase 2 payload budget"
             )
 
         remaining_budget = self.context_state.get_remaining_budget()

--- a/nexus/memory/manager.py
+++ b/nexus/memory/manager.py
@@ -77,6 +77,25 @@ def resolve_base_storyteller_context_window(settings: Mapping[str, Any]) -> int:
     return apex_context_window
 
 
+def resolve_storyteller_prompt_overhead_tokens(
+    settings: Mapping[str, Any],
+) -> int:
+    """Resolve the post-assembly reserve for LOGON prompt formatting."""
+    token_budget = _storyteller_token_budget(settings)
+    if "prompt_overhead_tokens" not in token_budget:
+        raise ValueError(
+            "prompt_overhead_tokens must be configured under LORE token_budget"
+        )
+    prompt_overhead_tokens = token_budget["prompt_overhead_tokens"]
+    if isinstance(prompt_overhead_tokens, bool) or not isinstance(
+        prompt_overhead_tokens, int
+    ):
+        raise TypeError("prompt_overhead_tokens must be an integer")
+    if prompt_overhead_tokens < 0:
+        raise ValueError("prompt_overhead_tokens cannot be negative")
+    return prompt_overhead_tokens
+
+
 def resolve_storyteller_context_window(
     settings: Mapping[str, Any], provider_wire_type: Optional[str]
 ) -> int:
@@ -692,6 +711,7 @@ class ContextMemoryManager:
 
         # STEP 3: Keep chunks that fit in the remaining Phase 2 budget.
         kept_chunks = []
+        kept_token_costs: Dict[MemoryIdentity, int] = {}
         total_tokens = 0
         for chunk in raw_search_results:
             chunk_text = chunk.get("text", "")
@@ -700,12 +720,26 @@ class ContextMemoryManager:
             chunk_tokens = self._estimate_tokens(chunk_text)
             if total_tokens + chunk_tokens > available_budget:
                 break
+            identity = self._memory_identity(chunk)
+            if identity is None:
+                raise RuntimeError(
+                    "Incremental retrieval returned a chunk without a memory identity"
+                )
             kept_chunks.append(chunk)
+            kept_token_costs[identity] = chunk_tokens
             total_tokens += chunk_tokens
 
         if kept_chunks:
-            new_chunks = self.context_state.register_additional_chunks(kept_chunks)
-            self.context_state.consume_budget(total_tokens)
+            new_chunks = self.context_state.register_additional_chunks(
+                kept_chunks,
+                token_costs=kept_token_costs,
+            )
+            total_tokens = sum(
+                kept_token_costs[identity]
+                for chunk in new_chunks
+                for identity in [self._memory_identity(chunk)]
+                if identity is not None
+            )
             budget_percentage = (
                 total_tokens / available_budget * 100 if available_budget else 0
             )
@@ -729,10 +763,17 @@ class ContextMemoryManager:
 
         return Pass2Update(
             divergence,
-            kept_chunks,
+            new_chunks if kept_chunks else [],
             total_tokens,
             baseline_available=True,
         )
+
+    def unregister_payload_chunks(
+        self, chunks: Iterable[Dict[str, Any]]
+    ) -> tuple[Set[MemoryIdentity], int]:
+        """Remove Phase-5 drops from memory state and refund tracked retrievals."""
+
+        return self.context_state.unregister_chunks(chunks)
 
     # ------------------------------------------------------------------
     # Helper Methods

--- a/nexus/memory/manager.py
+++ b/nexus/memory/manager.py
@@ -6,7 +6,7 @@ import logging
 import re
 from collections import Counter
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Set
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Set
 
 from sqlalchemy import text
 
@@ -24,12 +24,79 @@ from .incremental import IncrementalRetriever
 from .query_memory import QueryMemory
 from .retrieval_coverage import audit_retrieval_coverage, coerce_chunk_id
 
+load_aliases_from_db: Optional[Callable[[Any], Dict[str, List[str]]]]
 try:  # pragma: no cover - optional dependency during unit tests
-    from nexus.agents.memnon.utils.alias_search import load_aliases_from_db
+    from nexus.agents.memnon.utils.alias_search import (
+        load_aliases_from_db as _load_aliases_from_db,
+    )
+
+    load_aliases_from_db = _load_aliases_from_db
 except ImportError:  # pragma: no cover - fallback if module unavailable
     load_aliases_from_db = None
 
 logger = logging.getLogger(__name__)
+
+_STORYTELLER_WIRE_CLASSES = frozenset({"openai", "anthropic", "local"})
+
+
+def resolve_storyteller_context_window(
+    settings: Mapping[str, Any], provider_wire_type: Optional[str]
+) -> int:
+    """Resolve the assembled-context ceiling for one storyteller provider class."""
+    if provider_wire_type not in _STORYTELLER_WIRE_CLASSES:
+        raise RuntimeError(
+            "Cannot resolve the storyteller context budget without a valid active "
+            "provider wire class; expected one of "
+            f"{sorted(_STORYTELLER_WIRE_CLASSES)}, got {provider_wire_type!r}"
+        )
+
+    legacy_agent_settings = settings.get("Agent Settings")
+    legacy_lore_settings = (
+        legacy_agent_settings.get("LORE")
+        if isinstance(legacy_agent_settings, Mapping)
+        else None
+    )
+    lore_settings = (
+        legacy_lore_settings
+        if isinstance(legacy_lore_settings, Mapping)
+        else settings.get("lore")
+    )
+    if not isinstance(lore_settings, Mapping):
+        raise ValueError("LORE settings are required to resolve the context budget")
+
+    token_budget = lore_settings.get("token_budget")
+    if not isinstance(token_budget, Mapping):
+        raise ValueError(
+            "token_budget must be configured under the LORE settings section"
+        )
+    if "apex_context_window" not in token_budget:
+        raise ValueError(
+            "apex_context_window must be configured under LORE token_budget"
+        )
+
+    apex_context_window = token_budget["apex_context_window"]
+    if not isinstance(apex_context_window, int):
+        raise TypeError("apex_context_window must be an integer")
+
+    provider_overrides = token_budget.get("provider_overrides", {})
+    if not isinstance(provider_overrides, Mapping):
+        raise TypeError("token_budget provider_overrides must be a mapping")
+
+    override = provider_overrides.get(provider_wire_type)
+    if override is None:
+        return apex_context_window
+    if not isinstance(override, int):
+        raise TypeError(
+            f"token budget provider override for {provider_wire_type!r} must be "
+            "an integer"
+        )
+
+    logger.debug(
+        "Storyteller payload budget override: class=%s effective=%s tokens",
+        provider_wire_type,
+        override,
+    )
+    return override
 
 
 _COMMON_STOPWORDS: Set[str] = {
@@ -138,6 +205,7 @@ class ContextMemoryManager:
         settings: Dict[str, Any],
         memnon: Optional[object] = None,
         token_manager: Optional[object] = None,
+        provider_wire_type: Optional[str] = None,
     ) -> None:
         self.settings = settings
         self.memnon = memnon  # Store reference for entity detector
@@ -154,17 +222,12 @@ class ContextMemoryManager:
             memory_settings.get("skip_simple_choices", True)
         )
 
-        # Calculate actual Phase 2 budget from apex window
-        apex_context_window = (
-            settings.get("Agent Settings", {})
-            .get("LORE", {})
-            .get("token_budget", {})
-            .get("apex_context_window", 75000)
-        )
-        self.phase2_budget = int(apex_context_window * self.phase2_fraction)
-        logger.info(
-            f"Phase 2 budget: {self.phase2_budget} tokens ({self.phase2_fraction * 100:.0f}% of {apex_context_window})"
-        )
+        # The active storyteller class is resolved per turn because slots can
+        # change models while a LORE instance remains alive.
+        self.provider_wire_type: Optional[str] = None
+        self.phase2_budget: Optional[int] = None
+        if provider_wire_type is not None:
+            self.configure_storyteller_budget(provider_wire_type)
 
         # Legacy settings (kept for compatibility but may be deprecated)
         self.pass2_reserve = float(memory_settings.get("pass2_budget_reserve", 0.25))
@@ -211,6 +274,21 @@ class ContextMemoryManager:
         self.idf_dictionary = getattr(memnon, "idf_dictionary", None)
 
         self._initialize_entity_maps(memnon)
+
+    def configure_storyteller_budget(self, provider_wire_type: str) -> int:
+        """Apply the active provider class to every memory payload budget."""
+        apex_context_window = resolve_storyteller_context_window(
+            self.settings, provider_wire_type
+        )
+        self.provider_wire_type = provider_wire_type
+        self.phase2_budget = int(apex_context_window * self.phase2_fraction)
+        logger.info(
+            "Phase 2 budget: %s tokens (%.0f%% of %s)",
+            self.phase2_budget,
+            self.phase2_fraction * 100,
+            apex_context_window,
+        )
+        return apex_context_window
 
     def get_memory_summary(self) -> Dict[str, Any]:
         """Get a summary of the current memory state for status reporting."""
@@ -364,7 +442,8 @@ class ContextMemoryManager:
         # Pass 2 queries are always reset when a new baseline is stored
         self.query_memory.reset_pass("pass2")
         logger.debug(
-            "Pass 1 baseline stored: %s baseline chunks, %s expected themes, remaining budget=%s",
+            "Pass 1 baseline stored: %s baseline chunks, %s expected themes, "
+            "remaining budget=%s",
             len(baseline_chunks),
             len(expected_user_themes),
             remaining_budget,
@@ -433,6 +512,13 @@ class ContextMemoryManager:
     ) -> int:
         """Determine the usable Phase 2 budget for this turn."""
 
+        phase2_budget = self.phase2_budget
+        if phase2_budget is None or self.provider_wire_type is None:
+            raise RuntimeError(
+                "Storyteller provider wire class must be configured before "
+                "resolving the Phase 2 payload budget"
+            )
+
         remaining_budget = self.context_state.get_remaining_budget()
 
         if token_counts:
@@ -445,14 +531,15 @@ class ContextMemoryManager:
                 actual_remaining = max(0, int(total_available) - int(baseline_tokens))
                 if actual_remaining != remaining_budget:
                     logger.debug(
-                        "Adjusting remaining budget from %s to %s based on token counts",
+                        "Adjusting remaining budget from %s to %s based on "
+                        "token counts",
                         remaining_budget,
                         actual_remaining,
                     )
                     self.context_state.adjust_budget(actual_remaining)
                     remaining_budget = actual_remaining
 
-        return max(0, min(self.phase2_budget, remaining_budget))
+        return max(0, min(phase2_budget, remaining_budget))
 
     def handle_user_input(
         self,
@@ -571,14 +658,19 @@ class ContextMemoryManager:
             )
 
         logger.info(
-            f"Raw search retrieved {len(raw_search_results)} chunks (~{raw_tokens} tokens)"
+            "Raw search retrieved %s chunks (~%s tokens)",
+            len(raw_search_results),
+            raw_tokens,
         )
 
         # STEP 3: Keep chunks that fit in the remaining Phase 2 budget.
         kept_chunks = []
         total_tokens = 0
         for chunk in raw_search_results:
-            chunk_tokens = self._estimate_tokens(chunk.get("text", ""))
+            chunk_text = chunk.get("text", "")
+            if not isinstance(chunk_text, str):
+                raise TypeError("Retrieved chunk text must be a string")
+            chunk_tokens = self._estimate_tokens(chunk_text)
             if total_tokens + chunk_tokens > available_budget:
                 break
             kept_chunks.append(chunk)
@@ -587,10 +679,12 @@ class ContextMemoryManager:
         if kept_chunks:
             new_chunks = self.context_state.register_additional_chunks(kept_chunks)
             self.context_state.consume_budget(total_tokens)
+            budget_percentage = (
+                total_tokens / available_budget * 100 if available_budget else 0
+            )
             logger.info(
                 f"✅ Phase 2 complete: {len(new_chunks)} new chunks, "
-                f"{total_tokens} tokens ("
-                f"{(total_tokens / available_budget * 100) if available_budget else 0:.1f}% of budget)"
+                f"{total_tokens} tokens ({budget_percentage:.1f}% of budget)"
             )
         else:
             logger.info("Phase 2 complete: No chunks fit in remaining budget")
@@ -685,7 +779,7 @@ class ContextMemoryManager:
     def _initialize_entity_maps(self, memnon: Optional[object]) -> None:
         """Load alias and location metadata for canonical entity detection."""
 
-        if not memnon or not load_aliases_from_db:  # pragma: no cover - defensive
+        if not memnon or load_aliases_from_db is None:  # pragma: no cover - defensive
             return
 
         engine = getattr(getattr(memnon, "db_manager", None), "engine", None)
@@ -714,14 +808,13 @@ class ContextMemoryManager:
                         text("SELECT name FROM characters WHERE id = :id"),
                         {"id": result[0]},
                     ).fetchone()
-                    if user_row and user_row[0]:
-                        self.user_character_name = user_row[0]
-                        canonical = self.user_character_name.lower()
+                    user_character_name = user_row[0] if user_row else None
+                    if user_character_name:
+                        self.user_character_name = user_character_name
+                        canonical = user_character_name.lower()
                         if canonical not in self.alias_lookup:
-                            self.alias_lookup[canonical] = [self.user_character_name]
-                            self.canonical_name_map[canonical] = (
-                                self.user_character_name
-                            )
+                            self.alias_lookup[canonical] = [user_character_name]
+                            self.canonical_name_map[canonical] = user_character_name
                         for alias in self.alias_lookup[canonical]:
                             self.alias_inverse[alias.lower()] = canonical
                         for pronoun in ("you", "your", "yours", "yourself"):
@@ -819,7 +912,8 @@ class ContextMemoryManager:
                     locations.append(location_name)
                 continue
 
-            # Fallback: treat standalone capitalised tokens as provisional character names
+            # Fallback: standalone capitalised tokens are provisional
+            # character names.
             lower_normalized = normalized.lower()
             if (
                 " " not in normalized

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -123,6 +123,7 @@ def test_token_budget_provider_overrides_parse() -> None:
     settings = Settings(**_nexus_toml_dict())
 
     assert settings.lore.token_budget.provider_overrides == {"local": 24_000}
+    assert settings.lore.token_budget.prompt_overhead_tokens == 4_000
     assert settings.ui.lore_budget_slider.min == 24_000
     assert all(
         stop >= settings.ui.lore_budget_slider.min
@@ -155,6 +156,28 @@ def test_token_budget_provider_overrides_reject_too_small_value() -> None:
 
     with pytest.raises(ValidationError, match="greater than or equal to 1000"):
         Settings(**raw)
+
+
+def test_token_budget_rejects_negative_prompt_overhead() -> None:
+    """Post-assembly prompt headroom can be zero but never negative."""
+    raw = _nexus_toml_dict()
+    raw["lore"]["token_budget"]["prompt_overhead_tokens"] = -1
+
+    with pytest.raises(
+        ValidationError,
+        match="prompt_overhead_tokens",
+    ):
+        Settings(**raw)
+
+
+def test_token_budget_accepts_zero_prompt_overhead() -> None:
+    """Zero remains legal for targeted final-prompt invariant tests."""
+    raw = _nexus_toml_dict()
+    raw["lore"]["token_budget"]["prompt_overhead_tokens"] = 0
+
+    settings = Settings(**raw)
+
+    assert settings.lore.token_budget.prompt_overhead_tokens == 0
 
 
 def test_summaries_follow_anthropic_storyteller_with_registry_route():

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -118,6 +118,40 @@ def test_apex_rejects_unknown_anthropic_storyteller_transport() -> None:
         Settings(**raw)
 
 
+def test_token_budget_provider_overrides_parse() -> None:
+    """Legal provider-class reductions survive settings validation."""
+    settings = Settings(**_nexus_toml_dict())
+
+    assert settings.lore.token_budget.provider_overrides == {"local": 24_000}
+
+
+def test_token_budget_provider_overrides_reject_unknown_key() -> None:
+    """Provider override keys are the closed storyteller wire-class set."""
+    raw = _nexus_toml_dict()
+    raw["lore"]["token_budget"]["provider_overrides"]["bedrock"] = 20_000
+
+    with pytest.raises(ValidationError, match="unknown provider classes.*bedrock"):
+        Settings(**raw)
+
+
+def test_token_budget_provider_overrides_reject_over_base() -> None:
+    """An override cannot accidentally enlarge the assembled payload."""
+    raw = _nexus_toml_dict()
+    raw["lore"]["token_budget"]["provider_overrides"]["local"] = 75_001
+
+    with pytest.raises(ValidationError, match="may only shrink"):
+        Settings(**raw)
+
+
+def test_token_budget_provider_overrides_reject_too_small_value() -> None:
+    """Overrides retain the base field's 1,000-token lower bound."""
+    raw = _nexus_toml_dict()
+    raw["lore"]["token_budget"]["provider_overrides"]["local"] = 999
+
+    with pytest.raises(ValidationError, match="greater than or equal to 1000"):
+        Settings(**raw)
+
+
 def test_summaries_follow_anthropic_storyteller_with_registry_route():
     """A native Anthropic storyteller remains the default summarizer."""
     raw = _nexus_toml_dict()

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -123,6 +123,11 @@ def test_token_budget_provider_overrides_parse() -> None:
     settings = Settings(**_nexus_toml_dict())
 
     assert settings.lore.token_budget.provider_overrides == {"local": 24_000}
+    assert settings.ui.lore_budget_slider.min == 24_000
+    assert all(
+        stop >= settings.ui.lore_budget_slider.min
+        for stop in settings.ui.lore_budget_slider.stops
+    )
 
 
 def test_token_budget_provider_overrides_reject_unknown_key() -> None:

--- a/tests/test_lore/test_context_validation.py
+++ b/tests/test_lore/test_context_validation.py
@@ -1,311 +1,295 @@
-"""
-Unit tests for context_validation.py
-
-Tests validation of context payloads against percentage-based constraints.
-"""
-
-import pytest
-from pathlib import Path
-import sys
-
-# Add nexus module to path
-nexus_root = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(nexus_root))
+"""Tests for percentage-based context payload validation."""
 
 from nexus.agents.lore.utils.context_validation import (
-    validate_context,
-    validate_token_allocation,
     check_utilization,
-    validate_phase_completion
+    validate_context,
+    validate_phase_completion,
+    validate_token_allocation,
 )
 
 
 class TestContextValidation:
     """Test context payload validation."""
-    
+
     def test_validate_context_complete(self, settings):
         """Test validation of a complete, valid context."""
         context = {
-            'user_input': 'Test input',
-            'narrative_context': {
-                'warm_slice': [{'id': 1, 'text': 'chunk1'}]
-            },
-            'metadata': {
-                'token_counts': {
-                    'warm_slice': 10000,      # 50% of 20k
-                    'structured': 3000,        # 15% of 20k
-                    'augmentation': 6000,      # 30% of 20k
-                    'user_input': 1000         # 5% of 20k
+            "user_input": "Test input",
+            "narrative_context": {"warm_slice": [{"id": 1, "text": "chunk1"}]},
+            "metadata": {
+                "token_counts": {
+                    "warm_slice": 10000,  # 50% of 20k
+                    "structured": 3000,  # 15% of 20k
+                    "augmentation": 6000,  # 30% of 20k
+                    "user_input": 1000,  # 5% of 20k
                 }
-            }
+            },
         }
-        
-        is_valid, errors = validate_context(context, settings)
+
+        is_valid, errors = validate_context(context, settings, "openai")
         assert is_valid
         assert len(errors) == 0
-    
+
     def test_validate_context_missing_fields(self, settings):
         """Test validation catches missing required fields."""
         context = {
             # Missing user_input
-            'narrative_context': {
-                'warm_slice': []
-            }
+            "narrative_context": {"warm_slice": []}
         }
-        
-        is_valid, errors = validate_context(context, settings)
+
+        is_valid, errors = validate_context(context, settings, "openai")
         assert not is_valid
-        assert 'Missing user_input' in errors
-    
+        assert "Missing user_input" in errors
+
     def test_validate_context_empty_warm_slice(self, settings):
         """Test validation catches empty warm slice."""
         context = {
-            'user_input': 'Test',
-            'narrative_context': {
-                'warm_slice': []  # Empty
-            }
+            "user_input": "Test",
+            "narrative_context": {"warm_slice": []},  # Empty
         }
-        
-        is_valid, errors = validate_context(context, settings)
+
+        is_valid, errors = validate_context(context, settings, "openai")
         assert not is_valid
-        assert any('warm_slice' in e for e in errors)
-    
+        assert any("warm_slice" in e for e in errors)
+
     def test_validate_context_token_limit_exceeded(self, settings):
         """Test validation catches token limit violations."""
         context = {
-            'user_input': 'Test',
-            'narrative_context': {
-                'warm_slice': [{'id': 1}]
-            },
-            'metadata': {
-                'token_counts': {
-                    'warm_slice': 100000,
-                    'structured': 50000,
-                    'augmentation': 60000
+            "user_input": "Test",
+            "narrative_context": {"warm_slice": [{"id": 1}]},
+            "metadata": {
+                "token_counts": {
+                    "warm_slice": 100000,
+                    "structured": 50000,
+                    "augmentation": 60000,
                 }
-            }
+            },
         }
-        
-        is_valid, errors = validate_context(context, settings)
+
+        is_valid, errors = validate_context(context, settings, "openai")
         assert not is_valid
-        assert any('Token limit exceeded' in e for e in errors)
-    
+        assert any("Token limit exceeded" in e for e in errors)
+
     def test_validate_context_percentage_violations(self, settings):
         """Test validation catches percentage constraint violations."""
         context = {
-            'user_input': 'Test',
-            'narrative_context': {
-                'warm_slice': [{'id': 1}]
-            },
-            'metadata': {
-                'token_counts': {
-                    'warm_slice': 2000,       # 10% - below 40% minimum
-                    'structured': 8000,        # 40% - above 25% maximum  
-                    'augmentation': 10000      # 50% - above 40% maximum
+            "user_input": "Test",
+            "narrative_context": {"warm_slice": [{"id": 1}]},
+            "metadata": {
+                "token_counts": {
+                    "warm_slice": 2000,  # 10% - below 40% minimum
+                    "structured": 8000,  # 40% - above 25% maximum
+                    "augmentation": 10000,  # 50% - above 40% maximum
                 }
-            }
+            },
         }
-        
-        is_valid, errors = validate_context(context, settings)
+
+        is_valid, errors = validate_context(context, settings, "openai")
         assert not is_valid
         # Should have errors for all three components
-        assert any('Warm slice below minimum' in e for e in errors)
-        assert any('Structured data above maximum' in e for e in errors)
-        assert any('Augmentation above maximum' in e for e in errors)
+        assert any("Warm slice below minimum" in e for e in errors)
+        assert any("Structured data above maximum" in e for e in errors)
+        assert any("Augmentation above maximum" in e for e in errors)
 
 
 class TestTokenAllocation:
     """Test token allocation validation."""
-    
+
     def test_validate_allocation_valid(self, settings):
         """Test validation of valid token allocations."""
         allocations = {
-            'warm_slice': 10000,           # 50% of 20k
-            'structured_data': 3000,        # 15% of 20k
-            'contextual_augmentation': 6000 # 30% of 20k
+            "warm_slice": 10000,  # 50% of 20k
+            "structured_data": 3000,  # 15% of 20k
+            "contextual_augmentation": 6000,  # 30% of 20k
         }
-        
+
         is_valid, errors = validate_token_allocation(allocations, 20000, settings)
         assert is_valid
         assert len(errors) == 0
-    
+
     def test_validate_allocation_exceeds_budget(self, settings):
         """Test validation catches over-budget allocations."""
         allocations = {
-            'warm_slice': 10000,
-            'structured_data': 5000,
-            'contextual_augmentation': 8000  # Total = 23k > 20k budget
+            "warm_slice": 10000,
+            "structured_data": 5000,
+            "contextual_augmentation": 8000,  # Total = 23k > 20k budget
         }
-        
+
         is_valid, errors = validate_token_allocation(allocations, 20000, settings)
         assert not is_valid
-        assert any('exceeds budget' in e for e in errors)
-    
+        assert any("exceeds budget" in e for e in errors)
+
     def test_validate_allocation_warm_slice_bounds(self, settings):
         """Test warm slice percentage boundaries (40-70%)."""
         # Too low (30%)
         allocations = {
-            'warm_slice': 6000,  # 30% of 20k
-            'structured_data': 3000,
-            'contextual_augmentation': 6000
+            "warm_slice": 6000,  # 30% of 20k
+            "structured_data": 3000,
+            "contextual_augmentation": 6000,
         }
-        
+
         is_valid, errors = validate_token_allocation(allocations, 20000, settings)
         assert not is_valid
-        assert any('Warm slice' in e and 'outside bounds' in e for e in errors)
-        
+        assert any("Warm slice" in e and "outside bounds" in e for e in errors)
+
         # Too high (80%)
-        allocations['warm_slice'] = 16000  # 80% of 20k
-        allocations['structured_data'] = 2000
-        allocations['contextual_augmentation'] = 2000
-        
+        allocations["warm_slice"] = 16000  # 80% of 20k
+        allocations["structured_data"] = 2000
+        allocations["contextual_augmentation"] = 2000
+
         is_valid, errors = validate_token_allocation(allocations, 20000, settings)
         assert not is_valid
-        assert any('Warm slice' in e and 'outside bounds' in e for e in errors)
-    
+        assert any("Warm slice" in e and "outside bounds" in e for e in errors)
+
     def test_validate_allocation_structured_bounds(self, settings):
         """Test structured data percentage boundaries (10-25%)."""
         # Too low (5%)
         allocations = {
-            'warm_slice': 10000,
-            'structured_data': 1000,  # 5% of 20k
-            'contextual_augmentation': 7000
+            "warm_slice": 10000,
+            "structured_data": 1000,  # 5% of 20k
+            "contextual_augmentation": 7000,
         }
-        
+
         is_valid, errors = validate_token_allocation(allocations, 20000, settings)
         assert not is_valid
-        assert any('Structured data' in e and 'outside bounds' in e for e in errors)
-    
+        assert any("Structured data" in e and "outside bounds" in e for e in errors)
+
     def test_validate_allocation_augmentation_bounds(self, settings):
         """Test augmentation percentage boundaries (25-40%)."""
         # Too low (20%)
         allocations = {
-            'warm_slice': 12000,
-            'structured_data': 3000,
-            'contextual_augmentation': 4000  # 20% of 20k
+            "warm_slice": 12000,
+            "structured_data": 3000,
+            "contextual_augmentation": 4000,  # 20% of 20k
         }
-        
+
         is_valid, errors = validate_token_allocation(allocations, 20000, settings)
         assert not is_valid
-        assert any('Augmentation' in e and 'outside bounds' in e for e in errors)
+        assert any("Augmentation" in e and "outside bounds" in e for e in errors)
 
 
 class TestUtilizationCheck:
     """Test token utilization checking."""
-    
+
     def test_utilization_optimal(self, settings):
         """Test optimal utilization (95% target)."""
         token_counts = {
-            'total_available': 20000,
-            'user_input': 500,
-            'warm_slice': 9500,
-            'structured': 3000,
-            'augmentation': 6000
+            "total_available": 20000,
+            "user_input": 500,
+            "warm_slice": 9500,
+            "structured": 3000,
+            "augmentation": 6000,
         }
         # Total used: 19000 = 95%
-        
-        utilization, is_within_target, message = check_utilization(token_counts, settings)
+
+        utilization, is_within_target, message = check_utilization(
+            token_counts, settings
+        )
         assert utilization == 95.0
         assert is_within_target
-        assert 'Optimal' in message
-    
+        assert "Optimal" in message
+
     def test_utilization_acceptable(self, settings):
         """Test acceptable utilization (90-98% range)."""
         token_counts = {
-            'total_available': 20000,
-            'user_input': 500,
-            'warm_slice': 8500,
-            'structured': 3000,
-            'augmentation': 6000
+            "total_available": 20000,
+            "user_input": 500,
+            "warm_slice": 8500,
+            "structured": 3000,
+            "augmentation": 6000,
         }
         # Total used: 18000 = 90%
-        
-        utilization, is_within_target, message = check_utilization(token_counts, settings)
+
+        utilization, is_within_target, message = check_utilization(
+            token_counts, settings
+        )
         assert utilization == 90.0
         assert is_within_target
-        assert 'Acceptable' in message
-    
+        assert "Acceptable" in message
+
     def test_utilization_underutilized(self, settings):
         """Test underutilization detection (<90%)."""
         token_counts = {
-            'total_available': 20000,
-            'user_input': 500,
-            'warm_slice': 7000,
-            'structured': 2500,
-            'augmentation': 5000
+            "total_available": 20000,
+            "user_input": 500,
+            "warm_slice": 7000,
+            "structured": 2500,
+            "augmentation": 5000,
         }
         # Total used: 15000 = 75%
-        
-        utilization, is_within_target, message = check_utilization(token_counts, settings)
+
+        utilization, is_within_target, message = check_utilization(
+            token_counts, settings
+        )
         assert utilization == 75.0
         assert not is_within_target
-        assert 'Underutilized' in message
-    
+        assert "Underutilized" in message
+
     def test_utilization_overutilized(self, settings):
         """Test overutilization detection (>98%)."""
         token_counts = {
-            'total_available': 20000,
-            'user_input': 500,
-            'warm_slice': 10000,
-            'structured': 3500,
-            'augmentation': 6200
+            "total_available": 20000,
+            "user_input": 500,
+            "warm_slice": 10000,
+            "structured": 3500,
+            "augmentation": 6200,
         }
         # Total used: 20200 = 101% (shouldn't happen but test the check)
-        
-        utilization, is_within_target, message = check_utilization(token_counts, settings)
+
+        utilization, is_within_target, message = check_utilization(
+            token_counts, settings
+        )
         assert utilization > 98
         assert not is_within_target
-        assert 'Overutilized' in message
-    
+        assert "Overutilized" in message
+
     def test_utilization_zero_available(self, settings):
         """Test handling of zero available tokens."""
-        token_counts = {
-            'total_available': 0,
-            'user_input': 100,
-            'warm_slice': 100
-        }
-        
-        utilization, is_within_target, message = check_utilization(token_counts, settings)
+        token_counts = {"total_available": 0, "user_input": 100, "warm_slice": 100}
+
+        utilization, is_within_target, message = check_utilization(
+            token_counts, settings
+        )
         assert utilization == 0
         assert not is_within_target
 
 
 class TestPhaseCompletion:
     """Test phase completion validation."""
-    
+
     def test_phase_completion_all_complete(self, mock_turn_context):
         """Test when all required phases are complete."""
         mock_turn_context.phase_states = {
-            'user_input': 'completed',
-            'warm_analysis': 'completed',
-            'entity_state': 'completed',
-            'deep_queries': 'completed',
-            'payload_assembly': 'completed'
+            "user_input": "completed",
+            "warm_analysis": "completed",
+            "entity_state": "completed",
+            "deep_queries": "completed",
+            "payload_assembly": "completed",
         }
-        
+
         all_complete, incomplete = validate_phase_completion(mock_turn_context)
         assert all_complete
         assert len(incomplete) == 0
-    
+
     def test_phase_completion_missing_phases(self, mock_turn_context):
         """Test detection of missing phases."""
         mock_turn_context.phase_states = {
-            'user_input': 'completed',
-            'warm_analysis': 'completed'
+            "user_input": "completed",
+            "warm_analysis": "completed",
             # Missing: entity_state, deep_queries, payload_assembly
         }
-        
+
         all_complete, incomplete = validate_phase_completion(mock_turn_context)
         assert not all_complete
         assert len(incomplete) == 3
-        assert 'entity_state' in incomplete
-        assert 'deep_queries' in incomplete
-        assert 'payload_assembly' in incomplete
-    
+        assert "entity_state" in incomplete
+        assert "deep_queries" in incomplete
+        assert "payload_assembly" in incomplete
+
     def test_phase_completion_empty(self, mock_turn_context):
         """Test with no completed phases."""
         mock_turn_context.phase_states = {}
-        
+
         all_complete, incomplete = validate_phase_completion(mock_turn_context)
         assert not all_complete
         assert len(incomplete) == 5  # All 5 required phases missing

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -217,7 +217,7 @@ def test_anthropic_storyteller_transport_and_guide_follow_settings(
         ("local", "http://127.0.0.1:1234/v1", "local"),
     ],
 )
-def test_provider_wire_type_resolves_without_constructing_provider(
+def test_storyteller_route_resolves_without_constructing_provider(
     monkeypatch: pytest.MonkeyPatch,
     provider_type: str,
     base_url: str | None,
@@ -234,8 +234,45 @@ def test_provider_wire_type_resolves_without_constructing_provider(
     )
     logon = LogonUtility({}, model_override="storyteller-model")
 
-    assert logon.resolve_provider_wire_type() == expected_wire_type
+    assert logon.resolve_storyteller_route() == (
+        "storyteller-model",
+        expected_wire_type,
+    )
     assert logon.provider is None
+
+
+def test_provider_initialization_reuses_the_compared_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A matching Phase 6 comparison must not perform a third route read."""
+    logon = LogonUtility({}, model_override="storyteller-model")
+    route = ("storyteller-model", "openai", None, "openai")
+    route_calls = {"count": 0}
+    initialized_routes: list[tuple[Any, ...] | None] = []
+
+    def resolve_route() -> tuple[str, str, None, str]:
+        route_calls["count"] += 1
+        return route
+
+    def initialize_provider(
+        _is_bootstrap: bool | None = None,
+        *,
+        resolved_route: tuple[Any, ...] | None = None,
+    ) -> None:
+        initialized_routes.append(resolved_route)
+        logon.provider = cast(Any, _DummyProvider())
+
+    monkeypatch.setattr(logon, "_resolve_storyteller_route", resolve_route)
+    monkeypatch.setattr(logon, "_initialize_provider", initialize_provider)
+
+    logon._ensure_provider(
+        _minimal_payload(),
+        expected_model="storyteller-model",
+        expected_wire_type="openai",
+    )
+
+    assert route_calls["count"] == 1
+    assert initialized_routes == [route]
 
 
 @pytest.mark.requires_postgres

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -209,6 +209,35 @@ def test_anthropic_storyteller_transport_and_guide_follow_settings(
     assert utility._system_prompt == expected_system
 
 
+@pytest.mark.parametrize(
+    ("provider_type", "base_url", "expected_wire_type"),
+    [
+        ("openai", None, "openai"),
+        ("anthropic", None, "anthropic"),
+        ("local", "http://127.0.0.1:1234/v1", "local"),
+    ],
+)
+def test_provider_wire_type_resolves_without_constructing_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    provider_type: str,
+    base_url: str | None,
+    expected_wire_type: str,
+) -> None:
+    """Budget classification reuses LOGON routing while provider init stays lazy."""
+    monkeypatch.setattr(
+        "nexus.agents.lore.logon_utility.get_provider_for_model",
+        lambda _model: provider_type,
+    )
+    monkeypatch.setattr(
+        "nexus.config.get_openai_compatible_endpoint",
+        lambda _model: {"base_url": base_url} if base_url else None,
+    )
+    logon = LogonUtility({}, model_override="storyteller-model")
+
+    assert logon.resolve_provider_wire_type() == expected_wire_type
+    assert logon.provider is None
+
+
 @pytest.mark.requires_postgres
 def test_lore_keeps_logon_lazy(patched_provider: Dict[str, int]) -> None:
     """LORE should not initialize LOGON on construction when lazy mode is enabled."""

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, cast, Dict
 
 import pytest
@@ -13,6 +14,9 @@ from nexus.agents.logon.skald_wire import SkaldTurnWire, skald_wire_prompt_guide
 from nexus.agents.lore import logon_utility
 from nexus.agents.lore.lore import LORE
 from nexus.agents.lore.logon_utility import LogonUtility
+from nexus.agents.lore.utils.turn_context import TurnContext
+from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
+from nexus.memory import ContextMemoryManager
 
 
 class _DummyResponse:
@@ -37,14 +41,14 @@ class _DummyProvider:
         return _DummyResponse(prompt)
 
     def get_structured_completion(
-        self, prompt: str, schema_model: type
+        self, prompt: str, schema_model: type, **_kwargs: Any
     ) -> tuple[Any, _DummyResponse]:
         self.calls += 1
         self.schema_models.append(schema_model)
         return self._response(prompt, schema_model), _DummyResponse(prompt)
 
     async def get_structured_completion_async(
-        self, prompt: str, schema_model: type
+        self, prompt: str, schema_model: type, **_kwargs: Any
     ) -> tuple[Any, _DummyResponse]:
         self.calls += 1
         self.schema_models.append(schema_model)
@@ -73,7 +77,7 @@ class _FailingProvider:
         self.completion_calls = 0
 
     async def get_structured_completion_async(
-        self, prompt: str, schema_model: type
+        self, prompt: str, schema_model: type, **_kwargs: Any
     ) -> tuple[Any, _DummyResponse]:
         self.structured_calls += 1
         raise RuntimeError("structured boom")
@@ -95,6 +99,7 @@ def patched_provider(monkeypatch: pytest.MonkeyPatch) -> Dict[str, int]:
         self._provider_bootstrap_mode = (
             self.bootstrap_mode if is_bootstrap is None else is_bootstrap
         )
+        self._provider_wire_type = "openai"
 
     for target in (
         "nexus.agents.lore.logon_utility.LogonUtility._initialize_provider",
@@ -275,6 +280,31 @@ def test_provider_initialization_reuses_the_compared_route(
     assert initialized_routes == [route]
 
 
+def test_sync_generation_rejects_mid_turn_route_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The synchronous generation path compares the authoritative turn route."""
+    logon = LogonUtility({}, model_override="phase-one-model")
+    monkeypatch.setattr(
+        logon,
+        "_resolve_storyteller_route",
+        lambda: ("changed-model", "openai", None, "local"),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="slot model changed mid-turn; aborting the turn",
+    ):
+        logon.generate_narrative(
+            _minimal_payload(),
+            expected_model="phase-one-model",
+            expected_wire_type="openai",
+            effective_context_window=75_000,
+        )
+
+    assert logon.provider is None
+
+
 @pytest.mark.requires_postgres
 def test_lore_keeps_logon_lazy(patched_provider: Dict[str, int]) -> None:
     """LORE should not initialize LOGON on construction when lazy mode is enabled."""
@@ -321,8 +351,12 @@ async def test_logon_async_generation_uses_structured_provider() -> None:
     logon = LogonUtility({}, model_override="dummy-model")
     logon.provider = cast(Any, provider)
     logon._provider_bootstrap_mode = False
+    logon._provider_wire_type = "openai"
 
-    response = await logon.generate_narrative_async(_minimal_payload())
+    response = await logon.generate_narrative_async(
+        _minimal_payload(),
+        effective_context_window=75_000,
+    )
 
     assert provider.calls == 1
     assert provider.completion_calls == 0
@@ -340,8 +374,12 @@ async def test_logon_async_generation_uses_bootstrap_schema_for_bootstrap() -> N
     logon = LogonUtility({}, model_override="dummy-model")
     logon.provider = cast(Any, provider)
     logon._provider_bootstrap_mode = True
+    logon._provider_wire_type = "openai"
 
-    response = await logon.generate_narrative_async(_minimal_payload(is_bootstrap=True))
+    response = await logon.generate_narrative_async(
+        _minimal_payload(is_bootstrap=True),
+        effective_context_window=75_000,
+    )
 
     assert provider.calls == 1
     assert provider.completion_calls == 0
@@ -359,17 +397,25 @@ async def test_logon_stamps_model_exposed_by_last_successful_attempt() -> None:
         model = "first-attempt-model"
 
         async def get_structured_completion_async(
-            self, prompt: str, schema_model: type
+            self, prompt: str, schema_model: type, **kwargs: Any
         ) -> tuple[Any, _DummyResponse]:
             self.model = "successful-attempt-model"
-            return await super().get_structured_completion_async(prompt, schema_model)
+            return await super().get_structured_completion_async(
+                prompt,
+                schema_model,
+                **kwargs,
+            )
 
     provider = RetrySwitchingProvider()
     logon = LogonUtility({}, model_override="first-attempt-model")
     logon.provider = cast(Any, provider)
     logon._provider_bootstrap_mode = False
+    logon._provider_wire_type = "openai"
 
-    response = await logon.generate_narrative_async(_minimal_payload())
+    response = await logon.generate_narrative_async(
+        _minimal_payload(),
+        effective_context_window=75_000,
+    )
 
     assert response.generation_model == "successful-attempt-model"
 
@@ -382,9 +428,13 @@ async def test_logon_structured_failure_does_not_call_plain_text_fallback() -> N
     logon = LogonUtility({}, model_override="dummy-model")
     logon.provider = cast(Any, provider)
     logon._provider_bootstrap_mode = False
+    logon._provider_wire_type = "openai"
 
     with pytest.raises(RuntimeError, match="structured boom"):
-        await logon.generate_narrative_async(_minimal_payload())
+        await logon.generate_narrative_async(
+            _minimal_payload(),
+            effective_context_window=75_000,
+        )
 
     assert provider.structured_calls == 1
     assert provider.completion_calls == 0
@@ -403,13 +453,84 @@ def test_context_bootstrap_mode_does_not_mutate_logon_instance(
         self._provider_bootstrap_mode = (
             self.bootstrap_mode if is_bootstrap is None else is_bootstrap
         )
+        self._provider_wire_type = "openai"
 
     monkeypatch.setattr(LogonUtility, "_initialize_provider", _fake_initialize)
 
     logon = LogonUtility({}, model_override="dummy-model", bootstrap_mode=False)
 
-    logon.generate_narrative(_minimal_payload(is_bootstrap=True))
+    logon.generate_narrative(
+        _minimal_payload(is_bootstrap=True),
+        effective_context_window=75_000,
+    )
 
     assert initialized_modes == [True]
     assert logon.bootstrap_mode is False
     assert logon._provider_bootstrap_mode is True
+
+
+@pytest.mark.asyncio
+async def test_final_prompt_overflow_from_tag_library_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Too-small overhead cannot let LOGON send an oversized final prompt."""
+    settings = {
+        "Agent Settings": {
+            "LORE": {
+                "token_budget": {
+                    "apex_context_window": 1_000,
+                    "prompt_overhead_tokens": 0,
+                    "provider_overrides": {"local": 1_000},
+                }
+            }
+        }
+    }
+    provider = _DummyProvider()
+    logon = LogonUtility(settings, model_override="dummy-model")
+    logon.provider = cast(Any, provider)
+    logon._provider_bootstrap_mode = False
+    logon._provider_wire_type = "local"
+
+    class PromptLore:
+        def __init__(self) -> None:
+            self.settings = settings
+            self.memnon = None
+            self.memory_manager = ContextMemoryManager(settings)
+            self.token_manager = None
+
+    turn_manager = TurnCycleManager(PromptLore())
+    turn_context = TurnContext(
+        turn_id="undersized-overhead",
+        user_input="Continue.",
+        start_time=0,
+    )
+    turn_context.provider_wire_type = "local"
+    turn_context.warm_slice = [{"chunk_id": 1, "text": "Parent.", "is_target": True}]
+    turn_context.token_counts = {
+        "total_available": 1_000,
+        "warm_slice": 100,
+        "structured": 0,
+        "augmentation": 0,
+    }
+    await turn_manager.assemble_context_payload(turn_context)
+    assert turn_context.phase_states["payload_assembly"]["payload_ceiling"] == 1_000
+
+    monkeypatch.setattr(
+        logon,
+        "_format_turn_tag_library",
+        lambda _context, *, presence_baseline: "oversized-tag " * 2_000,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="nexus.lore.logon"):
+        with pytest.raises(
+            ValueError,
+            match="Final storyteller prompt exceeds the effective context window",
+        ):
+            await logon.generate_narrative_async(
+                turn_context.context_payload,
+                effective_context_window=1_000,
+            )
+
+    assert provider.calls == 0
+    assert "Final storyteller prompt size: wire_class=local" in caplog.text

--- a/tests/test_lore/test_memory_manager.py
+++ b/tests/test_lore/test_memory_manager.py
@@ -146,6 +146,18 @@ def test_missing_provider_wire_type_is_programming_error(minimal_settings) -> No
         manager.configure_storyteller_budget(None)  # type: ignore[arg-type]
 
 
+def test_explicit_base_budget_mode_configures_phase2(minimal_settings) -> None:
+    """LOGON-disabled callers can deliberately select the base window."""
+    manager = ContextMemoryManager(minimal_settings)
+
+    effective_window = manager.configure_base_storyteller_budget()
+
+    assert effective_window == 75_000
+    assert manager.provider_wire_type is None
+    assert manager.phase2_budget == 7_500
+    assert manager._compute_available_phase2_budget({"total_available": 7_500}) == 7_500
+
+
 def test_pass1_baseline_tracks_chunks_and_budget(
     minimal_settings, dummy_memnon, baseline_inputs
 ):

--- a/tests/test_lore/test_memory_manager.py
+++ b/tests/test_lore/test_memory_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 from typing import Dict, List
 
 import pytest
@@ -15,12 +16,20 @@ from nexus.memory.entity_detector import HighSpecificityEntityDetector
 @pytest.fixture
 def minimal_settings() -> Dict[str, object]:
     return {
+        "Agent Settings": {
+            "LORE": {
+                "token_budget": {
+                    "apex_context_window": 75_000,
+                    "provider_overrides": {"local": 24_000},
+                }
+            }
+        },
         "memory": {
             "pass2_budget_reserve": 0.25,
             "divergence_threshold": 0.4,
             "warm_slice_default": True,
             "max_sql_iterations": 3,
-        }
+        },
     }
 
 
@@ -56,7 +65,10 @@ def dummy_memnon() -> DummyMemnon:
 
 @pytest.fixture
 def baseline_inputs() -> Dict[str, object]:
-    narrative = "Alex and Emilia secure the Crystal Orb inside the sealed vault while Pete monitors the perimeter."
+    narrative = (
+        "Alex and Emilia secure the Crystal Orb inside the sealed vault while "
+        "Pete monitors the perimeter."
+    )
     warm_slice = [
         {"chunk_id": 101, "text": "Setup: extraction plan finalised."},
         {"chunk_id": 102, "text": "Alex briefs Emilia on the vault sequence."},
@@ -76,10 +88,72 @@ def baseline_inputs() -> Dict[str, object]:
     }
 
 
+@pytest.mark.parametrize(
+    ("provider_wire_type", "expected_window", "expected_phase2_budget"),
+    [
+        ("local", 24_000, 2_400),
+        ("openai", 75_000, 7_500),
+        ("anthropic", 75_000, 7_500),
+    ],
+)
+def test_provider_override_resolves_at_memory_manager_seam(
+    minimal_settings,
+    caplog: pytest.LogCaptureFixture,
+    provider_wire_type: str,
+    expected_window: int,
+    expected_phase2_budget: int,
+) -> None:
+    """The turn-cycle seam resolves one provider-class budget for assembly."""
+    manager = ContextMemoryManager(minimal_settings)
+
+    with caplog.at_level(logging.DEBUG, logger="nexus.memory.manager"):
+        effective_window = manager.configure_storyteller_budget(provider_wire_type)
+
+    assert effective_window == expected_window
+    assert manager.phase2_budget == expected_phase2_budget
+    override_logs = [
+        record
+        for record in caplog.records
+        if "Storyteller payload budget override" in record.getMessage()
+    ]
+    assert len(override_logs) == (1 if provider_wire_type == "local" else 0)
+    if override_logs:
+        assert "class=local" in override_logs[0].getMessage()
+        assert "effective=24000" in override_logs[0].getMessage()
+
+
+def test_empty_provider_override_table_uses_base_budget(
+    minimal_settings, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An empty override table preserves pure base-window behavior."""
+    settings = copy.deepcopy(minimal_settings)
+    settings["Agent Settings"]["LORE"]["token_budget"]["provider_overrides"] = {}
+    manager = ContextMemoryManager(settings)
+
+    with caplog.at_level(logging.DEBUG, logger="nexus.memory.manager"):
+        effective_window = manager.configure_storyteller_budget("local")
+
+    assert effective_window == 75_000
+    assert manager.phase2_budget == 7_500
+    assert "Storyteller payload budget override" not in caplog.text
+
+
+def test_missing_provider_wire_type_is_programming_error(minimal_settings) -> None:
+    """Budget resolution cannot silently assume a frontier provider."""
+    manager = ContextMemoryManager(minimal_settings)
+
+    with pytest.raises(RuntimeError, match="valid active provider wire class"):
+        manager.configure_storyteller_budget(None)  # type: ignore[arg-type]
+
+
 def test_pass1_baseline_tracks_chunks_and_budget(
     minimal_settings, dummy_memnon, baseline_inputs
 ):
-    manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
+    manager = ContextMemoryManager(
+        minimal_settings,
+        memnon=dummy_memnon,
+        provider_wire_type="openai",
+    )
 
     package = manager.handle_storyteller_response(
         narrative=baseline_inputs["narrative"],
@@ -106,7 +180,11 @@ def test_pass1_baseline_tracks_chunks_and_budget(
 def test_pass1_records_reserve_shortfall(
     minimal_settings, dummy_memnon, baseline_inputs
 ):
-    manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
+    manager = ContextMemoryManager(
+        minimal_settings,
+        memnon=dummy_memnon,
+        provider_wire_type="openai",
+    )
 
     tight_tokens = {
         "total_available": 1000,
@@ -134,7 +212,11 @@ def test_pass1_records_reserve_shortfall(
 def test_pass2_divergence_triggers_incremental_retrieval(
     minimal_settings, dummy_memnon, baseline_inputs
 ):
-    manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
+    manager = ContextMemoryManager(
+        minimal_settings,
+        memnon=dummy_memnon,
+        provider_wire_type="openai",
+    )
 
     manager.handle_storyteller_response(
         narrative=baseline_inputs["narrative"],
@@ -179,7 +261,11 @@ def test_pass2_divergence_triggers_incremental_retrieval(
 def test_pass2_preserves_entity_detection_when_character_is_in_baseline(
     minimal_settings, dummy_memnon, baseline_inputs
 ):
-    manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
+    manager = ContextMemoryManager(
+        minimal_settings,
+        memnon=dummy_memnon,
+        provider_wire_type="openai",
+    )
     manager.entity_detector.character_lookup = {
         "emilia": {"id": 2, "name": "Emilia", "summary": None}
     }
@@ -201,7 +287,11 @@ def test_pass2_preserves_entity_detection_when_character_is_in_baseline(
 def test_pass2_marks_matched_entities_outside_baseline(
     minimal_settings, dummy_memnon, baseline_inputs
 ):
-    manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
+    manager = ContextMemoryManager(
+        minimal_settings,
+        memnon=dummy_memnon,
+        provider_wire_type="openai",
+    )
     manager.entity_detector.character_lookup = {
         "victor": {"id": 99, "name": "Victor", "summary": None}
     }
@@ -231,7 +321,11 @@ def test_entity_detector_raises_when_database_load_fails():
 def test_pass1_separates_structured_passages(
     minimal_settings, dummy_memnon, baseline_inputs
 ):
-    manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
+    manager = ContextMemoryManager(
+        minimal_settings,
+        memnon=dummy_memnon,
+        provider_wire_type="openai",
+    )
 
     structured = {
         "id": "character:alex",
@@ -263,7 +357,11 @@ def test_pass1_separates_structured_passages(
 def test_pass2_warm_slice_expansion_without_divergence(
     minimal_settings, dummy_memnon, baseline_inputs
 ):
-    manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
+    manager = ContextMemoryManager(
+        minimal_settings,
+        memnon=dummy_memnon,
+        provider_wire_type="openai",
+    )
 
     manager.handle_storyteller_response(
         narrative=baseline_inputs["narrative"],
@@ -292,7 +390,11 @@ def test_pass2_warm_slice_expansion_without_divergence(
 def test_augment_warm_slice_merges_incremental_additions(
     minimal_settings, dummy_memnon, baseline_inputs
 ):
-    manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
+    manager = ContextMemoryManager(
+        minimal_settings,
+        memnon=dummy_memnon,
+        provider_wire_type="openai",
+    )
 
     manager.handle_storyteller_response(
         narrative=baseline_inputs["narrative"],
@@ -324,7 +426,11 @@ def test_augment_warm_slice_merges_incremental_additions(
 def test_get_memory_summary_reports_state(
     minimal_settings, dummy_memnon, baseline_inputs
 ):
-    manager = ContextMemoryManager(minimal_settings, memnon=dummy_memnon)
+    manager = ContextMemoryManager(
+        minimal_settings,
+        memnon=dummy_memnon,
+        provider_wire_type="openai",
+    )
 
     manager.handle_storyteller_response(
         narrative=baseline_inputs["narrative"],

--- a/tests/test_lore/test_pass2_chunk1369.py
+++ b/tests/test_lore/test_pass2_chunk1369.py
@@ -1,4 +1,4 @@
-"""Integration test verifying Pass 2 retrieves karaoke context when baseline is naive."""
+"""Integration test for Pass 2 karaoke retrieval from a naive baseline."""
 
 from __future__ import annotations
 
@@ -100,8 +100,8 @@ def test_pass2_handles_karaoke_divergence(
     assert "karaoke" not in storyteller_only.lower()
 
     warm_slice = _build_warm_slice(lore_agent, KARAOKE_CHUNK_ID)
-    token_counts = lore_agent.token_manager.calculate_budget("karaoke divergence probe")
     context = _run_pass1_phases(lore_agent, warm_slice, monkeypatch)
+    token_counts = context.token_counts
     authorial_passages = _execute_authorial_queries(lore_agent)
     structured_stub = {
         "id": "character:karaoke_incident",
@@ -144,8 +144,9 @@ def test_pass2_handles_karaoke_divergence(
     assert directive_history == []
 
     divergence_prompt = (
-        "Walk me back through the Virginia Beach karaoke ambush—the Driftlight cocktails, "
-        "Pete's duet trap, and why Emilia swore off stage lights after that meltdown."
+        "Walk me back through the Virginia Beach karaoke ambush—the Driftlight "
+        "cocktails, Pete's duet trap, and why Emilia swore off stage lights "
+        "after that meltdown."
     )
     update = lore_agent.memory_manager.handle_user_input(
         user_input=divergence_prompt,
@@ -158,13 +159,16 @@ def test_pass2_handles_karaoke_divergence(
 
     additional_ids = {
         int(chunk.get("chunk_id") or chunk.get("id"))
-        for chunk in lore_agent.memory_manager.context_state.get_additional_chunk_details()
+        for chunk in (
+            lore_agent.memory_manager.context_state.get_additional_chunk_details()
+        )
     }
     additional_ids.discard(None)
     karaoke_hits = [cid for cid in additional_ids if cid in KARAOKE_DEEP_CUT_RANGE]
-    assert (
-        karaoke_hits
-    ), f"Expected karaoke chunks in {KARAOKE_DEEP_CUT_RANGE}, got {sorted(additional_ids)}"
+    assert karaoke_hits, (
+        f"Expected karaoke chunks in {KARAOKE_DEEP_CUT_RANGE}, got "
+        f"{sorted(additional_ids)}"
+    )
 
     summary = lore_agent.memory_manager.get_memory_summary()
     assert summary["pass2"]["divergence_detected"] is True

--- a/tests/test_lore/test_retrieval_coverage.py
+++ b/tests/test_lore/test_retrieval_coverage.py
@@ -24,8 +24,14 @@ def test_handle_user_input_skips_retrieval_coverage_without_database(
     caplog,
 ) -> None:
     manager = ContextMemoryManager(
-        {"memory": {"skip_simple_choices": False}},
+        {
+            "Agent Settings": {
+                "LORE": {"token_budget": {"apex_context_window": 75_000}}
+            },
+            "memory": {"skip_simple_choices": False},
+        },
         memnon=FakeMemnon(),
+        provider_wire_type="openai",
     )
     manager.handle_storyteller_response(
         narrative="The briefing ends.",

--- a/tests/test_lore/test_retrieval_coverage_live.py
+++ b/tests/test_lore/test_retrieval_coverage_live.py
@@ -92,8 +92,14 @@ def test_handle_user_input_writes_exact_coverage_and_empty_detection() -> None:
             ).one()
 
             manager = ContextMemoryManager(
-                {"memory": {"skip_simple_choices": False}},
+                {
+                    "Agent Settings": {
+                        "LORE": {"token_budget": {"apex_context_window": 75_000}}
+                    },
+                    "memory": {"skip_simple_choices": False},
+                },
                 memnon=LiveReferenceMemnon(connection, int(covered.chunk_id)),
+                provider_wire_type="openai",
             )
             manager.handle_storyteller_response(
                 narrative="The prior scene closes.",

--- a/tests/test_lore/test_token_budget.py
+++ b/tests/test_lore/test_token_budget.py
@@ -63,6 +63,40 @@ class TestTokenBudgetManager:
         # Should have reasoning reserve
         assert "reasoning_reserve" in budget or budget["total_available"] < 200000
 
+    def test_local_reasoning_model_cannot_return_negative_allocations(self, settings):
+        """A reasoning reserve that consumes a local profile fails loudly."""
+        manager = TokenBudgetManager(settings)
+
+        with pytest.raises(ValueError) as exc_info:
+            manager.calculate_budget(
+                "Test input",
+                apex_model="gpt-5-local-reasoning",
+                apex_context_window=24_000,
+            )
+
+        message = str(exc_info.value)
+        assert "window=24000" in message
+        assert "system_prompt=5000" in message
+        assert "reasoning_reserve=30000" in message
+        assert "response_reserve=4000" in message
+        assert "model=gpt-5-local-reasoning" in message
+
+    def test_real_local_model_produces_positive_allocations(self, settings):
+        """Hermes uses the local window without inheriting frontier reasoning."""
+        manager = TokenBudgetManager(settings)
+
+        budget = manager.calculate_budget(
+            "Test input",
+            apex_model="nousresearch/hermes-4-70b",
+            apex_context_window=24_000,
+        )
+
+        assert budget["reasoning_reserve"] == 0
+        assert budget["total_available"] >= 1_000
+        assert budget["warm_slice"] > 0
+        assert budget["structured"] > 0
+        assert budget["augmentation"] > 0
+
     def test_calculate_budget_respects_window(self, settings):
         """Test that budget doesn't exceed context window."""
         manager = TokenBudgetManager(settings)

--- a/tests/test_lore/test_token_budget.py
+++ b/tests/test_lore/test_token_budget.py
@@ -10,6 +10,7 @@ import pytest
 from unittest.mock import patch
 
 from nexus.agents.lore.utils.token_budget import TokenBudgetManager
+from nexus.config import load_settings_as_dict
 
 
 def _calculate_budget(
@@ -63,14 +64,17 @@ class TestTokenBudgetManager:
         # Should have reasoning reserve
         assert "reasoning_reserve" in budget or budget["total_available"] < 200000
 
-    def test_local_reasoning_model_cannot_return_negative_allocations(self, settings):
-        """A reasoning reserve that consumes a local profile fails loudly."""
+    def test_local_reasoning_model_cannot_return_negative_allocations(self):
+        """The committed role-resolved route cannot yield negative allocations."""
+        settings = load_settings_as_dict()
+        committed_model = settings["API Settings"]["apex"]["model"]
+        assert not committed_model.startswith("@")
         manager = TokenBudgetManager(settings)
 
         with pytest.raises(ValueError) as exc_info:
             manager.calculate_budget(
                 "Test input",
-                apex_model="gpt-5-local-reasoning",
+                apex_model=committed_model,
                 apex_context_window=24_000,
             )
 
@@ -79,7 +83,7 @@ class TestTokenBudgetManager:
         assert "system_prompt=5000" in message
         assert "reasoning_reserve=30000" in message
         assert "response_reserve=4000" in message
-        assert "model=gpt-5-local-reasoning" in message
+        assert f"model={committed_model}" in message
 
     def test_real_local_model_produces_positive_allocations(self, settings):
         """Hermes uses the local window without inheriting frontier reasoning."""

--- a/tests/test_lore/test_token_budget.py
+++ b/tests/test_lore/test_token_budget.py
@@ -5,202 +5,234 @@ Tests token budget allocation and management with 20k limit for testing.
 """
 
 import copy
-import pytest
-from pathlib import Path
-import sys
-from unittest.mock import patch, MagicMock
 
-# Add nexus module to path
-nexus_root = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(nexus_root))
+import pytest
+from unittest.mock import patch
 
 from nexus.agents.lore.utils.token_budget import TokenBudgetManager
 
 
+def _calculate_budget(
+    manager: TokenBudgetManager,
+    user_input: str,
+    *,
+    apex_model: str | None = None,
+) -> dict[str, int]:
+    """Exercise allocation with an already-resolved base provider window."""
+    return manager.calculate_budget(
+        user_input,
+        apex_model=apex_model,
+        apex_context_window=manager.token_budget_config["apex_context_window"],
+    )
+
+
 class TestTokenBudgetManager:
     """Test the TokenBudgetManager class."""
-    
+
     def test_manager_initialization(self, settings):
         """Test manager initializes with correct settings."""
         manager = TokenBudgetManager(settings)
-        
+
         assert manager.settings == settings
         assert manager.token_budget_config is not None
-        assert 'apex_context_window' in manager.token_budget_config
-    
+        assert "apex_context_window" in manager.token_budget_config
+
     def test_calculate_budget_basic(self, settings):
         """Test basic budget calculation."""
         manager = TokenBudgetManager(settings)
-        
+
         user_input = "Test user input"
-        budget = manager.calculate_budget(user_input)
-        
+        budget = _calculate_budget(manager, user_input)
+
         # Should return dictionary with allocations
         assert isinstance(budget, dict)
-        assert 'total_available' in budget
-        assert 'warm_slice' in budget
-        assert 'structured' in budget
-        assert 'augmentation' in budget
-    
+        assert "total_available" in budget
+        assert "warm_slice" in budget
+        assert "structured" in budget
+        assert "augmentation" in budget
+
     def test_calculate_budget_with_reasoning_model(self, settings):
         """Test budget calculation with reasoning model (o1, gpt-5)."""
         manager = TokenBudgetManager(settings)
-        
+
         user_input = "Test input"
-        
+
         # Test with o1 model (reasoning)
-        budget = manager.calculate_budget(user_input, apex_model="o1-preview")
-        
+        budget = _calculate_budget(manager, user_input, apex_model="o1-preview")
+
         # Should have reasoning reserve
-        assert 'reasoning_reserve' in budget or budget['total_available'] < 200000
-    
+        assert "reasoning_reserve" in budget or budget["total_available"] < 200000
+
     def test_calculate_budget_respects_window(self, settings):
         """Test that budget doesn't exceed context window."""
         manager = TokenBudgetManager(settings)
-        
+
         user_input = "Test input"
-        budget = manager.calculate_budget(user_input)
-        
+        budget = _calculate_budget(manager, user_input)
+
         # Total allocations shouldn't exceed apex window
-        apex_window = manager.token_budget_config.get('apex_context_window', 200000)
-        total_allocated = sum([
-            budget.get('warm_slice', 0),
-            budget.get('structured', 0),
-            budget.get('augmentation', 0),
-            budget.get('user_input', 0),
-            budget.get('system_prompt', 0)
-        ])
-        
+        apex_window = manager.token_budget_config.get("apex_context_window", 200000)
+        total_allocated = sum(
+            [
+                budget.get("warm_slice", 0),
+                budget.get("structured", 0),
+                budget.get("augmentation", 0),
+                budget.get("user_input", 0),
+                budget.get("system_prompt", 0),
+            ]
+        )
+
         assert total_allocated <= apex_window
-    
+
     def test_calculate_budget_with_long_input(self, settings):
         """Test budget calculation with very long user input."""
         manager = TokenBudgetManager(settings)
-        
+
         # Create a very long input
         long_input = "This is a test. " * 1000  # ~4000 tokens
-        budget = manager.calculate_budget(long_input)
-        
+        budget = _calculate_budget(manager, long_input)
+
         # Should account for the long input
-        assert budget['user_input'] > 3000
-        
+        assert budget["user_input"] > 3000
+
         # Should reduce other allocations accordingly
-        assert budget['warm_slice'] < budget['total_available'] * 0.7
-    
-    @patch('nexus.agents.lore.utils.token_budget.calculate_chunk_tokens')
+        assert budget["warm_slice"] < budget["total_available"] * 0.7
+
+    @patch("nexus.agents.lore.utils.token_budget.calculate_chunk_tokens")
     def test_calculate_budget_token_counting(self, mock_calc_tokens, settings):
         """Test that token counting is called correctly."""
         mock_calc_tokens.return_value = 100
-        
+
         manager = TokenBudgetManager(settings)
         user_input = "Test input"
-        budget = manager.calculate_budget(user_input)
-        
+        budget = _calculate_budget(manager, user_input)
+
         # Should have called token calculation
         mock_calc_tokens.assert_called_with(user_input)
-        assert budget['user_input'] == 100
+        assert budget["user_input"] == 100
 
 
 class TestBudgetAllocation:
     """Test budget allocation logic."""
-    
+
     def test_allocation_percentages(self, settings):
         """Test that allocations follow percentage constraints."""
         manager = TokenBudgetManager(settings)
-        
+
         user_input = "Test"
-        budget = manager.calculate_budget(user_input)
-        
+        budget = _calculate_budget(manager, user_input)
+
         # Get percentage constraints from settings
-        percent_config = settings['Agent Settings']['LORE']['payload_percent_budget']
-        
+        percent_config = settings["Agent Settings"]["LORE"]["payload_percent_budget"]
+
         # Calculate actual percentages
-        total_context = budget['warm_slice'] + budget['structured'] + budget['augmentation']
-        
+        total_context = (
+            budget["warm_slice"] + budget["structured"] + budget["augmentation"]
+        )
+
         if total_context > 0:
-            warm_percent = (budget['warm_slice'] / total_context) * 100
-            struct_percent = (budget['structured'] / total_context) * 100
-            augment_percent = (budget['augmentation'] / total_context) * 100
-            
+            warm_percent = (budget["warm_slice"] / total_context) * 100
+            struct_percent = (budget["structured"] / total_context) * 100
+            augment_percent = (budget["augmentation"] / total_context) * 100
+
             # Check warm slice (40-70%)
-            assert percent_config['warm_slice']['min'] <= warm_percent <= percent_config['warm_slice']['max']
-            
+            assert (
+                percent_config["warm_slice"]["min"]
+                <= warm_percent
+                <= percent_config["warm_slice"]["max"]
+            )
+
             # Check structured (10-25%)
-            assert percent_config['structured_summaries']['min'] <= struct_percent <= percent_config['structured_summaries']['max']
-            
+            assert (
+                percent_config["structured_summaries"]["min"]
+                <= struct_percent
+                <= percent_config["structured_summaries"]["max"]
+            )
+
             # Check augmentation (25-40%)
-            assert percent_config['contextual_augmentation']['min'] <= augment_percent <= percent_config['contextual_augmentation']['max']
-    
+            assert (
+                percent_config["contextual_augmentation"]["min"]
+                <= augment_percent
+                <= percent_config["contextual_augmentation"]["max"]
+            )
+
     def test_allocation_with_test_limit(self, settings):
         """Test allocation with reduced context window."""
         # Modify settings to use smaller window for testing
         test_settings = copy.deepcopy(settings)
-        test_settings['Agent Settings']['LORE']['token_budget']['apex_context_window'] = 20000
-        
+        test_settings["Agent Settings"]["LORE"]["token_budget"][
+            "apex_context_window"
+        ] = 20000
+
         manager = TokenBudgetManager(test_settings)
         user_input = "Test"
-        budget = manager.calculate_budget(user_input)
-        
+        budget = _calculate_budget(manager, user_input)
+
         # With 20k window, allocations should be smaller
-        total = sum([
-            budget.get('warm_slice', 0),
-            budget.get('structured', 0),
-            budget.get('augmentation', 0),
-            budget.get('user_input', 0),
-            budget.get('system_prompt', 0)
-        ])
-        
+        total = sum(
+            [
+                budget.get("warm_slice", 0),
+                budget.get("structured", 0),
+                budget.get("augmentation", 0),
+                budget.get("user_input", 0),
+                budget.get("system_prompt", 0),
+            ]
+        )
+
         # Should respect the 20k window
         assert total <= 20000
-        assert budget['apex_window'] == 20000
+        assert budget["apex_window"] == 20000
 
 
 class TestEdgeCases:
     """Test edge cases and error handling."""
-    
+
     def test_empty_user_input(self, settings):
         """Test with empty user input."""
         manager = TokenBudgetManager(settings)
-        
-        budget = manager.calculate_budget("")
-        
+
+        budget = _calculate_budget(manager, "")
+
         # Should still allocate budget
-        assert budget['total_available'] > 0
-        assert budget['user_input'] == 0
-    
+        assert budget["total_available"] > 0
+        assert budget["user_input"] == 0
+
     def test_missing_settings(self):
         """Test with missing/minimal settings."""
         minimal_settings = {
-            'Agent Settings': {
-                'LORE': {
-                    'token_budget': {},
-                    'payload_percent_budget': {
-                        'warm_slice': {'min': 40, 'max': 70},
-                        'structured_summaries': {'min': 10, 'max': 25},
-                        'contextual_augmentation': {'min': 25, 'max': 40}
-                    }
+            "Agent Settings": {
+                "LORE": {
+                    "token_budget": {},
+                    "payload_percent_budget": {
+                        "warm_slice": {"min": 40, "max": 70},
+                        "structured_summaries": {"min": 10, "max": 25},
+                        "contextual_augmentation": {"min": 25, "max": 40},
+                    },
                 }
             }
         }
-        
+
         manager = TokenBudgetManager(minimal_settings)
-        with pytest.raises(ValueError, match="apex_context_window must be configured"):
+        with pytest.raises(
+            RuntimeError,
+            match="Effective storyteller apex_context_window must be resolved",
+        ):
             manager.calculate_budget("Test")
-    
+
     def test_extreme_percentages(self, settings):
         """Test with extreme percentage configurations."""
         # Modify settings to have extreme percentages
         extreme_settings = copy.deepcopy(settings)
-        extreme_settings['Agent Settings']['LORE']['payload_percent_budget'] = {
-            'warm_slice': {'min': 80, 'max': 90},  # Very high
-            'structured_summaries': {'min': 5, 'max': 10},  # Very low
-            'contextual_augmentation': {'min': 5, 'max': 10}  # Very low
+        extreme_settings["Agent Settings"]["LORE"]["payload_percent_budget"] = {
+            "warm_slice": {"min": 80, "max": 90},  # Very high
+            "structured_summaries": {"min": 5, "max": 10},  # Very low
+            "contextual_augmentation": {"min": 5, "max": 10},  # Very low
         }
-        
+
         manager = TokenBudgetManager(extreme_settings)
-        budget = manager.calculate_budget("Test")
-        
+        budget = _calculate_budget(manager, "Test")
+
         # Should still produce valid budget
-        assert budget['warm_slice'] > 0
-        assert budget['structured'] > 0
-        assert budget['augmentation'] > 0
+        assert budget["warm_slice"] > 0
+        assert budget["structured"] > 0
+        assert budget["augmentation"] > 0

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -23,7 +23,17 @@ class DummyLore:
     """Minimal LORE stub for exercising turn cycle logic."""
 
     def __init__(self) -> None:
-        self.settings: Dict[str, Any] = {"memory": {}}
+        self.settings: Dict[str, Any] = {
+            "Agent Settings": {
+                "LORE": {
+                    "token_budget": {
+                        "apex_context_window": 75_000,
+                        "prompt_overhead_tokens": 0,
+                    }
+                }
+            },
+            "memory": {},
+        }
         self.memnon = None
         self.memory_manager = ContextMemoryManager(self.settings)
         self.token_manager = None
@@ -218,7 +228,7 @@ def test_local_payload_trims_oldest_warm_chunks_and_keeps_parent(
     asyncio.run(turn_manager.process_user_input(ctx))
     ctx.warm_slice = [
         {"chunk_id": 1, "text": "oldest " * 10_000},
-        {"chunk_id": 2, "text": "middle " * 10_000},
+        {"chunk_id": 2, "text": "middle " * 7_000},
         {"chunk_id": 3, "text": "parent " * 2_000, "is_target": True},
     ]
 
@@ -234,8 +244,12 @@ def test_local_payload_trims_oldest_warm_chunks_and_keeps_parent(
         if "Storyteller payload trimmed" in record.getMessage()
     ]
 
-    assert phase_state["total_tokens_used"] <= ctx.token_counts["total_available"]
+    assert phase_state["total_tokens_used"] <= phase_state["payload_ceiling"]
     assert ctx.token_counts["apex_window"] == 24_000
+    assert phase_state["prompt_overhead_tokens"] == 4_000
+    assert phase_state["payload_ceiling"] == (
+        ctx.token_counts["total_available"] - 4_000
+    )
     assert 1 not in assembled_ids
     assert assembled_ids[-1] == 3
     assert len(ctx.warm_slice) == 3
@@ -299,7 +313,10 @@ def test_frontier_payload_below_ceiling_is_unchanged(
 def test_payload_trims_retrieved_passages_last_first(
     turn_manager: TurnCycleManager,
 ) -> None:
-    """After warm trimming is exhausted, lowest-ranked retrievals go first."""
+    """The overhead-reduced ceiling drops lowest-ranked retrievals first."""
+    turn_manager.settings["Agent Settings"]["LORE"]["token_budget"][
+        "prompt_overhead_tokens"
+    ] = 400
     ctx = TurnContext(
         turn_id="retrieval-trim",
         user_input="Continue.",
@@ -312,7 +329,7 @@ def test_payload_trims_retrieved_passages_last_first(
         {"chunk_id": 2, "text": "last " * 250},
     ]
     ctx.token_counts = {
-        "total_available": 1_000,
+        "total_available": 1_400,
         "warm_slice": 600,
         "structured": 100,
         "augmentation": 300,
@@ -325,6 +342,118 @@ def test_payload_trims_retrieved_passages_last_first(
     ]
     assert ctx.phase_states["payload_assembly"]["warm_chunks_dropped"] == 0
     assert ctx.phase_states["payload_assembly"]["retrieved_passages_dropped"] == 1
+    assert ctx.phase_states["payload_assembly"]["payload_ceiling"] == 1_000
+    assert ctx.phase_states["payload_assembly"]["tokens_before_trimming"] <= 1_400
+    assert ctx.phase_states["payload_assembly"]["tokens_before_trimming"] > 1_000
+
+
+def test_trimmed_pass2_chunk_is_unregistered_refunded_and_retrievable() -> None:
+    """Phase 5 reverses Pass-2 registration so a dropped chunk can resurface."""
+
+    class RetrievalMemnon:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+
+        def query_memory(
+            self, query: str, k: int = 5, use_hybrid: bool = True
+        ) -> Dict[str, Any]:
+            self.queries.append(query)
+            return {
+                "results": [
+                    {
+                        "chunk_id": 501,
+                        "text": "retrieved " * 600,
+                    }
+                ]
+            }
+
+    class RetrievalLore:
+        def __init__(self) -> None:
+            self.settings = load_settings_as_dict()
+            self.settings["orrery"]["enabled"] = False
+            self.settings["Agent Settings"]["LORE"]["token_budget"][
+                "prompt_overhead_tokens"
+            ] = 500
+            self.memnon = RetrievalMemnon()
+            self.memory_manager = ContextMemoryManager(
+                self.settings,
+                memnon=self.memnon,
+                provider_wire_type="openai",
+            )
+            self.token_manager = None
+
+    lore = RetrievalLore()
+    manager = TurnCycleManager(lore)
+    parent = {"chunk_id": 100, "text": "Parent.", "is_target": True}
+    lore.memory_manager.handle_storyteller_response(
+        narrative="Prior storyteller response.",
+        warm_slice=[parent],
+        retrieved_passages=[],
+        token_usage={
+            "total_available": 2_000,
+            "warm_slice": 100,
+            "structured": 0,
+            "augmentation": 0,
+        },
+    )
+    initial_budget = lore.memory_manager.context_state.get_remaining_budget()
+
+    first_turn = TurnContext(
+        turn_id="pass2-first",
+        user_input="Find the first missing memory.",
+        start_time=time.time(),
+    )
+    asyncio.run(manager.process_user_input(first_turn))
+    first_cost = first_turn.memory_state["pass2"]["tokens_used"]
+    assert first_turn.memory_state["pass2"]["retrieved_chunk_ids"] == [501]
+    assert lore.memory_manager.context_state.is_chunk_known(501)
+    assert lore.memory_manager.context_state.get_remaining_budget() == (
+        initial_budget - first_cost
+    )
+
+    first_turn.provider_wire_type = "openai"
+    first_turn.warm_slice = lore.memory_manager.augment_warm_slice([parent])
+    first_turn.token_counts = {
+        "total_available": 1_000,
+        "warm_slice": 100,
+        "structured": 0,
+        "augmentation": 0,
+    }
+    asyncio.run(manager.assemble_context_payload(first_turn))
+
+    assert [
+        chunk["chunk_id"]
+        for chunk in first_turn.context_payload["warm_slice"]["chunks"]
+    ] == [100]
+    assert not lore.memory_manager.context_state.is_chunk_known(501)
+    assert lore.memory_manager.context_state.get_remaining_budget() == initial_budget
+    assert first_turn.memory_state["pass2"]["retrieved_chunk_ids"] == []
+    assert first_turn.memory_state["pass2"]["tokens_used"] == 0
+    assert (
+        first_turn.phase_states["payload_assembly"]["memory_budget_refunded"]
+        == first_cost
+    )
+
+    asyncio.run(manager.integrate_response(first_turn, "New storyteller response."))
+    assert 501 not in lore.memory_manager.context_state.context.baseline_chunks
+    next_turn_budget = lore.memory_manager.context_state.get_remaining_budget()
+
+    second_turn = TurnContext(
+        turn_id="pass2-second",
+        user_input="Find that missing memory again.",
+        start_time=time.time(),
+    )
+    asyncio.run(manager.process_user_input(second_turn))
+
+    assert second_turn.memory_state["pass2"]["retrieved_chunk_ids"] == [501]
+    assert lore.memory_manager.context_state.is_chunk_known(501)
+    assert lore.memory_manager.context_state.get_remaining_budget() == (
+        next_turn_budget - second_turn.memory_state["pass2"]["tokens_used"]
+    )
+    assert lore.memnon.queries == [
+        "Find the first missing memory.",
+        "Find that missing memory again.",
+    ]
 
 
 def test_structured_payload_overflow_raises(
@@ -365,6 +494,10 @@ def test_integrate_response_does_not_pass_authorial_directives(
         "warm_slice": 100,
         "structured": 0,
         "augmentation": 0,
+    }
+    ctx.context_payload = {
+        "warm_slice": {"chunks": ctx.warm_slice},
+        "retrieved_passages": {"results": ctx.retrieved_passages},
     }
 
     captured: Dict[str, Any] = {}
@@ -521,6 +654,10 @@ def test_integrate_response_sorts_mixed_chunk_id_payloads(
     ctx.warm_slice = []
     ctx.retrieved_passages = []
     ctx.token_counts = {"total_available": 1000}
+    ctx.context_payload = {
+        "warm_slice": {"chunks": ctx.warm_slice},
+        "retrieved_passages": {"results": ctx.retrieved_passages},
+    }
 
     def fake_handle_storyteller_response(**kwargs: Any) -> ContextPackage:
         package = ContextPackage(

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 from typing import Any, Dict
 
 import pytest
 
+from nexus.agents.lore.logon_utility import LogonUtility
 from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
 from nexus.agents.lore.utils.turn_context import TurnContext
 from nexus.agents.lore.utils.token_budget import TokenBudgetManager
+from nexus.config import load_settings_as_dict
 from nexus.memory import ContextMemoryManager
 from nexus.memory.context_state import ContextPackage, PassTransition
 
@@ -56,40 +59,37 @@ def _stub_baseline(
 
 
 @pytest.mark.parametrize(
-    ("provider_wire_type", "expected_window"),
-    [("local", 24_000), ("openai", 75_000), ("anthropic", 75_000)],
+    ("apex_model", "provider_wire_type", "expected_window"),
+    [
+        ("nousresearch/hermes-4-70b", "local", 24_000),
+        (None, "openai", 75_000),
+        ("claude-opus-4-8", "anthropic", 75_000),
+    ],
 )
 def test_process_user_input_uses_provider_profile_budget(
-    provider_wire_type: str, expected_window: int
+    apex_model: str | None, provider_wire_type: str, expected_window: int
 ) -> None:
     """The real turn-cycle seam feeds one resolved window to both managers."""
 
     class BudgetLore:
         def __init__(self) -> None:
-            self.settings = {
-                "Agent Settings": {
-                    "LORE": {
-                        "token_budget": {
-                            "apex_context_window": 75_000,
-                            "system_prompt_tokens": 5_000,
-                            "provider_overrides": {"local": 24_000},
-                        },
-                        "payload_percent_budget": {},
-                    }
-                },
-                "API Settings": {"apex": {"model": "gpt-4o"}},
-                "memory": {},
-            }
+            self.settings = load_settings_as_dict()
+            self.apex_model = (
+                apex_model
+                if apex_model is not None
+                else self.settings["API Settings"]["apex"]["model"]
+            )
             self.memnon = None
             self.memory_manager = ContextMemoryManager(self.settings)
             self.token_manager = TokenBudgetManager(self.settings)
             self.logon = self
+            self.enable_logon = True
 
         def ensure_logon(self) -> None:
             return None
 
-        def resolve_provider_wire_type(self) -> str:
-            return provider_wire_type
+        def resolve_storyteller_route(self) -> tuple[str, str]:
+            return self.apex_model, provider_wire_type
 
     lore = BudgetLore()
     manager = TurnCycleManager(lore)
@@ -101,9 +101,253 @@ def test_process_user_input_uses_provider_profile_budget(
 
     asyncio.run(manager.process_user_input(ctx))
 
+    assert ctx.apex_model == lore.apex_model
     assert ctx.provider_wire_type == provider_wire_type
     assert ctx.token_counts["apex_window"] == expected_window
     assert lore.memory_manager.phase2_budget == expected_window // 10
+    if apex_model is None:
+        assert ctx.token_counts["reasoning_reserve"] == 30_000
+
+
+def test_process_user_input_uses_base_budget_when_logon_is_disabled() -> None:
+    """LOGON-disabled analysis uses an explicit base-window mode."""
+
+    class DisabledLore:
+        def __init__(self) -> None:
+            self.settings = load_settings_as_dict()
+            self.memnon = None
+            self.memory_manager = ContextMemoryManager(self.settings)
+            self.token_manager = TokenBudgetManager(self.settings)
+            self.logon = None
+            self.enable_logon = False
+
+        def ensure_logon(self) -> None:
+            raise AssertionError("LOGON-disabled turns must not resolve a route")
+
+    lore = DisabledLore()
+    manager = TurnCycleManager(lore)
+    ctx = TurnContext(
+        turn_id="logon-disabled-base-budget",
+        user_input="Continue.",
+        start_time=time.time(),
+    )
+
+    asyncio.run(manager.process_user_input(ctx))
+
+    assert ctx.apex_model is None
+    assert ctx.provider_wire_type is None
+    assert ctx.token_counts["apex_window"] == 75_000
+    assert ctx.token_counts["reasoning_reserve"] == 30_000
+    assert lore.memory_manager.phase2_budget == 7_500
+
+
+def test_slot_model_change_mid_turn_aborts_before_provider_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phase 6 must reject a route that differs from Phase 1's snapshot."""
+
+    class RouteLore:
+        def __init__(self) -> None:
+            self.settings = load_settings_as_dict()
+            self.memnon = None
+            self.memory_manager = ContextMemoryManager(self.settings)
+            self.token_manager = TokenBudgetManager(self.settings)
+            self.enable_logon = True
+            self.logon = LogonUtility(self.settings)
+
+        def ensure_logon(self) -> None:
+            return None
+
+    lore = RouteLore()
+    manager = TurnCycleManager(lore)
+    ctx = TurnContext(
+        turn_id="slot-change",
+        user_input="Continue.",
+        start_time=time.time(),
+    )
+    route_calls = {"count": 0}
+
+    def resolve_route() -> tuple[str, str, None, str]:
+        route_calls["count"] += 1
+        if route_calls["count"] == 1:
+            return ("gpt-5.5", "openai", None, "openai")
+        return ("nousresearch/hermes-4-70b", "openai", None, "local")
+
+    monkeypatch.setattr(lore.logon, "_resolve_storyteller_route", resolve_route)
+
+    asyncio.run(manager.process_user_input(ctx))
+    ctx.context_payload = {"user_input": ctx.user_input}
+
+    with pytest.raises(
+        RuntimeError, match="slot model changed mid-turn; aborting the turn"
+    ):
+        asyncio.run(manager.call_apex_ai(ctx))
+
+    assert route_calls["count"] == 2
+    assert lore.logon.provider is None
+
+
+def test_local_payload_trims_oldest_warm_chunks_and_keeps_parent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The real Phase 5 seam bounds a local payload without dropping its parent."""
+
+    class LocalLore:
+        def __init__(self) -> None:
+            self.settings = load_settings_as_dict()
+            self.settings["orrery"]["enabled"] = False
+            self.memnon = None
+            self.memory_manager = ContextMemoryManager(self.settings)
+            self.token_manager = TokenBudgetManager(self.settings)
+            self.logon = self
+            self.enable_logon = True
+
+        def ensure_logon(self) -> None:
+            return None
+
+        def resolve_storyteller_route(self) -> tuple[str, str]:
+            return "nousresearch/hermes-4-70b", "local"
+
+    lore = LocalLore()
+    turn_manager = TurnCycleManager(lore)
+    ctx = TurnContext(
+        turn_id="local-payload-trim",
+        user_input="Continue.",
+        start_time=time.time(),
+    )
+    asyncio.run(turn_manager.process_user_input(ctx))
+    ctx.warm_slice = [
+        {"chunk_id": 1, "text": "oldest " * 10_000},
+        {"chunk_id": 2, "text": "middle " * 10_000},
+        {"chunk_id": 3, "text": "parent " * 2_000, "is_target": True},
+    ]
+
+    with caplog.at_level(logging.INFO, logger="nexus.lore.turn_cycle"):
+        asyncio.run(turn_manager.assemble_context_payload(ctx))
+
+    assembled_chunks = ctx.context_payload["warm_slice"]["chunks"]
+    assembled_ids = [chunk["chunk_id"] for chunk in assembled_chunks]
+    phase_state = ctx.phase_states["payload_assembly"]
+    trim_logs = [
+        record
+        for record in caplog.records
+        if "Storyteller payload trimmed" in record.getMessage()
+    ]
+
+    assert phase_state["total_tokens_used"] <= ctx.token_counts["total_available"]
+    assert ctx.token_counts["apex_window"] == 24_000
+    assert 1 not in assembled_ids
+    assert assembled_ids[-1] == 3
+    assert len(ctx.warm_slice) == 3
+    assert len(trim_logs) == 1
+    assert "wire_class=local" in trim_logs[0].getMessage()
+    assert "warm_chunks_dropped=1" in trim_logs[0].getMessage()
+
+
+def test_frontier_payload_below_ceiling_is_unchanged(
+    turn_manager: TurnCycleManager, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Typical frontier assembly remains byte-for-byte equivalent in content."""
+    ctx = TurnContext(
+        turn_id="frontier-payload",
+        user_input="Continue.",
+        start_time=time.time(),
+    )
+    ctx.provider_wire_type = "openai"
+    ctx.warm_slice = [{"chunk_id": 10, "text": "Recent narrative.", "is_target": True}]
+    ctx.entity_data = {"characters": [{"name": "Mara", "summary": "Alert."}]}
+    ctx.retrieved_passages = [{"chunk_id": 2, "text": "Earlier context."}]
+    ctx.memory_state = {"pass2": {"detected": False}}
+    ctx.token_counts = {
+        "total_available": 36_000,
+        "warm_slice": 1_800,
+        "structured": 3_600,
+        "augmentation": 1_800,
+    }
+
+    with caplog.at_level(logging.INFO, logger="nexus.lore.turn_cycle"):
+        asyncio.run(turn_manager.assemble_context_payload(ctx))
+
+    timestamp = ctx.context_payload["metadata"]["timestamp"]
+    expected_payload = {
+        "user_input": "Continue.",
+        "warm_slice": {"chunks": ctx.warm_slice, "token_count": 1_800},
+        "entity_data": ctx.entity_data,
+        "retrieved_passages": {
+            "results": ctx.retrieved_passages,
+            "token_count": 1_800,
+        },
+        "metadata": {"turn_id": "frontier-payload", "timestamp": timestamp},
+        "memory_state": ctx.memory_state,
+    }
+
+    assembled_bytes = json.dumps(
+        ctx.context_payload, ensure_ascii=False, separators=(",", ":")
+    ).encode()
+    expected_bytes = json.dumps(
+        expected_payload, ensure_ascii=False, separators=(",", ":")
+    ).encode()
+
+    assert assembled_bytes == expected_bytes
+    assert ctx.context_payload["warm_slice"]["chunks"] is ctx.warm_slice
+    assert (
+        ctx.context_payload["retrieved_passages"]["results"] is ctx.retrieved_passages
+    )
+    assert "Storyteller payload trimmed" not in caplog.text
+
+
+def test_payload_trims_retrieved_passages_last_first(
+    turn_manager: TurnCycleManager,
+) -> None:
+    """After warm trimming is exhausted, lowest-ranked retrievals go first."""
+    ctx = TurnContext(
+        turn_id="retrieval-trim",
+        user_input="Continue.",
+        start_time=time.time(),
+    )
+    ctx.provider_wire_type = "local"
+    ctx.warm_slice = [{"chunk_id": 3, "text": "parent " * 600, "is_target": True}]
+    ctx.retrieved_passages = [
+        {"chunk_id": 1, "text": "first " * 250},
+        {"chunk_id": 2, "text": "last " * 250},
+    ]
+    ctx.token_counts = {
+        "total_available": 1_000,
+        "warm_slice": 600,
+        "structured": 100,
+        "augmentation": 300,
+    }
+
+    asyncio.run(turn_manager.assemble_context_payload(ctx))
+
+    assert ctx.context_payload["retrieved_passages"]["results"] == [
+        ctx.retrieved_passages[0]
+    ]
+    assert ctx.phase_states["payload_assembly"]["warm_chunks_dropped"] == 0
+    assert ctx.phase_states["payload_assembly"]["retrieved_passages_dropped"] == 1
+
+
+def test_structured_payload_overflow_raises(
+    turn_manager: TurnCycleManager,
+) -> None:
+    """A structured core that cannot fit is a loud configuration error."""
+    ctx = TurnContext(
+        turn_id="structured-overflow",
+        user_input="Continue.",
+        start_time=time.time(),
+    )
+    ctx.provider_wire_type = "local"
+    ctx.warm_slice = [{"chunk_id": 3, "text": "Parent.", "is_target": True}]
+    ctx.entity_data = {"characters": [{"summary": "structured " * 1_500}]}
+    ctx.token_counts = {
+        "total_available": 1_000,
+        "warm_slice": 100,
+        "structured": 800,
+        "augmentation": 0,
+    }
+
+    with pytest.raises(ValueError, match="structured core is a configuration error"):
+        asyncio.run(turn_manager.assemble_context_payload(ctx))
 
 
 def test_integrate_response_does_not_pass_authorial_directives(

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -11,6 +11,7 @@ import pytest
 
 from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
 from nexus.agents.lore.utils.turn_context import TurnContext
+from nexus.agents.lore.utils.token_budget import TokenBudgetManager
 from nexus.memory import ContextMemoryManager
 from nexus.memory.context_state import ContextPackage, PassTransition
 
@@ -52,6 +53,57 @@ def _stub_baseline(
     )
     manager.context_state.store_baseline(package, transition, warm_slice)
     return package
+
+
+@pytest.mark.parametrize(
+    ("provider_wire_type", "expected_window"),
+    [("local", 24_000), ("openai", 75_000), ("anthropic", 75_000)],
+)
+def test_process_user_input_uses_provider_profile_budget(
+    provider_wire_type: str, expected_window: int
+) -> None:
+    """The real turn-cycle seam feeds one resolved window to both managers."""
+
+    class BudgetLore:
+        def __init__(self) -> None:
+            self.settings = {
+                "Agent Settings": {
+                    "LORE": {
+                        "token_budget": {
+                            "apex_context_window": 75_000,
+                            "system_prompt_tokens": 5_000,
+                            "provider_overrides": {"local": 24_000},
+                        },
+                        "payload_percent_budget": {},
+                    }
+                },
+                "API Settings": {"apex": {"model": "gpt-4o"}},
+                "memory": {},
+            }
+            self.memnon = None
+            self.memory_manager = ContextMemoryManager(self.settings)
+            self.token_manager = TokenBudgetManager(self.settings)
+            self.logon = self
+
+        def ensure_logon(self) -> None:
+            return None
+
+        def resolve_provider_wire_type(self) -> str:
+            return provider_wire_type
+
+    lore = BudgetLore()
+    manager = TurnCycleManager(lore)
+    ctx = TurnContext(
+        turn_id=f"provider-profile-{provider_wire_type}",
+        user_input="Continue.",
+        start_time=time.time(),
+    )
+
+    asyncio.run(manager.process_user_input(ctx))
+
+    assert ctx.provider_wire_type == provider_wire_type
+    assert ctx.token_counts["apex_window"] == expected_window
+    assert lore.memory_manager.phase2_budget == expected_window // 10
 
 
 def test_integrate_response_does_not_pass_authorial_directives(

--- a/tests/test_orrery/test_bleed.py
+++ b/tests/test_orrery/test_bleed.py
@@ -186,12 +186,20 @@ def _select(
 
 def _settings():
     return {
+        "Agent Settings": {
+            "LORE": {
+                "token_budget": {
+                    "apex_context_window": 75_000,
+                    "prompt_overhead_tokens": 4_000,
+                }
+            }
+        },
         "orrery": {
             "enabled": True,
             "bleed": {
                 "max_candidates": 3,
             },
-        }
+        },
     }
 
 
@@ -587,6 +595,7 @@ async def test_call_apex_ai_records_bleed_offers_after_generation_success() -> N
     context = TurnContext(turn_id="t1", user_input="Continue.", start_time=0)
     context.apex_model = "resolved-bleed-test-model"
     context.provider_wire_type = "openai"
+    context.token_counts = {"apex_window": 75_000}
     context.context_payload = {"user_input": "Continue."}
     context.bleed_menu = load_bleed_candidates(
         FakeSession(candidate_rows=[_candidate_row()]),
@@ -628,6 +637,7 @@ async def test_call_apex_ai_does_not_record_bleed_offers_on_generation_failure()
     context = TurnContext(turn_id="t1", user_input="Continue.", start_time=0)
     context.apex_model = "resolved-bleed-test-model"
     context.provider_wire_type = "openai"
+    context.token_counts = {"apex_window": 75_000}
     context.context_payload = {"user_input": "Continue."}
     context.bleed_menu = load_bleed_candidates(
         FakeSession(candidate_rows=[_candidate_row()]),

--- a/tests/test_orrery/test_bleed.py
+++ b/tests/test_orrery/test_bleed.py
@@ -110,14 +110,14 @@ class FakeStoryResponse:
 class FakeLogon:
     """LOGON stand-in returning a successful structured narrative."""
 
-    async def generate_narrative_async(self, _payload):
+    async def generate_narrative_async(self, _payload, **_route):
         return FakeStoryResponse()
 
 
 class FailingLogon:
     """LOGON stand-in that raises before a response is surfaced."""
 
-    async def generate_narrative_async(self, _payload):
+    async def generate_narrative_async(self, _payload, **_route):
         raise RuntimeError("generation failed")
 
 
@@ -467,6 +467,7 @@ async def test_assemble_context_payload_includes_bleed_menu() -> None:
         start_time=0,
         warm_slice=[{"id": 100, "text": "Rain ticks against the glass."}],
     )
+    context.token_counts = {"total_available": 75_000}
 
     await manager.assemble_context_payload(context)
 
@@ -491,6 +492,7 @@ async def test_assemble_context_payload_does_not_initialize_bleed_llm() -> None:
         start_time=0,
         warm_slice=[{"id": 100, "text": "Rain ticks against the glass."}],
     )
+    context.token_counts = {"total_available": 75_000}
 
     await manager.assemble_context_payload(context)
 
@@ -510,6 +512,7 @@ async def test_assemble_context_payload_reuses_orrery_proposal_anchor() -> None:
         start_time=0,
         warm_slice=[],
     )
+    context.token_counts = {"total_available": 75_000}
     context.orrery_proposal = SimpleNamespace(anchor_chunk_id=77, pressure_count=0)
 
     await manager.assemble_context_payload(context)
@@ -535,6 +538,7 @@ async def test_assemble_context_payload_attaches_scene_conditions() -> None:
         start_time=0,
         warm_slice=[],
     )
+    context.token_counts = {"total_available": 75_000}
     context.orrery_proposal = SimpleNamespace(
         anchor_chunk_id=77,
         pressure_count=0,
@@ -558,6 +562,7 @@ async def test_assemble_context_payload_preserves_scene_moods() -> None:
     context = TurnContext(
         turn_id="t1", user_input="Continue.", start_time=0, warm_slice=[]
     )
+    context.token_counts = {"total_available": 75_000}
     context.orrery_proposal = SimpleNamespace(
         anchor_chunk_id=77,
         pressure_count=0,
@@ -580,6 +585,8 @@ async def test_call_apex_ai_records_bleed_offers_after_generation_success() -> N
     session = FakeSession()
     manager = TurnCycleManager(FakeLore(_settings(), session, logon=FakeLogon()))
     context = TurnContext(turn_id="t1", user_input="Continue.", start_time=0)
+    context.apex_model = "resolved-bleed-test-model"
+    context.provider_wire_type = "openai"
     context.context_payload = {"user_input": "Continue."}
     context.bleed_menu = load_bleed_candidates(
         FakeSession(candidate_rows=[_candidate_row()]),
@@ -619,6 +626,8 @@ async def test_call_apex_ai_does_not_record_bleed_offers_on_generation_failure()
     session = FakeSession()
     manager = TurnCycleManager(FakeLore(_settings(), session, logon=FailingLogon()))
     context = TurnContext(turn_id="t1", user_input="Continue.", start_time=0)
+    context.apex_model = "resolved-bleed-test-model"
+    context.provider_wire_type = "openai"
     context.context_payload = {"user_input": "Continue."}
     context.bleed_menu = load_bleed_candidates(
         FakeSession(candidate_rows=[_candidate_row()]),

--- a/tests/test_orrery/test_knowledge_surfacing_live.py
+++ b/tests/test_orrery/test_knowledge_surfacing_live.py
@@ -578,6 +578,7 @@ async def test_turn_payload_conditionally_attaches_world_knowledge(
         user_input="Continue.",
         start_time=0,
     )
+    context.token_counts = {"total_available": 75_000}
     context.orrery_proposal = cast(
         Any,
         SimpleNamespace(

--- a/tests/test_orrery/test_knowledge_surfacing_live.py
+++ b/tests/test_orrery/test_knowledge_surfacing_live.py
@@ -555,11 +555,19 @@ class _LiveLoreHarness:
 
     def __init__(self, session: Session, *, enabled: bool) -> None:
         self.settings = {
+            "Agent Settings": {
+                "LORE": {
+                    "token_budget": {
+                        "apex_context_window": 75_000,
+                        "prompt_overhead_tokens": 4_000,
+                    }
+                }
+            },
             "orrery": {
                 "enabled": True,
                 "bleed": {"max_candidates": 0},
                 "knowledge": _settings(enabled=enabled),
-            }
+            },
         }
         self.memnon = _LiveMemnonHarness(session)
 

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -1259,6 +1259,7 @@ def test_sync_logon_reads_and_supplies_parent_baseline(
     )
     utility.provider = cast(Any, WireProvider())
     utility._provider_bootstrap_mode = False
+    utility._provider_wire_type = "openai"
     response = utility.generate_narrative(
         {
             "user_input": "Continue.",
@@ -1266,7 +1267,8 @@ def test_sync_logon_reads_and_supplies_parent_baseline(
             "entity_data": {},
             "retrieved_passages": {"results": []},
             "metadata": {"target_chunk_id": 77},
-        }
+        },
+        effective_context_window=75_000,
     )
     assert calls == [("save_05", 77)]
     assert isinstance(response, StorytellerResponseExtended)
@@ -1309,6 +1311,7 @@ async def test_async_logon_reads_and_supplies_parent_baseline(
     )
     utility.provider = cast(Any, WireProvider())
     utility._provider_bootstrap_mode = False
+    utility._provider_wire_type = "openai"
     response = await utility.generate_narrative_async(
         {
             "user_input": "Continue.",
@@ -1316,7 +1319,8 @@ async def test_async_logon_reads_and_supplies_parent_baseline(
             "entity_data": {},
             "retrieved_passages": {"results": []},
             "metadata": {"target_chunk_id": 77},
-        }
+        },
+        effective_context_window=75_000,
     )
     assert calls == [("save_05", 77)]
     assert isinstance(response, StorytellerResponseExtended)


### PR DESCRIPTION
## Summary

Implements D2 of Arachne ruling seq 8 (relayed on #566): a per-provider-class payload profile so **local storyteller turns assemble a smaller context while frontier turns keep theirs**. Measured motivation from the trials: Hermes 4.3-36B at 6–8 min/attempt on a frontier-sized ~30K-token payload blows the turn ceiling once retries multiply — the schema stopped being the local bottleneck; the payload is.

## Design

- New optional `[lore.token_budget.provider_overrides]` table, keys restricted to the wire classes (`openai` / `anthropic` / `local`), values validated `≥1000` and **shrink-only** (an override above base is rejected loudly). Committed default: `local = 24_000`.
- `resolve_storyteller_context_window(settings, wire_class)` is the one resolution authority — missing config, wrong types, or an unknown class raise instead of defaulting. The old silent `75000` fallback in the memory manager is gone.
- LOGON grows `resolve_provider_wire_type()`, extracted from provider construction into a shared `_resolve_storyteller_route()` — one classification authority, and sizing never constructs a provider.
- The turn cycle resolves the class once per turn, configures the memory-manager budget (per-turn because slots can switch models under a live instance), and passes the effective window **explicitly** into `TokenBudgetManager.calculate_budget`, which now refuses to re-read the base itself. Percent allocations (`[lore.payload_percent_budget.*]`) apply to the effective number unchanged.
- UI slider and settings PATCH endpoints intentionally keep targeting the base value (audited in the consumer table on the build report; no UI changes).

## Test Results

```
197 passed, 13 skipped (postgres-gated) pre-rebase; 191 passed, 13 skipped post-rebase onto the wire-v3 main
mypy: Success · black --check: clean · flake8: clean · config loads: OK
```

Pre-commit's model-drift checker caught one casualty of Black's rewrap (the `gpt-5` family-detection literal separated from its `# pin:` comment) — fixed by keeping the pin on the literal's line.

## Sequencing

Independent of the in-flight Anthropic prompted-transport PR except for `nexus.toml`/settings adjacency; rebased onto the merged wire-v3 main (e5aaecb4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ