### PR TITLE
Switch the Anthropic storyteller to prompted-schema transport (#566)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -1002,6 +1002,7 @@ provider = "openai"           # API provider: "openai", "anthropic", or "local"
 model = "@openai.default"     # Resolved via api_models registry; edit roles to migrate
 reasoning_effort = "medium"   # Reasoning effort level (low/medium/high)
 max_output_tokens = 25000     # Maximum tokens for generated narrative
+anthropic_storyteller_transport = "prompted" # "prompted" or "native"
 structured_output_retries = 3 # Validation retry budget for structured story turns
 # HTTP client timeout for a narrative continue turn. Frontier generation runs
 # inside the request and blocks the API worker, so status polls aren't answered

--- a/nexus/agents/logon/skald_wire.py
+++ b/nexus/agents/logon/skald_wire.py
@@ -709,8 +709,9 @@ def _prompt_guide_type(
     if ref is not None:
         ref_name = _prompt_guide_ref_name(ref)
         target = definitions[ref_name]
-        target_type = _prompt_guide_type(target, definitions)
-        return ref_name if target_type == "object" else target_type
+        if target.get("type") == "object":
+            return ref_name
+        return _prompt_guide_type(target, definitions)
 
     schema_type = schema_node.get("type")
     if schema_type == "array":
@@ -718,6 +719,11 @@ def _prompt_guide_type(
         if not isinstance(items, dict):
             raise ValueError("Skald wire array schema is missing an items schema")
         return f"{_prompt_guide_type(items, definitions)}[]"
+    if schema_type == "object":
+        raise ValueError(
+            "Skald wire prompt guide does not support inline object schemas; "
+            "use a named $defs model"
+        )
     if isinstance(schema_type, str):
         return schema_type
 

--- a/nexus/agents/logon/skald_wire.py
+++ b/nexus/agents/logon/skald_wire.py
@@ -6,6 +6,7 @@ per-chunk mentions, never members of the carried scene roster.
 
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -687,3 +688,172 @@ def skald_wire_lenient_schema() -> Dict[str, Any]:
     """Build the omittable-field schema for Anthropic and local endpoints."""
 
     return de_null_schema(SkaldTurnWire.model_json_schema())
+
+
+def _prompt_guide_ref_name(ref: str) -> str:
+    """Return a local definition name from a JSON Schema reference."""
+
+    prefix = "#/$defs/"
+    if not ref.startswith(prefix) or not ref[len(prefix) :]:
+        raise ValueError(f"Unsupported Skald wire schema reference: {ref!r}")
+    return ref[len(prefix) :]
+
+
+def _prompt_guide_type(
+    schema_node: Dict[str, Any],
+    definitions: Dict[str, Any],
+) -> str:
+    """Render one compact type expression from a JSON Schema node."""
+
+    ref = schema_node.get("$ref")
+    if ref is not None:
+        ref_name = _prompt_guide_ref_name(ref)
+        target = definitions[ref_name]
+        target_type = _prompt_guide_type(target, definitions)
+        return ref_name if target_type == "object" else target_type
+
+    schema_type = schema_node.get("type")
+    if schema_type == "array":
+        items = schema_node.get("items")
+        if not isinstance(items, dict):
+            raise ValueError("Skald wire array schema is missing an items schema")
+        return f"{_prompt_guide_type(items, definitions)}[]"
+    if isinstance(schema_type, str):
+        return schema_type
+
+    for union_key in ("anyOf", "oneOf"):
+        members = schema_node.get(union_key)
+        if isinstance(members, list) and members:
+            return "|".join(
+                _prompt_guide_type(member, definitions) for member in members
+            )
+    raise ValueError(f"Unsupported Skald wire schema node: {schema_node!r}")
+
+
+def _prompt_guide_enum(
+    schema_node: Dict[str, Any],
+    definitions: Dict[str, Any],
+) -> Optional[List[Any]]:
+    """Return the enum governing a field, following local references."""
+
+    ref = schema_node.get("$ref")
+    if ref is not None:
+        return _prompt_guide_enum(
+            definitions[_prompt_guide_ref_name(ref)],
+            definitions,
+        )
+    enum_values = schema_node.get("enum")
+    if enum_values is not None:
+        if not isinstance(enum_values, list):
+            raise ValueError("Skald wire enum schema must contain a list")
+        return enum_values
+    items = schema_node.get("items")
+    if isinstance(items, dict):
+        return _prompt_guide_enum(items, definitions)
+    return None
+
+
+def _prompt_guide_object_refs(
+    schema_node: Dict[str, Any],
+    definitions: Dict[str, Any],
+) -> List[str]:
+    """Collect directly referenced object definitions in declaration order."""
+
+    refs: List[str] = []
+    ref = schema_node.get("$ref")
+    if ref is not None:
+        ref_name = _prompt_guide_ref_name(ref)
+        target = definitions[ref_name]
+        if target.get("type") == "object":
+            refs.append(ref_name)
+        return refs
+
+    items = schema_node.get("items")
+    if isinstance(items, dict):
+        refs.extend(_prompt_guide_object_refs(items, definitions))
+    for union_key in ("anyOf", "oneOf", "allOf"):
+        members = schema_node.get(union_key)
+        if isinstance(members, list):
+            for member in members:
+                refs.extend(_prompt_guide_object_refs(member, definitions))
+    return refs
+
+
+def skald_wire_prompt_guide() -> str:
+    """Render a compact prompted-output guide from the lenient wire schema."""
+
+    schema = skald_wire_lenient_schema()
+    definitions = schema.get("$defs", {})
+    if not isinstance(definitions, dict):
+        raise ValueError("Skald wire schema definitions must be an object")
+
+    root_name = schema.get("title")
+    if not isinstance(root_name, str) or not root_name:
+        raise ValueError("Skald wire schema must have a title")
+
+    lines = [
+        "=== OUTPUT FORMAT ===",
+        (
+            "Respond with a single JSON object matching this structure. "
+            "Omit optional fields that have no value. No prose outside the JSON."
+        ),
+        "Legend: ! required; ? optional; named types are objects; T[] is an array.",
+        "```text",
+    ]
+    object_queue: List[tuple[str, Dict[str, Any]]] = [(root_name, schema)]
+    queued_names = {root_name}
+
+    for object_name, object_schema in object_queue:
+        properties = object_schema.get("properties")
+        if not isinstance(properties, dict):
+            raise ValueError(
+                f"Skald wire object {object_name!r} has no property mapping"
+            )
+        required = object_schema.get("required", [])
+        if not isinstance(required, list):
+            raise ValueError(
+                f"Skald wire object {object_name!r} has an invalid required list"
+            )
+        required_names = set(required)
+
+        lines.append(f"{object_name}{{")
+        for property_name, property_schema in properties.items():
+            if not isinstance(property_schema, dict):
+                raise ValueError(
+                    f"Skald wire property {object_name}.{property_name} is invalid"
+                )
+            field_type = _prompt_guide_type(property_schema, definitions)
+            status = "!" if property_name in required_names else "?"
+            enum_values = _prompt_guide_enum(property_schema, definitions)
+            enum_text = (
+                "|enum="
+                + json.dumps(
+                    enum_values,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                )
+                if enum_values is not None
+                else ""
+            )
+            description = property_schema.get("description", "")
+            if not isinstance(description, str):
+                raise ValueError(
+                    f"Skald wire property {object_name}.{property_name} "
+                    "has a non-string description"
+                )
+            description_text = json.dumps(description, ensure_ascii=False)
+            lines.append(
+                f"{property_name}{status}:{field_type}{enum_text}|{description_text}"
+            )
+
+            for ref_name in _prompt_guide_object_refs(
+                property_schema,
+                definitions,
+            ):
+                if ref_name not in queued_names:
+                    object_queue.append((ref_name, definitions[ref_name]))
+                    queued_names.add(ref_name)
+        lines.append("}")
+
+    lines.append("```")
+    return "\n".join(lines)

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -506,6 +506,7 @@ class LogonUtility:
                 max_tokens=apex_settings.get(
                     "max_output_tokens", apex_settings.get("max_tokens", 4000)
                 ),
+                reasoning_effort=apex_settings.get("reasoning_effort"),
                 system_prompt=system_prompt,
                 structured_transport=anthropic_transport,
                 structured_output_retries=structured_output_retries,
@@ -773,11 +774,11 @@ class LogonUtility:
                     )
                 }
             elif self._provider_wire_type == "anthropic":
-                anthropic_transport = getattr(
-                    self.provider,
-                    "structured_transport",
-                    "prompted",
-                )
+                if self.provider is None:
+                    raise RuntimeError(
+                        "Anthropic schema formatting requires an initialized provider"
+                    )
+                anthropic_transport = self.provider.structured_transport
                 if anthropic_transport == "prompted":
                     kwargs = {}
                 elif anthropic_transport == "native":

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -29,6 +29,7 @@ from nexus.agents.logon.skald_wire import (  # noqa: E402
     SkaldTurnWire,
     hydrate_skald_turn,
     skald_wire_lenient_schema,
+    skald_wire_prompt_guide,
     skald_wire_strict_text_format,
 )
 from nexus.agents.orrery.tag_library import (  # noqa: E402
@@ -455,6 +456,21 @@ class LogonUtility:
 
         # Load system prompt
         system_prompt = self._load_system_prompt(provider_bootstrap_mode)
+        anthropic_transport: Literal["native", "prompted"] = "native"
+        if provider_type == "anthropic":
+            configured_transport = apex_settings.get("anthropic_storyteller_transport")
+            if configured_transport not in {"native", "prompted"}:
+                raise ValueError(
+                    "API Settings.apex.anthropic_storyteller_transport must be "
+                    "'native' or 'prompted'"
+                )
+            anthropic_transport = (
+                "native"
+                if provider_bootstrap_mode
+                else cast(Literal["native", "prompted"], configured_transport)
+            )
+            if anthropic_transport == "prompted":
+                system_prompt = f"{system_prompt}\n\n{skald_wire_prompt_guide()}"
         self._system_prompt = system_prompt
         self._provider_bootstrap_mode = provider_bootstrap_mode
 
@@ -491,6 +507,7 @@ class LogonUtility:
                     "max_output_tokens", apex_settings.get("max_tokens", 4000)
                 ),
                 system_prompt=system_prompt,
+                structured_transport=anthropic_transport,
                 structured_output_retries=structured_output_retries,
                 output_validator=output_validator,
             )
@@ -756,12 +773,25 @@ class LogonUtility:
                     )
                 }
             elif self._provider_wire_type == "anthropic":
-                kwargs = {
-                    "output_config": anthropic_output_config(
-                        SkaldTurnWire,
-                        schema=skald_wire_lenient_schema(),
+                anthropic_transport = getattr(
+                    self.provider,
+                    "structured_transport",
+                    "prompted",
+                )
+                if anthropic_transport == "prompted":
+                    kwargs = {}
+                elif anthropic_transport == "native":
+                    kwargs = {
+                        "output_config": anthropic_output_config(
+                            SkaldTurnWire,
+                            schema=skald_wire_lenient_schema(),
+                        )
+                    }
+                else:
+                    raise ValueError(
+                        "Anthropic provider has an invalid structured transport: "
+                        f"{anthropic_transport!r}"
                     )
-                }
             else:
                 kwargs = {}
         elif self._provider_wire_type in {"openai", "local"}:

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -2485,6 +2485,12 @@ class APEXSettings(BaseModel):
     model: str
     reasoning_effort: str = Field(..., pattern="^(low|medium|high)$")
     max_output_tokens: int = Field(..., ge=1)
+    anthropic_storyteller_transport: Literal["prompted", "native"] = Field(
+        default="prompted",
+        description=(
+            "Structured transport for non-bootstrap Anthropic storyteller turns."
+        ),
+    )
     tag_library: APEXTagLibrarySettings = Field(default_factory=APEXTagLibrarySettings)
     structured_output_retries: int = Field(
         default=3,

--- a/scripts/api_anthropic.py
+++ b/scripts/api_anthropic.py
@@ -2,7 +2,8 @@
 """
 NEXUS Anthropic API Library
 
-This module provides reusable components for Anthropic Claude API access across NEXUS scripts.
+This module provides reusable components for Anthropic Claude API access
+across NEXUS scripts.
 It centralizes common functionality to maintain consistency and avoid code duplication.
 
 Features:
@@ -27,9 +28,9 @@ LLM Provider Options:
     --timeout INT           Request timeout in seconds (default: 120)
 
 Processing Options:
-    --batch-size INT        Number of items to process before prompting to continue (default: 10)
+    --batch-size INT        Number of items processed before confirmation (default: 10)
     --dry-run               Don't actually save results to the database
-    --db-url URL            Database connection URL (optional, defaults to environment variables)
+    --db-url URL            Database URL (optional, defaults to environment variables)
 """
 
 import os
@@ -38,17 +39,25 @@ import abc
 import argparse
 import asyncio
 import logging
-import re
 import json
 import time
 import signal
-import threading
-from typing import List, Dict, Any, Tuple, Optional, Union, Protocol, Type, TypeVar
+from typing import (
+    List,
+    Dict,
+    Any,
+    Tuple,
+    Optional,
+    Union,
+    Type,
+    Literal,
+    cast,
+)
 from datetime import datetime, timedelta
 
 # Try to import keyboard module for abort functionality
 try:
-    import keyboard
+    import keyboard  # type: ignore[import-untyped]
 
     KEYBOARD_AVAILABLE = True
 except ImportError:
@@ -58,17 +67,14 @@ except ImportError:
 try:
     import anthropic
 except ImportError:
-    anthropic = None
+    anthropic = None  # type: ignore[assignment]
 
 # For token counting
 try:
     import tiktoken
 except ImportError:
-    tiktoken = None
+    tiktoken = None  # type: ignore[assignment]
 
-# For database connection (utilities only, no ORM)
-import sqlalchemy as sa
-from sqlalchemy import create_engine
 from pydantic import ValidationError
 
 from nexus.api.native_structured_output import (
@@ -150,22 +156,27 @@ def get_token_count(text: str, model: str) -> int:
     # For Claude models, we can use the anthropic library if available
     if anthropic and model.startswith("claude"):
         try:
-            client = anthropic.Anthropic()
+            client = cast(Any, anthropic.Anthropic())
             token_count = client.count_tokens(text)
             return token_count
         except Exception as e:
             logger.warning(
-                f"Failed to get token count using anthropic library: {str(e)}. Falling back to approximation."
+                "Failed to get token count using anthropic library: %s. "
+                "Falling back to approximation.",
+                e,
             )
 
-    # If anthropic not available, use tiktoken with cl100k_base which is similar to Claude's tokenizer
+    # cl100k_base is a reasonable approximation when Anthropic's counter is
+    # unavailable.
     if tiktoken:
         try:
             encoding = tiktoken.get_encoding("cl100k_base")
             return len(encoding.encode(text))
         except Exception as e:
             logger.warning(
-                f"Failed to get token count using tiktoken: {str(e)}. Falling back to character-based estimation."
+                "Failed to get token count using tiktoken: %s. "
+                "Falling back to character-based estimation.",
+                e,
             )
 
     # Fallback to character-based estimation if all else fails
@@ -192,7 +203,7 @@ class LLMProvider(abc.ABC):
         self.temperature = temperature
         self.max_tokens = max_tokens
         self.system_prompt = system_prompt
-        self.provider_name = None  # Will be set by subclasses
+        self.provider_name: Optional[str] = None  # Will be set by subclasses
         self.initialize()
 
     @abc.abstractmethod
@@ -207,6 +218,8 @@ class LLMProvider(abc.ABC):
 
     def count_tokens(self, text: str) -> int:
         """Count tokens for the provider's model."""
+        if self.model is None:
+            raise RuntimeError("Provider model is not initialized")
         return get_token_count(text, self.model)
 
     def check_tpm_limit(
@@ -217,7 +230,7 @@ class LLMProvider(abc.ABC):
 
         Args:
             prompt: The prompt text to be sent
-            estimated_output_tokens: Optional estimate of output tokens (calculated if not provided)
+            estimated_output_tokens: Optional output-token estimate
 
         Returns:
             Tuple of (within_limit, input_tokens, total_tokens)
@@ -225,7 +238,8 @@ class LLMProvider(abc.ABC):
         if not self.provider_name or self.provider_name.lower() not in TPM_LIMITS:
             # No provider name or no limit defined - assume it's safe
             logger.warning(
-                f"No TPM limit found for provider {self.provider_name}. Proceeding without limits."
+                "No TPM limit found for provider %s. Proceeding without limits.",
+                self.provider_name,
             )
             return True, 0, 0
 
@@ -248,7 +262,9 @@ class LLMProvider(abc.ABC):
 
         if not within_limit:
             logger.warning(
-                f"TPM limit exceeded: Request would use {total_tokens} tokens but limit is {tpm_limit}"
+                "TPM limit exceeded: request would use %s tokens but limit is %s",
+                total_tokens,
+                tpm_limit,
             )
             logger.warning(
                 f"This exceeds the {self.provider_name} TPM limit set in settings.json"
@@ -277,6 +293,7 @@ class AnthropicProvider(LLMProvider):
         reasoning_effort: Optional[str] = None,
         thinking_enabled: bool = False,
         thinking_budget_tokens: Optional[int] = None,
+        structured_transport: Literal["native", "prompted"] = "native",
         structured_output_retries: Optional[int] = None,
         output_validator: Optional[Any] = None,
     ):
@@ -295,6 +312,7 @@ class AnthropicProvider(LLMProvider):
             reasoning_effort: Anthropic output effort for structured requests
             thinking_enabled: Enable extended thinking (requires Claude 4+ models)
             thinking_budget_tokens: Thinking token budget (typically 32000)
+            structured_transport: Anthropic Messages structured-output transport
             structured_output_retries: Validation retry budget for structured
                 output agents (apex.structured_output_retries in nexus.toml)
             output_validator: Optional async pydantic_ai output validator
@@ -306,6 +324,9 @@ class AnthropicProvider(LLMProvider):
         self.reasoning_effort = reasoning_effort
         self.thinking_enabled = thinking_enabled
         self.thinking_budget_tokens = thinking_budget_tokens
+        if structured_transport not in {"native", "prompted"}:
+            raise ValueError("structured_transport must be 'native' or 'prompted'")
+        self.structured_transport = structured_transport
         self.structured_output_retries = (
             structured_output_retries
             if structured_output_retries is not None
@@ -336,7 +357,8 @@ class AnthropicProvider(LLMProvider):
         """Initialize the Anthropic client."""
         if not anthropic:
             raise ImportError(
-                "The 'anthropic' package is required for AnthropicProvider. Install with 'pip install anthropic'."
+                "The 'anthropic' package is required for AnthropicProvider. "
+                "Install with 'pip install anthropic'."
             )
 
         self.provider_name = "anthropic"
@@ -351,13 +373,15 @@ class AnthropicProvider(LLMProvider):
             if self.temperature is None:
                 logger.info(
                     f"Using Anthropic model: {self.model} with default temperature, "
-                    f"extended thinking enabled (budget: {self.thinking_budget_tokens} tokens, "
+                    "extended thinking enabled "
+                    f"(budget: {self.thinking_budget_tokens} tokens, "
                     f"total max_tokens: {self.max_tokens})"
                 )
             else:
                 logger.info(
-                    f"Using Anthropic model: {self.model} with temperature: {self.temperature}, "
-                    f"extended thinking enabled (budget: {self.thinking_budget_tokens} tokens, "
+                    f"Using Anthropic model: {self.model} with temperature: "
+                    f"{self.temperature}, extended thinking enabled "
+                    f"(budget: {self.thinking_budget_tokens} tokens, "
                     f"total max_tokens: {self.max_tokens})"
                 )
         else:
@@ -367,7 +391,8 @@ class AnthropicProvider(LLMProvider):
                 )
             else:
                 logger.info(
-                    f"Using Anthropic model: {self.model} with temperature: {self.temperature}"
+                    f"Using Anthropic model: {self.model} with temperature: "
+                    f"{self.temperature}"
                 )
 
     def get_completion(self, prompt: str, enable_cache: bool = False) -> LLMResponse:
@@ -381,7 +406,12 @@ class AnthropicProvider(LLMProvider):
         Returns:
             LLMResponse with completion and cache usage stats
         """
+        if self.model is None:
+            raise RuntimeError("Anthropic provider model is not initialized")
+
         # Format messages for the API
+        messages: List[Dict[str, Any]]
+        system: Optional[Union[str, List[Dict[str, Any]]]]
         if enable_cache:
             # Use structured content with cache control
             messages = self._format_messages_with_cache(prompt)
@@ -391,7 +421,7 @@ class AnthropicProvider(LLMProvider):
             system = self.system_prompt
 
         # Prepare parameters for the API call
-        params = {
+        params: Dict[str, Any] = {
             "model": self.model,
             "messages": messages,
             "max_tokens": self.max_tokens,
@@ -423,7 +453,7 @@ class AnthropicProvider(LLMProvider):
             # Call the API
             if extra_body:
                 params["extra_body"] = extra_body
-            response = self.client.messages.create(**params)
+            response = cast(Any, self.client.messages).create(**params)
 
             # Extract the content from the response
             # For extended thinking, skip "thinking" blocks and get the first text block
@@ -508,7 +538,9 @@ class AnthropicProvider(LLMProvider):
 
             # Define your output schema
             class SentimentAnalysis(BaseModel):
-                sentiment: str = Field(description="Sentiment of the text (positive, negative, neutral)")
+                sentiment: str = Field(
+                    description="Sentiment (positive, negative, or neutral)"
+                )
                 score: float = Field(description="Confidence score (0-1)")
 
             # Get structured completion
@@ -572,6 +604,17 @@ class AnthropicProvider(LLMProvider):
     ) -> Tuple[Any, LLMResponse]:
         """Run a native JSON-schema Messages request with bounded repair."""
 
+        if self.structured_transport == "prompted":
+            if output_config is not None or output_format is not None:
+                raise ValueError(
+                    "Prompted Anthropic structured transport does not accept "
+                    "output_config or output_format"
+                )
+            return self._get_structured_completion_prompted_sync(
+                prompt,
+                schema_model,
+            )
+
         from pydantic_ai import ModelRetry
 
         active_prompt = prompt
@@ -596,6 +639,50 @@ class AnthropicProvider(LLMProvider):
                 )
                 return parsed_output, self._native_response_to_llm_response(
                     parsed_output, response
+                )
+            except ModelRetry as exc:
+                last_error = exc
+                if attempt >= self.structured_output_retries:
+                    raise
+                active_prompt = retry_prompt(prompt, exc.message)
+            except (ValidationError, json.JSONDecodeError, ValueError) as exc:
+                last_error = exc
+                if attempt >= self.structured_output_retries:
+                    raise
+                active_prompt = retry_prompt(prompt, str(exc))
+
+        raise RuntimeError("Structured completion failed") from last_error
+
+    def _get_structured_completion_prompted_sync(
+        self,
+        prompt: str,
+        schema_model: Type,
+    ) -> Tuple[Any, LLMResponse]:
+        """Run a prompted-schema Messages request with bounded repair."""
+
+        from pydantic_ai import ModelRetry
+
+        active_prompt = prompt
+        last_error: Optional[BaseException] = None
+        for attempt in range(self.structured_output_retries + 1):
+            try:
+                response = self.client.beta.messages.create(
+                    **self._build_prompted_structured_request_params(active_prompt)
+                )
+                parsed_output = self._extract_prompted_parsed_output(
+                    response,
+                    schema_model,
+                )
+                parsed_output = asyncio.run(
+                    run_output_validator(
+                        self.output_validator,
+                        parsed_output,
+                        retry=attempt,
+                    )
+                )
+                return parsed_output, self._native_response_to_llm_response(
+                    parsed_output,
+                    response,
                 )
             except ModelRetry as exc:
                 last_error = exc
@@ -651,6 +738,34 @@ class AnthropicProvider(LLMProvider):
             }
         return params
 
+    def _build_prompted_structured_request_params(
+        self,
+        prompt: str,
+    ) -> Dict[str, Any]:
+        """Build Anthropic Messages params without a native output schema."""
+
+        params: Dict[str, Any] = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": self.max_tokens,
+        }
+        if self.reasoning_effort is not None:
+            params["output_config"] = {"effort": self.reasoning_effort}
+        if self.system_prompt:
+            params["system"] = self.system_prompt
+        if self.temperature is not None:
+            params["temperature"] = self.temperature
+        if self.top_p is not None:
+            params["top_p"] = self.top_p
+        if self.top_k is not None:
+            params["top_k"] = self.top_k
+        if self.thinking_enabled:
+            params["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": self.thinking_budget_tokens,
+            }
+        return params
+
     @staticmethod
     def _extract_native_parsed_output(response: Any, schema_model: Type) -> Any:
         """Extract and validate Anthropic native JSON output."""
@@ -670,11 +785,46 @@ class AnthropicProvider(LLMProvider):
 
         raise ValueError("Anthropic structured response did not include JSON output")
 
+    @staticmethod
+    def _extract_prompted_parsed_output(response: Any, schema_model: Type) -> Any:
+        """Validate one text JSON value, tolerating one outer Markdown fence."""
+
+        text_parts: List[str] = []
+        for block in getattr(response, "content", []) or []:
+            if getattr(block, "type", None) != "text":
+                continue
+            text = getattr(block, "text", None)
+            if text:
+                text_parts.append(text)
+
+        output_text = "".join(text_parts)
+        if not output_text:
+            raise ValueError(
+                "Anthropic prompted structured response did not include text output"
+            )
+
+        try:
+            return schema_model.model_validate_json(output_text)
+        except (ValidationError, json.JSONDecodeError, ValueError):
+            fenced_text = output_text.strip()
+            if not fenced_text.endswith("```"):
+                raise
+            if fenced_text.startswith("```json"):
+                opening_fence = "```json"
+            elif fenced_text.startswith("```"):
+                opening_fence = "```"
+            else:
+                raise
+            unfenced_text = fenced_text[len(opening_fence) : -3].strip()
+            return schema_model.model_validate_json(unfenced_text)
+
     def _native_response_to_llm_response(
         self, parsed_output: Any, response: Any
     ) -> LLMResponse:
         """Convert an Anthropic native structured response into LLMResponse."""
 
+        if self.model is None:
+            raise RuntimeError("Anthropic provider model is not initialized")
         content = (
             parsed_output.model_dump_json()
             if hasattr(parsed_output, "model_dump_json")
@@ -712,11 +862,13 @@ class AnthropicProvider(LLMProvider):
         """
         try:
             # Use Anthropic's built-in token counter
-            return self.client.count_tokens(text)
+            return cast(Any, self.client).count_tokens(text)
         except Exception as e:
             # Fall back to base implementation if Anthropic's counter fails
             logger.warning(
-                f"Error using Anthropic token counter: {str(e)}. Falling back to approximation."
+                "Error using Anthropic token counter: %s. "
+                "Falling back to approximation.",
+                e,
             )
             return super().count_tokens(text)
 
@@ -765,14 +917,15 @@ class AnthropicProvider(LLMProvider):
 
         # Simple implementation: mark the entire user prompt as cacheable
         # More sophisticated: split on section markers and cache large sections
-        content_blocks = []
+        content_blocks: List[Dict[str, Any]] = []
+        block: Dict[str, Any]
 
         # Check if prompt contains section markers
         if "=== RECENT STORYTELLER CONTEXT ===" in prompt:
             # Split into sections
-            sections = []
-            current_section = []
-            current_name = None
+            sections: List[Tuple[Optional[str], str]] = []
+            current_section: List[str] = []
+            current_name: Optional[str] = None
 
             for line in prompt.split("\n"):
                 if line.startswith("===") and line.endswith("==="):
@@ -852,8 +1005,10 @@ def get_db_connection_string() -> str:
     else:
         connection_string = f"postgresql://{DB_USER}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 
+    safe_password = "********" if DB_PASSWORD else ""
     logger.info(
-        f"Using database connection: {connection_string.replace(DB_PASSWORD, '********' if DB_PASSWORD else '')}"
+        "Using database connection: %s",
+        connection_string.replace(DB_PASSWORD, safe_password),
     )
     return connection_string
 
@@ -974,8 +1129,6 @@ def setup_abort_handler(
     Returns:
         True if handlers were successfully set up, False otherwise
     """
-    global ABORT_REQUESTED
-
     # Setup keyboard handler if available
     if KEYBOARD_AVAILABLE:
 
@@ -1013,7 +1166,6 @@ def is_abort_requested() -> bool:
     Returns:
         True if abort has been requested, False otherwise
     """
-    global ABORT_REQUESTED
     return ABORT_REQUESTED
 
 

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -101,6 +101,23 @@ def test_apex_tag_library_settings_round_trip() -> None:
     assert dumped["apex"]["tag_library"] == raw["apex"]["tag_library"]
 
 
+def test_shipped_anthropic_storyteller_transport_is_prompted() -> None:
+    settings = Settings(**_nexus_toml_dict())
+
+    assert settings.apex.anthropic_storyteller_transport == "prompted"
+
+
+def test_apex_rejects_unknown_anthropic_storyteller_transport() -> None:
+    raw = _nexus_toml_dict()
+    raw["apex"]["anthropic_storyteller_transport"] = "tool"
+
+    with pytest.raises(
+        ValidationError,
+        match="anthropic_storyteller_transport",
+    ):
+        Settings(**raw)
+
+
 def test_summaries_follow_anthropic_storyteller_with_registry_route():
     """A native Anthropic storyteller remains the default summarizer."""
     raw = _nexus_toml_dict()

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -9,7 +9,8 @@ import pytest
 from nexus.agents.logon.apex_schema import (
     StorytellerResponseBootstrap,
 )
-from nexus.agents.logon.skald_wire import SkaldTurnWire
+from nexus.agents.logon.skald_wire import SkaldTurnWire, skald_wire_prompt_guide
+from nexus.agents.lore import logon_utility
 from nexus.agents.lore.lore import LORE
 from nexus.agents.lore.logon_utility import LogonUtility
 
@@ -137,6 +138,73 @@ def test_runtime_roster_reference_resolves_before_provider_call(
         == "resolved-roster-model"
     )
     assert seen == ["@openai.storyteller"]
+
+
+@pytest.mark.parametrize(
+    ("configured_transport", "is_bootstrap", "expected_transport", "has_guide"),
+    [
+        ("prompted", False, "prompted", True),
+        ("native", False, "native", False),
+        ("prompted", True, "native", False),
+    ],
+)
+def test_anthropic_storyteller_transport_and_guide_follow_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    configured_transport: str,
+    is_bootstrap: bool,
+    expected_transport: str,
+    has_guide: bool,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class RecordingAnthropicProvider:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+            self.model = kwargs["model"]
+            self.structured_transport = kwargs["structured_transport"]
+
+    monkeypatch.setattr(
+        logon_utility,
+        "get_provider_for_model",
+        lambda _model: "anthropic",
+    )
+    monkeypatch.setattr(
+        "nexus.config.get_openai_compatible_endpoint",
+        lambda _model: None,
+    )
+    monkeypatch.setattr(
+        "nexus.agents.logon.orrery_tag_validation." "build_storyteller_tag_validator",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        LogonUtility,
+        "_load_system_prompt",
+        lambda _self, _is_bootstrap=None: "Core prompt",
+    )
+    monkeypatch.setattr(
+        logon_utility,
+        "AnthropicProvider",
+        RecordingAnthropicProvider,
+    )
+    settings = {
+        "API Settings": {
+            "apex": {
+                "anthropic_storyteller_transport": configured_transport,
+                "max_output_tokens": 1234,
+                "structured_output_retries": 2,
+            }
+        }
+    }
+    utility = LogonUtility(settings, model_override="claude-sonnet-4-5")
+
+    utility._initialize_provider(is_bootstrap)
+
+    assert captured["structured_transport"] == expected_transport
+    expected_system = (
+        f"Core prompt\n\n{skald_wire_prompt_guide()}" if has_guide else "Core prompt"
+    )
+    assert captured["system_prompt"] == expected_system
+    assert utility._system_prompt == expected_system
 
 
 @pytest.mark.requires_postgres

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -191,6 +191,7 @@ def test_anthropic_storyteller_transport_and_guide_follow_settings(
             "apex": {
                 "anthropic_storyteller_transport": configured_transport,
                 "max_output_tokens": 1234,
+                "reasoning_effort": "medium",
                 "structured_output_retries": 2,
             }
         }
@@ -200,6 +201,7 @@ def test_anthropic_storyteller_transport_and_guide_follow_settings(
     utility._initialize_provider(is_bootstrap)
 
     assert captured["structured_transport"] == expected_transport
+    assert captured["reasoning_effort"] == "medium"
     expected_system = (
         f"Core prompt\n\n{skald_wire_prompt_guide()}" if has_guide else "Core prompt"
     )

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from pydantic import ValidationError
 
 from nexus.agents.logon.apex_schema import (
     StorytellerResponseBootstrap,
@@ -690,6 +691,258 @@ def test_anthropic_provider_uses_native_output_format() -> None:
     assert "tools" not in captured
     assert captured["system"] == "System prompt"
     assert captured["max_tokens"] == 5678
+
+
+def test_anthropic_provider_rejects_unknown_structured_transport() -> None:
+    with pytest.raises(
+        ValueError,
+        match="structured_transport must be 'native' or 'prompted'",
+    ):
+        AnthropicProvider(
+            model="claude-sonnet-4-5",
+            api_key="test-key",
+            structured_transport="unknown",  # type: ignore[arg-type]
+        )
+
+
+def test_anthropic_prompted_transport_omits_schema_and_parses_json_fence() -> None:
+    expected = _bootstrap_response()
+    captured = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content=[
+                    SimpleNamespace(
+                        type="text",
+                        text=f"```json\n{expected.model_dump_json()}\n```",
+                    )
+                ],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        system_prompt="System prompt",
+        temperature=0.2,
+        top_p=0.8,
+        top_k=40,
+        max_tokens=5678,
+        thinking_enabled=True,
+        thinking_budget_tokens=1024,
+        structured_transport="prompted",
+        structured_output_retries=0,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    parsed, llm_response = provider.get_structured_completion(
+        "Prompt",
+        StorytellerResponseBootstrap,
+    )
+
+    assert parsed == expected
+    assert llm_response.input_tokens == 33
+    assert llm_response.output_tokens == 44
+    assert captured == {
+        "model": "claude-sonnet-4-5",
+        "messages": [{"role": "user", "content": "Prompt"}],
+        "max_tokens": 5678,
+        "system": "System prompt",
+        "temperature": 0.2,
+        "top_p": 0.8,
+        "top_k": 40,
+        "thinking": {"type": "enabled", "budget_tokens": 1024},
+    }
+
+
+@pytest.mark.asyncio
+async def test_anthropic_prompted_transport_async_parses_bare_fence() -> None:
+    expected = _bootstrap_response()
+    calls = []
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(
+                content=[
+                    SimpleNamespace(
+                        type="text",
+                        text=f"```\n{expected.model_dump_json()}\n```",
+                    )
+                ],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        structured_transport="prompted",
+        structured_output_retries=0,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    parsed, _llm_response = await provider.get_structured_completion_async(
+        "Prompt",
+        StorytellerResponseBootstrap,
+    )
+
+    assert parsed == expected
+    assert len(calls) == 1
+    assert "output_config" not in calls[0]
+    assert "output_format" not in calls[0]
+
+
+def test_anthropic_prompted_transport_repairs_then_raises_on_garbage() -> None:
+    calls = []
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(
+                content=[SimpleNamespace(type="text", text="persistent garbage")],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        structured_transport="prompted",
+        structured_output_retries=1,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    with pytest.raises(ValidationError, match="Invalid JSON"):
+        provider.get_structured_completion("Prompt", StorytellerResponseBootstrap)
+
+    assert len(calls) == 2
+    assert calls[0]["messages"][0]["content"] == "Prompt"
+    assert "=== STRUCTURED OUTPUT RETRY ===" in calls[1]["messages"][0]["content"]
+    assert all("output_config" not in request for request in calls)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_prompted_transport_async_repairs_then_raises() -> None:
+    calls = []
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(
+                content=[SimpleNamespace(type="text", text="persistent garbage")],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        structured_transport="prompted",
+        structured_output_retries=1,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    with pytest.raises(ValidationError, match="Invalid JSON"):
+        await provider.get_structured_completion_async(
+            "Prompt",
+            StorytellerResponseBootstrap,
+        )
+
+    assert len(calls) == 2
+    assert "=== STRUCTURED OUTPUT RETRY ===" in calls[1]["messages"][0]["content"]
+    assert all("output_config" not in request for request in calls)
+
+
+def test_anthropic_prompted_transport_carries_effort_without_format() -> None:
+    expected = _bootstrap_response()
+    captured = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content=[SimpleNamespace(type="text", text=expected.model_dump_json())],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        reasoning_effort="medium",
+        structured_transport="prompted",
+        structured_output_retries=0,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    parsed, _llm_response = provider.get_structured_completion(
+        "Prompt",
+        StorytellerResponseBootstrap,
+    )
+
+    assert parsed == expected
+    assert captured["output_config"] == {"effort": "medium"}
+    assert "format" not in captured["output_config"]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_prompted_transport_async_carries_effort_without_format() -> (
+    None
+):
+    expected = _bootstrap_response()
+    captured = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content=[SimpleNamespace(type="text", text=expected.model_dump_json())],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        reasoning_effort="low",
+        structured_transport="prompted",
+        structured_output_retries=0,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    parsed, _llm_response = await provider.get_structured_completion_async(
+        "Prompt",
+        StorytellerResponseBootstrap,
+    )
+
+    assert parsed == expected
+    assert captured["output_config"] == {"effort": "low"}
+    assert "format" not in captured["output_config"]
+
+
+@pytest.mark.parametrize("schema_argument", ["output_config", "output_format"])
+def test_anthropic_prompted_transport_rejects_caller_schema_arguments(
+    schema_argument: str,
+) -> None:
+    create = Mock(side_effect=AssertionError("request must not be sent"))
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        structured_transport="prompted",
+    )
+    provider.client = SimpleNamespace(
+        beta=SimpleNamespace(messages=SimpleNamespace(create=create))
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="does not accept output_config or output_format",
+    ):
+        provider.get_structured_completion(
+            "Prompt",
+            StorytellerResponseBootstrap,
+            **{schema_argument: {}},
+        )
+
+    create.assert_not_called()
 
 
 def test_anthropic_provider_accepts_native_output_config_override() -> None:

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 import json
 import os
 from pathlib import Path
@@ -43,6 +44,7 @@ from nexus.agents.logon.skald_wire import (
     PresenceBaseline,
     PresenceRef,
     SkaldTurnWire,
+    _prompt_guide_type,
     hydrate_skald_turn,
     skald_wire_lenient_schema,
     skald_wire_prompt_guide,
@@ -924,6 +926,49 @@ def _reachable_schema_objects(
     return objects
 
 
+def _reachable_schema_property_names(schema: dict[str, Any]) -> list[str]:
+    """Collect every reachable property, including properties of inline objects."""
+
+    definitions = schema["$defs"]
+    property_names: list[str] = []
+    visited_definitions: set[str] = set()
+
+    def visit(node: Any) -> None:
+        if not isinstance(node, dict):
+            return
+        ref = node.get("$ref")
+        if isinstance(ref, str):
+            name = ref.removeprefix("#/$defs/")
+            if name not in visited_definitions:
+                visited_definitions.add(name)
+                visit(definitions[name])
+            return
+
+        properties = node.get("properties")
+        if isinstance(properties, dict):
+            for property_name, property_schema in properties.items():
+                property_names.append(property_name)
+                visit(property_schema)
+
+        visit(node.get("items"))
+        for key in ("anyOf", "oneOf", "allOf"):
+            for member in node.get(key, []):
+                visit(member)
+
+    visit(schema)
+    return property_names
+
+
+def test_prompt_guide_type_rejects_inline_object_schema() -> None:
+    inline_object = {
+        "type": "object",
+        "properties": {"nested": {"type": "string"}},
+    }
+
+    with pytest.raises(ValueError, match="does not support inline object schemas"):
+        _prompt_guide_type(inline_object, {})
+
+
 def test_skald_wire_prompt_guide_is_deterministic_and_complete() -> None:
     schema = skald_wire_lenient_schema()
     first = skald_wire_prompt_guide()
@@ -933,6 +978,15 @@ def test_skald_wire_prompt_guide_is_deterministic_and_complete() -> None:
     assert first.startswith("=== OUTPUT FORMAT ===\n")
     assert "Respond with a single JSON object" in first
     assert "No prose outside the JSON." in first
+
+    rendered_property_names = []
+    for line in first.splitlines():
+        field_label = line.split(":", 1)[0]
+        if field_label.endswith(("!", "?")):
+            rendered_property_names.append(field_label[:-1])
+    assert Counter(rendered_property_names) == Counter(
+        _reachable_schema_property_names(schema)
+    )
 
     for object_name, object_schema in _reachable_schema_objects(schema):
         marker = f"{object_name}{{\n"
@@ -1088,6 +1142,15 @@ def test_logon_selects_transport_appropriate_wire_serialization() -> None:
             schema=skald_wire_lenient_schema(),
         )
     }
+
+
+def test_anthropic_wire_serialization_requires_transport_attribute() -> None:
+    utility = LogonUtility({})
+    utility._provider_wire_type = "anthropic"
+    utility.provider = cast(Any, SimpleNamespace())
+
+    with pytest.raises(AttributeError, match="structured_transport"):
+        utility._schema_format_kwargs(SkaldTurnWire)
 
 
 def test_local_chat_response_format_carries_lenient_wire_schema() -> None:

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast, get_args
 
 import psycopg2
 import pytest
-import tiktoken
 from pydantic import BaseModel, ValidationError
 
 from nexus.agents.logon.apex_enums import (
@@ -45,6 +45,7 @@ from nexus.agents.logon.skald_wire import (
     SkaldTurnWire,
     hydrate_skald_turn,
     skald_wire_lenient_schema,
+    skald_wire_prompt_guide,
     skald_wire_strict_text_format,
 )
 from nexus.agents.lore import logon_utility
@@ -889,13 +890,95 @@ def test_lenient_wire_closes_every_object_schema_node() -> None:
 
 
 def test_shipped_anthropic_wire_has_no_union_typed_schema_nodes() -> None:
-    utility = LogonUtility({})
-    utility._provider_wire_type = "anthropic"
-    schema = utility._schema_format_kwargs(SkaldTurnWire)["output_config"]["format"][
-        "schema"
-    ]
+    assert _count_union_typed_parameters(skald_wire_lenient_schema()) == 0
 
-    assert _count_union_typed_parameters(schema) == 0
+
+def _reachable_schema_objects(
+    schema: dict[str, Any],
+) -> list[tuple[str, dict[str, Any]]]:
+    """Walk every object reachable through local schema references."""
+
+    definitions = schema["$defs"]
+    objects = [(schema["title"], schema)]
+    seen = {schema["title"]}
+
+    def visit(node: Any) -> None:
+        if not isinstance(node, dict):
+            return
+        ref = node.get("$ref")
+        if isinstance(ref, str):
+            name = ref.removeprefix("#/$defs/")
+            target = definitions[name]
+            if target.get("type") == "object" and name not in seen:
+                seen.add(name)
+                objects.append((name, target))
+            return
+        visit(node.get("items"))
+        for key in ("anyOf", "oneOf", "allOf"):
+            for member in node.get(key, []):
+                visit(member)
+
+    for _object_name, object_schema in objects:
+        for property_schema in object_schema["properties"].values():
+            visit(property_schema)
+    return objects
+
+
+def test_skald_wire_prompt_guide_is_deterministic_and_complete() -> None:
+    schema = skald_wire_lenient_schema()
+    first = skald_wire_prompt_guide()
+    second = skald_wire_prompt_guide()
+
+    assert first == second
+    assert first.startswith("=== OUTPUT FORMAT ===\n")
+    assert "Respond with a single JSON object" in first
+    assert "No prose outside the JSON." in first
+
+    for object_name, object_schema in _reachable_schema_objects(schema):
+        marker = f"{object_name}{{\n"
+        assert first.count(marker) == 1
+        block = first.split(marker, 1)[1].split("\n}", 1)[0]
+        block_lines = block.splitlines()
+        required = set(object_schema.get("required", []))
+        assert len(block_lines) == len(object_schema["properties"])
+
+        for property_name, property_schema in object_schema["properties"].items():
+            status = "!" if property_name in required else "?"
+            prefix = f"{property_name}{status}:"
+            matching_lines = [line for line in block_lines if line.startswith(prefix)]
+            assert len(matching_lines) == 1
+            description = json.dumps(
+                property_schema.get("description", ""),
+                ensure_ascii=False,
+            )
+            assert matching_lines[0].endswith(f"|{description}")
+            assert matching_lines[0][len(prefix) :].split("|", 1)[0]
+
+
+def test_skald_wire_prompt_guide_preserves_enum_values_verbatim() -> None:
+    guide = skald_wire_prompt_guide()
+
+    assert (
+        'transition?:string|enum=["new_episode","new_season"]|'
+        '"Episode or season transition."' in guide
+    )
+    assert (
+        'type?:string|enum=["family","romantic","friend","companion","ally",'
+        '"contact","pedagogical","acquaintance","stranger","complex"]|'
+        '"Canonical relationship type."' in guide
+    )
+    assert (
+        'declared_entity_role?:string|enum=["subject","object"]|'
+        '"Whether the declared entity is the subject or object of the directed '
+        'pair tag."' in guide
+    )
+
+
+def test_skald_wire_prompt_guide_stays_within_token_budget() -> None:
+    tiktoken = pytest.importorskip("tiktoken")
+    encoding = tiktoken.get_encoding("o200k_base")
+
+    assert len(encoding.encode(skald_wire_prompt_guide())) <= 1_400
 
 
 def test_wire_schema_size_and_description_budget() -> None:
@@ -985,6 +1068,19 @@ def test_logon_selects_transport_appropriate_wire_serialization() -> None:
     assert local_format["schema"] == skald_wire_lenient_schema()
 
     utility._provider_wire_type = "anthropic"
+    utility.provider = cast(
+        Any,
+        SimpleNamespace(structured_transport="prompted"),
+    )
+    utility._schema_format_cache = {}
+    prompted_kwargs = utility._schema_format_kwargs(SkaldTurnWire)
+    assert prompted_kwargs == {}
+    assert utility._schema_format_kwargs(SkaldTurnWire) is prompted_kwargs
+
+    utility.provider = cast(
+        Any,
+        SimpleNamespace(structured_transport="native"),
+    )
     utility._schema_format_cache = {}
     assert utility._schema_format_kwargs(SkaldTurnWire) == {
         "output_config": anthropic_output_config(
@@ -1023,6 +1119,17 @@ def test_bootstrap_schema_selection_and_contract_are_unchanged() -> None:
     ]
     assert text_format["name"] == "StorytellerResponseBootstrap"
     assert set(text_format["schema"]["properties"]) == {"narrative", "choices"}
+
+    utility._provider_wire_type = "anthropic"
+    utility.provider = cast(
+        Any,
+        SimpleNamespace(structured_transport="native"),
+    )
+    utility._schema_format_cache = {}
+    output_config = utility._schema_format_kwargs(StorytellerResponseBootstrap)[
+        "output_config"
+    ]
+    assert output_config == anthropic_output_config(StorytellerResponseBootstrap)
 
 
 def test_non_bootstrap_logon_requires_parent_chunk_id() -> None:
@@ -1197,6 +1304,7 @@ def test_presence_baseline_reads_real_slot_parent_rows() -> None:
 
 
 def test_schema_token_measurement_uses_o200k() -> None:
+    tiktoken = pytest.importorskip("tiktoken")
     encoding = tiktoken.get_encoding("o200k_base")
     strict_wire = _compact_schema_json(skald_wire_strict_text_format()["schema"])
     lenient_wire = _compact_schema_json(skald_wire_lenient_schema())


### PR DESCRIPTION
## Summary

Un-breaks Anthropic storyteller turns. Twenty live compile probes (#566) established that Anthropic's native structured-output grammar compiler cannot hold the full universal wire — the budget is cumulative and structural, shared by output_config and strict tools, and survives no spelling including maximal nesting contortion, text stripping, or totalized serialization. Per the decision recorded on #566 (convergent independent consult under the new escalation ladder): **the storyteller default becomes prompted-schema**, with the existing app-side gate as the sole boundary. Bootstrap and wizard schemas compile fine and stay native.

## Changes

- **`AnthropicProvider.structured_transport`** (`"native"` default | `"prompted"`), validated at construction — mirrors `OpenAIProvider`'s existing transport seam. The prompted path: same bounded-repair loop; rejects caller-supplied `output_config`/`output_format`; tolerates exactly one outer markdown fence (both spellings); **carries reasoning effort as effort-only `output_config {"effort": …}` with no `format` key** — the build initially raised here citing docs, but a live probe showed the API accepts the effort-only spelling, so the capability is preserved (rebut-with-evidence; the storyteller call site doesn't pass effort today, making it an explicit measurement-stage lever).
- **`skald_wire_prompt_guide()`** — a deterministic compact guide rendered mechanically from the de-nulled lenient schema (BFS over reachable object defs; enums and field descriptions carried; loud errors on unexpected shapes). 133 lines, **1,391 o200k tokens**, asserted ≤ 1,400. Appended to the turn-stable system prompt in prompted mode only.
- **Config:** `anthropic_storyteller_transport = "prompted"` under `[API Settings].apex` (Literal-validated, loud on illegal values); bootstrap turns force native regardless.
- `_schema_format_kwargs` emits no `output_config` for prompted storyteller turns; wizard/non-wire schemas unchanged (regression-pinned).

## Test Results (unsandboxed)

```
331 passed, 43 skipped in 6.84s   (includes the keychain API test that fails only inside the build sandbox)
mypy: Success (3 files) · black --check: clean · flake8: clean · config loads: OK
```

## Sequencing

Built on the merged wire-v3 main (e5aaecb4). The measurement stage unblocks on this PR: real Anthropic prompted turns, b-prompt vs b-tool arms, contextual-vocab A/B, two-pass arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ