### PR TITLE
Stringify database values in payload token counting

### DIFF
--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -150,17 +150,15 @@ def _context_component_token_count(payload: Dict[str, Any]) -> int:
     context_components = {
         key: value for key, value in payload.items() if key != "user_input"
     }
-    try:
-        serialized = json.dumps(
-            context_components,
-            ensure_ascii=False,
-            separators=(",", ":"),
-        )
-    except (TypeError, ValueError) as exc:
-        raise TypeError(
-            "Storyteller context payload must be JSON-serializable for token "
-            "budget enforcement"
-        ) from exc
+    # This is a counting seam, not a wire: DB-sourced values (datetime,
+    # Decimal) reach the storyteller as rendered text anyway, so measuring
+    # their stringified length is the honest approximation.
+    serialized = json.dumps(
+        context_components,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        default=str,
+    )
     return calculate_chunk_tokens(serialized)
 
 

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -685,3 +685,23 @@ def test_integrate_response_sorts_mixed_chunk_id_payloads(
     asyncio.run(turn_manager.integrate_response(ctx, "Story chunk text"))
 
     assert ctx.memory_state["pass1"]["baseline_chunks"] == [1, "2", 3]
+
+
+def test_payload_token_count_stringifies_database_values() -> None:
+    """DB-sourced datetimes and Decimals must count, not crash enforcement."""
+    from datetime import datetime
+    from decimal import Decimal
+
+    from nexus.agents.lore.utils.turn_cycle import _context_component_token_count
+
+    payload = {
+        "user_input": "ignored",
+        "entity_data": {
+            "world_time": datetime(2042, 8, 18, 8, 54),
+            "valence": Decimal("0.25"),
+        },
+        "warm_slice": {"chunks": []},
+        "retrieved_passages": {"results": []},
+    }
+
+    assert _context_component_token_count(payload) > 0


### PR DESCRIPTION
One-line hotfix: #570's Phase-5 enforcement raised on the first real turn — `json.dumps` over the assembled payload hit DB-sourced `datetime` values, which the synthetic fix-round payloads never carried. The counting seam now serializes with `default=str` (those values reach the storyteller as rendered text anyway, so stringified length is the honest measure); regression pins `datetime` and `Decimal` payload values. Caught live on the first Hermes trial turn; full lore suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ