### PR TITLE
Recalibrate the local payload profile to 32K from live measurement

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -125,7 +125,7 @@ theme = "veil"
 # Bounds, step, and preset ladder stops for the LORE budget slider in the
 # settings pane. Values are token counts for lore.token_budget.apex_context_window.
 # Keep this floor aligned with the largest committed provider override below.
-min = 24_000
+min = 32_000
 max = 200_000
 step = 1000
 stops = [75_000, 100_000, 150_000, 200_000]
@@ -216,7 +216,9 @@ prompt_overhead_tokens = 4_000
 [lore.token_budget.provider_overrides]
 # Effective apex_context_window per storyteller provider class. Absent key =
 # base value. Local models need a smaller assembled payload (see #566).
-local = 24_000
+# 32K floor measured live 2026-07-24: a mature slot's untrimmable structured
+# core alone is ~14.9K tokens; 24K left the enforcement nothing to trim to.
+local = 32_000
 
 [lore.payload_percent_budget.structured_summaries]
 # Percentage allocation for entity summaries, relationships, events

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -122,9 +122,9 @@ def test_token_budget_provider_overrides_parse() -> None:
     """Legal provider-class reductions survive settings validation."""
     settings = Settings(**_nexus_toml_dict())
 
-    assert settings.lore.token_budget.provider_overrides == {"local": 24_000}
+    assert settings.lore.token_budget.provider_overrides == {"local": 32_000}
     assert settings.lore.token_budget.prompt_overhead_tokens == 4_000
-    assert settings.ui.lore_budget_slider.min == 24_000
+    assert settings.ui.lore_budget_slider.min == 32_000
     assert all(
         stop >= settings.ui.lore_budget_slider.min
         for stop in settings.ui.lore_budget_slider.stops

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -71,7 +71,7 @@ def _stub_baseline(
 @pytest.mark.parametrize(
     ("apex_model", "provider_wire_type", "expected_window"),
     [
-        ("nousresearch/hermes-4-70b", "local", 24_000),
+        ("nousresearch/hermes-4-70b", "local", 32_000),
         (None, "openai", 75_000),
         ("claude-opus-4-8", "anthropic", 75_000),
     ],
@@ -245,7 +245,7 @@ def test_local_payload_trims_oldest_warm_chunks_and_keeps_parent(
     ]
 
     assert phase_state["total_tokens_used"] <= phase_state["payload_ceiling"]
-    assert ctx.token_counts["apex_window"] == 24_000
+    assert ctx.token_counts["apex_window"] == 32_000
     assert phase_state["prompt_overhead_tokens"] == 4_000
     assert phase_state["payload_ceiling"] == (
         ctx.token_counts["total_available"] - 4_000


### PR DESCRIPTION
The first live Hermes turn under #570's enforcement tripped the structured-core guard exactly as designed and produced a real measurement: `wire_class='local', tokens=14,862, ceiling=10,975`. A mature slot's untrimmable structured core (entity dossiers, relationships, world knowledge, the protected parent chunk) doesn't fit a 24K window after system/overhead/response reserves — the committed default was a guess; this is the measured floor. 32K fits the core plus reserves with ~4K left for a hard-trimmed warm slice, which is precisely what the profile is for. Slider floor moves in lockstep per its own comment.

Also worth noting: the error's arithmetic confirms the model-true reasoning heuristic — Hermes drew no 30K reasoning reserve.

Follow-up candidate (recorded on #566, not this PR): scale `[lore.entity_inclusion]` limits by provider class so the structured core itself shrinks on local turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ