### PR TITLE
Scale entity inclusion by storyteller provider class (#566)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -254,6 +254,14 @@ max_total_relationships = 100
 max_total_events = 15
 max_total_threats = 10
 
+[lore.entity_inclusion.provider_overrides.local]
+# Initial estimates measured against the 32K local window; calibrated by
+# overnight trials (see #566). Absent key = base value.
+warm_slice_lookback_chunks = 12
+max_characters_from_warm_slice = 12
+max_locations_from_warm_slice = 6
+include_all_relationships = false
+
 # =============================================================================
 # Orrery Settings (Off-Screen Behavior Resolver)
 # =============================================================================

--- a/nexus/agents/lore/utils/entity_inclusion.py
+++ b/nexus/agents/lore/utils/entity_inclusion.py
@@ -1,0 +1,83 @@
+"""Resolve provider-scaled entity inclusion for storyteller payloads."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any, Optional
+
+from nexus.config.settings_models import EntityInclusionConfig
+
+logger = logging.getLogger("nexus.lore.entity_inclusion")
+
+_STORYTELLER_WIRE_CLASSES = frozenset({"openai", "anthropic", "local"})
+
+
+def _base_entity_inclusion(
+    settings: Mapping[str, Any],
+) -> EntityInclusionConfig:
+    """Return the validated base entity-inclusion configuration."""
+    legacy_agent_settings = settings.get("Agent Settings")
+    legacy_lore_settings = (
+        legacy_agent_settings.get("LORE")
+        if isinstance(legacy_agent_settings, Mapping)
+        else None
+    )
+    lore_settings = (
+        legacy_lore_settings
+        if isinstance(legacy_lore_settings, Mapping)
+        else settings.get("lore")
+    )
+    if not isinstance(lore_settings, Mapping):
+        raise ValueError(
+            "LORE settings are required to resolve storyteller entity inclusion"
+        )
+
+    entity_inclusion = lore_settings.get("entity_inclusion")
+    if not isinstance(entity_inclusion, Mapping):
+        raise ValueError(
+            "entity_inclusion must be configured under the LORE settings section"
+        )
+    return EntityInclusionConfig.model_validate(entity_inclusion)
+
+
+def resolve_entity_inclusion(
+    settings: Mapping[str, Any],
+    provider_wire_type: Optional[str],
+) -> EntityInclusionConfig:
+    """Resolve effective entity inclusion for one storyteller wire class.
+
+    ``None`` is the named LOGON-disabled path and therefore returns base values.
+    Active LOGON callers must establish a wire class before calling this function.
+    """
+    if (
+        provider_wire_type is not None
+        and provider_wire_type not in _STORYTELLER_WIRE_CLASSES
+    ):
+        raise RuntimeError(
+            "Cannot resolve storyteller entity inclusion for an unknown provider "
+            "wire class; expected one of "
+            f"{sorted(_STORYTELLER_WIRE_CLASSES)}, got {provider_wire_type!r}"
+        )
+
+    base = _base_entity_inclusion(settings)
+    if provider_wire_type is None:
+        return base
+
+    override = base.provider_overrides.get(provider_wire_type)
+    if override is None:
+        return base
+
+    override_values = override.model_dump(exclude_none=True)
+    resolved_differences = {
+        field: value
+        for field, value in override_values.items()
+        if getattr(base, field) != value
+    }
+    if resolved_differences:
+        logger.debug(
+            "Storyteller entity inclusion override: class=%s resolved=%s",
+            provider_wire_type,
+            resolved_differences,
+        )
+    return base.model_copy(update=override_values)

--- a/nexus/agents/lore/utils/entity_queries.py
+++ b/nexus/agents/lore/utils/entity_queries.py
@@ -37,7 +37,7 @@ def fetch_all_characters_with_references(
     Args:
         session: SQLAlchemy session
         featured_chunk_ids: Chunk IDs to check for character references
-        max_featured_characters: Maximum warm-slice characters to feature
+        max_featured_characters: Maximum non-user warm-slice characters to feature
 
     Returns:
         Dict with:
@@ -85,6 +85,7 @@ def fetch_all_characters_with_references(
                     character_id, reference, chunk_id
                 FROM chunk_character_references
                 WHERE chunk_id = ANY(:chunk_ids)
+                  AND character_id IS DISTINCT FROM :user_character_id
                 ORDER BY character_id, chunk_id DESC
             ) AS latest_character_references
             ORDER BY chunk_id DESC, character_id
@@ -96,6 +97,7 @@ def fetch_all_characters_with_references(
             {
                 "chunk_ids": featured_chunk_ids,
                 "max_featured_characters": max_featured_characters,
+                "user_character_id": user_char_id,
             },
         ).fetchall()
         featured_ids = {row.character_id: str(row.reference) for row in ref_rows}
@@ -129,6 +131,50 @@ def fetch_all_characters_with_references(
             for row in featured_rows
         ],
     }
+
+
+def fetch_place_ids_by_names(
+    session: Session,
+    place_names: Set[str],
+) -> Set[int]:
+    """Resolve canonical place names to unique place IDs.
+
+    Missing or ambiguous names are data errors because callers use these IDs to
+    guarantee that featured-character locations receive full place dossiers.
+    """
+    if not place_names:
+        return set()
+
+    rows = session.execute(
+        text(
+            """
+            SELECT id, name
+            FROM places
+            WHERE name = ANY(:place_names)
+            ORDER BY name, id
+            """
+        ),
+        {"place_names": sorted(place_names)},
+    ).fetchall()
+
+    ids_by_name: Dict[str, List[int]] = {}
+    for row in rows:
+        ids_by_name.setdefault(str(row.name), []).append(int(row.id))
+
+    missing_names = place_names - set(ids_by_name)
+    if missing_names:
+        raise ValueError(
+            "Featured-character locations did not resolve to places: "
+            f"{sorted(missing_names)}"
+        )
+
+    ambiguous_names = {name: ids for name, ids in ids_by_name.items() if len(ids) != 1}
+    if ambiguous_names:
+        raise ValueError(
+            f"Featured-character location names are ambiguous: {ambiguous_names}"
+        )
+
+    return {ids[0] for ids in ids_by_name.values()}
 
 
 def fetch_all_places_with_references(
@@ -176,7 +222,18 @@ def fetch_all_places_with_references(
                     place_id, reference_type, chunk_id
                 FROM place_chunk_references
                 WHERE chunk_id = ANY(:chunk_ids)
-                ORDER BY place_id, chunk_id DESC
+                -- place_reference_type is setting, transit, mentioned.
+                -- Transit is the place-level present/passing-through tier.
+                ORDER BY
+                    place_id,
+                    chunk_id DESC,
+                    CASE reference_type::text
+                        WHEN 'setting' THEN 0
+                        WHEN 'transit' THEN 1
+                        WHEN 'mentioned' THEN 2
+                        ELSE 3
+                    END,
+                    reference_type::text
             ) AS latest_place_references
             ORDER BY chunk_id DESC, place_id
             LIMIT :max_featured_places

--- a/nexus/agents/lore/utils/entity_queries.py
+++ b/nexus/agents/lore/utils/entity_queries.py
@@ -5,7 +5,8 @@ Provides hierarchical entity queries with universal baseline + featured tracking
 """
 
 import logging
-from typing import Dict, List, Any, Set, Optional
+from typing import Any, Dict, List, Optional, Sequence, Set
+
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -27,6 +28,8 @@ FACTION_TAG_CONTEXT_CATEGORY_SQL = ", ".join(
 def fetch_all_characters_with_references(
     session: Session,
     featured_chunk_ids: List[int],
+    *,
+    max_featured_characters: int,
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
     Fetch ALL characters with baseline tracking fields, plus referenced details.
@@ -34,6 +37,7 @@ def fetch_all_characters_with_references(
     Args:
         session: SQLAlchemy session
         featured_chunk_ids: Chunk IDs to check for character references
+        max_featured_characters: Maximum warm-slice characters to feature
 
     Returns:
         Dict with:
@@ -75,13 +79,24 @@ def fetch_all_characters_with_references(
     if featured_chunk_ids:
         ref_query = text(
             """
-            SELECT DISTINCT character_id, reference
-            FROM chunk_character_references
-            WHERE chunk_id = ANY(:chunk_ids)
+            SELECT character_id, reference
+            FROM (
+                SELECT DISTINCT ON (character_id)
+                    character_id, reference, chunk_id
+                FROM chunk_character_references
+                WHERE chunk_id = ANY(:chunk_ids)
+                ORDER BY character_id, chunk_id DESC
+            ) AS latest_character_references
+            ORDER BY chunk_id DESC, character_id
+            LIMIT :max_featured_characters
         """
         )
         ref_rows = session.execute(
-            ref_query, {"chunk_ids": featured_chunk_ids}
+            ref_query,
+            {
+                "chunk_ids": featured_chunk_ids,
+                "max_featured_characters": max_featured_characters,
+            },
         ).fetchall()
         featured_ids = {row.character_id: str(row.reference) for row in ref_rows}
 
@@ -91,7 +106,7 @@ def fetch_all_characters_with_references(
         logger.debug(f"Added user character (ID {user_char_id}) to featured list")
 
     # Get full details for featured characters
-    featured_rows = []
+    featured_rows: Sequence[Any] = []
     if featured_ids:
         featured_query = text(
             """
@@ -120,6 +135,8 @@ def fetch_all_places_with_references(
     session: Session,
     featured_chunk_ids: List[int],
     featured_place_ids: Optional[Set[int]] = None,
+    *,
+    max_featured_places: int,
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
     Fetch ALL places with baseline tracking fields, plus referenced details.
@@ -128,6 +145,7 @@ def fetch_all_places_with_references(
         session: SQLAlchemy session
         featured_chunk_ids: Chunk IDs to check for place references
         featured_place_ids: Additional place IDs to include (e.g., character locations)
+        max_featured_places: Maximum warm-slice places to feature
 
     Returns:
         Dict with:
@@ -152,13 +170,24 @@ def fetch_all_places_with_references(
     if featured_chunk_ids:
         ref_query = text(
             """
-            SELECT DISTINCT place_id, reference_type
-            FROM place_chunk_references
-            WHERE chunk_id = ANY(:chunk_ids)
+            SELECT place_id, reference_type
+            FROM (
+                SELECT DISTINCT ON (place_id)
+                    place_id, reference_type, chunk_id
+                FROM place_chunk_references
+                WHERE chunk_id = ANY(:chunk_ids)
+                ORDER BY place_id, chunk_id DESC
+            ) AS latest_place_references
+            ORDER BY chunk_id DESC, place_id
+            LIMIT :max_featured_places
         """
         )
         ref_rows = session.execute(
-            ref_query, {"chunk_ids": featured_chunk_ids}
+            ref_query,
+            {
+                "chunk_ids": featured_chunk_ids,
+                "max_featured_places": max_featured_places,
+            },
         ).fetchall()
         featured_ids = {row.place_id: str(row.reference_type) for row in ref_rows}
 
@@ -168,7 +197,7 @@ def fetch_all_places_with_references(
             featured_ids.setdefault(pid, "character_location")
 
     # Get full details for featured places
-    featured_rows = []
+    featured_rows: Sequence[Any] = []
     if featured_ids:
         featured_query = text(
             """
@@ -263,7 +292,7 @@ def fetch_all_factions_with_references(
         featured_ids = {row.faction_id for row in ref_rows}
 
     # Get full details for featured factions
-    featured_rows = []
+    featured_rows: Sequence[Any] = []
     if featured_ids:
         featured_query = text(
             f"""

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -21,8 +21,9 @@ try:
     from .entity_inclusion import resolve_entity_inclusion
     from .entity_queries import (
         fetch_all_characters_with_references,
-        fetch_all_places_with_references,
         fetch_all_factions_with_references,
+        fetch_all_places_with_references,
+        fetch_place_ids_by_names,
     )
     from nexus.agents.logon.apex_schema import (
         StoryTurnResponse,
@@ -52,8 +53,9 @@ except ImportError:
     from nexus.agents.lore.utils.entity_inclusion import resolve_entity_inclusion
     from nexus.agents.lore.utils.entity_queries import (
         fetch_all_characters_with_references,
-        fetch_all_places_with_references,
         fetch_all_factions_with_references,
+        fetch_all_places_with_references,
+        fetch_place_ids_by_names,
     )
     from nexus.agents.logon.apex_schema import (
         StoryTurnResponse,
@@ -510,11 +512,31 @@ class TurnCycleManager:
         # Query places with baseline + featured structure
         # Include places that are current_location of featured characters
         featured_place_ids: set[int] = set()
+        featured_place_names: set[str] = set()
         for char in characters_data.get("featured", []):
-            loc_name = char.get("current_location")
-            if loc_name:
-                # Get place ID from name (we'll query by name in the function)
-                pass  # fetch_all_places_with_references handles this
+            current_location = char.get("current_location")
+            if current_location is None:
+                continue
+            if isinstance(current_location, int) and not isinstance(
+                current_location, bool
+            ):
+                featured_place_ids.add(current_location)
+                continue
+            if isinstance(current_location, str) and current_location.strip():
+                featured_place_names.add(current_location.strip())
+                continue
+            character_identity = char.get("id") or char.get("name") or "<unknown>"
+            raise TypeError(
+                "Featured character "
+                f"{character_identity!r} has invalid current_location "
+                f"{current_location!r}; expected places.id or canonical place name"
+            )
+
+        if featured_place_names:
+            with self.lore.memnon.Session() as session:
+                featured_place_ids.update(
+                    fetch_place_ids_by_names(session, featured_place_names)
+                )
 
         places_data: Dict[str, List[Dict[str, Any]]] = {
             "baseline": [],

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -18,6 +18,7 @@ logger = logging.getLogger("nexus.lore.turn_cycle")
 
 try:
     from .turn_context import TurnContext
+    from .entity_inclusion import resolve_entity_inclusion
     from .entity_queries import (
         fetch_all_characters_with_references,
         fetch_all_places_with_references,
@@ -48,6 +49,7 @@ try:
 except ImportError:
     # If relative import fails, try absolute
     from nexus.agents.lore.utils.turn_context import TurnContext
+    from nexus.agents.lore.utils.entity_inclusion import resolve_entity_inclusion
     from nexus.agents.lore.utils.entity_queries import (
         fetch_all_characters_with_references,
         fetch_all_places_with_references,
@@ -455,21 +457,28 @@ class TurnCycleManager:
             }
             return
 
-        # Get entity_inclusion settings
-        entity_settings = (
-            self.settings.get("Agent Settings", {})
-            .get("LORE", {})
-            .get("entity_inclusion", {})
-        )
-        include_relationships = entity_settings.get("include_all_relationships", True)
-        include_events = entity_settings.get("include_all_active_events", True)
-        include_threats = entity_settings.get("include_all_active_threats", True)
-        event_statuses = entity_settings.get(
-            "active_event_statuses", ["active", "ongoing", "escalating"]
-        )
+        if getattr(self.lore, "enable_logon", True):
+            if turn_context.provider_wire_type is None:
+                raise RuntimeError(
+                    "Active LOGON entity queries require the storyteller provider "
+                    "wire class resolved during Phase 1"
+                )
+            entity_settings = resolve_entity_inclusion(
+                self.settings, turn_context.provider_wire_type
+            )
+        else:
+            entity_settings = resolve_entity_inclusion(
+                self.settings, provider_wire_type=None
+            )
+        include_relationships = entity_settings.include_all_relationships
+        include_events = entity_settings.include_all_active_events
+        include_threats = entity_settings.include_all_active_threats
+        event_statuses = entity_settings.active_event_statuses
 
         # Get chunk IDs from warm slice for featured entity queries
-        warm_chunk_ids = _narrative_chunk_ids(turn_context.warm_slice)
+        warm_chunk_ids = _narrative_chunk_ids(turn_context.warm_slice)[
+            : entity_settings.warm_slice_lookback_chunks
+        ]
 
         if not warm_chunk_ids:
             logger.warning("No chunk IDs in warm slice for entity queries")
@@ -485,7 +494,11 @@ class TurnCycleManager:
 
             with self.lore.memnon.Session() as session:
                 characters_data = fetch_all_characters_with_references(
-                    session, warm_chunk_ids
+                    session,
+                    warm_chunk_ids,
+                    max_featured_characters=(
+                        entity_settings.max_characters_from_warm_slice
+                    ),
                 )
             logger.info(
                 f"Characters: {len(characters_data['baseline'])} baseline, "
@@ -510,7 +523,10 @@ class TurnCycleManager:
         try:
             with self.lore.memnon.Session() as session:
                 places_data = fetch_all_places_with_references(
-                    session, warm_chunk_ids, featured_place_ids
+                    session,
+                    warm_chunk_ids,
+                    featured_place_ids,
+                    max_featured_places=(entity_settings.max_locations_from_warm_slice),
                 )
             logger.info(
                 f"Places: {len(places_data['baseline'])} baseline, "
@@ -567,7 +583,7 @@ class TurnCycleManager:
         events = []
         if include_events:
             try:
-                max_events = entity_settings.get("max_total_events", 15)
+                max_events = entity_settings.max_total_events
                 with self.lore.memnon.Session() as session:
                     event_query = text(
                         """
@@ -596,7 +612,7 @@ class TurnCycleManager:
         threats = []
         if include_threats:
             try:
-                max_threats = entity_settings.get("max_total_threats", 10)
+                max_threats = entity_settings.max_total_threats
                 with self.lore.memnon.Session() as session:
                     # Note: threats table uses is_active boolean, not status enum
                     # Lifecycle stages: inception, developing, active, resolved, dormant

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -657,6 +657,19 @@ class PayloadPercentBudget(BaseModel):
     warm_slice: PayloadBudgetRange
 
 
+class EntityInclusionProviderOverride(BaseModel):
+    """Optional entity-inclusion overrides for one storyteller wire class."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    warm_slice_lookback_chunks: Optional[int] = Field(default=None, ge=1)
+    max_characters_from_warm_slice: Optional[int] = Field(default=None, ge=1)
+    max_locations_from_warm_slice: Optional[int] = Field(default=None, ge=1)
+    include_all_relationships: Optional[bool] = None
+    include_all_active_events: Optional[bool] = None
+    include_all_active_threats: Optional[bool] = None
+
+
 class EntityInclusionConfig(BaseModel):
     """Configuration for entity inclusion in context payloads."""
 
@@ -674,6 +687,23 @@ class EntityInclusionConfig(BaseModel):
     max_total_relationships: int = Field(..., ge=1)
     max_total_events: int = Field(..., ge=1)
     max_total_threats: int = Field(..., ge=1)
+    provider_overrides: Dict[str, EntityInclusionProviderOverride] = Field(
+        default_factory=dict,
+        description="Entity-inclusion overrides by storyteller provider class",
+    )
+
+    @model_validator(mode="after")
+    def _validate_provider_overrides(self) -> "EntityInclusionConfig":
+        """Provider overrides use the closed storyteller wire-class set."""
+        legal_provider_classes = {"openai", "anthropic", "local"}
+        unknown_provider_classes = set(self.provider_overrides) - legal_provider_classes
+        if unknown_provider_classes:
+            raise ValueError(
+                "entity inclusion provider_overrides contains unknown provider "
+                f"classes: {sorted(unknown_provider_classes)}; legal keys are "
+                f"{sorted(legal_provider_classes)}"
+            )
+        return self
 
 
 class LORERetrievalSettings(BaseModel):

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -194,6 +194,65 @@ def test_token_budget_accepts_zero_prompt_overhead() -> None:
     assert settings.lore.token_budget.prompt_overhead_tokens == 0
 
 
+def test_entity_inclusion_provider_overrides_parse() -> None:
+    """Shipped local entity limits survive settings validation."""
+    settings = Settings(**_nexus_toml_dict())
+
+    assert set(settings.lore.entity_inclusion.provider_overrides) == {"local"}
+    local = settings.lore.entity_inclusion.provider_overrides["local"]
+    assert local.model_dump(exclude_none=True) == {
+        "warm_slice_lookback_chunks": 12,
+        "max_characters_from_warm_slice": 12,
+        "max_locations_from_warm_slice": 6,
+        "include_all_relationships": False,
+    }
+
+
+def test_entity_inclusion_provider_overrides_reject_unknown_outer_key() -> None:
+    """Provider override tables use the closed storyteller wire-class set."""
+    raw = _nexus_toml_dict()
+    raw["lore"]["entity_inclusion"]["provider_overrides"]["bedrock"] = {}
+
+    with pytest.raises(ValidationError, match="unknown provider classes.*bedrock"):
+        Settings(**raw)
+
+
+def test_entity_inclusion_provider_overrides_reject_unknown_inner_key() -> None:
+    """Override fields cannot silently expand beyond the six allowed knobs."""
+    raw = _nexus_toml_dict()
+    raw["lore"]["entity_inclusion"]["provider_overrides"]["local"][
+        "max_factions_from_warm_slice"
+    ] = 4
+
+    with pytest.raises(ValidationError, match="max_factions_from_warm_slice"):
+        Settings(**raw)
+
+
+def test_entity_inclusion_provider_overrides_keep_integer_constraints() -> None:
+    """Override integer limits retain the base fields' positive constraint."""
+    raw = _nexus_toml_dict()
+    raw["lore"]["entity_inclusion"]["provider_overrides"]["local"][
+        "warm_slice_lookback_chunks"
+    ] = 0
+
+    with pytest.raises(
+        ValidationError,
+        match="warm_slice_lookback_chunks",
+    ):
+        Settings(**raw)
+
+
+def test_entity_inclusion_provider_overrides_allow_empty_table() -> None:
+    """An empty provider table represents pure inheritance."""
+    raw = _nexus_toml_dict()
+    raw["lore"]["entity_inclusion"]["provider_overrides"] = {"local": {}}
+
+    settings = Settings(**raw)
+
+    local = settings.lore.entity_inclusion.provider_overrides["local"]
+    assert local.model_dump(exclude_none=True) == {}
+
+
 def test_summaries_follow_anthropic_storyteller_with_registry_route():
     """A native Anthropic storyteller remains the default summarizer."""
     raw = _nexus_toml_dict()

--- a/tests/test_lore/test_entity_inclusion.py
+++ b/tests/test_lore/test_entity_inclusion.py
@@ -1,0 +1,100 @@
+"""Provider-scaled storyteller entity-inclusion tests."""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any, Dict
+
+import pytest
+
+from nexus.agents.lore.utils.entity_inclusion import resolve_entity_inclusion
+from nexus.config import load_settings_as_dict
+
+
+def _effective_values(config: Any) -> Dict[str, Any]:
+    """Return effective base fields without the routing table."""
+    return config.model_dump(exclude={"provider_overrides"})
+
+
+def test_local_entity_inclusion_resolves_shipped_overrides(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Local routing applies four overrides and inherits every absent field."""
+    settings = load_settings_as_dict()
+    base = resolve_entity_inclusion(settings, provider_wire_type=None)
+
+    with caplog.at_level(logging.DEBUG, logger="nexus.lore.entity_inclusion"):
+        resolved = resolve_entity_inclusion(settings, provider_wire_type="local")
+
+    assert resolved.warm_slice_lookback_chunks == 12
+    assert resolved.max_characters_from_warm_slice == 12
+    assert resolved.max_locations_from_warm_slice == 6
+    assert resolved.include_all_relationships is False
+    assert resolved.include_all_active_events == base.include_all_active_events
+    assert resolved.include_all_active_threats == base.include_all_active_threats
+    assert resolved.active_event_statuses == base.active_event_statuses
+    assert resolved.max_total_events == base.max_total_events
+
+    override_records = [
+        record
+        for record in caplog.records
+        if record.name == "nexus.lore.entity_inclusion"
+    ]
+    assert len(override_records) == 1
+    assert "class=local" in override_records[0].getMessage()
+    assert "'warm_slice_lookback_chunks': 12" in override_records[0].getMessage()
+    assert "'include_all_relationships': False" in override_records[0].getMessage()
+
+
+@pytest.mark.parametrize("provider_wire_type", ["openai", "anthropic"])
+def test_unconfigured_provider_entity_inclusion_is_pure_base(
+    provider_wire_type: str,
+) -> None:
+    """Provider classes without a table inherit the complete base config."""
+    settings = load_settings_as_dict()
+    base = resolve_entity_inclusion(settings, provider_wire_type=None)
+
+    resolved = resolve_entity_inclusion(settings, provider_wire_type)
+
+    assert _effective_values(resolved) == _effective_values(base)
+
+
+def test_logon_disabled_entity_inclusion_is_explicit_base() -> None:
+    """The named no-wire-class path preserves the complete base config."""
+    settings = load_settings_as_dict()
+
+    resolved = resolve_entity_inclusion(settings, provider_wire_type=None)
+
+    assert resolved.warm_slice_lookback_chunks == 20
+    assert resolved.max_characters_from_warm_slice == 25
+    assert resolved.max_locations_from_warm_slice == 10
+    assert resolved.include_all_relationships is True
+
+
+def test_empty_entity_inclusion_override_table_is_pure_base(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An empty provider table neither changes values nor emits an override log."""
+    settings = copy.deepcopy(load_settings_as_dict())
+    settings["lore"]["entity_inclusion"]["provider_overrides"] = {"local": {}}
+    base = resolve_entity_inclusion(settings, provider_wire_type=None)
+
+    with caplog.at_level(logging.DEBUG, logger="nexus.lore.entity_inclusion"):
+        resolved = resolve_entity_inclusion(settings, provider_wire_type="local")
+
+    assert _effective_values(resolved) == _effective_values(base)
+    assert not [
+        record
+        for record in caplog.records
+        if record.name == "nexus.lore.entity_inclusion"
+    ]
+
+
+def test_unknown_entity_inclusion_wire_class_fails_loudly() -> None:
+    """Runtime callers cannot bypass the closed provider-class contract."""
+    with pytest.raises(RuntimeError, match="unknown provider wire class.*bedrock"):
+        resolve_entity_inclusion(
+            load_settings_as_dict(),
+            provider_wire_type="bedrock",
+        )

--- a/tests/test_lore/test_entity_queries.py
+++ b/tests/test_lore/test_entity_queries.py
@@ -1,0 +1,245 @@
+"""Regressions for capped entity-reference query semantics."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import pytest
+
+from nexus.agents.lore.utils.entity_queries import (
+    fetch_all_characters_with_references,
+    fetch_all_places_with_references,
+    fetch_place_ids_by_names,
+)
+
+
+class _Row:
+    """Small SQLAlchemy row stand-in with attribute and mapping access."""
+
+    def __init__(self, **values: Any) -> None:
+        self._mapping = values
+        for key, value in values.items():
+            setattr(self, key, value)
+
+
+class _Result:
+    """Small SQLAlchemy result stand-in."""
+
+    def __init__(self, rows: Optional[list[_Row]] = None) -> None:
+        self.rows = rows or []
+
+    def fetchall(self) -> list[_Row]:
+        return self.rows
+
+    def fetchone(self) -> Optional[_Row]:
+        return self.rows[0] if self.rows else None
+
+    def __iter__(self):
+        return iter(self.rows)
+
+
+class _CharacterQuerySession:
+    """Evaluate the character query's cap-relevant behavior in memory."""
+
+    def __init__(self) -> None:
+        self.user_character_id = 1
+        self.references = [
+            _Row(character_id=1, reference="present", chunk_id=100),
+            _Row(character_id=2, reference="present", chunk_id=100),
+            _Row(character_id=3, reference="mentioned", chunk_id=99),
+            _Row(character_id=4, reference="mentioned", chunk_id=98),
+        ]
+        self.characters = {
+            character_id: _Row(
+                id=character_id,
+                name=f"Character {character_id}",
+                current_location=None,
+            )
+            for character_id in range(1, 5)
+        }
+        self.executed: list[tuple[str, Dict[str, Any]]] = []
+
+    def execute(
+        self,
+        statement: Any,
+        parameters: Optional[Dict[str, Any]] = None,
+    ) -> _Result:
+        sql = str(statement)
+        params = parameters or {}
+        self.executed.append((sql, params))
+
+        if "FROM global_variables" in sql:
+            return _Result([_Row(user_character=self.user_character_id)])
+
+        if "FROM chunk_character_references" in sql:
+            eligible = [
+                row for row in self.references if row.chunk_id in params["chunk_ids"]
+            ]
+            if "character_id IS DISTINCT FROM :user_character_id" in sql:
+                eligible = [
+                    row
+                    for row in eligible
+                    if row.character_id != params["user_character_id"]
+                ]
+
+            latest_by_character: dict[int, _Row] = {}
+            for row in sorted(
+                eligible,
+                key=lambda candidate: (
+                    candidate.character_id,
+                    -candidate.chunk_id,
+                ),
+            ):
+                latest_by_character.setdefault(row.character_id, row)
+            selected = sorted(
+                latest_by_character.values(),
+                key=lambda row: (-row.chunk_id, row.character_id),
+            )[: params["max_featured_characters"]]
+            return _Result(selected)
+
+        if "FROM characters" in sql and "WHERE id = ANY(:ids)" in sql:
+            return _Result(
+                [self.characters[character_id] for character_id in params["ids"]]
+            )
+
+        if "FROM characters" in sql:
+            return _Result(list(self.characters.values()))
+
+        raise AssertionError(f"Unexpected character query: {sql}")
+
+
+class _PlaceQuerySession:
+    """Evaluate place caps and reference winner priority in memory."""
+
+    def __init__(self) -> None:
+        self.places = {
+            10: _Row(id=10, name="Newest Setting"),
+            11: _Row(id=11, name="Transit Stop"),
+            12: _Row(id=12, name="Older Mention"),
+            13: _Row(id=13, name="Old Setting"),
+            99: _Row(id=99, name="Character Haven"),
+        }
+        self.references = [
+            _Row(place_id=10, reference_type="mentioned", chunk_id=100),
+            _Row(place_id=10, reference_type="setting", chunk_id=100),
+            _Row(place_id=11, reference_type="transit", chunk_id=99),
+            _Row(place_id=12, reference_type="mentioned", chunk_id=98),
+            _Row(place_id=13, reference_type="setting", chunk_id=97),
+        ]
+        self.executed: list[tuple[str, Dict[str, Any]]] = []
+
+    def execute(
+        self,
+        statement: Any,
+        parameters: Optional[Dict[str, Any]] = None,
+    ) -> _Result:
+        sql = str(statement)
+        params = parameters or {}
+        self.executed.append((sql, params))
+
+        if "WHERE name = ANY(:place_names)" in sql:
+            requested_names = set(params["place_names"])
+            return _Result(
+                [
+                    place
+                    for place in self.places.values()
+                    if place.name in requested_names
+                ]
+            )
+
+        if "FROM place_chunk_references" in sql:
+            eligible = [
+                row for row in self.references if row.chunk_id in params["chunk_ids"]
+            ]
+            priority = {"setting": 0, "transit": 1, "mentioned": 2}
+            has_priority_tiebreaker = "CASE reference_type::text" in sql
+            winner_by_place: dict[int, _Row] = {}
+            winner_keys: dict[int, tuple[int, int, str]] = {}
+            for row in eligible:
+                reference_priority = (
+                    priority[row.reference_type] if has_priority_tiebreaker else 0
+                )
+                key = (-row.chunk_id, reference_priority, row.reference_type)
+                if row.place_id not in winner_keys or key < winner_keys[row.place_id]:
+                    winner_by_place[row.place_id] = row
+                    winner_keys[row.place_id] = key
+            selected = sorted(
+                winner_by_place.values(),
+                key=lambda row: (-row.chunk_id, row.place_id),
+            )[: params["max_featured_places"]]
+            return _Result(selected)
+
+        if "FROM places" in sql and "WHERE id = ANY(:ids)" in sql:
+            return _Result([self.places[place_id] for place_id in params["ids"]])
+
+        if "FROM places" in sql:
+            return _Result(list(self.places.values()))
+
+        raise AssertionError(f"Unexpected place query: {sql}")
+
+
+def test_user_character_does_not_consume_non_user_character_cap() -> None:
+    """A newest user reference still permits the full NPC cap plus the user."""
+    session = _CharacterQuerySession()
+
+    result = fetch_all_characters_with_references(
+        session,
+        [100, 99, 98],
+        max_featured_characters=2,
+    )
+
+    featured_by_id = {row["id"]: row for row in result["featured"]}
+    assert set(featured_by_id) == {1, 2, 3}
+    assert len(set(featured_by_id) - {session.user_character_id}) == 2
+    assert featured_by_id[session.user_character_id]["reference_type"] == (
+        "user_character"
+    )
+
+    reference_sql, reference_params = next(
+        (sql, params)
+        for sql, params in session.executed
+        if "FROM chunk_character_references" in sql
+    )
+    assert "character_id IS DISTINCT FROM :user_character_id" in reference_sql
+    assert reference_params["user_character_id"] == session.user_character_id
+
+
+def test_featured_location_bypasses_cap_and_place_winner_is_deterministic() -> None:
+    """Character locations survive beyond the cap; setting wins a newest tie."""
+    session = _PlaceQuerySession()
+    featured_location_ids = fetch_place_ids_by_names(
+        session,
+        {"Character Haven"},
+    )
+
+    result = fetch_all_places_with_references(
+        session,
+        [100, 99, 98, 97],
+        featured_location_ids,
+        max_featured_places=2,
+    )
+
+    featured_by_id = {row["id"]: row for row in result["featured"]}
+    assert set(featured_by_id) == {10, 11, 99}
+    assert featured_by_id[10]["reference_type"] == "setting"
+    assert featured_by_id[99]["reference_type"] == "character_location"
+
+    reference_sql = next(
+        sql for sql, _params in session.executed if "FROM place_chunk_references" in sql
+    )
+    assert "place_reference_type is setting, transit, mentioned" in reference_sql
+    assert reference_sql.index("WHEN 'setting' THEN 0") < reference_sql.index(
+        "WHEN 'transit' THEN 1"
+    )
+    assert reference_sql.index("WHEN 'transit' THEN 1") < reference_sql.index(
+        "WHEN 'mentioned' THEN 2"
+    )
+
+
+def test_featured_location_name_resolution_fails_loudly() -> None:
+    """An unresolved location cannot silently lose its required dossier."""
+    with pytest.raises(ValueError, match="did not resolve.*Missing Place"):
+        fetch_place_ids_by_names(
+            _PlaceQuerySession(),
+            {"Missing Place"},
+        )

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 
+from nexus.agents.lore.utils import turn_cycle as turn_cycle_module
 from nexus.agents.lore.logon_utility import LogonUtility
 from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
 from nexus.agents.lore.utils.turn_context import TurnContext
@@ -149,6 +150,152 @@ def test_process_user_input_uses_base_budget_when_logon_is_disabled() -> None:
     assert ctx.token_counts["apex_window"] == 75_000
     assert ctx.token_counts["reasoning_reserve"] == 30_000
     assert lore.memory_manager.phase2_budget == 7_500
+
+
+@pytest.mark.parametrize(
+    (
+        "enable_logon",
+        "provider_wire_type",
+        "expected_lookback",
+        "expected_characters",
+        "expected_locations",
+        "expect_relationship_query",
+    ),
+    [
+        (True, "local", 12, 12, 6, False),
+        (False, None, 20, 25, 10, True),
+    ],
+)
+def test_query_entity_states_passes_resolved_limits_to_fetch_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    enable_logon: bool,
+    provider_wire_type: str | None,
+    expected_lookback: int,
+    expected_characters: int,
+    expected_locations: int,
+    expect_relationship_query: bool,
+) -> None:
+    """The real gather seam passes provider-resolved limits to DB fetches."""
+    captured: Dict[str, Any] = {}
+    statements: list[str] = []
+
+    class EmptySession:
+        def __enter__(self) -> "EmptySession":
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            return None
+
+        def execute(
+            self, statement: Any, parameters: Dict[str, Any] | None = None
+        ) -> list[Any]:
+            statements.append(str(statement))
+            return []
+
+    class EntityMemnon:
+        Session = EmptySession
+
+    class EntityLore:
+        def __init__(self) -> None:
+            self.settings = load_settings_as_dict()
+            self.memnon = EntityMemnon()
+            self.enable_logon = enable_logon
+
+    def fake_characters(
+        session: Any,
+        featured_chunk_ids: list[int],
+        *,
+        max_featured_characters: int,
+    ) -> Dict[str, list[Dict[str, Any]]]:
+        captured["characters"] = (
+            list(featured_chunk_ids),
+            max_featured_characters,
+        )
+        return {
+            "baseline": [],
+            "featured": [{"id": 1, "current_location": None}],
+        }
+
+    def fake_places(
+        session: Any,
+        featured_chunk_ids: list[int],
+        featured_place_ids: set[int],
+        *,
+        max_featured_places: int,
+    ) -> Dict[str, list[Dict[str, Any]]]:
+        captured["places"] = (
+            list(featured_chunk_ids),
+            set(featured_place_ids),
+            max_featured_places,
+        )
+        return {"baseline": [], "featured": []}
+
+    def fake_factions(
+        session: Any,
+        featured_chunk_ids: list[int],
+    ) -> Dict[str, list[Dict[str, Any]]]:
+        captured["factions"] = list(featured_chunk_ids)
+        return {"baseline": [], "featured": []}
+
+    monkeypatch.setattr(
+        turn_cycle_module,
+        "fetch_all_characters_with_references",
+        fake_characters,
+    )
+    monkeypatch.setattr(
+        turn_cycle_module,
+        "fetch_all_places_with_references",
+        fake_places,
+    )
+    monkeypatch.setattr(
+        turn_cycle_module,
+        "fetch_all_factions_with_references",
+        fake_factions,
+    )
+
+    manager = TurnCycleManager(EntityLore())
+    ctx = TurnContext(
+        turn_id="entity-provider-limits",
+        user_input="Continue.",
+        start_time=time.time(),
+        provider_wire_type=provider_wire_type,
+        warm_slice=[
+            {"chunk_id": chunk_id, "text": f"Chunk {chunk_id}."}
+            for chunk_id in range(30, 5, -1)
+        ],
+    )
+
+    asyncio.run(manager.query_entity_states(ctx))
+
+    expected_chunk_ids = list(range(30, 30 - expected_lookback, -1))
+    assert captured["characters"] == (expected_chunk_ids, expected_characters)
+    assert captured["places"] == (expected_chunk_ids, set(), expected_locations)
+    assert captured["factions"] == expected_chunk_ids
+    relationship_queried = any(
+        "character_relationships" in statement for statement in statements
+    )
+    assert relationship_queried is expect_relationship_query
+
+
+def test_query_entity_states_requires_wire_class_when_logon_is_active() -> None:
+    """A missing Phase 1 route cannot silently fall back to base entity limits."""
+
+    class EntityLore:
+        def __init__(self) -> None:
+            self.settings = load_settings_as_dict()
+            self.memnon = object()
+            self.enable_logon = True
+
+    manager = TurnCycleManager(EntityLore())
+    ctx = TurnContext(
+        turn_id="entity-missing-wire-class",
+        user_input="Continue.",
+        start_time=time.time(),
+        warm_slice=[{"chunk_id": 1, "text": "Parent."}],
+    )
+
+    with pytest.raises(RuntimeError, match="require.*provider wire class"):
+        asyncio.run(manager.query_entity_states(ctx))
 
 
 def test_slot_model_change_mid_turn_aborts_before_provider_initialization(

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -213,8 +213,18 @@ def test_query_entity_states_passes_resolved_limits_to_fetch_boundary(
         )
         return {
             "baseline": [],
-            "featured": [{"id": 1, "current_location": None}],
+            "featured": [
+                {"id": 1, "current_location": 9_001},
+                {"id": 2, "current_location": "Named Haven"},
+            ],
         }
+
+    def fake_place_ids_by_names(
+        session: Any,
+        place_names: set[str],
+    ) -> set[int]:
+        captured["place_names"] = set(place_names)
+        return {9_002}
 
     def fake_places(
         session: Any,
@@ -228,7 +238,15 @@ def test_query_entity_states_passes_resolved_limits_to_fetch_boundary(
             set(featured_place_ids),
             max_featured_places,
         )
-        return {"baseline": [], "featured": []}
+        warm_reference_ids = list(range(1_000, 1_000 + max_featured_places + 2))
+        featured_ids = [
+            *warm_reference_ids[:max_featured_places],
+            *sorted(featured_place_ids),
+        ]
+        return {
+            "baseline": [],
+            "featured": [{"id": place_id} for place_id in featured_ids],
+        }
 
     def fake_factions(
         session: Any,
@@ -246,6 +264,11 @@ def test_query_entity_states_passes_resolved_limits_to_fetch_boundary(
         turn_cycle_module,
         "fetch_all_places_with_references",
         fake_places,
+    )
+    monkeypatch.setattr(
+        turn_cycle_module,
+        "fetch_place_ids_by_names",
+        fake_place_ids_by_names,
     )
     monkeypatch.setattr(
         turn_cycle_module,
@@ -269,7 +292,20 @@ def test_query_entity_states_passes_resolved_limits_to_fetch_boundary(
 
     expected_chunk_ids = list(range(30, 30 - expected_lookback, -1))
     assert captured["characters"] == (expected_chunk_ids, expected_characters)
-    assert captured["places"] == (expected_chunk_ids, set(), expected_locations)
+    assert captured["place_names"] == {"Named Haven"}
+    assert captured["places"] == (
+        expected_chunk_ids,
+        {9_001, 9_002},
+        expected_locations,
+    )
+    featured_location_ids = {
+        place["id"] for place in ctx.entity_data["locations"]["featured"]
+    }
+    assert featured_location_ids == {
+        *range(1_000, 1_000 + expected_locations),
+        9_001,
+        9_002,
+    }
     assert captured["factions"] == expected_chunk_ids
     relationship_queried = any(
         "character_relationships" in statement for statement in statements


### PR DESCRIPTION
## Summary

Today's live Hermes trial exposed the next bottleneck behind the payload window: the **structured core** (~14.9K tokens of entity dossiers on a mature slot) is invisible to Phase-5 trimming — it's sized by `[lore.entity_inclusion]` regardless of the effective window. This PR shrinks the core at the source for local turns via optional `provider_overrides` tables mirroring the `token_budget` pattern.

## Design

- `[lore.entity_inclusion.provider_overrides.local]`: lookback 20→12, characters 25→12, locations 10→6, `include_all_relationships` off. **Initial estimates** — tonight's overnight run calibrates them against the 32K window.
- Closed outer keys (`openai`/`anthropic`/`local`), unknown inner fields forbidden, loud validation — same doctrine as #570's budget overrides.
- `resolve_entity_inclusion(settings, wire_class)` is the single authority; the turn cycle resolves once from `turn_context.provider_wire_type` (the threading #570 built); `None` is the *named* LOGON-disabled base path; unknown classes raise.
- Limits apply at the SQL fetch boundary; the always-featured user character and explicit character-location IDs stay outside the warm-slice caps.
- Full knob-consumer audit in the build report — including three fields with no runtime consumer today (honestly left base).

## Test Results

```
226 passed, 13 skipped · mypy clean (4 files) · black/flake8 clean · config loads OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ