### PR TITLE
Add the two-pass writer+clerk turn pipeline (#566 bakeoff arm)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -1014,6 +1014,7 @@ model = "@openai.default"     # Resolved via api_models registry; edit roles to 
 reasoning_effort = "medium"   # Reasoning effort level (low/medium/high)
 max_output_tokens = 25000     # Maximum tokens for generated narrative
 anthropic_storyteller_transport = "prompted" # "prompted" or "native"
+turn_pipeline = "single_pass" # "single_pass" or "two_pass" bakeoff lever
 structured_output_retries = 3 # Validation retry budget for structured story turns
 # HTTP client timeout for a narrative continue turn. Frontier generation runs
 # inside the request and blocks the API worker, so status polls aren't answered

--- a/nexus/agents/logon/skald_wire.py
+++ b/nexus/agents/logon/skald_wire.py
@@ -356,6 +356,50 @@ class UpdatesBlock(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class SkaldWriterWire(BaseModel):
+    """Provider-facing prose and scene deltas for pass one."""
+
+    narrative: str = Field(description="Narrative prose.")
+    choices: List[str] = Field(
+        min_length=2,
+        max_length=4,
+        description="Two to four actionable player choices.",
+    )
+    scene: Optional[SceneDelta] = Field(
+        default=None,
+        description="Changed chronology or scene attributes.",
+    )
+    presence: Optional[PresenceDelta] = Field(
+        default=None,
+        description="Scene presence and reference changes.",
+    )
+    operations: Optional[Operations] = Field(
+        default=None,
+        description="Special runtime requests, when needed.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class SkaldClerkWire(BaseModel):
+    """Provider-facing durable state record for pass two."""
+
+    updates: Optional[UpdatesBlock] = Field(
+        default=None,
+        description="Durable semantic state changes.",
+    )
+    orrery_adjudications: List[OrreryAdjudication] = Field(
+        default_factory=list,
+        description="Rulings on current Orrery proposals.",
+    )
+    new_entities: List[NewEntityDeclaration] = Field(
+        default_factory=list,
+        description="New persistent entities introduced by this turn.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class SkaldTurnWire(BaseModel):
     """Provider-facing semantic deltas for a non-bootstrap turn."""
 
@@ -391,6 +435,24 @@ class SkaldTurnWire(BaseModel):
     )
 
     model_config = ConfigDict(extra="forbid")
+
+
+def combine_two_pass(
+    writer: SkaldWriterWire,
+    clerk: SkaldClerkWire,
+) -> SkaldTurnWire:
+    """Combine writer and clerk outputs into the existing full wire contract."""
+
+    return SkaldTurnWire(
+        narrative=writer.narrative,
+        choices=writer.choices,
+        scene=writer.scene,
+        presence=writer.presence,
+        updates=clerk.updates,
+        operations=writer.operations,
+        orrery_adjudications=clerk.orrery_adjudications,
+        new_entities=clerk.new_entities,
+    )
 
 
 def _hydrate_scene(scene: Optional[SceneDelta]) -> ChunkMetadataUpdate:
@@ -684,10 +746,36 @@ def skald_wire_strict_text_format() -> Dict[str, Any]:
     return openai_response_text_format(SkaldTurnWire, schema=schema)
 
 
+def skald_writer_strict_text_format() -> Dict[str, Any]:
+    """Build the strict OpenAI Responses text format for writer passes."""
+
+    schema = strict_json_schema(SkaldWriterWire)
+    return openai_response_text_format(SkaldWriterWire, schema=schema)
+
+
+def skald_clerk_strict_text_format() -> Dict[str, Any]:
+    """Build the strict OpenAI Responses text format for clerk passes."""
+
+    schema = strict_json_schema(SkaldClerkWire)
+    return openai_response_text_format(SkaldClerkWire, schema=schema)
+
+
 def skald_wire_lenient_schema() -> Dict[str, Any]:
     """Build the omittable-field schema for Anthropic and local endpoints."""
 
     return de_null_schema(SkaldTurnWire.model_json_schema())
+
+
+def skald_writer_lenient_schema() -> Dict[str, Any]:
+    """Build the omittable-field schema for writer passes."""
+
+    return de_null_schema(SkaldWriterWire.model_json_schema())
+
+
+def skald_clerk_lenient_schema() -> Dict[str, Any]:
+    """Build the omittable-field schema for clerk passes."""
+
+    return de_null_schema(SkaldClerkWire.model_json_schema())
 
 
 def _prompt_guide_ref_name(ref: str) -> str:
@@ -785,10 +873,13 @@ def _prompt_guide_object_refs(
     return refs
 
 
-def skald_wire_prompt_guide() -> str:
-    """Render a compact prompted-output guide from the lenient wire schema."""
+def _render_prompt_guide(
+    schema: Dict[str, Any],
+    *,
+    include_descriptions: bool = True,
+) -> str:
+    """Render one compact prompted-output guide from a lenient wire schema."""
 
-    schema = skald_wire_lenient_schema()
     definitions = schema.get("$defs", {})
     if not isinstance(definitions, dict):
         raise ValueError("Skald wire schema definitions must be an object")
@@ -841,16 +932,17 @@ def skald_wire_prompt_guide() -> str:
                 if enum_values is not None
                 else ""
             )
-            description = property_schema.get("description", "")
-            if not isinstance(description, str):
-                raise ValueError(
-                    f"Skald wire property {object_name}.{property_name} "
-                    "has a non-string description"
-                )
-            description_text = json.dumps(description, ensure_ascii=False)
-            lines.append(
-                f"{property_name}{status}:{field_type}{enum_text}|{description_text}"
-            )
+            field_line = f"{property_name}{status}:{field_type}{enum_text}"
+            if include_descriptions:
+                description = property_schema.get("description", "")
+                if not isinstance(description, str):
+                    raise ValueError(
+                        f"Skald wire property {object_name}.{property_name} "
+                        "has a non-string description"
+                    )
+                description_text = json.dumps(description, ensure_ascii=False)
+                field_line = f"{field_line}|{description_text}"
+            lines.append(field_line)
 
             for ref_name in _prompt_guide_object_refs(
                 property_schema,
@@ -863,3 +955,18 @@ def skald_wire_prompt_guide() -> str:
 
     lines.append("```")
     return "\n".join(lines)
+
+
+def skald_wire_prompt_guide() -> str:
+    """Render a compact prompted-output guide from the lenient wire schema."""
+
+    return _render_prompt_guide(skald_wire_lenient_schema())
+
+
+def skald_clerk_prompt_guide() -> str:
+    """Render a compact prompted-output guide for the clerk pass."""
+
+    return _render_prompt_guide(
+        skald_clerk_lenient_schema(),
+        include_descriptions=False,
+    )

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -5,6 +5,7 @@ Manages communication with Apex AI providers (OpenAI, Anthropic, xAI).
 """
 
 import asyncio
+import copy
 import json
 import logging
 import os
@@ -26,11 +27,19 @@ from nexus.agents.logon.apex_schema import (  # noqa: E402
 from nexus.agents.logon.skald_wire import (  # noqa: E402
     PresenceBaseline,
     PresenceRef,
+    SkaldClerkWire,
     SkaldTurnWire,
+    SkaldWriterWire,
+    combine_two_pass,
     hydrate_skald_turn,
+    skald_clerk_lenient_schema,
+    skald_clerk_prompt_guide,
+    skald_clerk_strict_text_format,
     skald_wire_lenient_schema,
     skald_wire_prompt_guide,
     skald_wire_strict_text_format,
+    skald_writer_lenient_schema,
+    skald_writer_strict_text_format,
 )
 from nexus.agents.lore.utils.chunk_operations import (  # noqa: E402
     calculate_chunk_tokens,
@@ -286,6 +295,19 @@ class LogonUtility:
         self._validation_dbname: Optional[str] = None
         self._schema_format_cache: Dict[type, Dict[str, Any]] = {}
 
+    def _turn_pipeline(self) -> Literal["single_pass", "two_pass"]:
+        """Return the validated non-bootstrap storyteller pipeline lever."""
+
+        apex_settings = self.settings.get("API Settings", {}).get("apex")
+        if not isinstance(apex_settings, Mapping):
+            apex_settings = self.settings.get("apex") or {}
+        turn_pipeline = apex_settings.get("turn_pipeline", "single_pass")
+        if turn_pipeline not in {"single_pass", "two_pass"}:
+            raise ValueError(
+                "API Settings.apex.turn_pipeline must be 'single_pass' or 'two_pass'"
+            )
+        return cast(Literal["single_pass", "two_pass"], turn_pipeline)
+
     def _load_system_prompt(self, is_bootstrap: Optional[bool] = None) -> str:
         """Load and combine storyteller instructions with live slot context."""
         from nexus.api.slot_utils import require_slot_dbname
@@ -361,6 +383,18 @@ class LogonUtility:
         finally:
             if "conn" in locals():
                 conn.close()
+
+    @staticmethod
+    def _load_clerk_system_prompt() -> str:
+        """Load the dedicated clerk instructions without per-turn material."""
+
+        prompts_dir = Path(__file__).parent.parent.parent.parent / "prompts"
+        clerk_prompt_path = prompts_dir / "storyteller_clerk.md"
+        clerk_prompt = clerk_prompt_path.read_text()
+        if not clerk_prompt.strip():
+            raise ValueError(f"Clerk prompt is empty: {clerk_prompt_path}")
+        logger.info("Loaded storyteller clerk prompt (%s chars)", len(clerk_prompt))
+        return clerk_prompt
 
     @staticmethod
     def _format_setting_context(setting_data: Any) -> str:
@@ -517,6 +551,9 @@ class LogonUtility:
 
         # Load system prompt
         system_prompt = self._load_system_prompt(provider_bootstrap_mode)
+        use_two_pass = (
+            not provider_bootstrap_mode and self._turn_pipeline() == "two_pass"
+        )
         anthropic_transport: Literal["native", "prompted"] = "native"
         if provider_type == "anthropic":
             configured_transport = apex_settings.get("anthropic_storyteller_transport")
@@ -530,7 +567,7 @@ class LogonUtility:
                 if provider_bootstrap_mode
                 else cast(Literal["native", "prompted"], configured_transport)
             )
-            if anthropic_transport == "prompted":
+            if anthropic_transport == "prompted" and not use_two_pass:
                 system_prompt = f"{system_prompt}\n\n{skald_wire_prompt_guide()}"
         self._system_prompt = system_prompt
         self._provider_bootstrap_mode = provider_bootstrap_mode
@@ -713,21 +750,30 @@ class LogonUtility:
             prompt,
             effective_context_window=effective_context_window,
         )
-        schema_kwargs = self._schema_format_kwargs(schema_model)
 
         # Get structured completion from provider
         # This returns a tuple of (parsed_object, llm_response)
         try:
-            parsed_response, _llm_response = self.provider.get_structured_completion(
-                prompt,
-                schema_model,
-                **schema_kwargs,
-            )
-            response = self._hydrate_provider_response(
-                parsed_response,
-                schema_model,
-                presence_baseline=presence_baseline,
-            )
+            if self._is_two_pass_turn(schema_model):
+                response = self._generate_narrative_two_pass(
+                    prompt,
+                    presence_baseline=presence_baseline,
+                    effective_context_window=effective_context_window,
+                )
+            else:
+                schema_kwargs = self._schema_format_kwargs(schema_model)
+                parsed_response, _llm_response = (
+                    self.provider.get_structured_completion(
+                        prompt,
+                        schema_model,
+                        **schema_kwargs,
+                    )
+                )
+                response = self._hydrate_provider_response(
+                    parsed_response,
+                    schema_model,
+                    presence_baseline=presence_baseline,
+                )
             logger.debug(
                 "Received structured response with narrative length: %s",
                 len(response.narrative),
@@ -765,21 +811,28 @@ class LogonUtility:
             prompt,
             effective_context_window=effective_context_window,
         )
-        schema_kwargs = self._schema_format_kwargs(schema_model)
 
         try:
-            parsed_response, _llm_response = (
-                await self.provider.get_structured_completion_async(
+            if self._is_two_pass_turn(schema_model):
+                response = await self._generate_narrative_two_pass_async(
                     prompt,
-                    schema_model,
-                    **schema_kwargs,
+                    presence_baseline=presence_baseline,
+                    effective_context_window=effective_context_window,
                 )
-            )
-            response = self._hydrate_provider_response(
-                parsed_response,
-                schema_model,
-                presence_baseline=presence_baseline,
-            )
+            else:
+                schema_kwargs = self._schema_format_kwargs(schema_model)
+                parsed_response, _llm_response = (
+                    await self.provider.get_structured_completion_async(
+                        prompt,
+                        schema_model,
+                        **schema_kwargs,
+                    )
+                )
+                response = self._hydrate_provider_response(
+                    parsed_response,
+                    schema_model,
+                    presence_baseline=presence_baseline,
+                )
             logger.debug(
                 "Received structured response with narrative length: %s",
                 len(response.narrative),
@@ -788,6 +841,204 @@ class LogonUtility:
         except Exception:
             logger.exception("Failed to get structured response")
             raise
+
+    def _is_two_pass_turn(self, schema_model: type) -> bool:
+        """Return whether this non-bootstrap turn uses the bakeoff pipeline."""
+
+        return schema_model is SkaldTurnWire and self._turn_pipeline() == "two_pass"
+
+    def _clone_provider_for_two_pass(
+        self,
+        *,
+        system_prompt: Optional[str],
+        output_validator: Any,
+        anthropic_transport: Optional[Literal["native", "prompted"]] = None,
+    ) -> OpenAIProvider | AnthropicProvider:
+        """Create an isolated provider view for one pass."""
+
+        if self.provider is None:
+            raise RuntimeError("Two-pass generation requires an initialized provider")
+        pass_provider = copy.copy(self.provider)
+        pass_provider.system_prompt = system_prompt
+        pass_provider.output_validator = output_validator
+        if self._provider_wire_type == "anthropic":
+            if anthropic_transport is None:
+                raise ValueError(
+                    "Anthropic two-pass calls require an explicit transport"
+                )
+            cast(AnthropicProvider, pass_provider).structured_transport = (
+                anthropic_transport
+            )
+        elif anthropic_transport is not None:
+            raise ValueError(
+                "Anthropic transport cannot be set for a non-Anthropic provider"
+            )
+        return pass_provider
+
+    def _writer_system_prompt(self) -> Optional[str]:
+        """Return the existing storyteller system prompt for pass one."""
+
+        if self.provider is None:
+            raise RuntimeError("Writer prompt requires an initialized provider")
+        system_prompt = self._system_prompt
+        if system_prompt is None:
+            system_prompt = getattr(self.provider, "system_prompt", None)
+        if system_prompt is not None and not isinstance(system_prompt, str):
+            raise TypeError("Writer system prompt must be a string")
+        return system_prompt
+
+    def _clerk_system_prompt(self) -> str:
+        """Build the pass-two system content for the active provider."""
+
+        system_prompt = self._load_clerk_system_prompt()
+        if self._provider_wire_type == "anthropic":
+            system_prompt = f"{system_prompt}\n\n{skald_clerk_prompt_guide()}"
+        return system_prompt
+
+    @staticmethod
+    def _format_clerk_user_prompt(
+        turn_prompt: str,
+        writer: SkaldWriterWire,
+    ) -> str:
+        """Append the finished writer output to the stable turn context."""
+
+        scene = (
+            writer.scene.model_dump_json(exclude_none=True)
+            if writer.scene is not None
+            else "null"
+        )
+        presence = (
+            writer.presence.model_dump_json(exclude_none=True)
+            if writer.presence is not None
+            else "null"
+        )
+        operations = (
+            writer.operations.model_dump_json(exclude_none=True)
+            if writer.operations is not None
+            else "null"
+        )
+        choices = "\n\n".join(writer.choices)
+        return "\n\n".join(
+            [
+                turn_prompt,
+                "=== FINISHED WRITER NARRATIVE (VERBATIM) ===",
+                writer.narrative,
+                "=== FINISHED WRITER CHOICES (VERBATIM) ===",
+                choices,
+                "=== FINISHED WRITER SCENE (COMPACT JSON) ===",
+                scene,
+                "=== FINISHED WRITER PRESENCE (COMPACT JSON) ===",
+                presence,
+                "=== FINISHED WRITER OPERATIONS (COMPACT JSON) ===",
+                operations,
+            ]
+        )
+
+    def _generate_narrative_two_pass(
+        self,
+        turn_prompt: str,
+        *,
+        presence_baseline: Optional[PresenceBaseline],
+        effective_context_window: Optional[int],
+    ) -> StoryTurnResponse:
+        """Run synchronous writer and clerk calls, then hydrate once."""
+
+        if self.provider is None:
+            raise RuntimeError("Two-pass generation requires an initialized provider")
+        writer_provider = self._clone_provider_for_two_pass(
+            system_prompt=self._writer_system_prompt(),
+            output_validator=None,
+            anthropic_transport=(
+                "native" if self._provider_wire_type == "anthropic" else None
+            ),
+        )
+        writer, _writer_response = writer_provider.get_structured_completion(
+            turn_prompt,
+            SkaldWriterWire,
+            **self._two_pass_schema_format_kwargs(SkaldWriterWire),
+        )
+        if not isinstance(writer, SkaldWriterWire):
+            raise TypeError("LOGON writer pass returned a non-SkaldWriterWire response")
+
+        clerk_prompt = self._format_clerk_user_prompt(turn_prompt, writer)
+        self._enforce_final_prompt_window(
+            clerk_prompt,
+            effective_context_window=effective_context_window,
+        )
+        clerk_provider = self._clone_provider_for_two_pass(
+            system_prompt=self._clerk_system_prompt(),
+            output_validator=getattr(self.provider, "output_validator", None),
+            anthropic_transport=(
+                "prompted" if self._provider_wire_type == "anthropic" else None
+            ),
+        )
+        clerk, _clerk_response = clerk_provider.get_structured_completion(
+            clerk_prompt,
+            SkaldClerkWire,
+            **self._two_pass_schema_format_kwargs(SkaldClerkWire),
+        )
+        if not isinstance(clerk, SkaldClerkWire):
+            raise TypeError("LOGON clerk pass returned a non-SkaldClerkWire response")
+
+        return self._hydrate_provider_response(
+            combine_two_pass(writer, clerk),
+            SkaldTurnWire,
+            presence_baseline=presence_baseline,
+        )
+
+    async def _generate_narrative_two_pass_async(
+        self,
+        turn_prompt: str,
+        *,
+        presence_baseline: Optional[PresenceBaseline],
+        effective_context_window: Optional[int],
+    ) -> StoryTurnResponse:
+        """Run asynchronous writer and clerk calls, then hydrate once."""
+
+        if self.provider is None:
+            raise RuntimeError("Two-pass generation requires an initialized provider")
+        writer_provider = self._clone_provider_for_two_pass(
+            system_prompt=self._writer_system_prompt(),
+            output_validator=None,
+            anthropic_transport=(
+                "native" if self._provider_wire_type == "anthropic" else None
+            ),
+        )
+        writer, _writer_response = (
+            await writer_provider.get_structured_completion_async(
+                turn_prompt,
+                SkaldWriterWire,
+                **self._two_pass_schema_format_kwargs(SkaldWriterWire),
+            )
+        )
+        if not isinstance(writer, SkaldWriterWire):
+            raise TypeError("LOGON writer pass returned a non-SkaldWriterWire response")
+
+        clerk_prompt = self._format_clerk_user_prompt(turn_prompt, writer)
+        self._enforce_final_prompt_window(
+            clerk_prompt,
+            effective_context_window=effective_context_window,
+        )
+        clerk_provider = self._clone_provider_for_two_pass(
+            system_prompt=self._clerk_system_prompt(),
+            output_validator=getattr(self.provider, "output_validator", None),
+            anthropic_transport=(
+                "prompted" if self._provider_wire_type == "anthropic" else None
+            ),
+        )
+        clerk, _clerk_response = await clerk_provider.get_structured_completion_async(
+            clerk_prompt,
+            SkaldClerkWire,
+            **self._two_pass_schema_format_kwargs(SkaldClerkWire),
+        )
+        if not isinstance(clerk, SkaldClerkWire):
+            raise TypeError("LOGON clerk pass returned a non-SkaldClerkWire response")
+
+        return self._hydrate_provider_response(
+            combine_two_pass(writer, clerk),
+            SkaldTurnWire,
+            presence_baseline=presence_baseline,
+        )
 
     def _enforce_final_prompt_window(
         self,
@@ -976,6 +1227,63 @@ class LogonUtility:
             kwargs = {"output_config": anthropic_output_config(schema_model)}
         else:
             kwargs = {}
+
+        self._schema_format_cache[schema_model] = kwargs
+        return kwargs
+
+    def _two_pass_schema_format_kwargs(self, schema_model: type) -> Dict[str, Any]:
+        """Return the frozen writer or clerk transport schema arguments."""
+
+        if schema_model not in {SkaldWriterWire, SkaldClerkWire}:
+            raise TypeError("Two-pass schema formatting requires writer or clerk wire")
+        if self._provider_wire_type is None:
+            raise RuntimeError(
+                "Two-pass schema formatting requires an active provider wire class"
+            )
+        if schema_model in self._schema_format_cache:
+            return self._schema_format_cache[schema_model]
+
+        from nexus.api.native_structured_output import (
+            anthropic_output_config,
+            openai_response_text_format,
+        )
+
+        kwargs: Dict[str, Any]
+        if self._provider_wire_type == "openai":
+            kwargs = {
+                "text_format": (
+                    skald_writer_strict_text_format()
+                    if schema_model is SkaldWriterWire
+                    else skald_clerk_strict_text_format()
+                )
+            }
+        elif self._provider_wire_type == "local":
+            lenient_schema = (
+                skald_writer_lenient_schema()
+                if schema_model is SkaldWriterWire
+                else skald_clerk_lenient_schema()
+            )
+            kwargs = {
+                "text_format": openai_response_text_format(
+                    schema_model,
+                    schema=lenient_schema,
+                )
+            }
+        elif self._provider_wire_type == "anthropic":
+            if schema_model is SkaldWriterWire:
+                kwargs = {
+                    "output_config": anthropic_output_config(
+                        SkaldWriterWire,
+                        schema=skald_writer_lenient_schema(),
+                    )
+                }
+            else:
+                kwargs = {}
+        else:
+            raise ValueError(
+                "Unsupported two-pass provider wire class: "
+                f"{self._provider_wire_type!r}"
+            )
 
         self._schema_format_cache[schema_model] = kwargs
         return kwargs

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -2526,6 +2526,10 @@ class APEXSettings(BaseModel):
             "Structured transport for non-bootstrap Anthropic storyteller turns."
         ),
     )
+    turn_pipeline: Literal["single_pass", "two_pass"] = Field(
+        default="single_pass",
+        description="Storyteller turn pipeline used for non-bootstrap turns.",
+    )
     tag_library: APEXTagLibrarySettings = Field(default_factory=APEXTagLibrarySettings)
     structured_output_retries: int = Field(
         default=3,

--- a/prompts/storyteller_clerk.md
+++ b/prompts/storyteller_clerk.md
@@ -1,0 +1,28 @@
+## Skald Clerk
+
+You receive the same turn context as the writer plus the writer's finished beat.
+Your sole job is to author the structured state record grounded in what the
+writer actually wrote. Do not rewrite, continue, summarize, or embellish the
+narrative. Return only the requested structured output.
+
+Follow `storyteller_core.md` as the authoritative doctrine, especially:
+
+- **Continuity and Truth** for evidence and canon priority.
+- **Orrery and the Living World** for registered tags and proposal rulings.
+- **Output: Narrative and State** for sparse updates and declaration doctrine.
+
+Record only durable changes in `updates`. Omit the block when nothing durable
+changed. When present, use its namespace contract exactly: `characters`,
+`places`, `factions`, and `relationships`, with all four arrays included even
+when some are empty. Do not emit unchanged-state filler or infer events the
+writer did not establish.
+
+For every listed Orrery proposal that needs a ruling, author the grounded
+`orrery_adjudications` entry. Accepting a proposal needs no entry; use only the
+documented `defer`, `void`, or `replace` actions when the written beat requires
+one.
+
+Declare only likely-to-recur persistent characters, places, or factions in
+`new_entities`, using names exactly as written. Apply the declaration doctrine
+and registered-vocabulary rules from `storyteller_core.md`; omit optional tag
+hints rather than inventing names.

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -118,6 +118,20 @@ def test_apex_rejects_unknown_anthropic_storyteller_transport() -> None:
         Settings(**raw)
 
 
+def test_shipped_turn_pipeline_defaults_to_single_pass() -> None:
+    settings = Settings(**_nexus_toml_dict())
+
+    assert settings.apex.turn_pipeline == "single_pass"
+
+
+def test_apex_rejects_unknown_turn_pipeline() -> None:
+    raw = _nexus_toml_dict()
+    raw["apex"]["turn_pipeline"] = "fallback"
+
+    with pytest.raises(ValidationError, match="turn_pipeline"):
+        Settings(**raw)
+
+
 def test_token_budget_provider_overrides_parse() -> None:
     """Legal provider-class reductions survive settings validation."""
     settings = Settings(**_nexus_toml_dict())

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -146,17 +146,26 @@ def test_runtime_roster_reference_resolves_before_provider_call(
 
 
 @pytest.mark.parametrize(
-    ("configured_transport", "is_bootstrap", "expected_transport", "has_guide"),
+    (
+        "configured_transport",
+        "is_bootstrap",
+        "turn_pipeline",
+        "expected_transport",
+        "has_guide",
+    ),
     [
-        ("prompted", False, "prompted", True),
-        ("native", False, "native", False),
-        ("prompted", True, "native", False),
+        ("prompted", False, "single_pass", "prompted", True),
+        ("native", False, "single_pass", "native", False),
+        ("prompted", True, "single_pass", "native", False),
+        ("prompted", False, "two_pass", "prompted", False),
+        ("prompted", True, "two_pass", "native", False),
     ],
 )
 def test_anthropic_storyteller_transport_and_guide_follow_settings(
     monkeypatch: pytest.MonkeyPatch,
     configured_transport: str,
     is_bootstrap: bool,
+    turn_pipeline: str,
     expected_transport: str,
     has_guide: bool,
 ) -> None:
@@ -195,6 +204,7 @@ def test_anthropic_storyteller_transport_and_guide_follow_settings(
         "API Settings": {
             "apex": {
                 "anthropic_storyteller_transport": configured_transport,
+                "turn_pipeline": turn_pipeline,
                 "max_output_tokens": 1234,
                 "reasoning_effort": "medium",
                 "structured_output_retries": 2,

--- a/tests/test_lore/test_two_pass_pipeline.py
+++ b/tests/test_lore/test_two_pass_pipeline.py
@@ -1,0 +1,409 @@
+"""Tests for the config-switched writer and clerk storyteller pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from nexus.agents.logon.apex_schema import StorytellerResponseBootstrap
+from nexus.agents.logon.skald_wire import (
+    PresenceBaseline,
+    PresenceRef,
+    SkaldClerkWire,
+    SkaldWriterWire,
+    combine_two_pass,
+    hydrate_skald_turn,
+    skald_clerk_lenient_schema,
+    skald_clerk_prompt_guide,
+    skald_clerk_strict_text_format,
+    skald_writer_lenient_schema,
+    skald_writer_strict_text_format,
+)
+from nexus.agents.lore import logon_utility
+from nexus.agents.lore.logon_utility import LogonUtility
+from nexus.api.native_structured_output import (
+    anthropic_output_config,
+    openai_response_text_format,
+)
+
+
+WRITER = SkaldWriterWire.model_validate(
+    {
+        "narrative": 'Iona says, "Wait."\nThe drowned bell answers.',
+        "choices": [
+            "Follow Iona into the archive.",
+            "Stay beneath the sluice gate.",
+        ],
+        "scene": {"elapsed_minutes": 7, "weather": "rain"},
+        "presence": {
+            "mentions": [{"kind": "faction", "name": "The Glass Choir", "id": 13}]
+        },
+        "operations": {
+            "request_summary": {
+                "summary_type": "episode",
+                "reason": "The archive crossing closes the beat.",
+            }
+        },
+    }
+)
+CLERK = SkaldClerkWire.model_validate(
+    {
+        "updates": {
+            "characters": [
+                {
+                    "name": "Iona Vale",
+                    "id": 4,
+                    "activity": "listening for the drowned bell",
+                }
+            ],
+            "places": [],
+            "factions": [],
+            "relationships": [],
+        },
+        "orrery_adjudications": [],
+        "new_entities": [
+            {
+                "kind": "faction",
+                "name": "The Glass Choir",
+                "summary": "An unseen choir carried through flooded pipes.",
+            }
+        ],
+    }
+)
+BASELINE = PresenceBaseline(
+    present=[PresenceRef(kind="character", name="Iona Vale", id=4)],
+    setting=PresenceRef(kind="place", name="The Lower Sluice", id=9),
+)
+VALIDATOR = object()
+
+
+class _RecordingProvider:
+    """Shallow-copy-friendly provider stub recording pass-local state."""
+
+    def __init__(
+        self,
+        outputs: list[object],
+        *,
+        structured_transport: str = "responses",
+    ) -> None:
+        self.model = "two-pass-test-model"
+        self.system_prompt = "Core storyteller prompt"
+        self.output_validator = VALIDATOR
+        self.structured_transport = structured_transport
+        self.structured_output_retries = 3
+        self.outputs = outputs
+        self.calls: list[dict[str, Any]] = []
+
+    def _complete(
+        self,
+        prompt: str,
+        schema_model: type,
+        kwargs: dict[str, Any],
+    ) -> tuple[Any, object]:
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "schema_model": schema_model,
+                "kwargs": kwargs,
+                "system_prompt": self.system_prompt,
+                "output_validator": self.output_validator,
+                "structured_transport": self.structured_transport,
+                "structured_output_retries": self.structured_output_retries,
+            }
+        )
+        output = self.outputs.pop(0)
+        if isinstance(output, BaseException):
+            raise output
+        return output, object()
+
+    def get_structured_completion(
+        self,
+        prompt: str,
+        schema_model: type,
+        **kwargs: Any,
+    ) -> tuple[Any, object]:
+        return self._complete(prompt, schema_model, kwargs)
+
+    async def get_structured_completion_async(
+        self,
+        prompt: str,
+        schema_model: type,
+        **kwargs: Any,
+    ) -> tuple[Any, object]:
+        return self._complete(prompt, schema_model, kwargs)
+
+
+def _context(*, bootstrap: bool = False) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "user_input": "Open the archive.",
+        "warm_slice": {"chunks": []},
+        "entity_data": {},
+        "retrieved_passages": {"results": []},
+    }
+    if bootstrap:
+        payload["is_bootstrap"] = True
+        payload["metadata"] = {"is_bootstrap": True}
+    return payload
+
+
+def _utility(
+    provider_type: str,
+    outputs: list[object],
+    *,
+    bootstrap: bool = False,
+) -> tuple[LogonUtility, _RecordingProvider]:
+    settings = {
+        "API Settings": {
+            "apex": {
+                "turn_pipeline": "two_pass",
+                "anthropic_storyteller_transport": "prompted",
+            }
+        }
+    }
+    provider = _RecordingProvider(
+        outputs,
+        structured_transport=(
+            "prompted" if provider_type == "anthropic" else "responses"
+        ),
+    )
+    utility = LogonUtility(settings, model_override=provider.model)
+    utility.provider = cast(Any, provider)
+    utility._provider_bootstrap_mode = bootstrap
+    utility._provider_wire_type = cast(Any, provider_type)
+    utility._system_prompt = provider.system_prompt
+    return utility, provider
+
+
+def _expected_schema_kwargs(
+    provider_type: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if provider_type == "openai":
+        return (
+            {"text_format": skald_writer_strict_text_format()},
+            {"text_format": skald_clerk_strict_text_format()},
+        )
+    if provider_type == "local":
+        return (
+            {
+                "text_format": openai_response_text_format(
+                    SkaldWriterWire,
+                    schema=skald_writer_lenient_schema(),
+                )
+            },
+            {
+                "text_format": openai_response_text_format(
+                    SkaldClerkWire,
+                    schema=skald_clerk_lenient_schema(),
+                )
+            },
+        )
+    return (
+        {
+            "output_config": anthropic_output_config(
+                SkaldWriterWire,
+                schema=skald_writer_lenient_schema(),
+            )
+        },
+        {},
+    )
+
+
+def _assert_two_pass_calls(
+    provider: _RecordingProvider,
+    provider_type: str,
+) -> None:
+    assert len(provider.calls) == 2
+    writer_call, clerk_call = provider.calls
+    expected_writer_kwargs, expected_clerk_kwargs = _expected_schema_kwargs(
+        provider_type
+    )
+
+    assert writer_call["schema_model"] is SkaldWriterWire
+    assert clerk_call["schema_model"] is SkaldClerkWire
+    assert writer_call["kwargs"] == expected_writer_kwargs
+    assert clerk_call["kwargs"] == expected_clerk_kwargs
+    assert writer_call["output_validator"] is None
+    assert clerk_call["output_validator"] is VALIDATOR
+    assert writer_call["structured_output_retries"] == 3
+    assert clerk_call["structured_output_retries"] == 3
+    assert writer_call["system_prompt"] == "Core storyteller prompt"
+    assert "## Skald Clerk" in clerk_call["system_prompt"]
+    assert clerk_call["prompt"].startswith(writer_call["prompt"])
+    assert WRITER.narrative in clerk_call["prompt"]
+    assert WRITER.scene is not None
+    assert WRITER.scene.model_dump_json(exclude_none=True) in clerk_call["prompt"]
+    assert WRITER.presence is not None
+    assert WRITER.presence.model_dump_json(exclude_none=True) in clerk_call["prompt"]
+
+    if provider_type == "anthropic":
+        assert writer_call["structured_transport"] == "native"
+        assert clerk_call["structured_transport"] == "prompted"
+        assert clerk_call["system_prompt"].endswith(skald_clerk_prompt_guide())
+    else:
+        assert writer_call["structured_transport"] == "responses"
+        assert clerk_call["structured_transport"] == "responses"
+        assert "=== OUTPUT FORMAT ===" not in clerk_call["system_prompt"]
+
+
+@pytest.mark.parametrize("provider_type", ["openai", "local", "anthropic"])
+def test_sync_two_pass_pipeline_uses_provider_specific_transports(
+    provider_type: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    utility, provider = _utility(provider_type, [WRITER, CLERK])
+    monkeypatch.setattr(
+        utility,
+        "_read_presence_baseline_for_context",
+        lambda _context_payload, _schema_model: BASELINE,
+    )
+
+    response = utility.generate_narrative(
+        _context(),
+        effective_context_window=75_000,
+    )
+
+    _assert_two_pass_calls(provider, provider_type)
+    expected = hydrate_skald_turn(
+        combine_two_pass(WRITER, CLERK),
+        presence_baseline=BASELINE,
+    )
+    assert response.model_dump(exclude={"generation_model"}) == expected.model_dump(
+        exclude={"generation_model"}
+    )
+    assert response.generation_model == provider.model
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider_type", ["openai", "local", "anthropic"])
+async def test_async_two_pass_pipeline_uses_provider_specific_transports(
+    provider_type: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    utility, provider = _utility(provider_type, [WRITER, CLERK])
+
+    async def read_baseline(
+        _context_payload: dict[str, Any],
+        _schema_model: type,
+    ) -> PresenceBaseline:
+        return BASELINE
+
+    monkeypatch.setattr(
+        utility,
+        "_read_presence_baseline_for_context_async",
+        read_baseline,
+    )
+
+    response = await utility.generate_narrative_async(
+        _context(),
+        effective_context_window=75_000,
+    )
+
+    _assert_two_pass_calls(provider, provider_type)
+    expected = hydrate_skald_turn(
+        combine_two_pass(WRITER, CLERK),
+        presence_baseline=BASELINE,
+    )
+    assert response.model_dump(exclude={"generation_model"}) == expected.model_dump(
+        exclude={"generation_model"}
+    )
+    assert response.generation_model == provider.model
+
+
+def test_writer_failure_short_circuits_before_clerk_or_hydration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    utility, provider = _utility("openai", [RuntimeError("writer exhausted repairs")])
+    hydrated: list[object] = []
+    monkeypatch.setattr(
+        logon_utility,
+        "hydrate_skald_turn",
+        lambda *args, **kwargs: hydrated.append((args, kwargs)),
+    )
+
+    with pytest.raises(RuntimeError, match="writer exhausted repairs"):
+        utility.generate_narrative(
+            _context(),
+            effective_context_window=75_000,
+        )
+
+    assert [call["schema_model"] for call in provider.calls] == [SkaldWriterWire]
+    assert hydrated == []
+
+
+@pytest.mark.asyncio
+async def test_clerk_failure_raises_without_partial_hydration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    utility, provider = _utility(
+        "anthropic",
+        [WRITER, RuntimeError("clerk exhausted repairs")],
+    )
+    hydrated: list[object] = []
+    monkeypatch.setattr(
+        logon_utility,
+        "hydrate_skald_turn",
+        lambda *args, **kwargs: hydrated.append((args, kwargs)),
+    )
+
+    with pytest.raises(RuntimeError, match="clerk exhausted repairs"):
+        await utility.generate_narrative_async(
+            _context(),
+            effective_context_window=75_000,
+        )
+
+    assert [call["schema_model"] for call in provider.calls] == [
+        SkaldWriterWire,
+        SkaldClerkWire,
+    ]
+    assert hydrated == []
+
+
+def test_bootstrap_request_ignores_two_pass_lever() -> None:
+    bootstrap = StorytellerResponseBootstrap(
+        narrative="The first door opens.",
+        choices=["Enter.", "Wait."],
+    )
+    utility, provider = _utility("openai", [bootstrap], bootstrap=True)
+
+    response = utility.generate_narrative(
+        _context(bootstrap=True),
+        effective_context_window=75_000,
+    )
+
+    assert response.narrative == bootstrap.narrative
+    assert len(provider.calls) == 1
+    assert provider.calls[0]["schema_model"] is StorytellerResponseBootstrap
+    assert "FINISHED WRITER" not in provider.calls[0]["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_async_bootstrap_request_ignores_two_pass_lever() -> None:
+    bootstrap = StorytellerResponseBootstrap(
+        narrative="The first door opens.",
+        choices=["Enter.", "Wait."],
+    )
+    utility, provider = _utility("openai", [bootstrap], bootstrap=True)
+
+    response = await utility.generate_narrative_async(
+        _context(bootstrap=True),
+        effective_context_window=75_000,
+    )
+
+    assert response.narrative == bootstrap.narrative
+    assert len(provider.calls) == 1
+    assert provider.calls[0]["schema_model"] is StorytellerResponseBootstrap
+
+
+def test_clerk_prompt_is_concise_and_references_core_doctrine() -> None:
+    prompt_path = Path(__file__).parents[2] / "prompts" / "storyteller_clerk.md"
+    prompt = prompt_path.read_text()
+    normalized_prompt = " ".join(prompt.split())
+
+    assert len(prompt.splitlines()) < 60
+    assert "storyteller_core.md" in prompt
+    assert "Do not rewrite, continue, summarize, or embellish" in prompt
+    assert (
+        "`characters`, `places`, `factions`, and `relationships`" in normalized_prompt
+    )

--- a/tests/test_lore/test_two_pass_pipeline.py
+++ b/tests/test_lore/test_two_pass_pipeline.py
@@ -2,18 +2,27 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from pydantic_ai import ModelRetry
 
-from nexus.agents.logon.apex_schema import StorytellerResponseBootstrap
+from nexus.agents.logon.apex_schema import (
+    StorytellerResponseBootstrap,
+    StorytellerResponseExtended,
+)
+from nexus.agents.logon.orrery_tag_validation import (
+    StorytellerVocabulary,
+    build_storyteller_tag_validator,
+)
 from nexus.agents.logon.skald_wire import (
     PresenceBaseline,
     PresenceRef,
     SkaldClerkWire,
+    SkaldTurnWire,
     SkaldWriterWire,
-    combine_two_pass,
     hydrate_skald_turn,
     skald_clerk_lenient_schema,
     skald_clerk_prompt_guide,
@@ -26,57 +35,91 @@ from nexus.agents.lore.logon_utility import LogonUtility
 from nexus.api.native_structured_output import (
     anthropic_output_config,
     openai_response_text_format,
+    retry_prompt,
+    run_output_validator,
 )
 
 
-WRITER = SkaldWriterWire.model_validate(
-    {
-        "narrative": 'Iona says, "Wait."\nThe drowned bell answers.',
-        "choices": [
-            "Follow Iona into the archive.",
-            "Stay beneath the sluice gate.",
-        ],
-        "scene": {"elapsed_minutes": 7, "weather": "rain"},
-        "presence": {
-            "mentions": [{"kind": "faction", "name": "The Glass Choir", "id": 13}]
-        },
-        "operations": {
-            "request_summary": {
-                "summary_type": "episode",
-                "reason": "The archive crossing closes the beat.",
-            }
-        },
-    }
-)
-CLERK = SkaldClerkWire.model_validate(
-    {
-        "updates": {
-            "characters": [
-                {
-                    "name": "Iona Vale",
-                    "id": 4,
-                    "activity": "listening for the drowned bell",
-                }
-            ],
-            "places": [],
-            "factions": [],
-            "relationships": [],
-        },
-        "orrery_adjudications": [],
-        "new_entities": [
+WRITER_PAYLOAD: dict[str, Any] = {
+    "narrative": 'Iona says, "Wait."\nThe drowned bell answers.',
+    "choices": [
+        "Follow Iona into the archive.",
+        "Stay beneath the sluice gate.",
+    ],
+    "scene": {"elapsed_minutes": 7, "weather": "rain"},
+    "presence": {
+        "mentions": [{"kind": "faction", "name": "The Glass Choir", "id": 13}]
+    },
+    "operations": {
+        "request_summary": {
+            "summary_type": "episode",
+            "reason": "The archive crossing closes the beat.",
+        }
+    },
+}
+CLERK_PAYLOAD: dict[str, Any] = {
+    "updates": {
+        "characters": [
             {
-                "kind": "faction",
-                "name": "The Glass Choir",
-                "summary": "An unseen choir carried through flooded pipes.",
+                "name": "Iona Vale",
+                "id": 4,
+                "activity": "listening for the drowned bell",
             }
         ],
-    }
-)
+        "places": [],
+        "factions": [],
+        "relationships": [],
+    },
+    "orrery_adjudications": [],
+    "new_entities": [
+        {
+            "kind": "faction",
+            "name": "The Glass Choir",
+            "summary": "An unseen choir carried through flooded pipes.",
+        }
+    ],
+}
+SINGLE_PASS_PAYLOAD: dict[str, Any] = {
+    "narrative": 'Iona says, "Wait."\nThe drowned bell answers.',
+    "choices": [
+        "Follow Iona into the archive.",
+        "Stay beneath the sluice gate.",
+    ],
+    "scene": {"elapsed_minutes": 7, "weather": "rain"},
+    "presence": {
+        "mentions": [{"kind": "faction", "name": "The Glass Choir", "id": 13}]
+    },
+    "updates": {
+        "characters": [
+            {
+                "name": "Iona Vale",
+                "id": 4,
+                "activity": "listening for the drowned bell",
+            }
+        ],
+        "places": [],
+        "factions": [],
+        "relationships": [],
+    },
+    "operations": {
+        "request_summary": {
+            "summary_type": "episode",
+            "reason": "The archive crossing closes the beat.",
+        }
+    },
+    "orrery_adjudications": [],
+    "new_entities": [
+        {
+            "kind": "faction",
+            "name": "The Glass Choir",
+            "summary": "An unseen choir carried through flooded pipes.",
+        }
+    ],
+}
 BASELINE = PresenceBaseline(
     present=[PresenceRef(kind="character", name="Iona Vale", id=4)],
     setting=PresenceRef(kind="place", name="The Lower Sluice", id=9),
 )
-VALIDATOR = object()
 
 
 class _RecordingProvider:
@@ -87,21 +130,23 @@ class _RecordingProvider:
         outputs: list[object],
         *,
         structured_transport: str = "responses",
+        output_validator: Any = None,
+        structured_output_retries: int = 3,
     ) -> None:
         self.model = "two-pass-test-model"
         self.system_prompt = "Core storyteller prompt"
-        self.output_validator = VALIDATOR
+        self.output_validator = output_validator
         self.structured_transport = structured_transport
-        self.structured_output_retries = 3
+        self.structured_output_retries = structured_output_retries
         self.outputs = outputs
         self.calls: list[dict[str, Any]] = []
 
-    def _complete(
+    def _record_attempt(
         self,
         prompt: str,
         schema_model: type,
         kwargs: dict[str, Any],
-    ) -> tuple[Any, object]:
+    ) -> None:
         self.calls.append(
             {
                 "prompt": prompt,
@@ -113,10 +158,12 @@ class _RecordingProvider:
                 "structured_output_retries": self.structured_output_retries,
             }
         )
+
+    def _parse_next_output(self, schema_model: type) -> Any:
         output = self.outputs.pop(0)
         if isinstance(output, BaseException):
             raise output
-        return output, object()
+        return schema_model.model_validate(output)
 
     def get_structured_completion(
         self,
@@ -124,7 +171,24 @@ class _RecordingProvider:
         schema_model: type,
         **kwargs: Any,
     ) -> tuple[Any, object]:
-        return self._complete(prompt, schema_model, kwargs)
+        active_prompt = prompt
+        for attempt in range(self.structured_output_retries + 1):
+            self._record_attempt(active_prompt, schema_model, kwargs)
+            parsed = self._parse_next_output(schema_model)
+            try:
+                parsed = asyncio.run(
+                    run_output_validator(
+                        self.output_validator,
+                        parsed,
+                        retry=attempt,
+                    )
+                )
+                return parsed, object()
+            except ModelRetry as exc:
+                if attempt >= self.structured_output_retries:
+                    raise
+                active_prompt = retry_prompt(prompt, exc.message)
+        raise AssertionError("Structured retry loop did not return or raise")
 
     async def get_structured_completion_async(
         self,
@@ -132,7 +196,65 @@ class _RecordingProvider:
         schema_model: type,
         **kwargs: Any,
     ) -> tuple[Any, object]:
-        return self._complete(prompt, schema_model, kwargs)
+        active_prompt = prompt
+        for attempt in range(self.structured_output_retries + 1):
+            self._record_attempt(active_prompt, schema_model, kwargs)
+            parsed = self._parse_next_output(schema_model)
+            try:
+                parsed = await run_output_validator(
+                    self.output_validator,
+                    parsed,
+                    retry=attempt,
+                )
+                return parsed, object()
+            except ModelRetry as exc:
+                if attempt >= self.structured_output_retries:
+                    raise
+                active_prompt = retry_prompt(prompt, exc.message)
+        raise AssertionError("Structured retry loop did not return or raise")
+
+
+class _FixtureCursor:
+    """Context-managed cursor unused by single-entity fixture validation."""
+
+    def __enter__(self) -> "_FixtureCursor":
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+
+class _FixtureConnection:
+    """Connection stand-in for the real validator's read-only cursor seam."""
+
+    def __enter__(self) -> "_FixtureConnection":
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def cursor(self) -> _FixtureCursor:
+        return _FixtureCursor()
+
+
+def _clerk_payload_with_character_tag(tag: str) -> dict[str, Any]:
+    return {
+        "updates": {
+            "characters": [
+                {
+                    "name": "Iona Vale",
+                    "id": 4,
+                    "activity": "listening for the drowned bell",
+                    "tags_add": [tag],
+                }
+            ],
+            "places": [],
+            "factions": [],
+            "relationships": [],
+        },
+        "orrery_adjudications": [],
+        "new_entities": [],
+    }
 
 
 def _context(*, bootstrap: bool = False) -> dict[str, Any]:
@@ -153,6 +275,8 @@ def _utility(
     outputs: list[object],
     *,
     bootstrap: bool = False,
+    output_validator: Any = None,
+    structured_output_retries: int = 3,
 ) -> tuple[LogonUtility, _RecordingProvider]:
     settings = {
         "API Settings": {
@@ -167,6 +291,8 @@ def _utility(
         structured_transport=(
             "prompted" if provider_type == "anthropic" else "responses"
         ),
+        output_validator=output_validator,
+        structured_output_retries=structured_output_retries,
     )
     utility = LogonUtility(settings, model_override=provider.model)
     utility.provider = cast(Any, provider)
@@ -214,6 +340,7 @@ def _assert_two_pass_calls(
     provider: _RecordingProvider,
     provider_type: str,
 ) -> None:
+    writer = SkaldWriterWire.model_validate(WRITER_PAYLOAD)
     assert len(provider.calls) == 2
     writer_call, clerk_call = provider.calls
     expected_writer_kwargs, expected_clerk_kwargs = _expected_schema_kwargs(
@@ -225,17 +352,17 @@ def _assert_two_pass_calls(
     assert writer_call["kwargs"] == expected_writer_kwargs
     assert clerk_call["kwargs"] == expected_clerk_kwargs
     assert writer_call["output_validator"] is None
-    assert clerk_call["output_validator"] is VALIDATOR
+    assert clerk_call["output_validator"] is None
     assert writer_call["structured_output_retries"] == 3
     assert clerk_call["structured_output_retries"] == 3
     assert writer_call["system_prompt"] == "Core storyteller prompt"
     assert "## Skald Clerk" in clerk_call["system_prompt"]
     assert clerk_call["prompt"].startswith(writer_call["prompt"])
-    assert WRITER.narrative in clerk_call["prompt"]
-    assert WRITER.scene is not None
-    assert WRITER.scene.model_dump_json(exclude_none=True) in clerk_call["prompt"]
-    assert WRITER.presence is not None
-    assert WRITER.presence.model_dump_json(exclude_none=True) in clerk_call["prompt"]
+    assert writer.narrative in clerk_call["prompt"]
+    assert writer.scene is not None
+    assert writer.scene.model_dump_json(exclude_none=True) in clerk_call["prompt"]
+    assert writer.presence is not None
+    assert writer.presence.model_dump_json(exclude_none=True) in clerk_call["prompt"]
 
     if provider_type == "anthropic":
         assert writer_call["structured_transport"] == "native"
@@ -247,12 +374,30 @@ def _assert_two_pass_calls(
         assert "=== OUTPUT FORMAT ===" not in clerk_call["system_prompt"]
 
 
+def _assert_matches_independently_parsed_single_pass(
+    actual: StorytellerResponseExtended,
+) -> None:
+    """Compare canonical fields against a separately parsed full-wire payload."""
+
+    single_pass_wire = SkaldTurnWire.model_validate(SINGLE_PASS_PAYLOAD)
+    expected = hydrate_skald_turn(
+        single_pass_wire,
+        presence_baseline=BASELINE,
+    )
+    for field_name in StorytellerResponseExtended.model_fields:
+        if field_name != "generation_model":
+            assert getattr(actual, field_name) == getattr(expected, field_name)
+
+
 @pytest.mark.parametrize("provider_type", ["openai", "local", "anthropic"])
 def test_sync_two_pass_pipeline_uses_provider_specific_transports(
     provider_type: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    utility, provider = _utility(provider_type, [WRITER, CLERK])
+    utility, provider = _utility(
+        provider_type,
+        [WRITER_PAYLOAD, CLERK_PAYLOAD],
+    )
     monkeypatch.setattr(
         utility,
         "_read_presence_baseline_for_context",
@@ -265,13 +410,7 @@ def test_sync_two_pass_pipeline_uses_provider_specific_transports(
     )
 
     _assert_two_pass_calls(provider, provider_type)
-    expected = hydrate_skald_turn(
-        combine_two_pass(WRITER, CLERK),
-        presence_baseline=BASELINE,
-    )
-    assert response.model_dump(exclude={"generation_model"}) == expected.model_dump(
-        exclude={"generation_model"}
-    )
+    assert response.narrative == WRITER_PAYLOAD["narrative"]
     assert response.generation_model == provider.model
 
 
@@ -281,7 +420,10 @@ async def test_async_two_pass_pipeline_uses_provider_specific_transports(
     provider_type: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    utility, provider = _utility(provider_type, [WRITER, CLERK])
+    utility, provider = _utility(
+        provider_type,
+        [WRITER_PAYLOAD, CLERK_PAYLOAD],
+    )
 
     async def read_baseline(
         _context_payload: dict[str, Any],
@@ -301,14 +443,102 @@ async def test_async_two_pass_pipeline_uses_provider_specific_transports(
     )
 
     _assert_two_pass_calls(provider, provider_type)
-    expected = hydrate_skald_turn(
-        combine_two_pass(WRITER, CLERK),
-        presence_baseline=BASELINE,
-    )
-    assert response.model_dump(exclude={"generation_model"}) == expected.model_dump(
-        exclude={"generation_model"}
-    )
+    assert response.narrative == WRITER_PAYLOAD["narrative"]
     assert response.generation_model == provider.model
+
+
+def test_two_pass_hydration_matches_independent_single_pass_parse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Split and full raw payloads reach equivalent canonical hydration."""
+
+    utility, _provider = _utility(
+        "openai",
+        [WRITER_PAYLOAD, CLERK_PAYLOAD],
+    )
+    monkeypatch.setattr(
+        utility,
+        "_read_presence_baseline_for_context",
+        lambda _context_payload, _schema_model: BASELINE,
+    )
+
+    actual = utility.generate_narrative(
+        _context(),
+        effective_context_window=75_000,
+    )
+
+    _assert_matches_independently_parsed_single_pass(actual)
+
+
+def test_real_vocabulary_validator_belongs_to_clerk_and_consumes_repair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shipped validator traverses clerk fields and never reaches writer."""
+
+    from nexus.agents.logon import orrery_tag_validation
+    from nexus.api import db_pool
+
+    vocabulary = StorytellerVocabulary(
+        tag_names_by_kind={
+            "character": frozenset({"perceptive"}),
+            "place": frozenset(),
+            "faction": frozenset(),
+        },
+        pair_tag_names=frozenset(),
+        event_types=frozenset(),
+    )
+    monkeypatch.setattr(
+        orrery_tag_validation,
+        "read_storyteller_vocabulary",
+        lambda _dbname: vocabulary,
+    )
+    monkeypatch.setattr(
+        db_pool,
+        "get_connection",
+        lambda _dbname: _FixtureConnection(),
+    )
+    validator = build_storyteller_tag_validator(
+        "fixture_slot",
+        suggestion_limit=3,
+    )
+    assert validator is not None
+    utility, provider = _utility(
+        "openai",
+        [
+            WRITER_PAYLOAD,
+            _clerk_payload_with_character_tag("unregistered"),
+            _clerk_payload_with_character_tag("perceptive"),
+        ],
+        output_validator=validator,
+        structured_output_retries=1,
+    )
+    monkeypatch.setattr(
+        utility,
+        "_read_presence_baseline_for_context",
+        lambda _context_payload, _schema_model: BASELINE,
+    )
+
+    response = utility.generate_narrative(
+        _context(),
+        effective_context_window=75_000,
+    )
+
+    assert [call["schema_model"] for call in provider.calls] == [
+        SkaldWriterWire,
+        SkaldClerkWire,
+        SkaldClerkWire,
+    ]
+    assert provider.calls[0]["output_validator"] is None
+    assert all(call["output_validator"] is validator for call in provider.calls[1:])
+    retry_prompt_text = provider.calls[2]["prompt"]
+    assert "=== STRUCTURED OUTPUT RETRY ===" in retry_prompt_text
+    assert "failed closed-registry validation" in retry_prompt_text
+    assert "updates.characters[0]" in retry_prompt_text
+    assert "'unregistered'" in retry_prompt_text
+    assert provider.outputs == []
+    bestowal = response.state_updates.characters[0].orrery_tags
+    assert bestowal is not None
+    assert bestowal.applied_tags == ["perceptive"]
 
 
 def test_writer_failure_short_circuits_before_clerk_or_hydration(
@@ -338,7 +568,7 @@ async def test_clerk_failure_raises_without_partial_hydration(
 ) -> None:
     utility, provider = _utility(
         "anthropic",
-        [WRITER, RuntimeError("clerk exhausted repairs")],
+        [WRITER_PAYLOAD, RuntimeError("clerk exhausted repairs")],
     )
     hydrated: list[object] = []
     monkeypatch.setattr(

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -17,6 +17,7 @@ from nexus.agents.logon.skald_wire import (
     SkaldTurnWire,
     SkaldWriterWire,
     skald_wire_lenient_schema,
+    skald_writer_lenient_schema,
 )
 from nexus.agents.lore.logon_utility import LogonUtility
 from nexus.api.new_story_schemas import SettingCard, StorySeedSubmission, WizardResponse
@@ -223,14 +224,65 @@ def test_anthropic_preserves_wire_updates_namespace_after_lenient_transform() ->
     assert not _contains_key(transformed, "anyOf")
 
 
-def test_two_pass_writer_native_output_config_has_no_union_typed_nodes() -> None:
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_effort"),
+    [
+        ("high", "high"),
+        (None, None),
+    ],
+)
+def test_two_pass_writer_native_config_reaches_shipped_anthropic_request(
+    reasoning_effort: str | None,
+    expected_effort: str | None,
+) -> None:
     utility = LogonUtility({})
     utility._provider_wire_type = "anthropic"
+    schema_kwargs = utility._two_pass_schema_format_kwargs(SkaldWriterWire)
+    writer = SkaldWriterWire.model_validate(
+        {
+            "narrative": "The archive door opens.",
+            "choices": ["Enter.", "Wait."],
+        }
+    )
+    captured = {}
 
-    kwargs = utility._two_pass_schema_format_kwargs(SkaldWriterWire)
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content=[
+                    SimpleNamespace(type="text", text=writer.model_dump_json()),
+                ],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
 
-    assert set(kwargs) == {"output_config"}
-    assert _count_union_typed_nodes(kwargs["output_config"]) == 0
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        reasoning_effort=reasoning_effort,
+        structured_output_retries=0,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    parsed, _llm_response = provider.get_structured_completion(
+        "Write the next beat.",
+        SkaldWriterWire,
+        **schema_kwargs,
+    )
+
+    request_output_config = captured["output_config"]
+    request_schema = request_output_config["format"]["schema"]
+    expected_schema = anthropic_output_format(
+        SkaldWriterWire,
+        schema=skald_writer_lenient_schema(),
+    )["schema"]
+    assert parsed == writer
+    assert request_schema == expected_schema
+    assert _count_union_typed_nodes(request_schema) == 0
+    if expected_effort is None:
+        assert "effort" not in request_output_config
+    else:
+        assert request_output_config["effort"] == expected_effort
 
 
 def test_anthropic_one_of_rewrite_recurses_through_lists_and_dicts() -> None:

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -13,7 +13,12 @@ from nexus.agents.logon.apex_schema import (
     StorytellerResponseBootstrap,
     StorytellerResponseExtended,
 )
-from nexus.agents.logon.skald_wire import SkaldTurnWire, skald_wire_lenient_schema
+from nexus.agents.logon.skald_wire import (
+    SkaldTurnWire,
+    SkaldWriterWire,
+    skald_wire_lenient_schema,
+)
+from nexus.agents.lore.logon_utility import LogonUtility
 from nexus.api.new_story_schemas import SettingCard, StorySeedSubmission, WizardResponse
 from nexus.api.native_structured_output import (
     ANTHROPIC_UNSUPPORTED_SCHEMA_KEYS,
@@ -71,6 +76,17 @@ def _contains_nullable_any_of(value: object) -> bool:
     if isinstance(value, list):
         return any(_contains_nullable_any_of(item) for item in value)
     return False
+
+
+def _count_union_typed_nodes(value: object) -> int:
+    if isinstance(value, dict):
+        is_union = "anyOf" in value or isinstance(value.get("type"), list)
+        return int(is_union) + sum(
+            _count_union_typed_nodes(item) for item in value.values()
+        )
+    if isinstance(value, list):
+        return sum(_count_union_typed_nodes(item) for item in value)
+    return 0
 
 
 def _assert_property_maps_are_consistent(value: object, path: str = "$") -> None:
@@ -205,6 +221,16 @@ def test_anthropic_preserves_wire_updates_namespace_after_lenient_transform() ->
     assert not _contains_key(transformed, "oneOf")
     assert not _contains_key(transformed, "discriminator")
     assert not _contains_key(transformed, "anyOf")
+
+
+def test_two_pass_writer_native_output_config_has_no_union_typed_nodes() -> None:
+    utility = LogonUtility({})
+    utility._provider_wire_type = "anthropic"
+
+    kwargs = utility._two_pass_schema_format_kwargs(SkaldWriterWire)
+
+    assert set(kwargs) == {"output_config"}
+    assert _count_union_typed_nodes(kwargs["output_config"]) == 0
 
 
 def test_anthropic_one_of_rewrite_recurses_through_lists_and_dicts() -> None:

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -43,12 +43,20 @@ from nexus.agents.logon.apex_schema import (
 from nexus.agents.logon.skald_wire import (
     PresenceBaseline,
     PresenceRef,
+    SkaldClerkWire,
     SkaldTurnWire,
+    SkaldWriterWire,
     _prompt_guide_type,
+    combine_two_pass,
     hydrate_skald_turn,
+    skald_clerk_lenient_schema,
+    skald_clerk_prompt_guide,
+    skald_clerk_strict_text_format,
     skald_wire_lenient_schema,
     skald_wire_prompt_guide,
     skald_wire_strict_text_format,
+    skald_writer_lenient_schema,
+    skald_writer_strict_text_format,
 )
 from nexus.agents.lore import logon_utility
 from nexus.agents.lore.logon_utility import LogonUtility, read_presence_baseline
@@ -217,6 +225,93 @@ RICH_WIRE_PAYLOAD: dict[str, Any] = {
         }
     ],
 }
+
+
+def test_two_pass_wire_fields_match_and_partition_full_wire() -> None:
+    writer_fields = SkaldWriterWire.model_fields
+    clerk_fields = SkaldClerkWire.model_fields
+    full_fields = SkaldTurnWire.model_fields
+
+    assert list(writer_fields) == [
+        "narrative",
+        "choices",
+        "scene",
+        "presence",
+        "operations",
+    ]
+    assert list(clerk_fields) == [
+        "updates",
+        "orrery_adjudications",
+        "new_entities",
+    ]
+    assert set(writer_fields).isdisjoint(clerk_fields)
+    assert set(writer_fields) | set(clerk_fields) == set(full_fields)
+
+    for field_name, split_field in {**writer_fields, **clerk_fields}.items():
+        full_field = full_fields[field_name]
+        assert split_field.annotation == full_field.annotation
+        assert split_field.default == full_field.default
+        assert split_field.default_factory == full_field.default_factory
+        assert split_field.description == full_field.description
+        assert split_field.metadata == full_field.metadata
+
+
+def test_combine_two_pass_is_property_complete() -> None:
+    writer = SkaldWriterWire.model_validate(
+        {
+            field_name: field_value
+            for field_name, field_value in RICH_WIRE_PAYLOAD.items()
+            if field_name in SkaldWriterWire.model_fields
+        }
+    )
+    clerk = SkaldClerkWire.model_validate(
+        {
+            field_name: field_value
+            for field_name, field_value in RICH_WIRE_PAYLOAD.items()
+            if field_name in SkaldClerkWire.model_fields
+        }
+    )
+
+    sources = {
+        field_name: getattr(source, field_name)
+        for source in (writer, clerk)
+        for field_name in source.__class__.model_fields
+    }
+    assert set(sources) == set(SkaldTurnWire.model_fields)
+
+    combined = combine_two_pass(writer, clerk)
+    for field_name in SkaldTurnWire.model_fields:
+        assert getattr(combined, field_name) == sources[field_name]
+    assert combined.model_dump(mode="json") == SkaldTurnWire.model_validate(
+        RICH_WIRE_PAYLOAD
+    ).model_dump(mode="json")
+
+
+def test_two_pass_strict_and_lenient_schema_shapes() -> None:
+    writer_strict = skald_writer_strict_text_format()
+    clerk_strict = skald_clerk_strict_text_format()
+    writer_lenient = skald_writer_lenient_schema()
+    clerk_lenient = skald_clerk_lenient_schema()
+
+    assert writer_strict["name"] == "SkaldWriterWire"
+    assert clerk_strict["name"] == "SkaldClerkWire"
+    assert set(writer_strict["schema"]["properties"]) == set(
+        SkaldWriterWire.model_fields
+    )
+    assert set(clerk_strict["schema"]["properties"]) == set(SkaldClerkWire.model_fields)
+    assert set(writer_strict["schema"]["required"]) == set(SkaldWriterWire.model_fields)
+    assert set(clerk_strict["schema"]["required"]) == set(SkaldClerkWire.model_fields)
+    assert writer_strict["schema"]["additionalProperties"] is False
+    assert clerk_strict["schema"]["additionalProperties"] is False
+
+    assert set(writer_lenient["properties"]) == set(SkaldWriterWire.model_fields)
+    assert set(clerk_lenient["properties"]) == set(SkaldClerkWire.model_fields)
+    assert writer_lenient["required"] == ["narrative", "choices"]
+    assert clerk_lenient.get("required", []) == []
+    assert writer_lenient["additionalProperties"] is False
+    assert clerk_lenient["additionalProperties"] is False
+    assert "anyOf" not in writer_lenient["properties"]["scene"]
+    assert "anyOf" not in clerk_lenient["properties"]["updates"]
 
 
 def _assert_canonical_fields_equal(
@@ -1009,6 +1104,24 @@ def test_skald_wire_prompt_guide_is_deterministic_and_complete() -> None:
             assert matching_lines[0][len(prefix) :].split("|", 1)[0]
 
 
+def test_skald_clerk_prompt_guide_is_deterministic_and_complete() -> None:
+    schema = skald_clerk_lenient_schema()
+    first = skald_clerk_prompt_guide()
+
+    assert first == skald_clerk_prompt_guide()
+    assert first.startswith("=== OUTPUT FORMAT ===\n")
+    rendered_property_names = []
+    for line in first.splitlines():
+        field_label = line.split(":", 1)[0]
+        if field_label.endswith(("!", "?")):
+            rendered_property_names.append(field_label[:-1])
+    assert Counter(rendered_property_names) == Counter(
+        _reachable_schema_property_names(schema)
+    )
+    for object_name, _object_schema in _reachable_schema_objects(schema):
+        assert first.count(f"{object_name}{{\n") == 1
+
+
 def test_skald_wire_prompt_guide_preserves_enum_values_verbatim() -> None:
     guide = skald_wire_prompt_guide()
 
@@ -1033,6 +1146,13 @@ def test_skald_wire_prompt_guide_stays_within_token_budget() -> None:
     encoding = tiktoken.get_encoding("o200k_base")
 
     assert len(encoding.encode(skald_wire_prompt_guide())) <= 1_400
+
+
+def test_skald_clerk_prompt_guide_stays_within_token_budget() -> None:
+    tiktoken = pytest.importorskip("tiktoken")
+    encoding = tiktoken.get_encoding("o200k_base")
+
+    assert len(encoding.encode(skald_clerk_prompt_guide())) <= 900
 
 
 def test_wire_schema_size_and_description_budget() -> None:


### PR DESCRIPTION
## Summary

The last ruled piece of the schema-weight campaign: a config-switched **two-pass turn pipeline** for the measurement stage. Pass 1 (writer) authors narrative/choices/scene/presence/operations; pass 2 (clerk) receives the writer's finished beat plus the same context and authors only the structured record (updates/adjudications/declarations). `combine_two_pass()` reassembles the one universal `SkaldTurnWire`; hydration and commit are untouched downstream.

**Why this arm matters:** the writer wire *compiles* under Anthropic native enforcement (probe G2a on #566, 4,251 B) while the full wire cannot — so two-pass lets Anthropic run real grammar enforcement on the writer with a focused prompted clerk (597-token mechanical guide, zero hand-authored schema text) behind it. OpenAI runs both passes strict-native; local runs both lenient.

## Contract Points

- `[apex] turn_pipeline = "single_pass"` (committed default) | `"two_pass"` — a bakeoff lever, not a new default. Bootstrap always single-pass.
- Vocabulary validation attaches to the **clerk only** — every tag-bearing block is clerk-side; the writer's blocks carry no registered tags. Clean custody split.
- Per-pass bounded repair budgets; writer exhaustion short-circuits (no clerk call); clerk exhaustion fails the turn loudly with nothing hydrated. **No silent fallback to single-pass — a failed arm is data.**
- Clerk instructions live in `prompts/storyteller_clerk.md` (house rule), referencing core doctrine rather than duplicating it.
- Regression: shipped Anthropic writer `output_config` has **zero union-typed schema nodes** (real-entry-point assertion); hydration equivalence proven — combined two-pass output hydrates identically to single-pass for identical content.

## Test Results

```
344 passed, 14 skipped · mypy clean (3 files) · black/flake8 clean · config loads OK · deviations: none
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ