### PR TITLE
Add the tool-envelope Anthropic transport (#566 bakeoff arm)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -1021,7 +1021,7 @@ provider = "openai"           # API provider: "openai", "anthropic", or "local"
 model = "@openai.default"     # Resolved via api_models registry; edit roles to migrate
 reasoning_effort = "medium"   # Reasoning effort level (low/medium/high)
 max_output_tokens = 25000     # Maximum tokens for generated narrative
-anthropic_storyteller_transport = "prompted" # "prompted" or "native"
+anthropic_storyteller_transport = "prompted" # "prompted", "native", or "tool_envelope"
 turn_pipeline = "single_pass" # "single_pass" or "two_pass" bakeoff lever
 structured_output_retries = 3 # Validation retry budget for structured story turns
 # HTTP client timeout for a narrative continue turn. Frontier generation runs

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -859,7 +859,9 @@ class LogonUtility:
         *,
         system_prompt: Optional[str],
         output_validator: Any,
-        anthropic_transport: Optional[Literal["native", "prompted"]] = None,
+        anthropic_transport: Optional[
+            Literal["native", "prompted", "tool_envelope"]
+        ] = None,
     ) -> OpenAIProvider | AnthropicProvider:
         """Create an isolated provider view for one pass."""
 
@@ -894,12 +896,46 @@ class LogonUtility:
             raise TypeError("Writer system prompt must be a string")
         return system_prompt
 
-    def _clerk_system_prompt(self) -> str:
+    def _resolve_anthropic_two_pass_clerk_transport(
+        self,
+    ) -> Optional[Literal["prompted", "tool_envelope"]]:
+        """Resolve the schema-free Anthropic clerk arm or reject native."""
+
+        if self._provider_wire_type != "anthropic":
+            return None
+        if self.provider is None:
+            raise RuntimeError("Two-pass generation requires an initialized provider")
+
+        transport = self.provider.structured_transport
+        if transport == "native":
+            raise ValueError(
+                "Anthropic two-pass execution cannot use "
+                "anthropic_storyteller_transport='native': the clerk wire cannot "
+                "compile under Anthropic native enforcement (probe G2b, issue #566). "
+                "Choose 'prompted' or 'tool_envelope' for the clerk."
+            )
+        if transport not in {"prompted", "tool_envelope"}:
+            raise ValueError(
+                "Anthropic two-pass clerk transport must be 'prompted' or "
+                f"'tool_envelope', got {transport!r}"
+            )
+        return cast(Literal["prompted", "tool_envelope"], transport)
+
+    def _clerk_system_prompt(
+        self,
+        *,
+        anthropic_transport: Optional[Literal["prompted", "tool_envelope"]] = None,
+    ) -> str:
         """Build the pass-two system content for the active provider."""
 
         system_prompt = self._load_clerk_system_prompt()
         if self._provider_wire_type == "anthropic":
-            system_prompt = f"{system_prompt}\n\n{skald_clerk_prompt_guide()}"
+            if anthropic_transport is None:
+                raise ValueError(
+                    "Anthropic clerk system prompt requires an explicit transport"
+                )
+            if anthropic_transport == "prompted":
+                system_prompt = f"{system_prompt}\n\n{skald_clerk_prompt_guide()}"
         return system_prompt
 
     @staticmethod
@@ -952,6 +988,7 @@ class LogonUtility:
 
         if self.provider is None:
             raise RuntimeError("Two-pass generation requires an initialized provider")
+        anthropic_clerk_transport = self._resolve_anthropic_two_pass_clerk_transport()
         writer_provider = self._clone_provider_for_two_pass(
             system_prompt=self._writer_system_prompt(),
             output_validator=None,
@@ -973,11 +1010,11 @@ class LogonUtility:
             effective_context_window=effective_context_window,
         )
         clerk_provider = self._clone_provider_for_two_pass(
-            system_prompt=self._clerk_system_prompt(),
-            output_validator=getattr(self.provider, "output_validator", None),
-            anthropic_transport=(
-                "prompted" if self._provider_wire_type == "anthropic" else None
+            system_prompt=self._clerk_system_prompt(
+                anthropic_transport=anthropic_clerk_transport,
             ),
+            output_validator=getattr(self.provider, "output_validator", None),
+            anthropic_transport=anthropic_clerk_transport,
         )
         clerk, _clerk_response = clerk_provider.get_structured_completion(
             clerk_prompt,
@@ -1004,6 +1041,7 @@ class LogonUtility:
 
         if self.provider is None:
             raise RuntimeError("Two-pass generation requires an initialized provider")
+        anthropic_clerk_transport = self._resolve_anthropic_two_pass_clerk_transport()
         writer_provider = self._clone_provider_for_two_pass(
             system_prompt=self._writer_system_prompt(),
             output_validator=None,
@@ -1027,11 +1065,11 @@ class LogonUtility:
             effective_context_window=effective_context_window,
         )
         clerk_provider = self._clone_provider_for_two_pass(
-            system_prompt=self._clerk_system_prompt(),
-            output_validator=getattr(self.provider, "output_validator", None),
-            anthropic_transport=(
-                "prompted" if self._provider_wire_type == "anthropic" else None
+            system_prompt=self._clerk_system_prompt(
+                anthropic_transport=anthropic_clerk_transport,
             ),
+            output_validator=getattr(self.provider, "output_validator", None),
+            anthropic_transport=anthropic_clerk_transport,
         )
         clerk, _clerk_response = await clerk_provider.get_structured_completion_async(
             clerk_prompt,
@@ -1287,7 +1325,15 @@ class LogonUtility:
                     )
                 }
             else:
-                kwargs = {}
+                clerk_transport = self._resolve_anthropic_two_pass_clerk_transport()
+                if clerk_transport == "prompted":
+                    kwargs = {}
+                elif clerk_transport == "tool_envelope":
+                    kwargs = {"input_schema": skald_clerk_lenient_schema()}
+                else:
+                    raise AssertionError(
+                        "Anthropic clerk transport resolution returned no transport"
+                    )
         else:
             raise ValueError(
                 "Unsupported two-pass provider wire class: "

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -554,18 +554,25 @@ class LogonUtility:
         use_two_pass = (
             not provider_bootstrap_mode and self._turn_pipeline() == "two_pass"
         )
-        anthropic_transport: Literal["native", "prompted"] = "native"
+        anthropic_transport: Literal["native", "prompted", "tool_envelope"] = "native"
         if provider_type == "anthropic":
             configured_transport = apex_settings.get("anthropic_storyteller_transport")
-            if configured_transport not in {"native", "prompted"}:
+            if configured_transport not in {
+                "native",
+                "prompted",
+                "tool_envelope",
+            }:
                 raise ValueError(
                     "API Settings.apex.anthropic_storyteller_transport must be "
-                    "'native' or 'prompted'"
+                    "'native', 'prompted', or 'tool_envelope'"
                 )
             anthropic_transport = (
                 "native"
                 if provider_bootstrap_mode
-                else cast(Literal["native", "prompted"], configured_transport)
+                else cast(
+                    Literal["native", "prompted", "tool_envelope"],
+                    configured_transport,
+                )
             )
             if anthropic_transport == "prompted" and not use_two_pass:
                 system_prompt = f"{system_prompt}\n\n{skald_wire_prompt_guide()}"
@@ -1207,6 +1214,8 @@ class LogonUtility:
                 anthropic_transport = self.provider.structured_transport
                 if anthropic_transport == "prompted":
                     kwargs = {}
+                elif anthropic_transport == "tool_envelope":
+                    kwargs = {"input_schema": skald_wire_lenient_schema()}
                 elif anthropic_transport == "native":
                     kwargs = {
                         "output_config": anthropic_output_config(

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -2550,11 +2550,13 @@ class APEXSettings(BaseModel):
     model: str
     reasoning_effort: str = Field(..., pattern="^(low|medium|high)$")
     max_output_tokens: int = Field(..., ge=1)
-    anthropic_storyteller_transport: Literal["prompted", "native"] = Field(
-        default="prompted",
-        description=(
-            "Structured transport for non-bootstrap Anthropic storyteller turns."
-        ),
+    anthropic_storyteller_transport: Literal["prompted", "native", "tool_envelope"] = (
+        Field(
+            default="prompted",
+            description=(
+                "Structured transport for non-bootstrap Anthropic storyteller turns."
+            ),
+        )
     )
     turn_pipeline: Literal["single_pass", "two_pass"] = Field(
         default="single_pass",

--- a/scripts/api_anthropic.py
+++ b/scripts/api_anthropic.py
@@ -293,7 +293,7 @@ class AnthropicProvider(LLMProvider):
         reasoning_effort: Optional[str] = None,
         thinking_enabled: bool = False,
         thinking_budget_tokens: Optional[int] = None,
-        structured_transport: Literal["native", "prompted"] = "native",
+        structured_transport: Literal["native", "prompted", "tool_envelope"] = "native",
         structured_output_retries: Optional[int] = None,
         output_validator: Optional[Any] = None,
     ):
@@ -324,8 +324,11 @@ class AnthropicProvider(LLMProvider):
         self.reasoning_effort = reasoning_effort
         self.thinking_enabled = thinking_enabled
         self.thinking_budget_tokens = thinking_budget_tokens
-        if structured_transport not in {"native", "prompted"}:
-            raise ValueError("structured_transport must be 'native' or 'prompted'")
+        if structured_transport not in {"native", "prompted", "tool_envelope"}:
+            raise ValueError(
+                "structured_transport must be 'native', 'prompted', or "
+                "'tool_envelope'"
+            )
         self.structured_transport = structured_transport
         self.structured_output_retries = (
             structured_output_retries
@@ -519,6 +522,7 @@ class AnthropicProvider(LLMProvider):
         prompt: str,
         schema_model: Type,
         *,
+        input_schema: Optional[Dict[str, Any]] = None,
         output_config: Optional[Dict[str, Any]] = None,
         output_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
@@ -561,6 +565,7 @@ class AnthropicProvider(LLMProvider):
         return self._get_structured_completion_native_sync(
             prompt,
             schema_model,
+            input_schema=input_schema,
             output_config=output_config,
             output_format=output_format,
         )
@@ -570,6 +575,7 @@ class AnthropicProvider(LLMProvider):
         prompt: str,
         schema_model: Type,
         *,
+        input_schema: Optional[Dict[str, Any]] = None,
         output_config: Optional[Dict[str, Any]] = None,
         output_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
@@ -578,6 +584,7 @@ class AnthropicProvider(LLMProvider):
             self._get_structured_completion_native_sync,
             prompt,
             schema_model,
+            input_schema=input_schema,
             output_config=output_config,
             output_format=output_format,
         )
@@ -599,6 +606,7 @@ class AnthropicProvider(LLMProvider):
         prompt: str,
         schema_model: Type,
         *,
+        input_schema: Optional[Dict[str, Any]] = None,
         output_config: Optional[Dict[str, Any]] = None,
         output_format: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, LLMResponse]:
@@ -610,9 +618,29 @@ class AnthropicProvider(LLMProvider):
                     "Prompted Anthropic structured transport does not accept "
                     "output_config or output_format"
                 )
+            if input_schema is not None:
+                raise ValueError(
+                    "Prompted Anthropic structured transport does not accept "
+                    "input_schema"
+                )
             return self._get_structured_completion_prompted_sync(
                 prompt,
                 schema_model,
+            )
+        if self.structured_transport == "tool_envelope":
+            if output_config is not None or output_format is not None:
+                raise ValueError(
+                    "Tool-envelope Anthropic structured transport does not accept "
+                    "output_config or output_format"
+                )
+            return self._get_structured_completion_tool_envelope_sync(
+                prompt,
+                schema_model,
+                input_schema=input_schema,
+            )
+        if input_schema is not None:
+            raise ValueError(
+                "Native Anthropic structured transport does not accept input_schema"
             )
 
         from pydantic_ai import ModelRetry
@@ -639,6 +667,56 @@ class AnthropicProvider(LLMProvider):
                 )
                 return parsed_output, self._native_response_to_llm_response(
                     parsed_output, response
+                )
+            except ModelRetry as exc:
+                last_error = exc
+                if attempt >= self.structured_output_retries:
+                    raise
+                active_prompt = retry_prompt(prompt, exc.message)
+            except (ValidationError, json.JSONDecodeError, ValueError) as exc:
+                last_error = exc
+                if attempt >= self.structured_output_retries:
+                    raise
+                active_prompt = retry_prompt(prompt, str(exc))
+
+        raise RuntimeError("Structured completion failed") from last_error
+
+    def _get_structured_completion_tool_envelope_sync(
+        self,
+        prompt: str,
+        schema_model: Type,
+        *,
+        input_schema: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Any, LLMResponse]:
+        """Run a forced non-strict tool call with bounded validation repair."""
+
+        from pydantic_ai import ModelRetry
+
+        active_prompt = prompt
+        last_error: Optional[BaseException] = None
+        for attempt in range(self.structured_output_retries + 1):
+            try:
+                response = self.client.beta.messages.create(
+                    **self._build_tool_envelope_structured_request_params(
+                        active_prompt,
+                        schema_model,
+                        input_schema=input_schema,
+                    )
+                )
+                parsed_output = self._extract_tool_envelope_parsed_output(
+                    response,
+                    schema_model,
+                )
+                parsed_output = asyncio.run(
+                    run_output_validator(
+                        self.output_validator,
+                        parsed_output,
+                        retry=attempt,
+                    )
+                )
+                return parsed_output, self._native_response_to_llm_response(
+                    parsed_output,
+                    response,
                 )
             except ModelRetry as exc:
                 last_error = exc
@@ -766,6 +844,37 @@ class AnthropicProvider(LLMProvider):
             }
         return params
 
+    def _build_tool_envelope_structured_request_params(
+        self,
+        prompt: str,
+        schema_model: Type,
+        *,
+        input_schema: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Build a forced non-strict tool request carrying an advisory schema."""
+
+        tool_input_schema = (
+            input_schema
+            if input_schema is not None
+            else cast(Dict[str, Any], schema_model.model_json_schema())
+        )
+        params = self._build_prompted_structured_request_params(prompt)
+        params["tools"] = [
+            {
+                "name": "submit_structured_response",
+                "description": (
+                    "Return the complete structured response for the current NEXUS "
+                    "generation request."
+                ),
+                "input_schema": tool_input_schema,
+            }
+        ]
+        params["tool_choice"] = {
+            "type": "tool",
+            "name": "submit_structured_response",
+        }
+        return params
+
     @staticmethod
     def _extract_native_parsed_output(response: Any, schema_model: Type) -> Any:
         """Extract and validate Anthropic native JSON output."""
@@ -784,6 +893,31 @@ class AnthropicProvider(LLMProvider):
             return schema_model.model_validate_json(output_text)
 
         raise ValueError("Anthropic structured response did not include JSON output")
+
+    @staticmethod
+    def _extract_tool_envelope_parsed_output(
+        response: Any,
+        schema_model: Type,
+    ) -> Any:
+        """Validate the parsed input from the one forced structured tool."""
+
+        for block in getattr(response, "content", []) or []:
+            if (
+                getattr(block, "type", None) != "tool_use"
+                or getattr(block, "name", None) != "submit_structured_response"
+            ):
+                continue
+            tool_input = getattr(block, "input", None)
+            if not isinstance(tool_input, dict):
+                raise ValueError(
+                    "Anthropic tool-envelope response input must be a dict"
+                )
+            return schema_model.model_validate(tool_input)
+
+        raise ValueError(
+            "Anthropic tool-envelope response did not include the "
+            "submit_structured_response tool_use block"
+        )
 
     @staticmethod
     def _extract_prompted_parsed_output(response: Any, schema_model: Type) -> Any:

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -107,6 +107,19 @@ def test_shipped_anthropic_storyteller_transport_is_prompted() -> None:
     assert settings.apex.anthropic_storyteller_transport == "prompted"
 
 
+@pytest.mark.parametrize(
+    "transport",
+    ["prompted", "native", "tool_envelope"],
+)
+def test_apex_accepts_anthropic_storyteller_transports(transport: str) -> None:
+    raw = _nexus_toml_dict()
+    raw["apex"]["anthropic_storyteller_transport"] = transport
+
+    settings = Settings(**raw)
+
+    assert settings.apex.anthropic_storyteller_transport == transport
+
+
 def test_apex_rejects_unknown_anthropic_storyteller_transport() -> None:
     raw = _nexus_toml_dict()
     raw["apex"]["anthropic_storyteller_transport"] = "tool"

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -120,6 +120,17 @@ def test_apex_accepts_anthropic_storyteller_transports(transport: str) -> None:
     assert settings.apex.anthropic_storyteller_transport == transport
 
 
+def test_apex_allows_native_anthropic_transport_with_two_pass_pipeline() -> None:
+    raw = _nexus_toml_dict()
+    raw["apex"]["anthropic_storyteller_transport"] = "native"
+    raw["apex"]["turn_pipeline"] = "two_pass"
+
+    settings = Settings(**raw)
+
+    assert settings.apex.anthropic_storyteller_transport == "native"
+    assert settings.apex.turn_pipeline == "two_pass"
+
+
 def test_apex_rejects_unknown_anthropic_storyteller_transport() -> None:
     raw = _nexus_toml_dict()
     raw["apex"]["anthropic_storyteller_transport"] = "tool"

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -164,6 +164,8 @@ def test_runtime_roster_reference_resolves_before_provider_call(
         ("prompted", True, "single_pass", "native", False),
         ("tool_envelope", True, "single_pass", "native", False),
         ("prompted", False, "two_pass", "prompted", False),
+        ("tool_envelope", False, "two_pass", "tool_envelope", False),
+        ("native", False, "two_pass", "native", False),
         ("prompted", True, "two_pass", "native", False),
     ],
 )
@@ -228,7 +230,7 @@ def test_anthropic_storyteller_transport_and_guide_follow_settings(
     )
     assert captured["system_prompt"] == expected_system
     assert utility._system_prompt == expected_system
-    if expected_transport == "tool_envelope":
+    if expected_transport == "tool_envelope" and turn_pipeline == "single_pass":
         assert utility._schema_format_kwargs(SkaldTurnWire) == {
             "input_schema": skald_wire_lenient_schema()
         }

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -10,7 +10,11 @@ import pytest
 from nexus.agents.logon.apex_schema import (
     StorytellerResponseBootstrap,
 )
-from nexus.agents.logon.skald_wire import SkaldTurnWire, skald_wire_prompt_guide
+from nexus.agents.logon.skald_wire import (
+    SkaldTurnWire,
+    skald_wire_lenient_schema,
+    skald_wire_prompt_guide,
+)
 from nexus.agents.lore import logon_utility
 from nexus.agents.lore.lore import LORE
 from nexus.agents.lore.logon_utility import LogonUtility
@@ -156,7 +160,9 @@ def test_runtime_roster_reference_resolves_before_provider_call(
     [
         ("prompted", False, "single_pass", "prompted", True),
         ("native", False, "single_pass", "native", False),
+        ("tool_envelope", False, "single_pass", "tool_envelope", False),
         ("prompted", True, "single_pass", "native", False),
+        ("tool_envelope", True, "single_pass", "native", False),
         ("prompted", False, "two_pass", "prompted", False),
         ("prompted", True, "two_pass", "native", False),
     ],
@@ -222,6 +228,10 @@ def test_anthropic_storyteller_transport_and_guide_follow_settings(
     )
     assert captured["system_prompt"] == expected_system
     assert utility._system_prompt == expected_system
+    if expected_transport == "tool_envelope":
+        assert utility._schema_format_kwargs(SkaldTurnWire) == {
+            "input_schema": skald_wire_lenient_schema()
+        }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lore/test_two_pass_pipeline.py
+++ b/tests/test_lore/test_two_pass_pipeline.py
@@ -274,23 +274,30 @@ def _utility(
     provider_type: str,
     outputs: list[object],
     *,
+    anthropic_transport: str | None = None,
     bootstrap: bool = False,
     output_validator: Any = None,
     structured_output_retries: int = 3,
 ) -> tuple[LogonUtility, _RecordingProvider]:
+    if provider_type == "anthropic":
+        if anthropic_transport is None:
+            raise ValueError("Anthropic test utility requires a transport")
+        provider_transport = anthropic_transport
+    else:
+        if anthropic_transport is not None:
+            raise ValueError("Non-Anthropic test utility cannot set a transport")
+        provider_transport = "responses"
     settings = {
         "API Settings": {
             "apex": {
                 "turn_pipeline": "two_pass",
-                "anthropic_storyteller_transport": "prompted",
+                "anthropic_storyteller_transport": (anthropic_transport or "prompted"),
             }
         }
     }
     provider = _RecordingProvider(
         outputs,
-        structured_transport=(
-            "prompted" if provider_type == "anthropic" else "responses"
-        ),
+        structured_transport=provider_transport,
         output_validator=output_validator,
         structured_output_retries=structured_output_retries,
     )
@@ -304,6 +311,7 @@ def _utility(
 
 def _expected_schema_kwargs(
     provider_type: str,
+    anthropic_transport: str | None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     if provider_type == "openai":
         return (
@@ -325,6 +333,13 @@ def _expected_schema_kwargs(
                 )
             },
         )
+    if anthropic_transport not in {"prompted", "tool_envelope"}:
+        raise ValueError("Successful Anthropic test requires a schema-free transport")
+    clerk_kwargs = (
+        {}
+        if anthropic_transport == "prompted"
+        else {"input_schema": skald_clerk_lenient_schema()}
+    )
     return (
         {
             "output_config": anthropic_output_config(
@@ -332,19 +347,21 @@ def _expected_schema_kwargs(
                 schema=skald_writer_lenient_schema(),
             )
         },
-        {},
+        clerk_kwargs,
     )
 
 
 def _assert_two_pass_calls(
     provider: _RecordingProvider,
     provider_type: str,
+    anthropic_transport: str | None,
 ) -> None:
     writer = SkaldWriterWire.model_validate(WRITER_PAYLOAD)
     assert len(provider.calls) == 2
     writer_call, clerk_call = provider.calls
     expected_writer_kwargs, expected_clerk_kwargs = _expected_schema_kwargs(
-        provider_type
+        provider_type,
+        anthropic_transport,
     )
 
     assert writer_call["schema_model"] is SkaldWriterWire
@@ -365,10 +382,21 @@ def _assert_two_pass_calls(
     assert writer.presence.model_dump_json(exclude_none=True) in clerk_call["prompt"]
 
     if provider_type == "anthropic":
+        assert anthropic_transport is not None
         assert writer_call["structured_transport"] == "native"
-        assert clerk_call["structured_transport"] == "prompted"
-        assert clerk_call["system_prompt"].endswith(skald_clerk_prompt_guide())
+        assert clerk_call["structured_transport"] == anthropic_transport
+        if anthropic_transport == "prompted":
+            assert clerk_call["kwargs"] == {}
+            assert clerk_call["system_prompt"].endswith(skald_clerk_prompt_guide())
+        else:
+            assert clerk_call["kwargs"] == {
+                "input_schema": skald_clerk_lenient_schema()
+            }
+            assert "output_config" not in clerk_call["kwargs"]
+            assert skald_clerk_prompt_guide() not in clerk_call["system_prompt"]
+            assert "=== OUTPUT FORMAT ===" not in clerk_call["system_prompt"]
     else:
+        assert anthropic_transport is None
         assert writer_call["structured_transport"] == "responses"
         assert clerk_call["structured_transport"] == "responses"
         assert "=== OUTPUT FORMAT ===" not in clerk_call["system_prompt"]
@@ -389,14 +417,24 @@ def _assert_matches_independently_parsed_single_pass(
             assert getattr(actual, field_name) == getattr(expected, field_name)
 
 
-@pytest.mark.parametrize("provider_type", ["openai", "local", "anthropic"])
+@pytest.mark.parametrize(
+    ("provider_type", "anthropic_transport"),
+    [
+        ("openai", None),
+        ("local", None),
+        ("anthropic", "prompted"),
+        ("anthropic", "tool_envelope"),
+    ],
+)
 def test_sync_two_pass_pipeline_uses_provider_specific_transports(
     provider_type: str,
+    anthropic_transport: str | None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     utility, provider = _utility(
         provider_type,
         [WRITER_PAYLOAD, CLERK_PAYLOAD],
+        anthropic_transport=anthropic_transport,
     )
     monkeypatch.setattr(
         utility,
@@ -409,20 +447,30 @@ def test_sync_two_pass_pipeline_uses_provider_specific_transports(
         effective_context_window=75_000,
     )
 
-    _assert_two_pass_calls(provider, provider_type)
+    _assert_two_pass_calls(provider, provider_type, anthropic_transport)
     assert response.narrative == WRITER_PAYLOAD["narrative"]
     assert response.generation_model == provider.model
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("provider_type", ["openai", "local", "anthropic"])
+@pytest.mark.parametrize(
+    ("provider_type", "anthropic_transport"),
+    [
+        ("openai", None),
+        ("local", None),
+        ("anthropic", "prompted"),
+        ("anthropic", "tool_envelope"),
+    ],
+)
 async def test_async_two_pass_pipeline_uses_provider_specific_transports(
     provider_type: str,
+    anthropic_transport: str | None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     utility, provider = _utility(
         provider_type,
         [WRITER_PAYLOAD, CLERK_PAYLOAD],
+        anthropic_transport=anthropic_transport,
     )
 
     async def read_baseline(
@@ -442,9 +490,73 @@ async def test_async_two_pass_pipeline_uses_provider_specific_transports(
         effective_context_window=75_000,
     )
 
-    _assert_two_pass_calls(provider, provider_type)
+    _assert_two_pass_calls(provider, provider_type, anthropic_transport)
     assert response.narrative == WRITER_PAYLOAD["narrative"]
     assert response.generation_model == provider.model
+
+
+def test_sync_anthropic_two_pass_rejects_native_before_provider_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    utility, provider = _utility(
+        "anthropic",
+        [],
+        anthropic_transport="native",
+    )
+    monkeypatch.setattr(
+        utility,
+        "_read_presence_baseline_for_context",
+        lambda _context_payload, _schema_model: BASELINE,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        utility.generate_narrative(
+            _context(),
+            effective_context_window=75_000,
+        )
+
+    message = str(exc_info.value)
+    assert "clerk wire cannot compile under Anthropic native enforcement" in message
+    assert "probe G2b, issue #566" in message
+    assert "'prompted'" in message
+    assert "'tool_envelope'" in message
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_anthropic_two_pass_rejects_native_before_provider_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    utility, provider = _utility(
+        "anthropic",
+        [],
+        anthropic_transport="native",
+    )
+
+    async def read_baseline(
+        _context_payload: dict[str, Any],
+        _schema_model: type,
+    ) -> PresenceBaseline:
+        return BASELINE
+
+    monkeypatch.setattr(
+        utility,
+        "_read_presence_baseline_for_context_async",
+        read_baseline,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        await utility.generate_narrative_async(
+            _context(),
+            effective_context_window=75_000,
+        )
+
+    message = str(exc_info.value)
+    assert "clerk wire cannot compile under Anthropic native enforcement" in message
+    assert "probe G2b, issue #566" in message
+    assert "'prompted'" in message
+    assert "'tool_envelope'" in message
+    assert provider.calls == []
 
 
 def test_two_pass_hydration_matches_independent_single_pass_parse(
@@ -569,6 +681,7 @@ async def test_clerk_failure_raises_without_partial_hydration(
     utility, provider = _utility(
         "anthropic",
         [WRITER_PAYLOAD, RuntimeError("clerk exhausted repairs")],
+        anthropic_transport="prompted",
     )
     hydrated: list[object] = []
     monkeypatch.setattr(

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -46,6 +46,13 @@ def _bootstrap_response() -> StorytellerResponseBootstrap:
     )
 
 
+def _wire_response() -> SkaldTurnWire:
+    return SkaldTurnWire(
+        narrative="[TEST MODE] Tool-envelope structured output.",
+        choices=["Continue", "Wait"],
+    )
+
+
 def _contains_key(value: object, key: str) -> bool:
     if isinstance(value, dict):
         return key in value or any(_contains_key(item, key) for item in value.values())
@@ -774,13 +781,221 @@ def test_anthropic_provider_uses_native_output_format() -> None:
 def test_anthropic_provider_rejects_unknown_structured_transport() -> None:
     with pytest.raises(
         ValueError,
-        match="structured_transport must be 'native' or 'prompted'",
+        match=(
+            "structured_transport must be 'native', 'prompted', or " "'tool_envelope'"
+        ),
     ):
         AnthropicProvider(
             model="claude-sonnet-4-5",
             api_key="test-key",
             structured_transport="unknown",  # type: ignore[arg-type]
         )
+
+
+def test_anthropic_tool_envelope_forces_non_strict_tool_and_validates_input() -> None:
+    expected = _wire_response()
+    captured = {}
+    input_schema = skald_wire_lenient_schema()
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content=[
+                    SimpleNamespace(
+                        type="text",
+                        text=expected.model_dump_json(),
+                    ),
+                    SimpleNamespace(
+                        type="tool_use",
+                        name="submit_structured_response",
+                        input=expected.model_dump(mode="json"),
+                    ),
+                ],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        system_prompt="System prompt",
+        temperature=0.2,
+        top_p=0.8,
+        top_k=40,
+        max_tokens=5678,
+        thinking_enabled=True,
+        thinking_budget_tokens=1024,
+        structured_transport="tool_envelope",
+        structured_output_retries=0,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    parsed, llm_response = provider.get_structured_completion(
+        "Prompt",
+        SkaldTurnWire,
+        input_schema=input_schema,
+    )
+
+    assert parsed == expected
+    assert llm_response.input_tokens == 33
+    assert llm_response.output_tokens == 44
+    assert captured["tools"] == [
+        {
+            "name": "submit_structured_response",
+            "description": (
+                "Return the complete structured response for the current NEXUS "
+                "generation request."
+            ),
+            "input_schema": input_schema,
+        }
+    ]
+    assert "strict" not in captured["tools"][0]
+    assert captured["tool_choice"] == {
+        "type": "tool",
+        "name": "submit_structured_response",
+    }
+    assert "output_config" not in captured
+    assert "output_format" not in captured
+    assert captured["system"] == "System prompt"
+    assert captured["temperature"] == 0.2
+    assert captured["top_p"] == 0.8
+    assert captured["top_k"] == 40
+    assert captured["thinking"] == {
+        "type": "enabled",
+        "budget_tokens": 1024,
+    }
+
+
+@pytest.mark.asyncio
+async def test_anthropic_tool_envelope_async_carries_effort_without_format() -> None:
+    expected = _wire_response()
+    calls = []
+    input_schema = skald_wire_lenient_schema()
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(
+                content=[
+                    SimpleNamespace(
+                        type="tool_use",
+                        name="submit_structured_response",
+                        input=expected.model_dump(mode="json"),
+                    )
+                ],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        reasoning_effort="low",
+        structured_transport="tool_envelope",
+        structured_output_retries=0,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    parsed, _llm_response = await provider.get_structured_completion_async(
+        "Prompt",
+        SkaldTurnWire,
+        input_schema=input_schema,
+    )
+
+    assert parsed == expected
+    assert len(calls) == 1
+    assert calls[0]["tools"][0]["input_schema"] == input_schema
+    assert "strict" not in calls[0]["tools"][0]
+    assert calls[0]["tool_choice"] == {
+        "type": "tool",
+        "name": "submit_structured_response",
+    }
+    assert calls[0]["output_config"] == {"effort": "low"}
+    assert "format" not in calls[0]["output_config"]
+    assert "output_format" not in calls[0]
+
+
+def test_anthropic_tool_envelope_repairs_text_only_then_raises() -> None:
+    expected = _wire_response()
+    calls = []
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(
+                content=[
+                    SimpleNamespace(
+                        type="text",
+                        text=expected.model_dump_json(),
+                    )
+                ],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        structured_transport="tool_envelope",
+        structured_output_retries=1,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    with pytest.raises(
+        ValueError,
+        match="did not include the submit_structured_response tool_use block",
+    ):
+        provider.get_structured_completion(
+            "Prompt",
+            SkaldTurnWire,
+            input_schema=skald_wire_lenient_schema(),
+        )
+
+    assert len(calls) == 2
+    assert calls[0]["messages"][0]["content"] == "Prompt"
+    assert "=== STRUCTURED OUTPUT RETRY ===" in calls[1]["messages"][0]["content"]
+    assert all("output_config" not in request for request in calls)
+    assert all("strict" not in request["tools"][0] for request in calls)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_tool_envelope_async_repairs_text_only_then_raises() -> None:
+    expected = _wire_response()
+    calls = []
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(
+                content=[
+                    SimpleNamespace(
+                        type="text",
+                        text=expected.model_dump_json(),
+                    )
+                ],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        structured_transport="tool_envelope",
+        structured_output_retries=1,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    with pytest.raises(
+        ValueError,
+        match="did not include the submit_structured_response tool_use block",
+    ):
+        await provider.get_structured_completion_async(
+            "Prompt",
+            SkaldTurnWire,
+            input_schema=skald_wire_lenient_schema(),
+        )
+
+    assert len(calls) == 2
+    assert "=== STRUCTURED OUTPUT RETRY ===" in calls[1]["messages"][0]["content"]
+    assert all("output_config" not in request for request in calls)
+    assert all("strict" not in request["tools"][0] for request in calls)
 
 
 def test_anthropic_prompted_transport_omits_schema_and_parses_json_fence() -> None:
@@ -996,15 +1211,20 @@ async def test_anthropic_prompted_transport_async_carries_effort_without_format(
     assert "format" not in captured["output_config"]
 
 
+@pytest.mark.parametrize(
+    "structured_transport",
+    ["prompted", "tool_envelope"],
+)
 @pytest.mark.parametrize("schema_argument", ["output_config", "output_format"])
-def test_anthropic_prompted_transport_rejects_caller_schema_arguments(
+def test_anthropic_non_native_transport_rejects_caller_schema_arguments(
+    structured_transport: str,
     schema_argument: str,
 ) -> None:
     create = Mock(side_effect=AssertionError("request must not be sent"))
     provider = AnthropicProvider(
         model="claude-sonnet-4-5",
         api_key="test-key",
-        structured_transport="prompted",
+        structured_transport=structured_transport,  # type: ignore[arg-type]
     )
     provider.client = SimpleNamespace(
         beta=SimpleNamespace(messages=SimpleNamespace(create=create))

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -14,8 +14,10 @@ from nexus.agents.logon.apex_schema import (
     StorytellerResponseExtended,
 )
 from nexus.agents.logon.skald_wire import (
+    SkaldClerkWire,
     SkaldTurnWire,
     SkaldWriterWire,
+    skald_clerk_lenient_schema,
     skald_wire_lenient_schema,
     skald_writer_lenient_schema,
 )
@@ -51,6 +53,10 @@ def _wire_response() -> SkaldTurnWire:
         narrative="[TEST MODE] Tool-envelope structured output.",
         choices=["Continue", "Wait"],
     )
+
+
+def _clerk_response() -> SkaldClerkWire:
+    return SkaldClerkWire()
 
 
 def _contains_key(value: object, key: str) -> bool:
@@ -290,6 +296,103 @@ def test_two_pass_writer_native_config_reaches_shipped_anthropic_request(
         assert "effort" not in request_output_config
     else:
         assert request_output_config["effort"] == expected_effort
+
+
+def test_two_pass_clerk_tool_envelope_reaches_forced_non_strict_tool() -> None:
+    utility = LogonUtility({})
+    utility._provider_wire_type = "anthropic"
+    utility.provider = SimpleNamespace(structured_transport="tool_envelope")
+    schema_kwargs = utility._two_pass_schema_format_kwargs(SkaldClerkWire)
+    clerk = _clerk_response()
+    captured = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content=[
+                    SimpleNamespace(
+                        type="tool_use",
+                        name="submit_structured_response",
+                        input=clerk.model_dump(mode="json"),
+                    ),
+                ],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        structured_transport="tool_envelope",
+        structured_output_retries=0,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    parsed, _llm_response = provider.get_structured_completion(
+        "Record the durable state.",
+        SkaldClerkWire,
+        **schema_kwargs,
+    )
+
+    assert parsed == clerk
+    assert captured["tools"][0]["name"] == "submit_structured_response"
+    assert captured["tools"][0]["input_schema"] == skald_clerk_lenient_schema()
+    assert "strict" not in captured["tools"][0]
+    assert captured["tool_choice"] == {
+        "type": "tool",
+        "name": "submit_structured_response",
+    }
+    assert "output_config" not in captured
+
+
+@pytest.mark.asyncio
+async def test_two_pass_clerk_tool_envelope_async_uses_effort_only_config() -> None:
+    utility = LogonUtility({})
+    utility._provider_wire_type = "anthropic"
+    utility.provider = SimpleNamespace(structured_transport="tool_envelope")
+    schema_kwargs = utility._two_pass_schema_format_kwargs(SkaldClerkWire)
+    clerk = _clerk_response()
+    captured = {}
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                content=[
+                    SimpleNamespace(
+                        type="tool_use",
+                        name="submit_structured_response",
+                        input=clerk.model_dump(mode="json"),
+                    ),
+                ],
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-5",
+        api_key="test-key",
+        reasoning_effort="medium",
+        structured_transport="tool_envelope",
+        structured_output_retries=0,
+    )
+    provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
+
+    parsed, _llm_response = await provider.get_structured_completion_async(
+        "Record the durable state.",
+        SkaldClerkWire,
+        **schema_kwargs,
+    )
+
+    assert parsed == clerk
+    assert captured["tools"][0]["name"] == "submit_structured_response"
+    assert captured["tools"][0]["input_schema"] == skald_clerk_lenient_schema()
+    assert "strict" not in captured["tools"][0]
+    assert captured["tool_choice"] == {
+        "type": "tool",
+        "name": "submit_structured_response",
+    }
+    assert captured["output_config"] == {"effort": "medium"}
+    assert "format" not in captured["output_config"]
 
 
 def test_anthropic_one_of_rewrite_recurses_through_lists_and_dicts() -> None:

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -1253,6 +1253,15 @@ def test_logon_selects_transport_appropriate_wire_serialization() -> None:
 
     utility.provider = cast(
         Any,
+        SimpleNamespace(structured_transport="tool_envelope"),
+    )
+    utility._schema_format_cache = {}
+    assert utility._schema_format_kwargs(SkaldTurnWire) == {
+        "input_schema": skald_wire_lenient_schema()
+    }
+
+    utility.provider = cast(
+        Any,
         SimpleNamespace(structured_transport="native"),
     )
     utility._schema_format_cache = {}


### PR DESCRIPTION
## Summary

The b-tool bakeoff arm from the transport decision on #566: `anthropic_storyteller_transport = "tool_envelope"` forces a **non-strict** named tool call as a pure JSON envelope. No `strict` flag → no grammar compilation → the compiled-grammar ceiling never engages. The de-nulled lenient wire schema rides the tool definition as advisory guidance, and the response arrives as an already-parsed `tool_use` input validated via `model_validate` — eliminating fence/extraction failure modes structurally rather than tolerantly.

## Contract Points

- Builder composes on the prompted request params, so effort rides the live-verified effort-only `output_config` spelling; system/sampling identical across the transport family.
- Missing tool block or text-only response → `ValueError` into the existing bounded repair loop → loud raise on exhaustion. No text salvage of any kind.
- Caller-supplied `output_config`/`output_format` rejected, same as prompted; guide NOT appended in this mode (the schema rides the tool definition); bootstrap stays native.
- Committed default remains `"prompted"` — this is a measurement arm.

## Test Results

```
200 passed, 3 skipped · mypy clean (3 files) · black/flake8 clean · config loads OK · deviations: none
(rebased onto the post-#574 main; suite re-run green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ