### PR TITLE
Register the casting roster, key resource profiles by provider name, default two-pass

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -238,8 +238,11 @@ system_prompt_tokens = 5000  # Reserved tokens for system prompt
 prompt_overhead_tokens = 4_000
 
 [lore.token_budget.provider_overrides]
-# Effective apex_context_window per storyteller provider class. Absent key =
-# base value. Local models need a smaller assembled payload (see #566).
+# Effective apex_context_window per REGISTRY PROVIDER NAME (not wire class).
+# Absent key = base value: openrouter shares the "local" wire dialect but has
+# no entry here, so its frontier models keep the full window. This "local"
+# key is the [api_models.local] provider — compute-bound GGUF serving needs a
+# smaller assembled payload (see #566).
 # 32K floor measured live 2026-07-24: a mature slot's untrimmable structured
 # core alone is ~14.9K tokens; 24K left the enforcement nothing to trim to.
 local = 32_000

--- a/nexus.toml
+++ b/nexus.toml
@@ -40,6 +40,7 @@ roles = { default = "claude-opus-4-8", deep = "claude-fable-5", fast = "claude-s
 models = [
     { id = "claude-sonnet-5-0", label = "Sonnet 5.0", native_structured_output = true },
     { id = "claude-opus-4-8", label = "Opus 4.8", unsupported_params = ["temperature", "top_p", "top_k"], native_structured_output = true },
+    { id = "claude-opus-5", label = "Opus 5", unsupported_params = ["temperature", "top_p", "top_k"], native_structured_output = true },
     { id = "claude-fable-5", label = "Fable 5", unsupported_params = ["temperature", "top_p", "top_k"], native_structured_output = true },
 ]
 
@@ -69,6 +70,29 @@ roles = { default = "nousresearch/hermes-4-70b" }
 models = [
     { id = "nousresearch/hermes-4-70b", label = "Hermes 4 70B (Local)", description = "Local llama-server inference (GGUF)" },
     { id = "nousresearch/hermes-4.3-36b", label = "Hermes 4.3 36B (Local)", description = "Local llama-server inference (GGUF, Seed-OSS)" },
+]
+
+# OpenRouter: one OpenAI-compatible funnel for the prose-model casting roster
+# (issue #578; writer-seat sampling 2026-07-25). Wire class is "local"
+# (chat_completions + lenient schema), but resource profiles key on the
+# provider NAME, so these frontier-quality remote models keep the full apex
+# context window and base entity inclusion — the 32K/thin-profile squeeze
+# belongs to compute-bound local GGUF serving only. Kimi K3 note: at default
+# reasoning it can spend its whole output budget thinking; sampled well at
+# low reasoning effort.
+[global.model.api_models.openrouter]
+base_url = "https://openrouter.ai/api/v1"
+api_key_secret = "openrouter"
+structured_transport = "chat_completions"
+request_timeout_seconds = 600
+roles = { default = "moonshotai/kimi-k2.5" }
+models = [
+    { id = "moonshotai/kimi-k2.5", label = "Kimi K2.5", description = "Moonshot K2.5 via OpenRouter" },
+    { id = "moonshotai/kimi-k3", label = "Kimi K3", description = "Moonshot K3 via OpenRouter" },
+    { id = "deepseek/deepseek-v4-pro", label = "DeepSeek V4 Pro", description = "DeepSeek V4 Pro via OpenRouter" },
+    { id = "nousresearch/hermes-4-405b", label = "Hermes 4 405B", description = "Nous Hermes 4 405B via OpenRouter" },
+    { id = "minimax/minimax-m3", label = "MiniMax M3", description = "MiniMax M3 via OpenRouter" },
+    { id = "z-ai/glm-5", label = "GLM-5", description = "Zhipu GLM-5 via OpenRouter" },
 ]
 
 # Interactive local GGUF management. The server port and alias remain sourced
@@ -1022,7 +1046,7 @@ model = "@openai.default"     # Resolved via api_models registry; edit roles to 
 reasoning_effort = "medium"   # Reasoning effort level (low/medium/high)
 max_output_tokens = 25000     # Maximum tokens for generated narrative
 anthropic_storyteller_transport = "prompted" # "prompted", "native", or "tool_envelope"
-turn_pipeline = "single_pass" # "single_pass" or "two_pass" bakeoff lever
+turn_pipeline = "two_pass" # "single_pass" or "two_pass"; two_pass default per #578 casting ruling (owner, 2026-07-26)
 structured_output_retries = 3 # Validation retry budget for structured story turns
 # HTTP client timeout for a narrative continue turn. Frontier generation runs
 # inside the request and blocks the API worker, so status polls aren't answered

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -292,6 +292,7 @@ class LogonUtility:
         self._provider_wire_type: Optional[Literal["openai", "anthropic", "local"]] = (
             None
         )
+        self._provider_type_name: Optional[str] = None
         self._validation_dbname: Optional[str] = None
         self._schema_format_cache: Dict[type, Dict[str, Any]] = {}
 
@@ -510,12 +511,12 @@ class LogonUtility:
 
     def resolve_storyteller_route(
         self,
-    ) -> tuple[str, Literal["openai", "anthropic", "local"]]:
-        """Return the concrete storyteller model and its wire class."""
-        model, _provider_type, _endpoint, provider_wire_type = (
+    ) -> tuple[str, Literal["openai", "anthropic", "local"], str]:
+        """Return the storyteller model, wire class, and provider name."""
+        model, provider_type, _endpoint, provider_wire_type = (
             self._resolve_storyteller_route()
         )
-        return model, provider_wire_type
+        return model, provider_wire_type, provider_type
 
     def _initialize_provider(
         self,
@@ -605,6 +606,7 @@ class LogonUtility:
         self._schema_format_cache = {}
 
         self._provider_wire_type = provider_wire_type
+        self._provider_type_name = provider_type
         if provider_wire_type == "anthropic":
             self.provider = AnthropicProvider(
                 model=model,
@@ -1093,15 +1095,17 @@ class LogonUtility:
     ) -> int:
         """Fail before generation when LOGON formatting exceeds the turn window."""
         provider_wire_type = self._provider_wire_type
-        if provider_wire_type is None:
+        provider_name = self._provider_type_name
+        if provider_wire_type is None or provider_name is None:
             raise RuntimeError(
                 "Final storyteller prompt sizing requires an active provider "
-                "wire class"
+                "wire class and provider name"
             )
         if effective_context_window is None:
             effective_context_window = resolve_storyteller_context_window(
                 self.settings,
                 provider_wire_type,
+                provider_name,
             )
         if isinstance(effective_context_window, bool) or not isinstance(
             effective_context_window, int

--- a/nexus/agents/lore/utils/context_validation.py
+++ b/nexus/agents/lore/utils/context_validation.py
@@ -17,6 +17,7 @@ def validate_context(
     context: Dict[str, Any],
     settings: Dict[str, Any],
     provider_wire_type: str,
+    provider_name: str,
 ) -> Tuple[bool, List[str]]:
     """
     Validate context payload against constraints from settings.
@@ -25,6 +26,7 @@ def validate_context(
         context: Context payload to validate
         settings: Settings dictionary
         provider_wire_type: Active LOGON storyteller wire class
+        provider_name: Active registry provider name (override lookup key)
 
     Returns:
         Tuple of (is_valid, list_of_errors)
@@ -34,7 +36,9 @@ def validate_context(
     # Get LORE settings
     lore_settings = settings.get("Agent Settings", {}).get("LORE", {})
 
-    apex_window = resolve_storyteller_context_window(settings, provider_wire_type)
+    apex_window = resolve_storyteller_context_window(
+        settings, provider_wire_type, provider_name
+    )
 
     # Get the percentage ranges
     ranges = lore_settings.get("payload_percent_budget", {})

--- a/nexus/agents/lore/utils/entity_inclusion.py
+++ b/nexus/agents/lore/utils/entity_inclusion.py
@@ -44,12 +44,22 @@ def _base_entity_inclusion(
 def resolve_entity_inclusion(
     settings: Mapping[str, Any],
     provider_wire_type: Optional[str],
+    provider_name: Optional[str],
 ) -> EntityInclusionConfig:
-    """Resolve effective entity inclusion for one storyteller wire class.
+    """Resolve effective entity inclusion for one storyteller provider.
 
-    ``None`` is the named LOGON-disabled path and therefore returns base values.
-    Active LOGON callers must establish a wire class before calling this function.
+    ``None``/``None`` is the named LOGON-disabled path and returns base values.
+    Active LOGON callers must establish the full route first. The override
+    lookup keys on the registry provider NAME: resource profiles belong to the
+    serving provider, not the wire dialect, so an OpenAI-compatible remote
+    provider (openrouter) shares the "local" wire class but keeps base
+    inclusion unless it has its own override entry.
     """
+    if (provider_wire_type is None) != (provider_name is None):
+        raise RuntimeError(
+            "provider_wire_type and provider_name must be supplied together; got "
+            f"wire={provider_wire_type!r}, provider={provider_name!r}"
+        )
     if (
         provider_wire_type is not None
         and provider_wire_type not in _STORYTELLER_WIRE_CLASSES
@@ -61,10 +71,10 @@ def resolve_entity_inclusion(
         )
 
     base = _base_entity_inclusion(settings)
-    if provider_wire_type is None:
+    if provider_wire_type is None or provider_name is None:
         return base
 
-    override = base.provider_overrides.get(provider_wire_type)
+    override = base.provider_overrides.get(provider_name)
     if override is None:
         return base
 
@@ -76,7 +86,9 @@ def resolve_entity_inclusion(
     }
     if resolved_differences:
         logger.debug(
-            "Storyteller entity inclusion override: class=%s resolved=%s",
+            "Storyteller entity inclusion override: provider=%s class=%s "
+            "resolved=%s",
+            provider_name,
             provider_wire_type,
             resolved_differences,
         )

--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -42,6 +42,7 @@ class TurnContext:
     error_log: List[str] = field(default_factory=list)
     token_counts: Dict[str, int] = field(default_factory=dict)
     provider_wire_type: Optional[str] = None
+    provider_name: Optional[str] = None
     apex_model: Optional[str] = None
     memory_state: Dict[str, Any] = field(default_factory=dict)
     target_chunk_id: Optional[int] = None

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -301,11 +301,14 @@ class TurnCycleManager:
                         "Active LOGON provider is required for storyteller payload "
                         "sizing"
                     )
-                apex_model, provider_wire_type = logon.resolve_storyteller_route()
+                apex_model, provider_wire_type, provider_name = (
+                    logon.resolve_storyteller_route()
+                )
                 turn_context.apex_model = apex_model
                 turn_context.provider_wire_type = provider_wire_type
+                turn_context.provider_name = provider_name
                 apex_context_window = memory_manager.configure_storyteller_budget(
-                    provider_wire_type
+                    provider_wire_type, provider_name
                 )
                 turn_context.token_counts = self.lore.token_manager.calculate_budget(
                     turn_context.user_input,
@@ -460,17 +463,22 @@ class TurnCycleManager:
             return
 
         if getattr(self.lore, "enable_logon", True):
-            if turn_context.provider_wire_type is None:
+            if (
+                turn_context.provider_wire_type is None
+                or turn_context.provider_name is None
+            ):
                 raise RuntimeError(
-                    "Active LOGON entity queries require the storyteller provider "
-                    "wire class resolved during Phase 1"
+                    "Active LOGON entity queries require the storyteller route "
+                    "(wire class and provider name) resolved during Phase 1"
                 )
             entity_settings = resolve_entity_inclusion(
-                self.settings, turn_context.provider_wire_type
+                self.settings,
+                turn_context.provider_wire_type,
+                turn_context.provider_name,
             )
         else:
             entity_settings = resolve_entity_inclusion(
-                self.settings, provider_wire_type=None
+                self.settings, provider_wire_type=None, provider_name=None
             )
         include_relationships = entity_settings.include_all_relationships
         include_events = entity_settings.include_all_active_events

--- a/nexus/api/mock_openai.py
+++ b/nexus/api/mock_openai.py
@@ -977,6 +977,28 @@ def _mock_storyteller_response(prompt: str) -> Dict[str, Any]:
     return response
 
 
+_WRITER_WIRE_FIELDS = ("narrative", "choices", "scene", "presence", "operations")
+_CLERK_WIRE_FIELDS = ("updates", "orrery_adjudications", "new_entities")
+
+
+def _mock_writer_response(prompt: str) -> Dict[str, Any]:
+    """Project the writer pass of the two-pass pipeline from the full fixture.
+
+    Projection (rather than a hand-built sibling dict) keeps the split
+    responses shape-coherent with the full turn fixture forever: any field the
+    full mock grows lands in exactly one pass, and extra=forbid on the pass
+    wires makes leakage loud in tests.
+    """
+    full = _mock_storyteller_response(prompt)
+    return {key: full[key] for key in _WRITER_WIRE_FIELDS if key in full}
+
+
+def _mock_clerk_response(prompt: str) -> Dict[str, Any]:
+    """Project the clerk pass of the two-pass pipeline from the full fixture."""
+    full = _mock_storyteller_response(prompt)
+    return {key: full[key] for key in _CLERK_WIRE_FIELDS if key in full}
+
+
 def _responses_payload(
     output_data: Dict[str, Any],
     *,
@@ -1095,19 +1117,37 @@ async def responses_create(request: ResponsesRequest):
     proposal_ids = _extract_orrery_proposal_ids(input_text)
 
     # Exact routing: the structured-output tool's schema says which
-    # Storyteller response the caller validates against. Turn requests
-    # (SkaldTurnWire) expose the optional updates namespace; bootstrap requests
-    # (StorytellerResponseBootstrap) do not.
+    # Storyteller response the caller validates against. The full turn wire
+    # (SkaldTurnWire) exposes BOTH narrative and updates; the two-pass split
+    # separates them (SkaldWriterWire = narrative/presence without updates,
+    # SkaldClerkWire = updates without narrative — extra=forbid, so each pass
+    # must receive only its own projection); bootstrap requests
+    # (StorytellerResponseBootstrap) carry neither updates nor presence.
     output_fields = _requested_output_properties(request)
     if output_fields:
         final_result_tool = _requested_output_uses_final_result_tool(request)
-        if "updates" in output_fields:
+        if "updates" in output_fields and "narrative" in output_fields:
             logger.info(
                 "[MOCK] Skald turn wire requested (%d Orrery proposals)",
                 len(proposal_ids),
             )
             return _responses_payload(
                 _mock_storyteller_response(input_text),
+                final_result_tool=final_result_tool,
+            )
+        if "updates" in output_fields:
+            logger.info(
+                "[MOCK] Skald clerk wire requested (%d Orrery proposals)",
+                len(proposal_ids),
+            )
+            return _responses_payload(
+                _mock_clerk_response(input_text),
+                final_result_tool=final_result_tool,
+            )
+        if "presence" in output_fields:
+            logger.info("[MOCK] Skald writer wire requested")
+            return _responses_payload(
+                _mock_writer_response(input_text),
                 final_result_tool=final_result_tool,
             )
         logger.info("[MOCK] Bootstrap schema requested, returning cached bootstrap")

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -608,19 +608,24 @@ class TokenBudgetConfig(BaseModel):
     )
     provider_overrides: Dict[str, int] = Field(
         default_factory=dict,
-        description="Smaller APEX context windows by storyteller provider class",
+        description=(
+            "Smaller APEX context windows by registry provider NAME. Providers "
+            "without an entry (e.g. openrouter) keep the full base window; "
+            "extend the legal-key set when a new provider actually needs a "
+            "constrained profile."
+        ),
     )
 
     @model_validator(mode="after")
     def _validate_provider_overrides(self) -> "TokenBudgetConfig":
         """Provider overrides are closed-keyed reductions of the base window."""
-        legal_provider_classes = {"openai", "anthropic", "local"}
-        unknown_provider_classes = set(self.provider_overrides) - legal_provider_classes
-        if unknown_provider_classes:
+        legal_provider_names = {"openai", "anthropic", "local"}
+        unknown_provider_names = set(self.provider_overrides) - legal_provider_names
+        if unknown_provider_names:
             raise ValueError(
                 "token budget provider_overrides contains unknown provider "
-                f"classes: {sorted(unknown_provider_classes)}; legal keys are "
-                f"{sorted(legal_provider_classes)}"
+                f"names: {sorted(unknown_provider_names)}; legal keys are "
+                f"{sorted(legal_provider_names)}"
             )
 
         for provider_class, override in self.provider_overrides.items():
@@ -689,19 +694,22 @@ class EntityInclusionConfig(BaseModel):
     max_total_threats: int = Field(..., ge=1)
     provider_overrides: Dict[str, EntityInclusionProviderOverride] = Field(
         default_factory=dict,
-        description="Entity-inclusion overrides by storyteller provider class",
+        description=(
+            "Entity-inclusion overrides by registry provider NAME. Providers "
+            "without an entry (e.g. openrouter) keep base inclusion."
+        ),
     )
 
     @model_validator(mode="after")
     def _validate_provider_overrides(self) -> "EntityInclusionConfig":
-        """Provider overrides use the closed storyteller wire-class set."""
-        legal_provider_classes = {"openai", "anthropic", "local"}
-        unknown_provider_classes = set(self.provider_overrides) - legal_provider_classes
-        if unknown_provider_classes:
+        """Provider overrides use a closed provider-name set."""
+        legal_provider_names = {"openai", "anthropic", "local"}
+        unknown_provider_names = set(self.provider_overrides) - legal_provider_names
+        if unknown_provider_names:
             raise ValueError(
                 "entity inclusion provider_overrides contains unknown provider "
-                f"classes: {sorted(unknown_provider_classes)}; legal keys are "
-                f"{sorted(legal_provider_classes)}"
+                f"names: {sorted(unknown_provider_names)}; legal keys are "
+                f"{sorted(legal_provider_names)}"
             )
         return self
 

--- a/nexus/memory/manager.py
+++ b/nexus/memory/manager.py
@@ -97,14 +97,28 @@ def resolve_storyteller_prompt_overhead_tokens(
 
 
 def resolve_storyteller_context_window(
-    settings: Mapping[str, Any], provider_wire_type: Optional[str]
+    settings: Mapping[str, Any],
+    provider_wire_type: Optional[str],
+    provider_name: Optional[str],
 ) -> int:
-    """Resolve the assembled-context ceiling for one storyteller provider class."""
+    """Resolve the assembled-context ceiling for one storyteller provider.
+
+    The wire class proves an active route was resolved; the override lookup
+    keys on the registry provider NAME, because resource profiles belong to
+    the serving provider, not the wire dialect (an OpenAI-compatible remote
+    provider such as openrouter shares the "local" wire class but must not
+    inherit the compute-bound local payload squeeze).
+    """
     if provider_wire_type not in _STORYTELLER_WIRE_CLASSES:
         raise RuntimeError(
             "Cannot resolve the storyteller context budget without a valid active "
             "provider wire class; expected one of "
             f"{sorted(_STORYTELLER_WIRE_CLASSES)}, got {provider_wire_type!r}"
+        )
+    if not isinstance(provider_name, str) or not provider_name.strip():
+        raise RuntimeError(
+            "Cannot resolve the storyteller context budget without the active "
+            f"registry provider name; got {provider_name!r}"
         )
 
     token_budget = _storyteller_token_budget(settings)
@@ -114,17 +128,19 @@ def resolve_storyteller_context_window(
     if not isinstance(provider_overrides, Mapping):
         raise TypeError("token_budget provider_overrides must be a mapping")
 
-    override = provider_overrides.get(provider_wire_type)
+    override = provider_overrides.get(provider_name)
     if override is None:
         return apex_context_window
     if not isinstance(override, int):
         raise TypeError(
-            f"token budget provider override for {provider_wire_type!r} must be "
+            f"token budget provider override for {provider_name!r} must be "
             "an integer"
         )
 
     logger.debug(
-        "Storyteller payload budget override: class=%s effective=%s tokens",
+        "Storyteller payload budget override: provider=%s class=%s effective=%s "
+        "tokens",
+        provider_name,
         provider_wire_type,
         override,
     )
@@ -238,6 +254,7 @@ class ContextMemoryManager:
         memnon: Optional[object] = None,
         token_manager: Optional[object] = None,
         provider_wire_type: Optional[str] = None,
+        provider_name: Optional[str] = None,
     ) -> None:
         self.settings = settings
         self.memnon = memnon  # Store reference for entity detector
@@ -257,10 +274,15 @@ class ContextMemoryManager:
         # The active storyteller class is resolved per turn because slots can
         # change models while a LORE instance remains alive.
         self.provider_wire_type: Optional[str] = None
+        self.provider_name: Optional[str] = None
         self.phase2_budget: Optional[int] = None
         self._storyteller_budget_configured = False
-        if provider_wire_type is not None:
-            self.configure_storyteller_budget(provider_wire_type)
+        if (provider_wire_type is None) != (provider_name is None):
+            raise ValueError(
+                "provider_wire_type and provider_name must be supplied together"
+            )
+        if provider_wire_type is not None and provider_name is not None:
+            self.configure_storyteller_budget(provider_wire_type, provider_name)
 
         # Legacy settings (kept for compatibility but may be deprecated)
         self.pass2_reserve = float(memory_settings.get("pass2_budget_reserve", 0.25))
@@ -308,12 +330,15 @@ class ContextMemoryManager:
 
         self._initialize_entity_maps(memnon)
 
-    def configure_storyteller_budget(self, provider_wire_type: str) -> int:
-        """Apply the active provider class to every memory payload budget."""
+    def configure_storyteller_budget(
+        self, provider_wire_type: str, provider_name: str
+    ) -> int:
+        """Apply the active provider's resource profile to payload budgets."""
         apex_context_window = resolve_storyteller_context_window(
-            self.settings, provider_wire_type
+            self.settings, provider_wire_type, provider_name
         )
         self.provider_wire_type = provider_wire_type
+        self.provider_name = provider_name
         self._storyteller_budget_configured = True
         self._configure_phase2_budget(apex_context_window)
         return apex_context_window
@@ -322,6 +347,7 @@ class ContextMemoryManager:
         """Use the base window for a turn where LOGON is explicitly disabled."""
         apex_context_window = resolve_base_storyteller_context_window(self.settings)
         self.provider_wire_type = None
+        self.provider_name = None
         self._storyteller_budget_configured = True
         self._configure_phase2_budget(apex_context_window)
         return apex_context_window

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -142,10 +142,11 @@ def test_apex_rejects_unknown_anthropic_storyteller_transport() -> None:
         Settings(**raw)
 
 
-def test_shipped_turn_pipeline_defaults_to_single_pass() -> None:
+def test_shipped_turn_pipeline_is_two_pass() -> None:
+    """Committed default per the #578 casting ruling (owner, 2026-07-26)."""
     settings = Settings(**_nexus_toml_dict())
 
-    assert settings.apex.turn_pipeline == "single_pass"
+    assert settings.apex.turn_pipeline == "two_pass"
 
 
 def test_apex_rejects_unknown_turn_pipeline() -> None:
@@ -170,11 +171,11 @@ def test_token_budget_provider_overrides_parse() -> None:
 
 
 def test_token_budget_provider_overrides_reject_unknown_key() -> None:
-    """Provider override keys are the closed storyteller wire-class set."""
+    """Provider override keys are a closed provider-name set."""
     raw = _nexus_toml_dict()
     raw["lore"]["token_budget"]["provider_overrides"]["bedrock"] = 20_000
 
-    with pytest.raises(ValidationError, match="unknown provider classes.*bedrock"):
+    with pytest.raises(ValidationError, match="unknown provider names.*bedrock"):
         Settings(**raw)
 
 
@@ -233,11 +234,11 @@ def test_entity_inclusion_provider_overrides_parse() -> None:
 
 
 def test_entity_inclusion_provider_overrides_reject_unknown_outer_key() -> None:
-    """Provider override tables use the closed storyteller wire-class set."""
+    """Provider override tables use a closed provider-name set."""
     raw = _nexus_toml_dict()
     raw["lore"]["entity_inclusion"]["provider_overrides"]["bedrock"] = {}
 
-    with pytest.raises(ValidationError, match="unknown provider classes.*bedrock"):
+    with pytest.raises(ValidationError, match="unknown provider names.*bedrock"):
         Settings(**raw)
 
 

--- a/tests/test_lore/test_context_validation.py
+++ b/tests/test_lore/test_context_validation.py
@@ -26,7 +26,7 @@ class TestContextValidation:
             },
         }
 
-        is_valid, errors = validate_context(context, settings, "openai")
+        is_valid, errors = validate_context(context, settings, "openai", "openai")
         assert is_valid
         assert len(errors) == 0
 
@@ -37,7 +37,7 @@ class TestContextValidation:
             "narrative_context": {"warm_slice": []}
         }
 
-        is_valid, errors = validate_context(context, settings, "openai")
+        is_valid, errors = validate_context(context, settings, "openai", "openai")
         assert not is_valid
         assert "Missing user_input" in errors
 
@@ -48,7 +48,7 @@ class TestContextValidation:
             "narrative_context": {"warm_slice": []},  # Empty
         }
 
-        is_valid, errors = validate_context(context, settings, "openai")
+        is_valid, errors = validate_context(context, settings, "openai", "openai")
         assert not is_valid
         assert any("warm_slice" in e for e in errors)
 
@@ -66,7 +66,7 @@ class TestContextValidation:
             },
         }
 
-        is_valid, errors = validate_context(context, settings, "openai")
+        is_valid, errors = validate_context(context, settings, "openai", "openai")
         assert not is_valid
         assert any("Token limit exceeded" in e for e in errors)
 
@@ -84,7 +84,7 @@ class TestContextValidation:
             },
         }
 
-        is_valid, errors = validate_context(context, settings, "openai")
+        is_valid, errors = validate_context(context, settings, "openai", "openai")
         assert not is_valid
         # Should have errors for all three components
         assert any("Warm slice below minimum" in e for e in errors)

--- a/tests/test_lore/test_entity_inclusion.py
+++ b/tests/test_lore/test_entity_inclusion.py
@@ -17,15 +17,23 @@ def _effective_values(config: Any) -> Dict[str, Any]:
     return config.model_dump(exclude={"provider_overrides"})
 
 
+def _base(settings: Dict[str, Any]) -> Any:
+    return resolve_entity_inclusion(
+        settings, provider_wire_type=None, provider_name=None
+    )
+
+
 def test_local_entity_inclusion_resolves_shipped_overrides(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Local routing applies four overrides and inherits every absent field."""
     settings = load_settings_as_dict()
-    base = resolve_entity_inclusion(settings, provider_wire_type=None)
+    base = _base(settings)
 
     with caplog.at_level(logging.DEBUG, logger="nexus.lore.entity_inclusion"):
-        resolved = resolve_entity_inclusion(settings, provider_wire_type="local")
+        resolved = resolve_entity_inclusion(
+            settings, provider_wire_type="local", provider_name="local"
+        )
 
     assert resolved.warm_slice_lookback_chunks == 12
     assert resolved.max_characters_from_warm_slice == 12
@@ -42,29 +50,47 @@ def test_local_entity_inclusion_resolves_shipped_overrides(
         if record.name == "nexus.lore.entity_inclusion"
     ]
     assert len(override_records) == 1
-    assert "class=local" in override_records[0].getMessage()
+    assert "provider=local" in override_records[0].getMessage()
     assert "'warm_slice_lookback_chunks': 12" in override_records[0].getMessage()
     assert "'include_all_relationships': False" in override_records[0].getMessage()
 
 
-@pytest.mark.parametrize("provider_wire_type", ["openai", "anthropic"])
+@pytest.mark.parametrize(
+    ("provider_wire_type", "provider_name"),
+    [("openai", "openai"), ("anthropic", "anthropic")],
+)
 def test_unconfigured_provider_entity_inclusion_is_pure_base(
     provider_wire_type: str,
+    provider_name: str,
 ) -> None:
-    """Provider classes without a table inherit the complete base config."""
+    """Providers without a table inherit the complete base config."""
     settings = load_settings_as_dict()
-    base = resolve_entity_inclusion(settings, provider_wire_type=None)
+    base = _base(settings)
 
-    resolved = resolve_entity_inclusion(settings, provider_wire_type)
+    resolved = resolve_entity_inclusion(settings, provider_wire_type, provider_name)
 
     assert _effective_values(resolved) == _effective_values(base)
+
+
+def test_remote_compatible_provider_keeps_base_inclusion() -> None:
+    """openrouter shares the local wire class but must NOT inherit its squeeze."""
+    settings = load_settings_as_dict()
+    base = _base(settings)
+
+    resolved = resolve_entity_inclusion(
+        settings, provider_wire_type="local", provider_name="openrouter"
+    )
+
+    assert _effective_values(resolved) == _effective_values(base)
+    assert resolved.max_characters_from_warm_slice == 25
+    assert resolved.include_all_relationships is True
 
 
 def test_logon_disabled_entity_inclusion_is_explicit_base() -> None:
     """The named no-wire-class path preserves the complete base config."""
     settings = load_settings_as_dict()
 
-    resolved = resolve_entity_inclusion(settings, provider_wire_type=None)
+    resolved = _base(settings)
 
     assert resolved.warm_slice_lookback_chunks == 20
     assert resolved.max_characters_from_warm_slice == 25
@@ -78,10 +104,12 @@ def test_empty_entity_inclusion_override_table_is_pure_base(
     """An empty provider table neither changes values nor emits an override log."""
     settings = copy.deepcopy(load_settings_as_dict())
     settings["lore"]["entity_inclusion"]["provider_overrides"] = {"local": {}}
-    base = resolve_entity_inclusion(settings, provider_wire_type=None)
+    base = _base(settings)
 
     with caplog.at_level(logging.DEBUG, logger="nexus.lore.entity_inclusion"):
-        resolved = resolve_entity_inclusion(settings, provider_wire_type="local")
+        resolved = resolve_entity_inclusion(
+            settings, provider_wire_type="local", provider_name="local"
+        )
 
     assert _effective_values(resolved) == _effective_values(base)
     assert not [
@@ -92,9 +120,23 @@ def test_empty_entity_inclusion_override_table_is_pure_base(
 
 
 def test_unknown_entity_inclusion_wire_class_fails_loudly() -> None:
-    """Runtime callers cannot bypass the closed provider-class contract."""
+    """Runtime callers cannot bypass the closed wire-class contract."""
     with pytest.raises(RuntimeError, match="unknown provider wire class.*bedrock"):
         resolve_entity_inclusion(
             load_settings_as_dict(),
             provider_wire_type="bedrock",
+            provider_name="bedrock",
+        )
+
+
+def test_incoherent_route_halves_fail_loudly() -> None:
+    """Wire class and provider name must be supplied together."""
+    settings = load_settings_as_dict()
+    with pytest.raises(RuntimeError, match="supplied together"):
+        resolve_entity_inclusion(
+            settings, provider_wire_type="local", provider_name=None
+        )
+    with pytest.raises(RuntimeError, match="supplied together"):
+        resolve_entity_inclusion(
+            settings, provider_wire_type=None, provider_name="local"
         )

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -104,6 +104,7 @@ def patched_provider(monkeypatch: pytest.MonkeyPatch) -> Dict[str, int]:
             self.bootstrap_mode if is_bootstrap is None else is_bootstrap
         )
         self._provider_wire_type = "openai"
+        self._provider_type_name = "openai"
 
     for target in (
         "nexus.agents.lore.logon_utility.LogonUtility._initialize_provider",
@@ -264,6 +265,7 @@ def test_storyteller_route_resolves_without_constructing_provider(
     assert logon.resolve_storyteller_route() == (
         "storyteller-model",
         expected_wire_type,
+        provider_type,
     )
     assert logon.provider is None
 
@@ -374,6 +376,7 @@ async def test_logon_async_generation_uses_structured_provider() -> None:
     logon.provider = cast(Any, provider)
     logon._provider_bootstrap_mode = False
     logon._provider_wire_type = "openai"
+    logon._provider_type_name = "openai"
 
     response = await logon.generate_narrative_async(
         _minimal_payload(),
@@ -397,6 +400,7 @@ async def test_logon_async_generation_uses_bootstrap_schema_for_bootstrap() -> N
     logon.provider = cast(Any, provider)
     logon._provider_bootstrap_mode = True
     logon._provider_wire_type = "openai"
+    logon._provider_type_name = "openai"
 
     response = await logon.generate_narrative_async(
         _minimal_payload(is_bootstrap=True),
@@ -433,6 +437,7 @@ async def test_logon_stamps_model_exposed_by_last_successful_attempt() -> None:
     logon.provider = cast(Any, provider)
     logon._provider_bootstrap_mode = False
     logon._provider_wire_type = "openai"
+    logon._provider_type_name = "openai"
 
     response = await logon.generate_narrative_async(
         _minimal_payload(),
@@ -451,6 +456,7 @@ async def test_logon_structured_failure_does_not_call_plain_text_fallback() -> N
     logon.provider = cast(Any, provider)
     logon._provider_bootstrap_mode = False
     logon._provider_wire_type = "openai"
+    logon._provider_type_name = "openai"
 
     with pytest.raises(RuntimeError, match="structured boom"):
         await logon.generate_narrative_async(
@@ -476,6 +482,7 @@ def test_context_bootstrap_mode_does_not_mutate_logon_instance(
             self.bootstrap_mode if is_bootstrap is None else is_bootstrap
         )
         self._provider_wire_type = "openai"
+        self._provider_type_name = "openai"
 
     monkeypatch.setattr(LogonUtility, "_initialize_provider", _fake_initialize)
 
@@ -513,6 +520,7 @@ async def test_final_prompt_overflow_from_tag_library_raises(
     logon.provider = cast(Any, provider)
     logon._provider_bootstrap_mode = False
     logon._provider_wire_type = "local"
+    logon._provider_type_name = "local"
 
     class PromptLore:
         def __init__(self) -> None:

--- a/tests/test_lore/test_memory_manager.py
+++ b/tests/test_lore/test_memory_manager.py
@@ -89,25 +89,36 @@ def baseline_inputs() -> Dict[str, object]:
 
 
 @pytest.mark.parametrize(
-    ("provider_wire_type", "expected_window", "expected_phase2_budget"),
+    (
+        "provider_wire_type",
+        "provider_name",
+        "expected_window",
+        "expected_phase2_budget",
+    ),
     [
-        ("local", 24_000, 2_400),
-        ("openai", 75_000, 7_500),
-        ("anthropic", 75_000, 7_500),
+        ("local", "local", 24_000, 2_400),
+        ("openai", "openai", 75_000, 7_500),
+        ("anthropic", "anthropic", 75_000, 7_500),
+        # OpenAI-compatible remote providers share the "local" wire class but
+        # have no override entry: they must keep the full frontier window.
+        ("local", "openrouter", 75_000, 7_500),
     ],
 )
 def test_provider_override_resolves_at_memory_manager_seam(
     minimal_settings,
     caplog: pytest.LogCaptureFixture,
     provider_wire_type: str,
+    provider_name: str,
     expected_window: int,
     expected_phase2_budget: int,
 ) -> None:
-    """The turn-cycle seam resolves one provider-class budget for assembly."""
+    """The turn-cycle seam resolves one provider-name budget for assembly."""
     manager = ContextMemoryManager(minimal_settings)
 
     with caplog.at_level(logging.DEBUG, logger="nexus.memory.manager"):
-        effective_window = manager.configure_storyteller_budget(provider_wire_type)
+        effective_window = manager.configure_storyteller_budget(
+            provider_wire_type, provider_name
+        )
 
     assert effective_window == expected_window
     assert manager.phase2_budget == expected_phase2_budget
@@ -116,9 +127,9 @@ def test_provider_override_resolves_at_memory_manager_seam(
         for record in caplog.records
         if "Storyteller payload budget override" in record.getMessage()
     ]
-    assert len(override_logs) == (1 if provider_wire_type == "local" else 0)
+    assert len(override_logs) == (1 if provider_name == "local" else 0)
     if override_logs:
-        assert "class=local" in override_logs[0].getMessage()
+        assert "provider=local" in override_logs[0].getMessage()
         assert "effective=24000" in override_logs[0].getMessage()
 
 
@@ -131,7 +142,7 @@ def test_empty_provider_override_table_uses_base_budget(
     manager = ContextMemoryManager(settings)
 
     with caplog.at_level(logging.DEBUG, logger="nexus.memory.manager"):
-        effective_window = manager.configure_storyteller_budget("local")
+        effective_window = manager.configure_storyteller_budget("local", "local")
 
     assert effective_window == 75_000
     assert manager.phase2_budget == 7_500
@@ -143,7 +154,17 @@ def test_missing_provider_wire_type_is_programming_error(minimal_settings) -> No
     manager = ContextMemoryManager(minimal_settings)
 
     with pytest.raises(RuntimeError, match="valid active provider wire class"):
-        manager.configure_storyteller_budget(None)  # type: ignore[arg-type]
+        manager.configure_storyteller_budget(None, "openai")  # type: ignore[arg-type]
+
+
+def test_missing_provider_name_is_programming_error(minimal_settings) -> None:
+    """The override lookup key cannot be silently absent or blank."""
+    manager = ContextMemoryManager(minimal_settings)
+
+    with pytest.raises(RuntimeError, match="registry provider name"):
+        manager.configure_storyteller_budget("local", None)  # type: ignore[arg-type]
+    with pytest.raises(RuntimeError, match="registry provider name"):
+        manager.configure_storyteller_budget("local", "  ")
 
 
 def test_explicit_base_budget_mode_configures_phase2(minimal_settings) -> None:
@@ -165,6 +186,7 @@ def test_pass1_baseline_tracks_chunks_and_budget(
         minimal_settings,
         memnon=dummy_memnon,
         provider_wire_type="openai",
+        provider_name="openai",
     )
 
     package = manager.handle_storyteller_response(
@@ -196,6 +218,7 @@ def test_pass1_records_reserve_shortfall(
         minimal_settings,
         memnon=dummy_memnon,
         provider_wire_type="openai",
+        provider_name="openai",
     )
 
     tight_tokens = {
@@ -228,6 +251,7 @@ def test_pass2_divergence_triggers_incremental_retrieval(
         minimal_settings,
         memnon=dummy_memnon,
         provider_wire_type="openai",
+        provider_name="openai",
     )
 
     manager.handle_storyteller_response(
@@ -277,6 +301,7 @@ def test_pass2_preserves_entity_detection_when_character_is_in_baseline(
         minimal_settings,
         memnon=dummy_memnon,
         provider_wire_type="openai",
+        provider_name="openai",
     )
     manager.entity_detector.character_lookup = {
         "emilia": {"id": 2, "name": "Emilia", "summary": None}
@@ -303,6 +328,7 @@ def test_pass2_marks_matched_entities_outside_baseline(
         minimal_settings,
         memnon=dummy_memnon,
         provider_wire_type="openai",
+        provider_name="openai",
     )
     manager.entity_detector.character_lookup = {
         "victor": {"id": 99, "name": "Victor", "summary": None}
@@ -337,6 +363,7 @@ def test_pass1_separates_structured_passages(
         minimal_settings,
         memnon=dummy_memnon,
         provider_wire_type="openai",
+        provider_name="openai",
     )
 
     structured = {
@@ -373,6 +400,7 @@ def test_pass2_warm_slice_expansion_without_divergence(
         minimal_settings,
         memnon=dummy_memnon,
         provider_wire_type="openai",
+        provider_name="openai",
     )
 
     manager.handle_storyteller_response(
@@ -406,6 +434,7 @@ def test_augment_warm_slice_merges_incremental_additions(
         minimal_settings,
         memnon=dummy_memnon,
         provider_wire_type="openai",
+        provider_name="openai",
     )
 
     manager.handle_storyteller_response(
@@ -442,6 +471,7 @@ def test_get_memory_summary_reports_state(
         minimal_settings,
         memnon=dummy_memnon,
         provider_wire_type="openai",
+        provider_name="openai",
     )
 
     manager.handle_storyteller_response(

--- a/tests/test_lore/test_retrieval_coverage.py
+++ b/tests/test_lore/test_retrieval_coverage.py
@@ -32,6 +32,7 @@ def test_handle_user_input_skips_retrieval_coverage_without_database(
         },
         memnon=FakeMemnon(),
         provider_wire_type="openai",
+        provider_name="openai",
     )
     manager.handle_storyteller_response(
         narrative="The briefing ends.",

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -70,15 +70,21 @@ def _stub_baseline(
 
 
 @pytest.mark.parametrize(
-    ("apex_model", "provider_wire_type", "expected_window"),
+    ("apex_model", "provider_wire_type", "provider_name", "expected_window"),
     [
-        ("nousresearch/hermes-4-70b", "local", 32_000),
-        (None, "openai", 75_000),
-        ("claude-opus-4-8", "anthropic", 75_000),
+        ("nousresearch/hermes-4-70b", "local", "local", 32_000),
+        (None, "openai", "openai", 75_000),
+        ("claude-opus-4-8", "anthropic", "anthropic", 75_000),
+        # Remote OpenAI-compatible providers share the local wire class but
+        # keep the full frontier window (no provider_overrides entry).
+        ("moonshotai/kimi-k2.5", "local", "openrouter", 75_000),
     ],
 )
 def test_process_user_input_uses_provider_profile_budget(
-    apex_model: str | None, provider_wire_type: str, expected_window: int
+    apex_model: str | None,
+    provider_wire_type: str,
+    provider_name: str,
+    expected_window: int,
 ) -> None:
     """The real turn-cycle seam feeds one resolved window to both managers."""
 
@@ -99,13 +105,13 @@ def test_process_user_input_uses_provider_profile_budget(
         def ensure_logon(self) -> None:
             return None
 
-        def resolve_storyteller_route(self) -> tuple[str, str]:
-            return self.apex_model, provider_wire_type
+        def resolve_storyteller_route(self) -> tuple[str, str, str]:
+            return self.apex_model, provider_wire_type, provider_name
 
     lore = BudgetLore()
     manager = TurnCycleManager(lore)
     ctx = TurnContext(
-        turn_id=f"provider-profile-{provider_wire_type}",
+        turn_id=f"provider-profile-{provider_name}",
         user_input="Continue.",
         start_time=time.time(),
     )
@@ -114,6 +120,7 @@ def test_process_user_input_uses_provider_profile_budget(
 
     assert ctx.apex_model == lore.apex_model
     assert ctx.provider_wire_type == provider_wire_type
+    assert ctx.provider_name == provider_name
     assert ctx.token_counts["apex_window"] == expected_window
     assert lore.memory_manager.phase2_budget == expected_window // 10
     if apex_model is None:
@@ -282,6 +289,7 @@ def test_query_entity_states_passes_resolved_limits_to_fetch_boundary(
         user_input="Continue.",
         start_time=time.time(),
         provider_wire_type=provider_wire_type,
+        provider_name=provider_wire_type,
         warm_slice=[
             {"chunk_id": chunk_id, "text": f"Chunk {chunk_id}."}
             for chunk_id in range(30, 5, -1)
@@ -330,7 +338,7 @@ def test_query_entity_states_requires_wire_class_when_logon_is_active() -> None:
         warm_slice=[{"chunk_id": 1, "text": "Parent."}],
     )
 
-    with pytest.raises(RuntimeError, match="require.*provider wire class"):
+    with pytest.raises(RuntimeError, match="require.*wire class and provider name"):
         asyncio.run(manager.query_entity_states(ctx))
 
 
@@ -398,8 +406,8 @@ def test_local_payload_trims_oldest_warm_chunks_and_keeps_parent(
         def ensure_logon(self) -> None:
             return None
 
-        def resolve_storyteller_route(self) -> tuple[str, str]:
-            return "nousresearch/hermes-4-70b", "local"
+        def resolve_storyteller_route(self) -> tuple[str, str, str]:
+            return "nousresearch/hermes-4-70b", "local", "local"
 
     lore = LocalLore()
     turn_manager = TurnCycleManager(lore)
@@ -451,6 +459,7 @@ def test_frontier_payload_below_ceiling_is_unchanged(
         start_time=time.time(),
     )
     ctx.provider_wire_type = "openai"
+    ctx.provider_name = "openai"
     ctx.warm_slice = [{"chunk_id": 10, "text": "Recent narrative.", "is_target": True}]
     ctx.entity_data = {"characters": [{"name": "Mara", "summary": "Alert."}]}
     ctx.retrieved_passages = [{"chunk_id": 2, "text": "Earlier context."}]
@@ -506,6 +515,7 @@ def test_payload_trims_retrieved_passages_last_first(
         start_time=time.time(),
     )
     ctx.provider_wire_type = "local"
+    ctx.provider_name = "local"
     ctx.warm_slice = [{"chunk_id": 3, "text": "parent " * 600, "is_target": True}]
     ctx.retrieved_passages = [
         {"chunk_id": 1, "text": "first " * 250},
@@ -562,6 +572,7 @@ def test_trimmed_pass2_chunk_is_unregistered_refunded_and_retrievable() -> None:
                 self.settings,
                 memnon=self.memnon,
                 provider_wire_type="openai",
+                provider_name="openai",
             )
             self.token_manager = None
 
@@ -595,6 +606,7 @@ def test_trimmed_pass2_chunk_is_unregistered_refunded_and_retrievable() -> None:
     )
 
     first_turn.provider_wire_type = "openai"
+    first_turn.provider_name = "openai"
     first_turn.warm_slice = lore.memory_manager.augment_warm_slice([parent])
     first_turn.token_counts = {
         "total_available": 1_000,
@@ -649,6 +661,7 @@ def test_structured_payload_overflow_raises(
         start_time=time.time(),
     )
     ctx.provider_wire_type = "local"
+    ctx.provider_name = "local"
     ctx.warm_slice = [{"chunk_id": 3, "text": "Parent.", "is_target": True}]
     ctx.entity_data = {"characters": [{"summary": "structured " * 1_500}]}
     ctx.token_counts = {

--- a/tests/test_lore/test_two_pass_pipeline.py
+++ b/tests/test_lore/test_two_pass_pipeline.py
@@ -305,6 +305,7 @@ def _utility(
     utility.provider = cast(Any, provider)
     utility._provider_bootstrap_mode = bootstrap
     utility._provider_wire_type = cast(Any, provider_type)
+    utility._provider_type_name = provider_type
     utility._system_prompt = provider.system_prompt
     return utility, provider
 

--- a/tests/test_mock_openai.py
+++ b/tests/test_mock_openai.py
@@ -7,11 +7,17 @@ import pytest
 from nexus.agents.logon.apex_schema import (
     StorytellerResponseBootstrap,
 )
-from nexus.agents.logon.skald_wire import SkaldTurnWire
+from nexus.agents.logon.skald_wire import (
+    SkaldClerkWire,
+    SkaldTurnWire,
+    SkaldWriterWire,
+)
 from nexus.api.mock_openai import (
     ResponsesRequest,
     _collect_text,
+    _mock_clerk_response,
     _mock_storyteller_response,
+    _mock_writer_response,
     _requested_output_properties,
     responses_create,
 )
@@ -207,6 +213,89 @@ async def test_mock_responses_routes_turn_schema_as_native_text_format() -> None
     payload = json.loads(response["output_text"])
     parsed = SkaldTurnWire.model_validate(payload)
     assert parsed.narrative.startswith("[TEST MODE]")
+    assert parsed.updates is None
+    assert parsed.orrery_adjudications == []
+
+
+_ORRERY_PROMPT = """
+=== ORRERY IMMINENT ACTIVITY ===
+- drink:aaa [Drink routinely]: state_delta={'character.current_activity': 'x'}
+"""
+
+
+def test_mock_two_pass_projections_partition_the_full_fixture() -> None:
+    """Every full-fixture key lands in exactly one pass (extra=forbid guard)."""
+
+    full = _mock_storyteller_response(_ORRERY_PROMPT)
+    writer = _mock_writer_response(_ORRERY_PROMPT)
+    clerk = _mock_clerk_response(_ORRERY_PROMPT)
+
+    SkaldWriterWire.model_validate(writer)
+    SkaldClerkWire.model_validate(clerk)
+    assert set(writer) | set(clerk) == set(full)
+    assert set(writer) & set(clerk) == set()
+
+
+@pytest.mark.asyncio
+async def test_mock_responses_routes_writer_schema_to_writer_projection() -> None:
+    """The two-pass writer request must not receive bootstrap or clerk fields.
+
+    Regression for the PR #579 Codex P1: before signature routing, a writer
+    schema (no updates property) fell through to the cached bootstrap payload.
+    """
+
+    response = await responses_create(
+        ResponsesRequest(
+            model="TEST",
+            input=[{"role": "user", "content": "Continue the protagonist story."}],
+            tools=[_final_result_tool(SkaldWriterWire)],
+        )
+    )
+
+    payload = json.loads(response["output_text"])
+    parsed = SkaldWriterWire.model_validate(payload)
+    assert parsed.narrative.startswith("[TEST MODE]")
+    assert "updates" not in payload
+
+
+@pytest.mark.asyncio
+async def test_mock_responses_routes_clerk_schema_to_clerk_projection() -> None:
+    """The two-pass clerk request must not receive narrative/choices extras.
+
+    Regression for the PR #579 Codex P1: the clerk schema contains the updates
+    property, so the old routing returned the FULL turn payload, whose
+    narrative/choices are forbidden extras under SkaldClerkWire.
+    """
+
+    response = await responses_create(
+        ResponsesRequest(
+            model="TEST",
+            input=[{"role": "user", "content": _ORRERY_PROMPT}],
+            tools=[_final_result_tool(SkaldClerkWire)],
+        )
+    )
+
+    payload = json.loads(response["output_text"])
+    parsed = SkaldClerkWire.model_validate(payload)
+    assert "narrative" not in payload
+    assert [item.action for item in parsed.orrery_adjudications] == ["defer"]
+
+
+@pytest.mark.asyncio
+async def test_mock_responses_clerk_schema_without_proposals_is_empty() -> None:
+    """A proposal-free clerk request returns a valid all-defaults payload."""
+
+    response = await responses_create(
+        ResponsesRequest(
+            model="TEST",
+            input=[{"role": "user", "content": "Continue the protagonist story."}],
+            tools=[_final_result_tool(SkaldClerkWire)],
+        )
+    )
+
+    payload = json.loads(response["output_text"])
+    parsed = SkaldClerkWire.model_validate(payload)
+    assert payload == {}
     assert parsed.updates is None
     assert parsed.orrery_adjudications == []
 

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -1231,17 +1231,20 @@ def test_logon_selects_transport_appropriate_wire_serialization() -> None:
     utility = LogonUtility({}, dbname="save_05")
 
     utility._provider_wire_type = "openai"
+    utility._provider_type_name = "openai"
     assert utility._schema_format_kwargs(SkaldTurnWire) == {
         "text_format": skald_wire_strict_text_format()
     }
 
     utility._provider_wire_type = "local"
+    utility._provider_type_name = "local"
     utility._schema_format_cache = {}
     local_format = utility._schema_format_kwargs(SkaldTurnWire)["text_format"]
     assert local_format["name"] == "SkaldTurnWire"
     assert local_format["schema"] == skald_wire_lenient_schema()
 
     utility._provider_wire_type = "anthropic"
+    utility._provider_type_name = "anthropic"
     utility.provider = cast(
         Any,
         SimpleNamespace(structured_transport="prompted"),
@@ -1276,6 +1279,7 @@ def test_logon_selects_transport_appropriate_wire_serialization() -> None:
 def test_anthropic_wire_serialization_requires_transport_attribute() -> None:
     utility = LogonUtility({})
     utility._provider_wire_type = "anthropic"
+    utility._provider_type_name = "anthropic"
     utility.provider = cast(Any, SimpleNamespace())
 
     with pytest.raises(AttributeError, match="structured_transport"):
@@ -1285,6 +1289,7 @@ def test_anthropic_wire_serialization_requires_transport_attribute() -> None:
 def test_local_chat_response_format_carries_lenient_wire_schema() -> None:
     utility = LogonUtility({})
     utility._provider_wire_type = "local"
+    utility._provider_type_name = "local"
     text_format = utility._schema_format_kwargs(SkaldTurnWire)["text_format"]
     response_format = OpenAIProvider._chat_response_format(
         SkaldTurnWire,
@@ -1306,6 +1311,7 @@ def test_bootstrap_schema_selection_and_contract_are_unchanged() -> None:
     assert utility._select_response_schema({}) is SkaldTurnWire
 
     utility._provider_wire_type = "openai"
+    utility._provider_type_name = "openai"
     text_format = utility._schema_format_kwargs(StorytellerResponseBootstrap)[
         "text_format"
     ]
@@ -1313,6 +1319,7 @@ def test_bootstrap_schema_selection_and_contract_are_unchanged() -> None:
     assert set(text_format["schema"]["properties"]) == {"narrative", "choices"}
 
     utility._provider_wire_type = "anthropic"
+    utility._provider_type_name = "anthropic"
     utility.provider = cast(
         Any,
         SimpleNamespace(structured_transport="native"),
@@ -1389,6 +1396,7 @@ def test_sync_logon_reads_and_supplies_parent_baseline(
     utility.provider = cast(Any, WireProvider())
     utility._provider_bootstrap_mode = False
     utility._provider_wire_type = "openai"
+    utility._provider_type_name = "openai"
     response = utility.generate_narrative(
         {
             "user_input": "Continue.",
@@ -1441,6 +1449,7 @@ async def test_async_logon_reads_and_supplies_parent_baseline(
     utility.provider = cast(Any, WireProvider())
     utility._provider_bootstrap_mode = False
     utility._provider_wire_type = "openai"
+    utility._provider_type_name = "openai"
     response = await utility.generate_narrative_async(
         {
             "user_input": "Continue.",


### PR DESCRIPTION
Owner ruling on #578 (2026-07-26): keep every sampled writer-seat candidate selectable for real play, and flip the committed default to the two-pass writer+clerk pipeline (single_pass preserved as an option).

## Registry

- **New `[global.model.api_models.openrouter]` provider** — one OpenAI-compatible funnel for the six sampled prose candidates (Kimi K2.5, Kimi K3, DeepSeek V4 Pro, Hermes 4 405B, MiniMax M3, GLM-5). `api_key_secret = "openrouter"` (key already in the platform store). Zero cost until selected.
- **`claude-opus-5`** added to the Anthropic list (live on the API; flags mirror opus-4-8). Storyteller default role unchanged.
- **`turn_pipeline = "two_pass"`** committed default.

## The one real code change: resource profiles key on provider NAME

`_resolve_storyteller_route` classifies any base_url provider as wire class `local`. Without this change, OpenRouter frontier models would inherit the **32K payload squeeze and thin entity profile** that exist for compute-bound local GGUF serving — sabotaging the evaluation they're being registered for.

Now: the wire class remains the serialization/guard axis (openrouter correctly rides chat_completions + lenient schema), while `provider_overrides` lookup (token budget AND entity inclusion) keys on the registry provider name. For the three existing providers the two strings coincide, so **shipped behavior is byte-identical**; openrouter simply finds no entry and keeps the full frontier window + base inclusion. Legal override keys stay closed (`openai`/`anthropic`/`local`) until a new provider actually needs a constrained profile.

Threading: `resolve_storyteller_route()` → 3-tuple `(model, wire_class, provider_name)`; `TurnContext.provider_name`; both resolvers raise loudly on incoherent route halves; `configure_storyteller_budget(wire, name)`.

## Verification

- `pytest tests/test_skald_wire.py tests/test_native_structured_output.py tests/test_lore/ tests/config/` → **383 passed, 14 skipped** (bare exit, unpiped)
- mypy clean on all 7 touched source files; black + flake8 clean
- New regressions: openrouter-name + local-wire → 75K window (memory-manager seam AND real turn-cycle seam) + base entity inclusion; blank/absent provider name raises; shipped-default test updated to two_pass
- Pre-commit validate-config + drift checker passed on the registry additions

Closes the rung-1 registration on #578. Live two-pass + OpenRouter turn verification happens post-merge on the restarted server (slot 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ