### PR TITLE
Pin the two-pass clerk seat to a registry model (#578 rung 2)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -1050,6 +1050,13 @@ reasoning_effort = "medium"   # Reasoning effort level (low/medium/high)
 max_output_tokens = 25000     # Maximum tokens for generated narrative
 anthropic_storyteller_transport = "prompted" # "prompted", "native", or "tool_envelope"
 turn_pipeline = "two_pass" # "single_pass" or "two_pass"; two_pass default per #578 casting ruling (owner, 2026-07-26)
+# Pinned clerk seat (#578 rung 2): the state-custody pass always runs on this
+# registry model, giving OpenAI native grammar enforcement on updates /
+# adjudications / declarations while the slot model picker rotates the prose
+# chair freely. Unset to have the clerk follow the slot model (required for
+# fully-local/offline installs). TEST-provider slots always stay
+# self-contained regardless of this setting.
+clerk_model = "@openai.default"
 structured_output_retries = 3 # Validation retry budget for structured story turns
 # HTTP client timeout for a narrative continue turn. Frontier generation runs
 # inside the request and blocks the API worker, so status polls aren't answered

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -294,7 +294,10 @@ class LogonUtility:
         )
         self._provider_type_name: Optional[str] = None
         self._validation_dbname: Optional[str] = None
-        self._schema_format_cache: Dict[type, Dict[str, Any]] = {}
+        # Keyed by schema type for single-pass entries and by
+        # (schema type, wire class) tuples for two-pass entries, because the
+        # pinned clerk seat can run a different wire class than the writer.
+        self._schema_format_cache: Dict[Any, Dict[str, Any]] = {}
 
     def _turn_pipeline(self) -> Literal["single_pass", "two_pass"]:
         """Return the validated non-bootstrap storyteller pipeline lever."""
@@ -898,17 +901,162 @@ class LogonUtility:
             raise TypeError("Writer system prompt must be a string")
         return system_prompt
 
+    def _resolve_clerk_route(
+        self,
+    ) -> Optional[
+        tuple[
+            str,
+            str,
+            Optional[Dict[str, Any]],
+            Literal["openai", "anthropic", "local"],
+        ]
+    ]:
+        """Resolve the pinned clerk seat, or None to follow the slot model.
+
+        Returns None whenever the clerk should ride the proven clone path:
+        no clerk_model configured; the active writer is the TEST mock (TEST
+        slots stay self-contained and offline); or the pinned model IS the
+        slot model (a fresh provider would be an identical twin).
+        """
+        apex_settings = self.settings.get("API Settings", {}).get("apex", {})
+        clerk_model = apex_settings.get("clerk_model")
+        if not clerk_model:
+            return None
+        if self._provider_type_name is None:
+            raise RuntimeError(
+                "Clerk route resolution requires an initialized provider"
+            )
+        if self._provider_type_name == "test":
+            return None
+        turn_model = getattr(self.provider, "model", None)
+        if turn_model is None:
+            raise RuntimeError(
+                "Clerk route resolution requires the active provider's model"
+            )
+        if clerk_model == turn_model:
+            return None
+
+        provider_type = get_provider_for_model(clerk_model)
+        if provider_type is None:
+            raise ValueError(
+                f"clerk_model {clerk_model!r} is not in the model registry"
+            )
+        from nexus.config import get_openai_compatible_endpoint
+
+        endpoint = get_openai_compatible_endpoint(clerk_model)
+        base_url = endpoint["base_url"] if endpoint else None
+        clerk_wire: Literal["openai", "anthropic", "local"]
+        if provider_type == "anthropic":
+            clerk_wire = "anthropic"
+        elif provider_type == "openai" or base_url:
+            clerk_wire = "local" if base_url else "openai"
+        else:
+            raise ValueError(f"Unsupported clerk provider type: {provider_type}")
+        return clerk_model, provider_type, endpoint, clerk_wire
+
+    def _build_clerk_provider(
+        self,
+        clerk_route: tuple[
+            str,
+            str,
+            Optional[Dict[str, Any]],
+            Literal["openai", "anthropic", "local"],
+        ],
+        *,
+        system_prompt: Optional[str],
+        output_validator: Any,
+        anthropic_transport: Optional[Literal["prompted", "tool_envelope"]],
+    ) -> "OpenAIProvider | AnthropicProvider":
+        """Construct a fresh provider for the pinned clerk seat.
+
+        Mirrors _initialize_provider's constructor arguments so the clerk
+        inherits the same apex generation settings as the writer, differing
+        only in model, endpoint, and transport.
+        """
+        clerk_model, _provider_type, endpoint, clerk_wire = clerk_route
+        apex_settings = self.settings.get("API Settings", {}).get("apex", {})
+        structured_output_retries = apex_settings.get("structured_output_retries", 3)
+        if clerk_wire == "anthropic":
+            if anthropic_transport is None:
+                raise ValueError("Anthropic clerk seat requires an explicit transport")
+            return AnthropicProvider(
+                model=clerk_model,
+                max_tokens=apex_settings.get(
+                    "max_output_tokens", apex_settings.get("max_tokens", 4000)
+                ),
+                reasoning_effort=apex_settings.get("reasoning_effort"),
+                system_prompt=system_prompt,
+                structured_transport=anthropic_transport,
+                structured_output_retries=structured_output_retries,
+                output_validator=output_validator,
+            )
+        base_url = endpoint["base_url"] if endpoint else None
+        api_key = endpoint["api_key"] if endpoint else None
+        structured_transport = cast(
+            Literal["responses", "chat_completions"],
+            endpoint["structured_transport"] if endpoint else "responses",
+        )
+        request_timeout = endpoint["request_timeout_seconds"] if endpoint else None
+        return OpenAIProvider(
+            model=clerk_model,
+            temperature=apex_settings.get("temperature", 0.7),
+            max_output_tokens=apex_settings.get("max_output_tokens", 25000),
+            reasoning_effort=apex_settings.get("reasoning_effort", "medium"),
+            system_prompt=system_prompt,
+            base_url=base_url,
+            api_key=api_key,
+            structured_transport=structured_transport,
+            request_timeout=request_timeout,
+            structured_output_retries=structured_output_retries,
+            output_validator=output_validator,
+        )
+
+    def _clerk_effective_window(
+        self,
+        clerk_route: tuple[
+            str,
+            str,
+            Optional[Dict[str, Any]],
+            Literal["openai", "anthropic", "local"],
+        ],
+    ) -> int:
+        """Resolve the pinned clerk provider's own context ceiling.
+
+        The clerk prompt (turn context + finished writer output) must be
+        enforced against the CLERK provider's window, not the writer's — a
+        32K local writer with a 75K frontier clerk must not false-raise.
+        """
+        _model, provider_type, _endpoint, clerk_wire = clerk_route
+        return resolve_storyteller_context_window(
+            self.settings, clerk_wire, provider_type
+        )
+
     def _resolve_anthropic_two_pass_clerk_transport(
         self,
+        wire_type: Optional[Literal["openai", "anthropic", "local"]] = None,
     ) -> Optional[Literal["prompted", "tool_envelope"]]:
-        """Resolve the schema-free Anthropic clerk arm or reject native."""
+        """Resolve the schema-free Anthropic clerk arm or reject native.
 
-        if self._provider_wire_type != "anthropic":
+        ``wire_type`` is the CLERK seat's wire class (defaults to the active
+        provider's). A non-Anthropic clerk needs no Anthropic transport even
+        under an Anthropic writer, and vice versa.
+        """
+
+        effective_wire = (
+            wire_type if wire_type is not None else self._provider_wire_type
+        )
+        if effective_wire != "anthropic":
             return None
         if self.provider is None:
             raise RuntimeError("Two-pass generation requires an initialized provider")
 
-        transport = self.provider.structured_transport
+        if self._provider_wire_type == "anthropic":
+            transport = self.provider.structured_transport
+        else:
+            # Pinned Anthropic clerk under a non-Anthropic writer: the active
+            # provider carries no Anthropic transport, so read the setting.
+            apex_settings = self.settings.get("API Settings", {}).get("apex", {})
+            transport = apex_settings.get("anthropic_storyteller_transport", "prompted")
         if transport == "native":
             raise ValueError(
                 "Anthropic two-pass execution cannot use "
@@ -926,12 +1074,16 @@ class LogonUtility:
     def _clerk_system_prompt(
         self,
         *,
+        wire_type: Optional[Literal["openai", "anthropic", "local"]] = None,
         anthropic_transport: Optional[Literal["prompted", "tool_envelope"]] = None,
     ) -> str:
-        """Build the pass-two system content for the active provider."""
+        """Build the pass-two system content for the clerk seat's wire class."""
 
+        effective_wire = (
+            wire_type if wire_type is not None else self._provider_wire_type
+        )
         system_prompt = self._load_clerk_system_prompt()
-        if self._provider_wire_type == "anthropic":
+        if effective_wire == "anthropic":
             if anthropic_transport is None:
                 raise ValueError(
                     "Anthropic clerk system prompt requires an explicit transport"
@@ -990,7 +1142,13 @@ class LogonUtility:
 
         if self.provider is None:
             raise RuntimeError("Two-pass generation requires an initialized provider")
-        anthropic_clerk_transport = self._resolve_anthropic_two_pass_clerk_transport()
+        clerk_route = self._resolve_clerk_route()
+        clerk_wire = (
+            clerk_route[3] if clerk_route is not None else self._provider_wire_type
+        )
+        anthropic_clerk_transport = self._resolve_anthropic_two_pass_clerk_transport(
+            clerk_wire
+        )
         writer_provider = self._clone_provider_for_two_pass(
             system_prompt=self._writer_system_prompt(),
             output_validator=None,
@@ -1007,21 +1165,37 @@ class LogonUtility:
             raise TypeError("LOGON writer pass returned a non-SkaldWriterWire response")
 
         clerk_prompt = self._format_clerk_user_prompt(turn_prompt, writer)
+        clerk_window = (
+            self._clerk_effective_window(clerk_route)
+            if clerk_route is not None
+            else effective_context_window
+        )
         self._enforce_final_prompt_window(
             clerk_prompt,
-            effective_context_window=effective_context_window,
+            effective_context_window=clerk_window,
         )
-        clerk_provider = self._clone_provider_for_two_pass(
-            system_prompt=self._clerk_system_prompt(
-                anthropic_transport=anthropic_clerk_transport,
-            ),
-            output_validator=getattr(self.provider, "output_validator", None),
+        clerk_system_prompt = self._clerk_system_prompt(
+            wire_type=clerk_wire,
             anthropic_transport=anthropic_clerk_transport,
         )
+        clerk_validator = getattr(self.provider, "output_validator", None)
+        if clerk_route is not None:
+            clerk_provider: Any = self._build_clerk_provider(
+                clerk_route,
+                system_prompt=clerk_system_prompt,
+                output_validator=clerk_validator,
+                anthropic_transport=anthropic_clerk_transport,
+            )
+        else:
+            clerk_provider = self._clone_provider_for_two_pass(
+                system_prompt=clerk_system_prompt,
+                output_validator=clerk_validator,
+                anthropic_transport=anthropic_clerk_transport,
+            )
         clerk, _clerk_response = clerk_provider.get_structured_completion(
             clerk_prompt,
             SkaldClerkWire,
-            **self._two_pass_schema_format_kwargs(SkaldClerkWire),
+            **self._two_pass_schema_format_kwargs(SkaldClerkWire, wire_type=clerk_wire),
         )
         if not isinstance(clerk, SkaldClerkWire):
             raise TypeError("LOGON clerk pass returned a non-SkaldClerkWire response")
@@ -1043,7 +1217,13 @@ class LogonUtility:
 
         if self.provider is None:
             raise RuntimeError("Two-pass generation requires an initialized provider")
-        anthropic_clerk_transport = self._resolve_anthropic_two_pass_clerk_transport()
+        clerk_route = self._resolve_clerk_route()
+        clerk_wire = (
+            clerk_route[3] if clerk_route is not None else self._provider_wire_type
+        )
+        anthropic_clerk_transport = self._resolve_anthropic_two_pass_clerk_transport(
+            clerk_wire
+        )
         writer_provider = self._clone_provider_for_two_pass(
             system_prompt=self._writer_system_prompt(),
             output_validator=None,
@@ -1062,21 +1242,37 @@ class LogonUtility:
             raise TypeError("LOGON writer pass returned a non-SkaldWriterWire response")
 
         clerk_prompt = self._format_clerk_user_prompt(turn_prompt, writer)
+        clerk_window = (
+            self._clerk_effective_window(clerk_route)
+            if clerk_route is not None
+            else effective_context_window
+        )
         self._enforce_final_prompt_window(
             clerk_prompt,
-            effective_context_window=effective_context_window,
+            effective_context_window=clerk_window,
         )
-        clerk_provider = self._clone_provider_for_two_pass(
-            system_prompt=self._clerk_system_prompt(
-                anthropic_transport=anthropic_clerk_transport,
-            ),
-            output_validator=getattr(self.provider, "output_validator", None),
+        clerk_system_prompt = self._clerk_system_prompt(
+            wire_type=clerk_wire,
             anthropic_transport=anthropic_clerk_transport,
         )
+        clerk_validator = getattr(self.provider, "output_validator", None)
+        if clerk_route is not None:
+            clerk_provider: Any = self._build_clerk_provider(
+                clerk_route,
+                system_prompt=clerk_system_prompt,
+                output_validator=clerk_validator,
+                anthropic_transport=anthropic_clerk_transport,
+            )
+        else:
+            clerk_provider = self._clone_provider_for_two_pass(
+                system_prompt=clerk_system_prompt,
+                output_validator=clerk_validator,
+                anthropic_transport=anthropic_clerk_transport,
+            )
         clerk, _clerk_response = await clerk_provider.get_structured_completion_async(
             clerk_prompt,
             SkaldClerkWire,
-            **self._two_pass_schema_format_kwargs(SkaldClerkWire),
+            **self._two_pass_schema_format_kwargs(SkaldClerkWire, wire_type=clerk_wire),
         )
         if not isinstance(clerk, SkaldClerkWire):
             raise TypeError("LOGON clerk pass returned a non-SkaldClerkWire response")
@@ -1282,17 +1478,30 @@ class LogonUtility:
         self._schema_format_cache[schema_model] = kwargs
         return kwargs
 
-    def _two_pass_schema_format_kwargs(self, schema_model: type) -> Dict[str, Any]:
-        """Return the frozen writer or clerk transport schema arguments."""
+    def _two_pass_schema_format_kwargs(
+        self,
+        schema_model: type,
+        *,
+        wire_type: Optional[Literal["openai", "anthropic", "local"]] = None,
+    ) -> Dict[str, Any]:
+        """Return the frozen transport schema arguments for one pass.
+
+        ``wire_type`` is the wire class of the provider EXECUTING the pass —
+        the pinned clerk seat may run a different class than the writer.
+        """
 
         if schema_model not in {SkaldWriterWire, SkaldClerkWire}:
             raise TypeError("Two-pass schema formatting requires writer or clerk wire")
-        if self._provider_wire_type is None:
+        effective_wire = (
+            wire_type if wire_type is not None else self._provider_wire_type
+        )
+        if effective_wire is None:
             raise RuntimeError(
                 "Two-pass schema formatting requires an active provider wire class"
             )
-        if schema_model in self._schema_format_cache:
-            return self._schema_format_cache[schema_model]
+        cache_key = (schema_model, effective_wire)
+        if cache_key in self._schema_format_cache:
+            return self._schema_format_cache[cache_key]
 
         from nexus.api.native_structured_output import (
             anthropic_output_config,
@@ -1300,7 +1509,7 @@ class LogonUtility:
         )
 
         kwargs: Dict[str, Any]
-        if self._provider_wire_type == "openai":
+        if effective_wire == "openai":
             kwargs = {
                 "text_format": (
                     skald_writer_strict_text_format()
@@ -1308,7 +1517,7 @@ class LogonUtility:
                     else skald_clerk_strict_text_format()
                 )
             }
-        elif self._provider_wire_type == "local":
+        elif effective_wire == "local":
             lenient_schema = (
                 skald_writer_lenient_schema()
                 if schema_model is SkaldWriterWire
@@ -1320,7 +1529,7 @@ class LogonUtility:
                     schema=lenient_schema,
                 )
             }
-        elif self._provider_wire_type == "anthropic":
+        elif effective_wire == "anthropic":
             if schema_model is SkaldWriterWire:
                 kwargs = {
                     "output_config": anthropic_output_config(
@@ -1329,7 +1538,9 @@ class LogonUtility:
                     )
                 }
             else:
-                clerk_transport = self._resolve_anthropic_two_pass_clerk_transport()
+                clerk_transport = self._resolve_anthropic_two_pass_clerk_transport(
+                    effective_wire
+                )
                 if clerk_transport == "prompted":
                     kwargs = {}
                 elif clerk_transport == "tool_envelope":
@@ -1340,11 +1551,10 @@ class LogonUtility:
                     )
         else:
             raise ValueError(
-                "Unsupported two-pass provider wire class: "
-                f"{self._provider_wire_type!r}"
+                "Unsupported two-pass provider wire class: " f"{effective_wire!r}"
             )
 
-        self._schema_format_cache[schema_model] = kwargs
+        self._schema_format_cache[cache_key] = kwargs
         return kwargs
 
     @staticmethod

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -59,6 +59,16 @@ from nexus.memory.retrieval_coverage import coerce_chunk_id  # noqa: E402
 
 logger = logging.getLogger("nexus.lore.logon")
 
+# One resolved storyteller/clerk seat: (model id, registry provider name,
+# OpenAI-compatible endpoint or None, wire class). Shared by the slot-model
+# route and the pinned clerk route so the tuple shape cannot drift.
+StorytellerRoute = tuple[
+    str,
+    str,
+    Optional[Dict[str, Any]],
+    Literal["openai", "anthropic", "local"],
+]
+
 _PROPOSAL_TAG_DELTA_KEYS = frozenset(
     {
         "entity_tags.add",
@@ -464,14 +474,7 @@ class LogonUtility:
         """Resolve a runtime roster reference before constructing the provider."""
         return resolve_model_ref(model) if model.startswith("@") else model
 
-    def _resolve_storyteller_route(
-        self,
-    ) -> tuple[
-        str,
-        str,
-        Optional[Dict[str, Any]],
-        Literal["openai", "anthropic", "local"],
-    ]:
+    def _resolve_storyteller_route(self) -> StorytellerRoute:
         """Resolve the active model, endpoint, and storyteller wire class."""
         apex_settings = self.settings.get("API Settings", {}).get("apex", {})
 
@@ -525,14 +528,7 @@ class LogonUtility:
         self,
         is_bootstrap: Optional[bool] = None,
         *,
-        resolved_route: Optional[
-            tuple[
-                str,
-                str,
-                Optional[Dict[str, Any]],
-                Literal["openai", "anthropic", "local"],
-            ]
-        ] = None,
+        resolved_route: Optional[StorytellerRoute] = None,
     ) -> None:
         """Initialize the appropriate API provider based on settings and slot config."""
         apex_settings = self.settings.get("API Settings", {}).get("apex", {})
@@ -901,16 +897,7 @@ class LogonUtility:
             raise TypeError("Writer system prompt must be a string")
         return system_prompt
 
-    def _resolve_clerk_route(
-        self,
-    ) -> Optional[
-        tuple[
-            str,
-            str,
-            Optional[Dict[str, Any]],
-            Literal["openai", "anthropic", "local"],
-        ]
-    ]:
+    def _resolve_clerk_route(self) -> Optional[StorytellerRoute]:
         """Resolve the pinned clerk seat, or None to follow the slot model.
 
         Returns None whenever the clerk should ride the proven clone path:
@@ -956,12 +943,7 @@ class LogonUtility:
 
     def _build_clerk_provider(
         self,
-        clerk_route: tuple[
-            str,
-            str,
-            Optional[Dict[str, Any]],
-            Literal["openai", "anthropic", "local"],
-        ],
+        clerk_route: StorytellerRoute,
         *,
         system_prompt: Optional[str],
         output_validator: Any,
@@ -1011,15 +993,7 @@ class LogonUtility:
             output_validator=output_validator,
         )
 
-    def _clerk_effective_window(
-        self,
-        clerk_route: tuple[
-            str,
-            str,
-            Optional[Dict[str, Any]],
-            Literal["openai", "anthropic", "local"],
-        ],
-    ) -> int:
+    def _clerk_effective_window(self, clerk_route: StorytellerRoute) -> int:
         """Resolve the pinned clerk provider's own context ceiling.
 
         The clerk prompt (turn context + finished writer output) must be

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -2570,6 +2570,16 @@ class APEXSettings(BaseModel):
         default="single_pass",
         description="Storyteller turn pipeline used for non-bootstrap turns.",
     )
+    clerk_model: Optional[str] = Field(
+        default=None,
+        description=(
+            "Registry model id or @provider.role ref pinning the two-pass "
+            "clerk seat (issue #578: grammar-enforced state custody while the "
+            "prose chair rotates via the slot model). None = the clerk follows "
+            "the slot model. TEST-provider slots always stay self-contained. "
+            "Resolved to a concrete id at config load."
+        ),
+    )
     tag_library: APEXTagLibrarySettings = Field(default_factory=APEXTagLibrarySettings)
     structured_output_retries: int = Field(
         default=3,
@@ -3034,6 +3044,7 @@ class Settings(BaseModel):
             (self.global_.model, "default_model", False),
             (self.global_.model, "default_slot_model", False),
             (self.apex, "model", False),
+            (self.apex, "clerk_model", True),
             (self.summaries, "model", True),
             (self.wizard, "default_model", False),
             (self.wizard, "fallback_model", True),

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -149,6 +149,25 @@ def test_shipped_turn_pipeline_is_two_pass() -> None:
     assert settings.apex.turn_pipeline == "two_pass"
 
 
+def test_shipped_clerk_model_resolves_to_openai_registry_id() -> None:
+    """Committed clerk seat = @openai.default, resolved concrete at load (#578)."""
+    settings = Settings(**_nexus_toml_dict())
+
+    openai_default = settings.global_.model.api_models["openai"].roles["default"]
+    assert settings.apex.clerk_model == openai_default
+    assert not settings.apex.clerk_model.startswith("@")
+
+
+def test_absent_clerk_model_stays_none() -> None:
+    """Unset clerk_model = clerk follows the slot model."""
+    raw = _nexus_toml_dict()
+    raw["apex"].pop("clerk_model", None)
+
+    settings = Settings(**raw)
+
+    assert settings.apex.clerk_model is None
+
+
 def test_apex_rejects_unknown_turn_pipeline() -> None:
     raw = _nexus_toml_dict()
     raw["apex"]["turn_pipeline"] = "fallback"

--- a/tests/test_lore/test_two_pass_pipeline.py
+++ b/tests/test_lore/test_two_pass_pipeline.py
@@ -751,3 +751,219 @@ def test_clerk_prompt_is_concise_and_references_core_doctrine() -> None:
     assert (
         "`characters`, `places`, `factions`, and `relationships`" in normalized_prompt
     )
+
+
+# --- Pinned clerk seat (#578 rung 2) -----------------------------------------
+
+
+def _pinned_clerk_utility(
+    provider_type: str,
+    outputs: list[object],
+    *,
+    anthropic_transport: str | None = None,
+) -> tuple[LogonUtility, _RecordingProvider]:
+    """Writer runs the active provider; clerk_model pins a different seat."""
+
+    utility, provider = _utility(
+        provider_type,
+        outputs,
+        anthropic_transport=anthropic_transport,
+    )
+    utility.settings["API Settings"]["apex"]["clerk_model"] = "pinned-clerk-model"
+    utility.settings["Agent Settings"] = {
+        "LORE": {
+            "token_budget": {
+                "apex_context_window": 75_000,
+                "provider_overrides": {"local": 32_000},
+            }
+        }
+    }
+    return utility, provider
+
+
+def _patch_clerk_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register the fake pinned clerk id as a native OpenAI model."""
+
+    monkeypatch.setattr(
+        "nexus.agents.lore.logon_utility.get_provider_for_model",
+        lambda model_id: "openai" if model_id == "pinned-clerk-model" else None,
+    )
+    monkeypatch.setattr(
+        "nexus.config.get_openai_compatible_endpoint",
+        lambda model_id: None,
+    )
+
+
+def _install_clerk_capture(
+    utility: LogonUtility,
+    monkeypatch: pytest.MonkeyPatch,
+    clerk_recorder: _RecordingProvider,
+) -> tuple[dict[str, Any], list[Any]]:
+    """Capture the clerk build args and every enforcement window."""
+
+    captured: dict[str, Any] = {}
+
+    def fake_build(
+        clerk_route: Any,
+        *,
+        system_prompt: Any,
+        output_validator: Any,
+        anthropic_transport: Any,
+    ) -> _RecordingProvider:
+        captured["route"] = clerk_route
+        captured["system_prompt"] = system_prompt
+        captured["anthropic_transport"] = anthropic_transport
+        clerk_recorder.system_prompt = system_prompt
+        clerk_recorder.output_validator = output_validator
+        return clerk_recorder
+
+    monkeypatch.setattr(utility, "_build_clerk_provider", fake_build)
+
+    windows: list[Any] = []
+    real_enforce = utility._enforce_final_prompt_window
+
+    def spy_enforce(prompt: str, *, effective_context_window: Any) -> int:
+        windows.append(effective_context_window)
+        return real_enforce(prompt, effective_context_window=effective_context_window)
+
+    monkeypatch.setattr(utility, "_enforce_final_prompt_window", spy_enforce)
+    return captured, windows
+
+
+@pytest.mark.parametrize(
+    ("writer_type", "writer_transport"),
+    [
+        ("anthropic", "prompted"),
+        ("local", None),
+        # Native + two_pass was rejected outright (probe G2b); with the clerk
+        # pinned OFF Anthropic, the writer's native output_config compiles
+        # (G2a) and the pipeline must proceed.
+        ("anthropic", "native"),
+    ],
+)
+def test_sync_pinned_clerk_runs_fresh_openai_seat(
+    writer_type: str,
+    writer_transport: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    utility, provider = _pinned_clerk_utility(
+        writer_type,
+        [WRITER_PAYLOAD],
+        anthropic_transport=writer_transport,
+    )
+    _patch_clerk_registry(monkeypatch)
+    clerk_recorder = _RecordingProvider([CLERK_PAYLOAD])
+    captured, windows = _install_clerk_capture(utility, monkeypatch, clerk_recorder)
+    monkeypatch.setattr(
+        utility,
+        "_read_presence_baseline_for_context",
+        lambda _context_payload, _schema_model: BASELINE,
+    )
+
+    response = utility.generate_narrative(
+        _context(),
+        effective_context_window=32_000,
+    )
+
+    # Writer ran on the active provider's clone; clerk on the pinned seat.
+    assert len(provider.calls) == 1
+    assert provider.calls[0]["schema_model"] is SkaldWriterWire
+    assert len(clerk_recorder.calls) == 1
+    clerk_call = clerk_recorder.calls[0]
+    assert clerk_call["schema_model"] is SkaldClerkWire
+    # Heterogeneous kwargs: strict OpenAI clerk schema under this writer wire.
+    assert clerk_call["kwargs"] == {"text_format": skald_clerk_strict_text_format()}
+    assert captured["route"][0] == "pinned-clerk-model"
+    assert captured["route"][3] == "openai"
+    assert captured["anthropic_transport"] is None
+    assert "## Skald Clerk" in captured["system_prompt"]
+    assert skald_clerk_prompt_guide() not in captured["system_prompt"]
+    # Clerk enforcement used the CLERK provider's window, not the writer's 32K.
+    assert windows[-1] == 75_000
+    assert response.narrative == WRITER_PAYLOAD["narrative"]
+
+
+@pytest.mark.asyncio
+async def test_async_pinned_clerk_runs_fresh_openai_seat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    utility, provider = _pinned_clerk_utility("local", [WRITER_PAYLOAD])
+    _patch_clerk_registry(monkeypatch)
+    clerk_recorder = _RecordingProvider([CLERK_PAYLOAD])
+    captured, windows = _install_clerk_capture(utility, monkeypatch, clerk_recorder)
+
+    async def read_baseline(
+        _context_payload: dict[str, Any],
+        _schema_model: type,
+    ) -> Any:
+        return BASELINE
+
+    monkeypatch.setattr(
+        utility,
+        "_read_presence_baseline_for_context_async",
+        read_baseline,
+    )
+
+    response = await utility.generate_narrative_async(
+        _context(),
+        effective_context_window=32_000,
+    )
+
+    assert len(provider.calls) == 1
+    assert len(clerk_recorder.calls) == 1
+    assert clerk_recorder.calls[0]["kwargs"] == {
+        "text_format": skald_clerk_strict_text_format()
+    }
+    assert captured["route"][3] == "openai"
+    assert windows[-1] == 75_000
+    assert response.narrative == WRITER_PAYLOAD["narrative"]
+
+
+def test_clerk_route_guards_fall_back_to_the_clone_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset, TEST-provider, and same-model configs all keep the clone path."""
+
+    unset_utility, _provider = _utility("openai", [])
+    assert unset_utility._resolve_clerk_route() is None
+
+    test_utility, _provider = _utility("openai", [])
+    test_utility.settings["API Settings"]["apex"]["clerk_model"] = "pinned-clerk-model"
+    test_utility._provider_type_name = "test"
+    assert test_utility._resolve_clerk_route() is None
+
+    same_utility, same_provider = _utility("openai", [])
+    same_utility.settings["API Settings"]["apex"]["clerk_model"] = same_provider.model
+    assert same_utility._resolve_clerk_route() is None
+
+    junk_utility, _provider = _utility("openai", [])
+    junk_utility.settings["API Settings"]["apex"]["clerk_model"] = "pinned-clerk-model"
+    monkeypatch.setattr(
+        "nexus.agents.lore.logon_utility.get_provider_for_model",
+        lambda _model_id: None,
+    )
+    with pytest.raises(ValueError, match="not in the model registry"):
+        junk_utility._resolve_clerk_route()
+
+
+def test_anthropic_clerk_under_non_anthropic_writer_reads_the_setting() -> None:
+    """A pinned Anthropic clerk must honor the configured transport loudly."""
+
+    utility, _provider = _utility("openai", [])
+    utility.settings["API Settings"]["apex"][
+        "anthropic_storyteller_transport"
+    ] = "native"
+    with pytest.raises(ValueError, match="clerk wire cannot"):
+        utility._resolve_anthropic_two_pass_clerk_transport("anthropic")
+
+
+def test_two_pass_schema_kwargs_cache_is_wire_keyed() -> None:
+    """The same schema must yield per-wire kwargs, never a stale cache hit."""
+
+    utility, _provider = _utility("anthropic", [], anthropic_transport="prompted")
+    anthropic_kwargs = utility._two_pass_schema_format_kwargs(SkaldClerkWire)
+    openai_kwargs = utility._two_pass_schema_format_kwargs(
+        SkaldClerkWire, wire_type="openai"
+    )
+    assert anthropic_kwargs == {}
+    assert openai_kwargs == {"text_format": skald_clerk_strict_text_format()}


### PR DESCRIPTION
Owner ruling on #578: rung 2 is worth building for the architectural guarantee alone — **OpenAI native grammar constraints on the clerk seat, unconditionally, while the prose chair rotates freely** via the slot model picker. State custody becomes reliable by construction, not by per-model luck; every writer candidate's clerk competence becomes irrelevant.

## Design

The slot model is always the writer (the picker IS the prose-chair rotation). One new key pins the custodian:

- **`[apex] clerk_model`** — registry id or `@provider.role` ref, resolved concrete at config load (added to the `_resolve_model_references` targets). Committed default: **`@openai.default`**. `None` = clerk follows the slot model (required for fully-local/offline installs — noted in the toml comment).
- Guards that keep the proven clone path: no pin configured; **TEST-provider slots** (stay self-contained and offline); pin equal to the slot model.

## Mechanics

- `_resolve_clerk_route()` classifies the pinned seat (same classification rules as the storyteller route); `_build_clerk_provider()` constructs a fresh `OpenAIProvider`/`AnthropicProvider` mirroring `_initialize_provider`'s constructor args exactly.
- Clerk-side helpers (`_clerk_system_prompt`, `_resolve_anthropic_two_pass_clerk_transport`, `_two_pass_schema_format_kwargs`) are now **wire-parameterized** — the clerk seat may run a different wire class than the writer. Schema-kwargs cache keys widen to `(schema, wire)`.
- **Clerk window enforcement uses the CLERK provider's own ceiling** (`_clerk_effective_window` → provider-name override lookup): a 32K local writer with a 75K frontier clerk must not false-raise when the appended writer output pushes the clerk prompt past the writer's window.
- A pinned Anthropic clerk under a non-Anthropic writer reads `anthropic_storyteller_transport` from settings (the active provider carries no Anthropic transport); native still raises G2b for an Anthropic clerk. **`native` + `two_pass` becomes legal when the clerk is pinned off Anthropic** — the writer's G2a config compiles; only the clerk half ever failed to.
- Sync/async parity throughout.

## Verification

- `pytest tests/test_skald_wire.py tests/test_native_structured_output.py tests/test_lore/ tests/config/ tests/test_mock_openai.py` → **405 passed, 16 skipped** (bare exit)
- mypy / black / flake8 clean; pre-commit config validation passed
- New tests: heterogeneous clerk kwargs under anthropic/local/native writers (sync + async), clerk-window regression (32K writer → 75K clerk enforcement), guard trio (unset / TEST / same-model), unregistered-pin loud raise, Anthropic-clerk-under-OpenAI-writer transport read, wire-keyed cache regression, shipped-default resolution + absent-pin None.

Live verification post-merge: kimi-k2.5 writer + pinned OpenAI clerk on slot 4 — the owner's target configuration end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ