### PR TITLE
Scope the writer pass explicitly (live Kimi failure at a proposal beat)

### DIFF
--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -896,7 +896,7 @@ class LogonUtility:
             )
         return pass_provider
 
-    def _writer_system_prompt(self) -> Optional[str]:
+    def _writer_system_prompt(self) -> str:
         """Return the storyteller system prompt scoped to the writer pass.
 
         The single-pass core doctrine instructs authoring updates,

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -411,6 +411,17 @@ class LogonUtility:
         return clerk_prompt
 
     @staticmethod
+    def _load_writer_pass_note() -> str:
+        """Load the writer-pass scope note appended in two-pass mode."""
+
+        prompts_dir = Path(__file__).parent.parent.parent.parent / "prompts"
+        note_path = prompts_dir / "storyteller_writer_pass.md"
+        note = note_path.read_text()
+        if not note.strip():
+            raise ValueError(f"Writer pass note is empty: {note_path}")
+        return note
+
+    @staticmethod
     def _format_setting_context(setting_data: Any) -> str:
         """Render persisted SettingCard JSON into system-prompt context."""
 
@@ -886,7 +897,15 @@ class LogonUtility:
         return pass_provider
 
     def _writer_system_prompt(self) -> Optional[str]:
-        """Return the existing storyteller system prompt for pass one."""
+        """Return the storyteller system prompt scoped to the writer pass.
+
+        The single-pass core doctrine instructs authoring updates,
+        adjudications, and declarations — clerk work. Grammar-enforced
+        writers physically cannot overflow into those fields, but schema-free
+        writers (OpenRouter passthrough) obey the doctrine over the repair
+        loop, so the writer pass must be told its own scope explicitly (live
+        failure: Kimi K2.5 at a proposal-bearing beat, #578).
+        """
 
         if self.provider is None:
             raise RuntimeError("Writer prompt requires an initialized provider")
@@ -895,7 +914,10 @@ class LogonUtility:
             system_prompt = getattr(self.provider, "system_prompt", None)
         if system_prompt is not None and not isinstance(system_prompt, str):
             raise TypeError("Writer system prompt must be a string")
-        return system_prompt
+        note = self._load_writer_pass_note()
+        if system_prompt is None:
+            return note
+        return f"{system_prompt}\n\n{note}"
 
     def _resolve_clerk_route(self) -> Optional[StorytellerRoute]:
         """Resolve the pinned clerk seat, or None to follow the slot model.

--- a/prompts/storyteller_writer_pass.md
+++ b/prompts/storyteller_writer_pass.md
@@ -1,0 +1,12 @@
+# Writer Pass
+
+This turn runs as a two-pass pipeline, and you are the writer pass.
+
+A separate clerk pass — run after you, with your finished output in hand —
+owns all durable bookkeeping: `updates`, `orrery_adjudications`, and
+`new_entities`. Do not produce those fields or their content in any form.
+
+Your output is exactly: `narrative`, `choices`, and (only when changed)
+`scene`, `presence`, `operations`. If the context shows imminent Orrery
+activity or introduces new entities, let that inform your prose — the clerk
+will derive the rulings and declarations from what you wrote.

--- a/tests/test_lore/test_two_pass_pipeline.py
+++ b/tests/test_lore/test_two_pass_pipeline.py
@@ -373,7 +373,11 @@ def _assert_two_pass_calls(
     assert clerk_call["output_validator"] is None
     assert writer_call["structured_output_retries"] == 3
     assert clerk_call["structured_output_retries"] == 3
-    assert writer_call["system_prompt"] == "Core storyteller prompt"
+    # Writer pass = core doctrine + explicit scope note (clerk work excluded);
+    # schema-free writers obey the core prompt over the repair loop without it.
+    assert writer_call["system_prompt"].startswith("Core storyteller prompt")
+    assert "# Writer Pass" in writer_call["system_prompt"]
+    assert "# Writer Pass" not in clerk_call["system_prompt"]
     assert "## Skald Clerk" in clerk_call["system_prompt"]
     assert clerk_call["prompt"].startswith(writer_call["prompt"])
     assert writer.narrative in clerk_call["prompt"]


### PR DESCRIPTION
Live verification of #581's target configuration (Kimi K2.5 writer + pinned OpenAI clerk) failed at the writer pass: at a beat with imminent Orrery proposals, Kimi emitted the FULL turn shape (`updates`, `new_entities`, `orrery_adjudications`) into `SkaldWriterWire` and burned all four repairs — the single-pass core doctrine in its system prompt told it to author clerk work, and a schema-free OpenRouter writer obeys the system prompt over the repair message. Pre-existing gap (writer prompt unchanged since #575), invisible under grammar-enforced writers, exposed by OR passthrough. The pinned clerk never ran.

Fix: `prompts/storyteller_writer_pass.md` (per the prompts-live-in-prompts/ doctrine) appended to the writer system prompt in two-pass mode — a separate clerk owns the bookkeeping; the writer outputs only `narrative`/`choices`/`scene`/`presence`/`operations`. Appended for all wire classes: harmless under grammar enforcement, load-bearing for schema-free writers.

Tests: writer prompt = core + note, note absent from the clerk prompt; suites `tests/test_lore/ tests/config/ tests/test_skald_wire.py` → 339 passed, 14 skipped; mypy/black/flake8 clean.

Live re-verification of the Kimi-writer + OpenAI-clerk turn happens post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ