### PR TITLE
Add per-model request_params passthrough for registry models (#580)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -88,7 +88,7 @@ request_timeout_seconds = 600
 roles = { default = "moonshotai/kimi-k2.5" }
 models = [
     { id = "moonshotai/kimi-k2.5", label = "Kimi K2.5", description = "Moonshot K2.5 via OpenRouter" },
-    { id = "moonshotai/kimi-k3", label = "Kimi K3", description = "Moonshot K3 via OpenRouter" },
+    { id = "moonshotai/kimi-k3", label = "Kimi K3", description = "Moonshot K3 via OpenRouter", request_params = { reasoning = { effort = "low" } } },
     { id = "deepseek/deepseek-v4-pro", label = "DeepSeek V4 Pro", description = "DeepSeek V4 Pro via OpenRouter" },
     { id = "nousresearch/hermes-4-405b", label = "Hermes 4 405B", description = "Nous Hermes 4 405B via OpenRouter" },
     { id = "minimax/minimax-m3", label = "MiniMax M3", description = "MiniMax M3 via OpenRouter" },

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -644,6 +644,7 @@ class LogonUtility:
                 request_timeout=request_timeout,
                 structured_output_retries=structured_output_retries,
                 output_validator=output_validator,
+                request_params=endpoint.get("request_params") if endpoint else None,
             )
 
         logger.info(
@@ -1013,6 +1014,7 @@ class LogonUtility:
             request_timeout=request_timeout,
             structured_output_retries=structured_output_retries,
             output_validator=output_validator,
+            request_params=endpoint.get("request_params") if endpoint else None,
         )
 
     def _clerk_effective_window(self, clerk_route: StorytellerRoute) -> int:

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -678,6 +678,7 @@ def _narration_provider(settings: Mapping[str, Any]) -> Any:
             api_key=endpoint["api_key"],
             structured_transport=endpoint["structured_transport"],
             request_timeout=endpoint["request_timeout_seconds"],
+            request_params=endpoint.get("request_params"),
         )
     raise ValueError(f"Unsupported Orrery narration provider: {provider_name}")
 

--- a/nexus/api/native_structured_output.py
+++ b/nexus/api/native_structured_output.py
@@ -253,6 +253,7 @@ def build_native_structured_provider(
             request_timeout=(endpoint["request_timeout_seconds"] if endpoint else None),
             structured_output_retries=structured_output_retries,
             output_validator=output_validator,
+            request_params=endpoint.get("request_params") if endpoint else None,
             **openai_kwargs,
         )
     raise ValueError(f"Unsupported provider type for model {model!r}: {provider_type}")

--- a/nexus/config/loader.py
+++ b/nexus/config/loader.py
@@ -263,11 +263,18 @@ def get_openai_compatible_endpoint(model_id: str) -> Optional[Dict[str, Any]]:
         api_key = get_secret(entry.api_key_secret)
     else:
         api_key = "nexus-local-no-key"
+    model_entry = next((model for model in entry.models if model.id == model_id), None)
+    if model_entry is None:
+        raise ValueError(
+            f"Model '{model_id}' maps to provider '{provider}' but is absent "
+            "from that provider's models list"
+        )
     return {
         "base_url": entry.base_url,
         "api_key": api_key,
         "structured_transport": entry.structured_transport,
         "request_timeout_seconds": entry.request_timeout_seconds,
+        "request_params": dict(model_entry.request_params),
     }
 
 

--- a/nexus/config/loader.py
+++ b/nexus/config/loader.py
@@ -242,9 +242,11 @@ def get_openai_compatible_endpoint(model_id: str) -> Optional[Dict[str, Any]]:
 
     Returns:
         ``{"base_url": ..., "api_key": ..., "structured_transport": ...,
-        "request_timeout_seconds": ...}`` for base_url providers, or None for
-        native providers and for models absent from the registry (callers that
-        accept ad-hoc model overrides treat those as native-SDK models).
+        "request_timeout_seconds": ..., "request_params": ...}`` for base_url
+        providers, or None for native providers and for models absent from
+        the registry (callers that accept ad-hoc model overrides treat those
+        as native-SDK models). ``request_params`` is the model entry's
+        provider-specific request-body table (issue #580), ``{}`` when unset.
         ``api_key`` is read from Keychain when the provider declares
         ``api_key_secret``; otherwise a placeholder is returned because OpenAI
         clients require a non-empty key.
@@ -263,6 +265,9 @@ def get_openai_compatible_endpoint(model_id: str) -> Optional[Dict[str, Any]]:
         api_key = get_secret(entry.api_key_secret)
     else:
         api_key = "nexus-local-no-key"
+    # get_provider_for_model and this function each call load_settings();
+    # a config reload landing between the two reads can desync them, so the
+    # membership guard is a real race check, not dead code.
     model_entry = next((model for model in entry.models if model.id == model_id), None)
     if model_entry is None:
         raise ValueError(

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -270,6 +270,34 @@ class ModelConfig(BaseModel):
                 )
         return self
 
+    @model_validator(mode="after")
+    def _validate_request_params_transport(self) -> "ModelConfig":
+        """request_params only reach chat-completions requests (issue #580).
+
+        Native SDK providers return no endpoint, and the 'responses'
+        transport's request builders never merge request_params — configuring
+        them there would silently no-op, which is exactly the failure mode
+        the field exists to prevent.
+        """
+        for provider, config in self.api_models.items():
+            offenders = [entry.id for entry in config.models if entry.request_params]
+            if not offenders:
+                continue
+            if provider in NATIVE_API_PROVIDERS:
+                raise ValueError(
+                    f"request_params on models {offenders} of native provider "
+                    f"'{provider}' would be silently ignored; the field only "
+                    "applies to chat_completions transports."
+                )
+            if config.structured_transport != "chat_completions":
+                raise ValueError(
+                    f"request_params on models {offenders} of provider "
+                    f"'{provider}' require structured_transport = "
+                    "'chat_completions'; the 'responses' transport ignores "
+                    "them."
+                )
+        return self
+
 
 class NarrativeConfig(BaseModel):
     """Narrative test mode settings."""

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -74,6 +74,40 @@ class APIModelEntry(BaseModel):
             "#454); False forces it OFF; None defers to pydantic-ai."
         ),
     )
+    request_params: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Provider-specific request-body parameters merged into every "
+            "chat-completions call for this model via the OpenAI SDK's "
+            "extra_body (issue #580; e.g. reasoning damping for models that "
+            "otherwise think away their output budget). Structural request "
+            "keys are reserved and rejected at config load."
+        ),
+    )
+
+    _RESERVED_REQUEST_PARAM_KEYS = frozenset(
+        {
+            "model",
+            "messages",
+            "stream",
+            "response_format",
+            "tools",
+            "tool_choice",
+            "text",
+            "extra_body",
+        }
+    )
+
+    @model_validator(mode="after")
+    def _validate_request_params(self) -> "APIModelEntry":
+        """request_params may not shadow structural request keys."""
+        reserved = self._RESERVED_REQUEST_PARAM_KEYS & set(self.request_params)
+        if reserved:
+            raise ValueError(
+                f"request_params for model '{self.id}' may not set reserved "
+                f"request keys: {sorted(reserved)}"
+            )
+        return self
 
 
 class ProviderModels(BaseModel):

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -886,6 +886,10 @@ class OpenAIProvider(LLMProvider):
         }
         if self.supports_temperature and self.temperature is not None:
             request_params["temperature"] = self.temperature
+        if self.request_params:
+            # Registry request_params (issue #580) apply to plain completions
+            # too — Orrery narration reaches OpenRouter through this path.
+            request_params["extra_body"] = copy.deepcopy(self.request_params)
 
         response = self.client.chat.completions.create(**request_params)
         choices = getattr(response, "choices", None) or []

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -34,6 +34,7 @@ Processing Options:
 import os
 import sys
 import abc
+import copy
 import argparse
 import asyncio
 import logging
@@ -295,6 +296,7 @@ class OpenAIProvider(LLMProvider):
         request_timeout: Optional[float] = None,
         structured_output_retries: Optional[int] = None,
         output_validator: Optional[Any] = None,
+        request_params: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize OpenAI provider with additional reasoning parameter.
@@ -318,8 +320,14 @@ class OpenAIProvider(LLMProvider):
                 output agents (apex.structured_output_retries in nexus.toml)
             output_validator: Optional async pydantic_ai output validator
                 registered on structured agents (may raise ModelRetry)
+            request_params: Per-model provider-specific request-body params
+                from the registry (issue #580), merged into chat-completions
+                calls via the SDK's extra_body
         """
         self.reasoning_effort = reasoning_effort
+        # Deep copy: nested param objects (e.g. {"reasoning": {"effort": ...}})
+        # must not alias caller state or the built request dicts.
+        self.request_params = copy.deepcopy(request_params) if request_params else {}
         self.max_output_tokens = max_output_tokens or max_tokens
         self.base_url = base_url
         self.request_timeout = request_timeout
@@ -688,6 +696,13 @@ class OpenAIProvider(LLMProvider):
         }
         if self.supports_temperature and self.temperature is not None:
             request_params["temperature"] = self.temperature
+        if self.request_params:
+            # Registry-declared provider-specific params (issue #580) ride
+            # extra_body: the OpenAI SDK rejects unknown kwargs, and servers
+            # (OpenRouter, llama-server) read them from the merged JSON body.
+            # Structural keys are reserved at config load. Deep copy so a
+            # caller mutating the built request cannot corrupt provider state.
+            request_params["extra_body"] = copy.deepcopy(self.request_params)
         return request_params
 
     @staticmethod

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -568,6 +568,7 @@ def test_get_openai_compatible_endpoint_routing():
         "api_key": "nexus-local-no-key",
         "structured_transport": "responses",
         "request_timeout_seconds": None,
+        "request_params": {},
     }
     local = settings.global_.model.api_models["local"]
     assert resolve_model_ref("@local.default") == "nousresearch/hermes-4-70b"
@@ -576,11 +577,34 @@ def test_get_openai_compatible_endpoint_routing():
         "api_key": "nexus-local-no-key",
         "structured_transport": "chat_completions",
         "request_timeout_seconds": 1800,
+        "request_params": {},
     }
     assert get_openai_compatible_endpoint("gpt-5.5") is None
     assert get_openai_compatible_endpoint("claude-opus-4-8") is None
     # Models absent from the registry are treated as native/legacy overrides.
     assert get_openai_compatible_endpoint("unregistered-model") is None
+
+
+def test_request_params_reserved_keys_rejected() -> None:
+    """Structural request keys may not be shadowed by request_params (#580)."""
+    raw = _nexus_toml_dict()
+    or_models = raw["global"]["model"]["api_models"]["openrouter"]["models"]
+    or_models[0]["request_params"] = {"messages": []}
+
+    with pytest.raises(ValidationError, match="reserved request keys.*messages"):
+        Settings(**raw)
+
+
+def test_shipped_kimi_k3_carries_reasoning_damping() -> None:
+    """K3's registry entry damps reasoning so it cannot think away its budget."""
+    settings = Settings(**_nexus_toml_dict())
+
+    k3 = next(
+        model
+        for model in settings.global_.model.api_models["openrouter"].models
+        if model.id == "moonshotai/kimi-k3"
+    )
+    assert k3.request_params == {"reasoning": {"effort": "low"}}
 
 
 def test_llama_server_runtime_service_parses():
@@ -658,6 +682,7 @@ def test_default_load_honors_runtime_config_env(tmp_path, monkeypatch):
         "api_key": "nexus-local-no-key",
         "structured_transport": "responses",
         "request_timeout_seconds": None,
+        "request_params": {},
     }
     assert (
         load_settings("nexus.toml")

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -595,6 +595,28 @@ def test_request_params_reserved_keys_rejected() -> None:
         Settings(**raw)
 
 
+def test_request_params_rejected_on_native_provider() -> None:
+    """Natively-served models cannot carry silently-ignored request_params."""
+    raw = _nexus_toml_dict()
+    raw["global"]["model"]["api_models"]["openai"]["models"][0]["request_params"] = {
+        "reasoning": {"effort": "low"}
+    }
+
+    with pytest.raises(ValidationError, match="native provider 'openai'"):
+        Settings(**raw)
+
+
+def test_request_params_rejected_on_responses_transport() -> None:
+    """The responses transport never merges request_params — reject loudly."""
+    raw = _nexus_toml_dict()
+    raw["global"]["model"]["api_models"]["test"]["models"][0]["request_params"] = {
+        "reasoning": {"effort": "low"}
+    }
+
+    with pytest.raises(ValidationError, match="require structured_transport"):
+        Settings(**raw)
+
+
 def test_shipped_kimi_k3_carries_reasoning_damping() -> None:
     """K3's registry entry damps reasoning so it cannot think away its budget."""
     settings = Settings(**_nexus_toml_dict())

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -1412,3 +1412,42 @@ def test_anthropic_provider_wraps_legacy_output_format_override() -> None:
     assert parsed == expected
     assert captured["output_config"] == {"format": output_format}
     assert "output_format" not in captured
+
+
+def test_chat_request_params_ride_extra_body() -> None:
+    """Registry request_params merge into chat-completions via extra_body (#580)."""
+
+    provider = OpenAIProvider(
+        model="moonshotai/kimi-k3",
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        structured_transport="chat_completions",
+        request_params={"reasoning": {"effort": "low"}},
+    )
+
+    params = provider._build_chat_structured_request_params(
+        "Prompt", StorytellerResponseBootstrap
+    )
+
+    assert params["extra_body"] == {"reasoning": {"effort": "low"}}
+    assert params["model"] == "moonshotai/kimi-k3"
+    # A mutation of the built dict must not leak back into provider state.
+    params["extra_body"]["reasoning"]["effort"] = "high"
+    assert provider.request_params == {"reasoning": {"effort": "low"}}
+
+
+def test_chat_request_without_request_params_omits_extra_body() -> None:
+    """Models without registry params keep the pre-#580 request shape."""
+
+    provider = OpenAIProvider(
+        model="local-model",
+        api_key="test-key",
+        base_url="http://127.0.0.1:1234/v1",
+        structured_transport="chat_completions",
+    )
+
+    params = provider._build_chat_structured_request_params(
+        "Prompt", StorytellerResponseBootstrap
+    )
+
+    assert "extra_body" not in params

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -1451,3 +1451,59 @@ def test_chat_request_without_request_params_omits_extra_body() -> None:
     )
 
     assert "extra_body" not in params
+
+
+def test_build_native_structured_provider_threads_request_params(
+    monkeypatch,
+) -> None:
+    """The shared factory must not drop registry request_params (#583 review)."""
+    from nexus.api import native_structured_output as nso
+
+    endpoint = {
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key": "test-key",
+        "structured_transport": "chat_completions",
+        "request_timeout_seconds": None,
+        "request_params": {"reasoning": {"effort": "low"}},
+    }
+    monkeypatch.setattr(
+        "nexus.config.get_openai_compatible_endpoint", lambda _model: endpoint
+    )
+    monkeypatch.setattr(
+        "nexus.config.loader.get_provider_for_model", lambda _model: "openrouter"
+    )
+
+    provider = nso.build_native_structured_provider(
+        model="moonshotai/kimi-k3",
+        max_tokens=1000,
+        system_prompt="s",
+        structured_output_retries=1,
+    )
+
+    assert provider.request_params == {"reasoning": {"effort": "low"}}
+
+
+def test_plain_chat_completion_merges_request_params() -> None:
+    """Orrery narration's plain-completion path must apply the damping too."""
+
+    provider = OpenAIProvider(
+        model="moonshotai/kimi-k3",
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        structured_transport="chat_completions",
+        request_params={"reasoning": {"effort": "low"}},
+    )
+    captured = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(choices=[], usage=None)
+
+    provider.client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions())
+    )
+
+    provider._get_completion_chat_completions("Prompt")
+
+    assert captured["extra_body"] == {"reasoning": {"effort": "low"}}


### PR DESCRIPTION
Closes #580. Registry model entries gain an optional `request_params` table merged into every chat-completions call via the OpenAI SDK's **`extra_body`** (the SDK rejects unknown kwargs; OpenAI-compatible servers — OpenRouter, llama-server — read the merged JSON body).

- **Config**: `APIModelEntry.request_params` (default `{}`), with structural request keys (`model`/`messages`/`response_format`/`tools`/`tool_choice`/`stream`/`text`/`extra_body`) reserved and rejected loudly at config load. Sibling of `unsupported_params` (which strips; this adds).
- **Plumbing**: `get_openai_compatible_endpoint` now locates the specific model entry (loud if the id maps to a provider but is absent from its models list) and carries `request_params`; both LOGON provider construction sites (slot provider + pinned clerk) thread it into `OpenAIProvider`.
- **Aliasing**: values deep-copied at both seams — the regression test caught the initial shallow copy letting a mutation of the built request corrupt provider state.
- **Payload**: Kimi K3's registry entry ships `request_params = { reasoning = { effort = "low" } }` — during #578 sampling, K3 at default reasoning returned null content with its entire budget consumed; with damping it sampled well. K3 stops being a slow-fail trap in the model picker.
- Scope: chat-completions transport only (where the need exists); native `responses`/Anthropic paths untouched.

Verification: `tests/test_native_structured_output.py tests/config/ tests/test_lore/` → 329 passed, 13 skipped; mypy/black clean; flake8 clean on changed lines (three pre-existing violations in loader.py's legacy-JSON region predate this PR, verified against origin/main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ