### PR TITLE
Add the post-commit presence-roster drift audit (#567)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -289,6 +289,12 @@ max_characters_from_warm_slice = 12
 max_locations_from_warm_slice = 6
 include_all_relationships = false
 
+[lore.presence_audit]
+# Post-commit roster-drift diagnostics (issue #567): warn when committed
+# prose names a character with no junction row for the chunk (candidate
+# missed entry under delta-presence). Read-only; never blocks a turn.
+enabled = true
+
 # =============================================================================
 # Orrery Settings (Off-Screen Behavior Resolver)
 # =============================================================================

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -796,13 +796,20 @@ async def commit_incubator_to_database(
 
     # Post-commit presence-roster drift audit (issue #567): read-only
     # diagnostics over the committed chunk, outside the transaction.
+    # raw_text is the committed prose (storyteller text + enacted choice);
+    # the parent chunk id enables authored-exit accounting.
     from nexus.api.presence_audit import (
         audit_chunk_presence_async,
         presence_audit_enabled,
     )
 
     if presence_audit_enabled():
-        await audit_chunk_presence_async(conn, chunk_id, storyteller_text)
+        await audit_chunk_presence_async(
+            conn,
+            chunk_id,
+            raw_text,
+            parent_chunk_id=incubator.get("parent_chunk_id"),
+        )
 
     logger.info("Successfully committed chunk %s from session %s", chunk_id, session_id)
     return chunk_id

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -794,6 +794,16 @@ async def commit_incubator_to_database(
                 "Failed to schedule summaries for session %s: %s", session_id, exc
             )
 
+    # Post-commit presence-roster drift audit (issue #567): read-only
+    # diagnostics over the committed chunk, outside the transaction.
+    from nexus.api.presence_audit import (
+        audit_chunk_presence_async,
+        presence_audit_enabled,
+    )
+
+    if presence_audit_enabled():
+        await audit_chunk_presence_async(conn, chunk_id, storyteller_text)
+
     logger.info("Successfully committed chunk %s from session %s", chunk_id, session_id)
     return chunk_id
 

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -656,10 +656,17 @@ def commit_incubator_to_database_sync(
 
     # Post-commit presence-roster drift audit (issue #567): read-only
     # diagnostics over the committed chunk, outside the transaction.
+    # raw_text is the committed prose (storyteller text + enacted choice);
+    # the parent chunk id enables authored-exit accounting.
     from nexus.api.presence_audit import audit_chunk_presence, presence_audit_enabled
 
     if presence_audit_enabled():
-        audit_chunk_presence(conn, chunk_id, storyteller_text)
+        audit_chunk_presence(
+            conn,
+            chunk_id,
+            raw_text,
+            parent_chunk_id=incubator.get("parent_chunk_id"),
+        )
 
     logger.info("Successfully committed chunk %s from session %s", chunk_id, session_id)
     return chunk_id

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -654,6 +654,13 @@ def commit_incubator_to_database_sync(
                 "Failed to schedule summaries for session %s: %s", session_id, exc
             )
 
+    # Post-commit presence-roster drift audit (issue #567): read-only
+    # diagnostics over the committed chunk, outside the transaction.
+    from nexus.api.presence_audit import audit_chunk_presence, presence_audit_enabled
+
+    if presence_audit_enabled():
+        audit_chunk_presence(conn, chunk_id, storyteller_text)
+
     logger.info("Successfully committed chunk %s from session %s", chunk_id, session_id)
     return chunk_id
 

--- a/nexus/api/presence_audit.py
+++ b/nexus/api/presence_audit.py
@@ -5,9 +5,10 @@ writer authors only entries/exits, so a missed entry accretes silently until
 a scene reset. The deterministic alias detector is deployed here as the
 AUDIT layer, exactly where its precision profile is strong:
 
-- A character name (or alias) appearing in committed prose while the chunk
-  has NO junction row for that character = candidate missed entry. Flag it
-  loudly.
+- A character name (or alias) appearing in the committed prose (raw_text:
+  storyteller prose plus the enacted choice line — what is stored, embedded,
+  and searched) while the chunk has no accounting for that character =
+  candidate missed entry. Flag it loudly.
 - Name-absence is NEVER evidence of absence (chunk n names her, chunk n+1
   says only "she") — this module only iterates DETECTED names, so it is
   structurally incapable of flagging a roster member whose name does not
@@ -15,9 +16,15 @@ AUDIT layer, exactly where its precision profile is strong:
 - The audit proposes; it never mutates. Output is one structured warning per
   finding plus a metrics-friendly findings list.
 
-The diff runs against ALL junction reference types for the chunk, not only
-``present``: a ``mentioned`` row means the writer deliberately accounted for
-an off-scene reference, which is not a missed entry.
+"Accounted" spans two sources:
+
+1. ANY junction reference row for the chunk (a ``mentioned`` row is the
+   writer deliberately accounting for an off-scene reference).
+2. A ``present`` row on the PARENT chunk. Under delta-presence, silence
+   carries a present character forward — the only way a parent-present
+   character lacks a row on this chunk is an authored ``presence.exit``, and
+   prose narrating a departure legitimately names the departing character
+   (PR #584 Codex finding). This exclusion is exact, not heuristic.
 """
 
 from __future__ import annotations
@@ -30,25 +37,33 @@ from nexus.memory.entity_detector import EntityMatch, HighSpecificityEntityDetec
 logger = logging.getLogger("nexus.api.presence_audit")
 
 
-class _PsycopgExecuteAdapter:
-    """Give the detector its expected ``.execute(statement)`` over psycopg2.
+def _character_only_detector(
+    character_rows: List[Any],
+    alias_rows: List[Any],
+) -> HighSpecificityEntityDetector:
+    """Build a detector from prefetched character/alias rows.
 
-    The detector issues parameterless SQL strings and reads columns by
-    attribute; this adapter runs them on a psycopg2 connection and returns
-    attribute-addressable rows.
+    Mirrors HighSpecificityEntityDetector._load_characters' record shape
+    ({id, name, summary}). Places and factions stay unloaded — the presence
+    audit only diffs characters, so loading and regex-scanning them would be
+    pure waste on every commit (both orchestrators share this builder).
     """
-
-    def __init__(self, conn: Any) -> None:
-        self._conn = conn
-
-    def execute(self, statement: Any) -> List[Any]:
-        import collections
-
-        with self._conn.cursor() as cur:
-            cur.execute(str(statement))
-            columns = [description[0] for description in cur.description]
-            row_type = collections.namedtuple("Row", columns)  # type: ignore[misc]
-            return [row_type(*row) for row in cur.fetchall()]
+    detector = HighSpecificityEntityDetector(db_connection=None)
+    characters: Dict[int, Dict[str, Any]] = {}
+    for row in character_rows:
+        record = {
+            "id": row["id"],
+            "name": row["name"],
+            "summary": (row["summary"] or "")[:100] or None,
+        }
+        characters[record["id"]] = record
+        detector.character_lookup[record["name"].lower()] = record
+    for row in alias_rows:
+        if row["character_id"] in characters:
+            detector.character_lookup[row["alias"].lower()] = characters[
+                row["character_id"]
+            ]
+    return detector
 
 
 def diff_presence(
@@ -57,7 +72,7 @@ def diff_presence(
     *,
     chunk_id: int,
 ) -> List[Dict[str, Any]]:
-    """Return one finding per prose-detected character with no junction row.
+    """Return one finding per prose-detected character with no accounting.
 
     Pure core: iterates only DETECTED characters (pronoun-blindness
     guardrail — roster members whose names are absent can never be flagged).
@@ -93,9 +108,10 @@ def audit_chunk_presence(
     chunk_id: int,
     prose: str,
     *,
+    parent_chunk_id: Optional[int] = None,
     detector: Optional[HighSpecificityEntityDetector] = None,
 ) -> List[Dict[str, Any]]:
-    """Audit one committed chunk's prose against its junction rows.
+    """Audit one committed chunk's prose against its accounting.
 
     Read-only. Runs post-commit on the sync commit handler's psycopg2
     connection; the chunk's junction rows are ground truth as committed.
@@ -107,6 +123,8 @@ def audit_chunk_presence(
     masking a failure.
     """
     try:
+        from psycopg2.extras import RealDictCursor
+
         with conn.cursor() as cur:
             cur.execute(
                 "SELECT character_id FROM chunk_character_references "
@@ -114,10 +132,26 @@ def audit_chunk_presence(
                 (chunk_id,),
             )
             accounted = {row[0] for row in cur.fetchall()}
+            if parent_chunk_id:
+                # Authored-exit accounting: see the module docstring.
+                cur.execute(
+                    "SELECT character_id FROM chunk_character_references "
+                    "WHERE chunk_id = %s AND reference::text = 'present'",
+                    (parent_chunk_id,),
+                )
+                accounted |= {row[0] for row in cur.fetchall()}
 
-        active_detector = detector or HighSpecificityEntityDetector(
-            _PsycopgExecuteAdapter(conn)
-        )
+        active_detector = detector
+        if active_detector is None:
+            with conn.cursor(cursor_factory=RealDictCursor) as dict_cur:
+                dict_cur.execute(
+                    "SELECT id, name, summary FROM characters " "WHERE name IS NOT NULL"
+                )
+                character_rows = dict_cur.fetchall()
+                dict_cur.execute("SELECT character_id, alias FROM character_aliases")
+                alias_rows = dict_cur.fetchall()
+            active_detector = _character_only_detector(character_rows, alias_rows)
+
         entity_match = active_detector.detect_entities(prose)
         findings = diff_presence(entity_match, accounted, chunk_id=chunk_id)
         _emit_findings(findings)
@@ -131,39 +165,12 @@ def audit_chunk_presence(
         return []
 
 
-def _character_only_detector(
-    character_rows: List[Any],
-    alias_rows: List[Any],
-) -> HighSpecificityEntityDetector:
-    """Build a detector from prefetched character/alias rows.
-
-    Mirrors HighSpecificityEntityDetector._load_characters' record shape
-    ({id, name, summary}) for callers whose connections cannot satisfy the
-    detector's synchronous execute seam (asyncpg). Places and factions stay
-    unloaded — the presence audit only diffs characters.
-    """
-    detector = HighSpecificityEntityDetector(db_connection=None)
-    characters: Dict[int, Dict[str, Any]] = {}
-    for row in character_rows:
-        record = {
-            "id": row["id"],
-            "name": row["name"],
-            "summary": (row["summary"] or "")[:100] or None,
-        }
-        characters[record["id"]] = record
-        detector.character_lookup[record["name"].lower()] = record
-    for row in alias_rows:
-        if row["character_id"] in characters:
-            detector.character_lookup[row["alias"].lower()] = characters[
-                row["character_id"]
-            ]
-    return detector
-
-
 async def audit_chunk_presence_async(
     conn: Any,
     chunk_id: int,
     prose: str,
+    *,
+    parent_chunk_id: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Asyncpg twin of audit_chunk_presence for the async commit handler."""
     try:
@@ -173,6 +180,14 @@ async def audit_chunk_presence_async(
             chunk_id,
         )
         accounted = {row["character_id"] for row in accounted_rows}
+        if parent_chunk_id:
+            # Authored-exit accounting: see the module docstring.
+            parent_rows = await conn.fetch(
+                "SELECT character_id FROM chunk_character_references "
+                "WHERE chunk_id = $1 AND reference::text = 'present'",
+                parent_chunk_id,
+            )
+            accounted |= {row["character_id"] for row in parent_rows}
 
         character_rows = await conn.fetch(
             "SELECT id, name, summary FROM characters WHERE name IS NOT NULL"

--- a/nexus/api/presence_audit.py
+++ b/nexus/api/presence_audit.py
@@ -1,0 +1,201 @@
+"""Post-commit presence-roster drift audit (issue #567).
+
+Delta-presence semantics (#555 ruling) carry rosters forward on silence: the
+writer authors only entries/exits, so a missed entry accretes silently until
+a scene reset. The deterministic alias detector is deployed here as the
+AUDIT layer, exactly where its precision profile is strong:
+
+- A character name (or alias) appearing in committed prose while the chunk
+  has NO junction row for that character = candidate missed entry. Flag it
+  loudly.
+- Name-absence is NEVER evidence of absence (chunk n names her, chunk n+1
+  says only "she") — this module only iterates DETECTED names, so it is
+  structurally incapable of flagging a roster member whose name does not
+  appear.
+- The audit proposes; it never mutates. Output is one structured warning per
+  finding plus a metrics-friendly findings list.
+
+The diff runs against ALL junction reference types for the chunk, not only
+``present``: a ``mentioned`` row means the writer deliberately accounted for
+an off-scene reference, which is not a missed entry.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from nexus.memory.entity_detector import EntityMatch, HighSpecificityEntityDetector
+
+logger = logging.getLogger("nexus.api.presence_audit")
+
+
+class _PsycopgExecuteAdapter:
+    """Give the detector its expected ``.execute(statement)`` over psycopg2.
+
+    The detector issues parameterless SQL strings and reads columns by
+    attribute; this adapter runs them on a psycopg2 connection and returns
+    attribute-addressable rows.
+    """
+
+    def __init__(self, conn: Any) -> None:
+        self._conn = conn
+
+    def execute(self, statement: Any) -> List[Any]:
+        import collections
+
+        with self._conn.cursor() as cur:
+            cur.execute(str(statement))
+            columns = [description[0] for description in cur.description]
+            row_type = collections.namedtuple("Row", columns)  # type: ignore[misc]
+            return [row_type(*row) for row in cur.fetchall()]
+
+
+def diff_presence(
+    entity_match: EntityMatch,
+    accounted_character_ids: set[int],
+    *,
+    chunk_id: int,
+) -> List[Dict[str, Any]]:
+    """Return one finding per prose-detected character with no junction row.
+
+    Pure core: iterates only DETECTED characters (pronoun-blindness
+    guardrail — roster members whose names are absent can never be flagged).
+    """
+    findings: List[Dict[str, Any]] = []
+    for character in entity_match.characters:
+        if character["id"] in accounted_character_ids:
+            continue
+        findings.append(
+            {
+                "chunk_id": chunk_id,
+                "character_id": character["id"],
+                "name": character["name"],
+            }
+        )
+    return findings
+
+
+def _emit_findings(findings: List[Dict[str, Any]]) -> None:
+    """Emit exactly one structured warning per finding."""
+    for finding in findings:
+        logger.warning(
+            "presence audit: chunk %s prose names %r (character id=%s) "
+            "with no junction row — candidate missed entry",
+            finding["chunk_id"],
+            finding["name"],
+            finding["character_id"],
+        )
+
+
+def audit_chunk_presence(
+    conn: Any,
+    chunk_id: int,
+    prose: str,
+    *,
+    detector: Optional[HighSpecificityEntityDetector] = None,
+) -> List[Dict[str, Any]]:
+    """Audit one committed chunk's prose against its junction rows.
+
+    Read-only. Runs post-commit on the sync commit handler's psycopg2
+    connection; the chunk's junction rows are ground truth as committed.
+    Emits exactly one warning per finding.
+
+    Diagnostics must never fail a turn whose chunk already committed, so any
+    internal error is contained and logged loudly instead of raised — this
+    is blast-radius containment for a read-only observer, not a fallback
+    masking a failure.
+    """
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT character_id FROM chunk_character_references "
+                "WHERE chunk_id = %s",
+                (chunk_id,),
+            )
+            accounted = {row[0] for row in cur.fetchall()}
+
+        active_detector = detector or HighSpecificityEntityDetector(
+            _PsycopgExecuteAdapter(conn)
+        )
+        entity_match = active_detector.detect_entities(prose)
+        findings = diff_presence(entity_match, accounted, chunk_id=chunk_id)
+        _emit_findings(findings)
+        return findings
+    except Exception:
+        logger.exception(
+            "presence audit failed for committed chunk %s; the commit itself "
+            "is unaffected",
+            chunk_id,
+        )
+        return []
+
+
+def _character_only_detector(
+    character_rows: List[Any],
+    alias_rows: List[Any],
+) -> HighSpecificityEntityDetector:
+    """Build a detector from prefetched character/alias rows.
+
+    Mirrors HighSpecificityEntityDetector._load_characters' record shape
+    ({id, name, summary}) for callers whose connections cannot satisfy the
+    detector's synchronous execute seam (asyncpg). Places and factions stay
+    unloaded — the presence audit only diffs characters.
+    """
+    detector = HighSpecificityEntityDetector(db_connection=None)
+    characters: Dict[int, Dict[str, Any]] = {}
+    for row in character_rows:
+        record = {
+            "id": row["id"],
+            "name": row["name"],
+            "summary": (row["summary"] or "")[:100] or None,
+        }
+        characters[record["id"]] = record
+        detector.character_lookup[record["name"].lower()] = record
+    for row in alias_rows:
+        if row["character_id"] in characters:
+            detector.character_lookup[row["alias"].lower()] = characters[
+                row["character_id"]
+            ]
+    return detector
+
+
+async def audit_chunk_presence_async(
+    conn: Any,
+    chunk_id: int,
+    prose: str,
+) -> List[Dict[str, Any]]:
+    """Asyncpg twin of audit_chunk_presence for the async commit handler."""
+    try:
+        accounted_rows = await conn.fetch(
+            "SELECT character_id FROM chunk_character_references "
+            "WHERE chunk_id = $1",
+            chunk_id,
+        )
+        accounted = {row["character_id"] for row in accounted_rows}
+
+        character_rows = await conn.fetch(
+            "SELECT id, name, summary FROM characters WHERE name IS NOT NULL"
+        )
+        alias_rows = await conn.fetch(
+            "SELECT character_id, alias FROM character_aliases"
+        )
+        detector = _character_only_detector(list(character_rows), list(alias_rows))
+        entity_match = detector.detect_entities(prose)
+        findings = diff_presence(entity_match, accounted, chunk_id=chunk_id)
+        _emit_findings(findings)
+        return findings
+    except Exception:
+        logger.exception(
+            "presence audit failed for committed chunk %s; the commit itself "
+            "is unaffected",
+            chunk_id,
+        )
+        return []
+
+
+def presence_audit_enabled() -> bool:
+    """Read the [lore.presence_audit] gate from validated settings."""
+    from nexus.config import load_settings
+
+    return load_settings().lore.presence_audit.enabled

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -726,6 +726,22 @@ class LORERetrievalSettings(BaseModel):
     )
 
 
+class PresenceAuditSettings(BaseModel):
+    """Post-commit presence-roster drift audit (issue #567)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Run the deterministic alias detector over each committed chunk's "
+            "prose and warn on characters named in prose with no junction row "
+            "(candidate missed entries under delta-presence). Diagnostics "
+            "only; never mutates state."
+        ),
+    )
+
+
 class LORESettings(BaseModel):
     """LORE agent configuration."""
 
@@ -737,6 +753,7 @@ class LORESettings(BaseModel):
     payload_percent_budget: PayloadPercentBudget
     entity_inclusion: EntityInclusionConfig
     retrieval: LORERetrievalSettings = Field(default_factory=LORERetrievalSettings)
+    presence_audit: PresenceAuditSettings = Field(default_factory=PresenceAuditSettings)
 
 
 # =============================================================================

--- a/tests/test_presence_audit.py
+++ b/tests/test_presence_audit.py
@@ -117,9 +117,9 @@ def test_live_audit_runs_read_only_on_a_real_chunk() -> None:
     try:
         with conn.cursor() as cur:
             cur.execute(
-                "SELECT nc.id, nc.storyteller_text FROM narrative_chunks nc "
+                "SELECT nc.id, nc.raw_text FROM narrative_chunks nc "
                 "JOIN chunk_character_references ccr ON ccr.chunk_id = nc.id "
-                "WHERE nc.storyteller_text IS NOT NULL "
+                "WHERE nc.raw_text IS NOT NULL "
                 "ORDER BY nc.id DESC LIMIT 1"
             )
             row = cur.fetchone()
@@ -139,3 +139,22 @@ def test_live_audit_runs_read_only_on_a_real_chunk() -> None:
             assert finding["chunk_id"] == chunk_id
     finally:
         conn.close()
+
+
+def test_narrated_departure_is_accounted_by_parent_presence() -> None:
+    """presence.exit removes the junction row by design; the departing
+    character's name in prose must not be flagged (PR #584 Codex finding).
+
+    Under delta-presence, silence carries a present character forward, so a
+    parent-present character can only lack a row via an authored exit —
+    the exclusion is exact.
+    """
+    detector = _detector_with_characters({"kosi": KOSI})
+    match = detector.detect_entities(
+        "Kosi shoulders the boat hook and walks into the rain."
+    )
+
+    parent_present = {7}
+    findings = diff_presence(match, set() | parent_present, chunk_id=4246)
+
+    assert findings == []

--- a/tests/test_presence_audit.py
+++ b/tests/test_presence_audit.py
@@ -1,0 +1,141 @@
+"""Presence-roster drift audit tests (issue #567)."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+
+from nexus.api.presence_audit import (
+    audit_chunk_presence,
+    diff_presence,
+    presence_audit_enabled,
+)
+from nexus.memory.entity_detector import HighSpecificityEntityDetector
+
+RUN_POSTGRES = os.environ.get("NEXUS_RUN_POSTGRES") == "1"
+
+
+def _detector_with_characters(
+    records: dict[str, dict],
+) -> HighSpecificityEntityDetector:
+    """Build a DB-less detector with an injected character lookup."""
+    detector = HighSpecificityEntityDetector(db_connection=None)
+    detector.character_lookup.update(records)
+    return detector
+
+
+KOSI = {"id": 7, "name": "Kosi", "summary": None}
+NNEKA = {"id": 9, "name": "Nneka", "summary": None}
+
+
+def test_prose_present_roster_absent_yields_one_finding_per_character(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Each unaccounted prose-named character = exactly one structured warning."""
+    detector = _detector_with_characters(
+        {"kosi": KOSI, "nneka": NNEKA, "the boatman": KOSI}
+    )
+    match = detector.detect_entities(
+        "Kosi lifts the boat hook while Nneka watches. Kosi nods. "
+        "The boatman says nothing."
+    )
+
+    with caplog.at_level(logging.WARNING, logger="nexus.api.presence_audit"):
+        findings = diff_presence(match, {9}, chunk_id=4242)
+        from nexus.api.presence_audit import _emit_findings
+
+        _emit_findings(findings)
+
+    # Kosi appears by name AND alias, twice by name — one finding, one warning.
+    assert findings == [{"chunk_id": 4242, "character_id": 7, "name": "Kosi"}]
+    warnings = [
+        record for record in caplog.records if record.name == "nexus.api.presence_audit"
+    ]
+    assert len(warnings) == 1
+    assert "chunk 4242" in warnings[0].getMessage()
+    assert "'Kosi'" in warnings[0].getMessage()
+    assert "id=7" in warnings[0].getMessage()
+
+
+def test_roster_present_name_absent_yields_no_warning() -> None:
+    """Pronoun-blindness guardrail: name-absence is never evidence of absence.
+
+    The roster carries character 7, the prose says only "she" — the audit
+    must stay silent (chunk n names her, chunk n+1 uses pronouns).
+    """
+    detector = _detector_with_characters({"kosi": KOSI})
+    match = detector.detect_entities("She lowers the hook and waits in the dark.")
+
+    findings = diff_presence(match, {7}, chunk_id=4243)
+
+    assert findings == []
+
+
+def test_accounted_mention_is_not_a_missed_entry() -> None:
+    """Any junction row (present OR mentioned) accounts for a prose name."""
+    detector = _detector_with_characters({"kosi": KOSI})
+    match = detector.detect_entities("They speak of Kosi in a low voice.")
+
+    findings = diff_presence(match, {7}, chunk_id=4244)
+
+    assert findings == []
+
+
+def test_audit_errors_never_escape(caplog: pytest.LogCaptureFixture) -> None:
+    """A diagnostics failure after a successful commit must not raise."""
+
+    class ExplodingConn:
+        def cursor(self):
+            raise RuntimeError("boom")
+
+    with caplog.at_level(logging.ERROR, logger="nexus.api.presence_audit"):
+        findings = audit_chunk_presence(ExplodingConn(), 4245, "Kosi waits.")
+
+    assert findings == []
+    assert any(
+        "presence audit failed for committed chunk 4245" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_presence_audit_enabled_reads_shipped_default() -> None:
+    """The shipped [lore.presence_audit] gate is on."""
+    assert presence_audit_enabled() is True
+
+
+@pytest.mark.skipif(not RUN_POSTGRES, reason="requires live slot database")
+def test_live_audit_runs_read_only_on_a_real_chunk() -> None:
+    """The sync orchestrator runs against a real slot without mutating state."""
+    import psycopg2
+
+    from nexus.api.slot_utils import require_slot_dbname
+
+    dbname = require_slot_dbname()
+    conn = psycopg2.connect(host="localhost", database=dbname, user="pythagor")
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT nc.id, nc.storyteller_text FROM narrative_chunks nc "
+                "JOIN chunk_character_references ccr ON ccr.chunk_id = nc.id "
+                "WHERE nc.storyteller_text IS NOT NULL "
+                "ORDER BY nc.id DESC LIMIT 1"
+            )
+            row = cur.fetchone()
+            assert row is not None, "slot has no chunk with junction rows"
+            chunk_id, prose = row
+            cur.execute("SELECT COUNT(*) FROM chunk_character_references")
+            before = cur.fetchone()[0]
+
+        findings = audit_chunk_presence(conn, chunk_id, prose)
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM chunk_character_references")
+            after = cur.fetchone()[0]
+        assert before == after
+        for finding in findings:
+            assert set(finding) == {"chunk_id", "character_id", "name"}
+            assert finding["chunk_id"] == chunk_id
+    finally:
+        conn.close()


### PR DESCRIPTION
Closes #567 — the deferred audit-layer follow-up from the #555 delta-presence ruling, built to the frozen doctrine on the issue.

## Shape

- **`nexus/api/presence_audit.py`**: pure diff core (`diff_presence`) + sync orchestrator (psycopg2, runs the real `HighSpecificityEntityDetector` through a tiny execute-adapter over the commit connection) + asyncpg twin (prefetch-fed detector — asyncpg cannot satisfy the detector's sync execute seam).
- **Both commit handlers** call it post-commit, outside the transaction, gated on `[lore.presence_audit] enabled` (shipped `true`).
- One structured warning per finding (`chunk_id`, `name`, `character_id`); findings list returned for metrics.

## Doctrine fidelity

- **Flag loudly**: prose-named character with no junction row → exactly one warning. Detector dedups by id, so name + alias + repeats = one finding (test-pinned).
- **Never trust name-absence**: the module only iterates DETECTED names — structurally incapable of flagging a roster member whose name doesn't appear. Pronoun guardrail test: roster carries her, prose says only "she", zero findings.
- **Proposes, never mutates**: read-only queries; live-gated test asserts junction counts unchanged.
- One deliberate refinement over the issue text: the diff runs against **all** junction reference types, not only `present` — a `mentioned` row is the writer deliberately accounting for an off-scene reference; flagging it would be a false positive on every mention. The signal is *zero rows*.
- One deliberate, documented containment: audit errors after a successful commit are logged loudly and never raised — a read-only observer must not fail a turn whose chunk already committed. This is blast-radius containment, not a fallback masking failure.

## Acceptance (from the issue)

- [x] Audit runs on the real commit path (both handlers) without mutating state
- [x] Prose-present/roster-absent → exactly one structured warning with chunk id + name
- [x] Roster-present/name-absent → NO warning (pronoun-blindness guardrail, test-enforced)
- [x] Live-gated test against a slot database (ran green on save_05)

Suites: commit handlers + config + presence audit → 88 passed; mypy/black/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ