### PR TITLE
Unify replacement vocabularies under the library treatment (#577)

### DIFF
--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -115,8 +115,7 @@ class NewEntityPairTagHint(BaseModel):
     declared_entity_role: Literal["subject", "object"] = Field(
         default="subject",
         description=(
-            "Whether the declared entity is the subject or object of the "
-            "directed pair tag."
+            "Whether the declared entity is subject or object of the pair tag."
         ),
     )
 
@@ -613,10 +612,7 @@ class OrreryAdjudication(BaseModel):
     )
     replacement_event_type: Optional[str] = Field(
         default=None,
-        description=(
-            "Optional registered event type for a replacement_state_delta. "
-            "Leave unset unless the replacement should emit a canonical world_event."
-        ),
+        description=("Registered event type when the replacement emits a world_event."),
     )
 
     model_config = ConfigDict(extra="forbid")

--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -612,8 +612,26 @@ class OrreryAdjudication(BaseModel):
     )
     replacement_event_type: Optional[str] = Field(
         default=None,
-        description=("Registered event type when the replacement emits a world_event."),
+        description=(
+            "Registered event type for a replacement_state_delta world_event."
+        ),
     )
+
+    @model_validator(mode="after")
+    def event_type_requires_replacement_delta(self) -> "OrreryAdjudication":
+        """An event type without a replacement delta would be silently ignored.
+
+        events.py's adjudication applier returns early when the delta is
+        missing, so accepting this shape would drop the expected canonical
+        world_event on the floor (PR #585 Codex P2). Rejecting it here feeds
+        the generation-time repair loop instead.
+        """
+        if self.replacement_event_type and self.replacement_state_delta is None:
+            raise ValueError(
+                "replacement_event_type requires replacement_state_delta; "
+                "supply the delta or drop the event type"
+            )
+        return self
 
     model_config = ConfigDict(extra="forbid")
 

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -77,7 +77,7 @@ DECLARED_ENTITY_ROLE_DESCRIPTION = (
     "Whether the declared entity is subject or object of the pair tag."
 )
 REPLACEMENT_EVENT_TYPE_DESCRIPTION = (
-    "Registered event type when the replacement emits a world_event."
+    "Registered event type for a replacement_state_delta world_event."
 )
 COORDINATES_DESCRIPTION = (
     "Earth-based lat/lon coordinates.\n\n"
@@ -1513,3 +1513,23 @@ def test_schema_token_measurement_uses_o200k() -> None:
     lenient_wire = _compact_schema_json(skald_wire_lenient_schema())
     assert len(encoding.encode(strict_wire)) > 0
     assert len(encoding.encode(lenient_wire)) > 0
+
+
+def test_replacement_event_type_requires_replacement_delta() -> None:
+    """An event type without a delta is silently dropped by the applier —
+    reject the shape at validation so the repair loop fixes it (#585 P2)."""
+
+    with pytest.raises(ValidationError, match="requires replacement_state_delta"):
+        OrreryAdjudication(
+            proposal_id="drink:aaa",
+            action="replace",
+            replacement_event_type="mock_replacement",
+        )
+
+    adjudication = OrreryAdjudication(
+        proposal_id="drink:aaa",
+        action="replace",
+        replacement_state_delta={"character_current_activity": "resting"},
+        replacement_event_type="mock_replacement",
+    )
+    assert adjudication.replacement_event_type == "mock_replacement"

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -70,12 +70,14 @@ SKALD_WIRE_STRICT_MAX_BYTES = 19_600
 SKALD_WIRE_LENIENT_MAX_BYTES = 18_950
 SKALD_WIRE_DESCRIPTION_MAX_CHARS = 70
 
+# Post-#577 unification: the replacement vocabulary's guidance lives in the
+# contextual tag library (Event-Type Names) and the imminent-activity prompt
+# block, so every wire field description sits under the uniform ceiling.
 DECLARED_ENTITY_ROLE_DESCRIPTION = (
-    "Whether the declared entity is the subject or object of the directed pair tag."
+    "Whether the declared entity is subject or object of the pair tag."
 )
 REPLACEMENT_EVENT_TYPE_DESCRIPTION = (
-    "Optional registered event type for a replacement_state_delta. "
-    "Leave unset unless the replacement should emit a canonical world_event."
+    "Registered event type when the replacement emits a world_event."
 )
 COORDINATES_DESCRIPTION = (
     "Earth-based lat/lon coordinates.\n\n"
@@ -84,11 +86,6 @@ COORDINATES_DESCRIPTION = (
     "for the location's described characteristics (climate, terrain, proximity\n"
     "to water)."
 )
-
-WIRE_DESCRIPTION_SURVIVORS = {
-    "NewEntityPairTagHint.declared_entity_role": DECLARED_ENTITY_ROLE_DESCRIPTION,
-    "OrreryAdjudication.replacement_event_type": REPLACEMENT_EVENT_TYPE_DESCRIPTION,
-}
 
 SPARSE_WIRE_PAYLOAD = {
     "narrative": "Rain beads on the sealed archive door.",
@@ -1136,8 +1133,7 @@ def test_skald_wire_prompt_guide_preserves_enum_values_verbatim() -> None:
     )
     assert (
         'declared_entity_role?:string|enum=["subject","object"]|'
-        '"Whether the declared entity is the subject or object of the directed '
-        'pair tag."' in guide
+        '"Whether the declared entity is subject or object of the pair tag."' in guide
     )
 
 
@@ -1172,7 +1168,9 @@ def test_wire_schema_size_and_description_budget() -> None:
         if field.description is not None
         and len(field.description) > SKALD_WIRE_DESCRIPTION_MAX_CHARS
     }
-    assert overlong_descriptions == WIRE_DESCRIPTION_SURVIVORS
+    # #577 unification: no field description may exceed the uniform ceiling —
+    # the replacement-vocabulary keep-list special case is deleted.
+    assert overlong_descriptions == {}
     overlong_new_model_descriptions = {
         model.__name__: description
         for model in described_models


### PR DESCRIPTION
Closes #577. The census found the issue's premise partially overtaken by events — validation custody (per-attempt `StorytellerVocabulary` snapshot, stage 1) and contextual delivery (the library renders **Event-Type Names** whenever proposals pend, #564) were already unified. The genuine residue was the **#560 description-diet keep-list**: `WIRE_DESCRIPTION_SURVIVORS`, two field descriptions exempted from the uniform 70-char ceiling.

Both exemptions are now obsolete:
- `OrreryAdjudication.replacement_event_type` (117 → 63 chars): usage semantics ("a replacement only emits a world_event if you provide replacement_event_type") live in the imminent-activity prompt block; names live in the library; the registry snapshot validates with suggestions. No guidance orphaned.
- `NewEntityPairTagHint.declared_entity_role` (79 → 66 chars): compressed within the ceiling with full meaning intact — it's structural positioning, not registry vocabulary, and could never move to the library.

The keep-list machinery is deleted: `test_wire_schema_size_and_description_budget` now asserts a **uniform ceiling with zero exemptions**, and the survives-both-serializations test pins the new terse strings.

**Deliberate scope exclusion:** `Coordinates`' long description is untouched — it is Earth-shaped-geography doctrine, not vocabulary, and dieting it would trade owner-doctrine fidelity for ~60 tokens.

Suites: skald_wire + native_structured_output + lore + config + mock → 405 passed, 16 skipped; mypy/black/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ