### PR TITLE
Gate maturation replay on checkpoint-recorded job membership (#552)

### DIFF
--- a/nexus/agents/orrery/reconstruction.py
+++ b/nexus/agents/orrery/reconstruction.py
@@ -155,9 +155,10 @@ _ADDITIVE_CHECKPOINT_TABLES = {"backstory_secrets": "backstory_secrets"}
 # are visible inside the capture transaction. Underscore-prefixed and
 # deliberately absent from CHECKPOINT_SECTIONS so verification never diffs it
 # as state; replay uses target-minus-base membership as the exact applied-at
-# boundary for asynchronously persisted maturation writes. MVCC gives the
-# exactness: whatever this SELECT can see is precisely what the section
-# snapshots in the same transaction saw.
+# boundary for asynchronously persisted maturation writes. Statement-level
+# MVCC gives the exactness: the control set and every section are read in
+# ONE statement (see _checkpoint_document_sql), so they share one snapshot
+# even under READ COMMITTED.
 #
 # The predicate is result_manifest.persisted — recorded by the worker in the
 # SAME transaction as the expansion writes — NOT state = 'succeeded', which
@@ -181,19 +182,31 @@ def _validate_label(label: str) -> None:
         )
 
 
-def capture_state_checkpoint_sync(
-    cur: Any,
-    *,
-    chunk_id: Optional[int],
-    label: str,
-) -> Optional[int]:
-    """Snapshot the mutable state surface. Returns the checkpoint id, or
-    ``None`` when a checkpoint for ``(chunk_id, label)`` already exists
-    (idempotent re-commit)."""
+def _checkpoint_document_sql(included_sections: list[str]) -> str:
+    """Build the single-statement capture for one coherent snapshot.
 
-    _validate_label(label)
-    state: dict[str, Any] = {}
-    for section, sql in CHECKPOINT_SECTIONS.items():
+    Under READ COMMITTED each statement sees its own snapshot, so capturing
+    sections with one query per section lets a concurrent writer (a delayed
+    maturation worker especially) land BETWEEN sections — the document would
+    then disagree with its own maturation-job control set (#552 review
+    finding). One SELECT = one snapshot for every section AND the control
+    key, which is what makes target-minus-base membership exact.
+    """
+
+    # Section names are trusted code constants (single-quote-free), rendered
+    # as SQL string literals.
+    parts = [
+        f"'{section}', ({CHECKPOINT_SECTIONS[section]})"
+        for section in included_sections
+    ]
+    parts.append(f"'{MATURATION_JOBS_CONTROL_KEY}', ({_MATURATION_JOBS_CONTROL_SQL})")
+    # jsonb_build_object caps at 100 arguments; nest concatenation instead.
+    return "SELECT " + " || ".join(f"jsonb_build_object({part})" for part in parts)
+
+
+def _included_checkpoint_sections_sync(cur: Any) -> list[str]:
+    included: list[str] = []
+    for section in CHECKPOINT_SECTIONS:
         additive_table = _ADDITIVE_CHECKPOINT_TABLES.get(section)
         if additive_table is not None:
             cur.execute(
@@ -205,16 +218,26 @@ def capture_state_checkpoint_sync(
                 # checkpoint document. Replay treats the absent key as the
                 # explicit cross-era compatibility boundary.
                 continue
-        cur.execute(sql)
-        row = cur.fetchone()
-        state[section] = row[0] if not hasattr(row, "keys") else list(row.values())[0]
-    cur.execute(_MATURATION_JOBS_CONTROL_SQL)
-    control_row = cur.fetchone()
-    state[MATURATION_JOBS_CONTROL_KEY] = (
-        control_row[0]
-        if not hasattr(control_row, "keys")
-        else list(control_row.values())[0]
-    )
+        included.append(section)
+    return included
+
+
+def capture_state_checkpoint_sync(
+    cur: Any,
+    *,
+    chunk_id: Optional[int],
+    label: str,
+) -> Optional[int]:
+    """Snapshot the mutable state surface. Returns the checkpoint id, or
+    ``None`` when a checkpoint for ``(chunk_id, label)`` already exists
+    (idempotent re-commit)."""
+
+    _validate_label(label)
+    included = _included_checkpoint_sections_sync(cur)
+    cur.execute(_checkpoint_document_sql(included))
+    row = cur.fetchone()
+    document = row[0] if not hasattr(row, "keys") else list(row.values())[0]
+    state = document if isinstance(document, dict) else json.loads(document)
     cur.execute(
         """
         INSERT INTO state_checkpoints (chunk_id, label, state)
@@ -235,20 +258,17 @@ async def capture_state_checkpoint_async(
     label: str,
 ) -> Optional[int]:
     _validate_label(label)
-    state: dict[str, Any] = {}
-    for section, sql in CHECKPOINT_SECTIONS.items():
+    included: list[str] = []
+    for section in CHECKPOINT_SECTIONS:
         additive_table = _ADDITIVE_CHECKPOINT_TABLES.get(section)
         if (
             additive_table is not None
             and await conn.fetchval("SELECT to_regclass($1)", additive_table) is None
         ):
             continue
-        value = await conn.fetchval(sql)
-        state[section] = json.loads(value) if isinstance(value, str) else value
-    control_value = await conn.fetchval(_MATURATION_JOBS_CONTROL_SQL)
-    state[MATURATION_JOBS_CONTROL_KEY] = (
-        json.loads(control_value) if isinstance(control_value, str) else control_value
-    )
+        included.append(section)
+    document = await conn.fetchval(_checkpoint_document_sql(included))
+    state = document if isinstance(document, dict) else json.loads(document)
     return await conn.fetchval(
         """
         INSERT INTO state_checkpoints (chunk_id, label, state)

--- a/nexus/agents/orrery/reconstruction.py
+++ b/nexus/agents/orrery/reconstruction.py
@@ -151,6 +151,25 @@ CHECKPOINT_SECTIONS: dict[str, str] = {
 
 _ADDITIVE_CHECKPOINT_TABLES = {"backstory_secrets": "backstory_secrets"}
 
+# Control key (#552): the set of maturation-job ids whose expansion WRITES
+# are visible inside the capture transaction. Underscore-prefixed and
+# deliberately absent from CHECKPOINT_SECTIONS so verification never diffs it
+# as state; replay uses target-minus-base membership as the exact applied-at
+# boundary for asynchronously persisted maturation writes. MVCC gives the
+# exactness: whatever this SELECT can see is precisely what the section
+# snapshots in the same transaction saw.
+#
+# The predicate is result_manifest.persisted — recorded by the worker in the
+# SAME transaction as the expansion writes — NOT state = 'succeeded', which
+# flips in a later transaction after embedding and would open a race band
+# where a capture sees the writes but not the membership.
+MATURATION_JOBS_CONTROL_KEY = "_maturation_jobs_succeeded"
+_MATURATION_JOBS_CONTROL_SQL = (
+    "SELECT coalesce(jsonb_agg(id ORDER BY id), '[]'::jsonb) "
+    "FROM orrery_maturation_jobs "
+    "WHERE (result_manifest ->> 'persisted')::boolean"
+)
+
 CHECKPOINT_LABELS = ("genesis", "interval", "manual")
 
 
@@ -189,6 +208,13 @@ def capture_state_checkpoint_sync(
         cur.execute(sql)
         row = cur.fetchone()
         state[section] = row[0] if not hasattr(row, "keys") else list(row.values())[0]
+    cur.execute(_MATURATION_JOBS_CONTROL_SQL)
+    control_row = cur.fetchone()
+    state[MATURATION_JOBS_CONTROL_KEY] = (
+        control_row[0]
+        if not hasattr(control_row, "keys")
+        else list(control_row.values())[0]
+    )
     cur.execute(
         """
         INSERT INTO state_checkpoints (chunk_id, label, state)
@@ -219,6 +245,10 @@ async def capture_state_checkpoint_async(
             continue
         value = await conn.fetchval(sql)
         state[section] = json.loads(value) if isinstance(value, str) else value
+    control_value = await conn.fetchval(_MATURATION_JOBS_CONTROL_SQL)
+    state[MATURATION_JOBS_CONTROL_KEY] = (
+        json.loads(control_value) if isinstance(control_value, str) else control_value
+    )
     return await conn.fetchval(
         """
         INSERT INTO state_checkpoints (chunk_id, label, state)

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -85,7 +85,10 @@ from nexus.agents.orrery.needs import (
     need_applies_to_tags,
     severity_tags_for_need,
 )
-from nexus.agents.orrery.reconstruction import CHECKPOINT_SECTIONS
+from nexus.agents.orrery.reconstruction import (
+    CHECKPOINT_SECTIONS,
+    MATURATION_JOBS_CONTROL_KEY,
+)
 from nexus.agents.orrery.substrate import ProjectPolicy, coerce_project_policy
 
 PROJECT_STAGE_LADDERS = {
@@ -126,6 +129,22 @@ MATURATION_PROJECT_STARTED_TYPES = {
 # edges: base-exclusive and target-inclusive.
 CHECKPOINTED_WRITE_WINDOW_SQL = "{column} > %(base)s AND {column} <= %(target)s"
 MATURATION_PROJECT_START_WINDOW_SQL = "{column} >= %(base)s AND {column} < %(target)s"
+
+# Issue #552: chunk-keyed windows misplace ASYNCHRONOUSLY persisted maturation
+# writes — a worker can commit its expansion after a later checkpoint was
+# captured, and the requesting-chunk window would then project rows into a
+# snapshot that never contained them. When both the base and target
+# checkpoints record MATURATION_JOBS_CONTROL_KEY, replay gates maturation
+# writes on job membership instead: include exactly the jobs that became
+# visible-succeeded between the two captures (target set minus base set).
+# Event refs are namespaced ``maturation_job_<id>_<skald_ref>``, so the job
+# id is the third underscore-separated token.
+MATURATION_JOB_REF_ID_SQL = (
+    "split_part(payload ->> 'retrograde_event_ref', '_', 3)::bigint"
+)
+MATURATION_GATE_FILTER_SQL = (
+    f" AND {MATURATION_JOB_REF_ID_SQL} = ANY(%(maturation_gate)s::bigint[])"
+)
 
 # Composite natural keys, verbatim column order (faction_relationships
 # enforces faction1_id < faction2_id; character_relationships only c1 <> c2
@@ -414,13 +433,23 @@ def _load_project_policy() -> ProjectPolicy:
 class _Replayer:
     """Single-use forward/backward replay over one (checkpoint, N] window."""
 
-    def __init__(self, cur: Any, target_chunk_id: int) -> None:
+    def __init__(
+        self,
+        cur: Any,
+        target_chunk_id: int,
+        *,
+        target_checkpoint_id: Optional[int] = None,
+    ) -> None:
         self.cur = cur
         self.target_chunk_id = target_chunk_id
+        self.target_checkpoint_id = target_checkpoint_id
         self.target_created_at = _fetch_chunk_created_at(cur, target_chunk_id)
         self.need_tuning = load_need_tuning()
         self.project_policy = _load_project_policy()
         self.missing_base_sections: set[str] = set()
+        # Resolved in replay() once the base document is loaded; None means
+        # legacy chunk-window behavior (issue #552).
+        self.maturation_gate: Optional[frozenset[int]] = None
 
     # -- base checkpoint ---------------------------------------------------
 
@@ -488,6 +517,92 @@ class _Replayer:
             self.missing_base_sections.add("backstory_secrets")
         return checkpoint_id, chunk_id, created_at, state
 
+    # -- maturation applied-at gating (issue #552) --------------------------
+
+    def _resolve_maturation_gate(
+        self,
+        base_state: dict[str, Any],
+        result: ReplayResult,
+    ) -> None:
+        """Resolve the job-membership gate from the checkpoint documents.
+
+        The gate exists only for checkpoint-targeted reconstruction (verify)
+        where BOTH documents recorded the control key. Arbitrary chunk
+        reconstruction and cross-era pairs keep the legacy chunk-window
+        rule — the acceptance's distinct boundary regimes.
+        """
+
+        if self.target_checkpoint_id is None:
+            return
+        base_ids = base_state.get(MATURATION_JOBS_CONTROL_KEY)
+        self.cur.execute(
+            "SELECT state -> %s FROM state_checkpoints WHERE id = %s",
+            (MATURATION_JOBS_CONTROL_KEY, self.target_checkpoint_id),
+        )
+        row = self.cur.fetchone()
+        target_ids = _as_document(_row_value(row, 0)) if row else None
+        if not isinstance(base_ids, list) or not isinstance(target_ids, list):
+            result.add_note(
+                "_maturation_gate",
+                "checkpoint pair predates the maturation-job control key; "
+                "maturation writes use the legacy chunk-window boundary",
+                approximate=True,
+            )
+            return
+        self.maturation_gate = frozenset(int(v) for v in target_ids) - frozenset(
+            int(v) for v in base_ids
+        )
+        result.add_note(
+            "_maturation_gate",
+            "maturation writes gated on jobs that became visible-succeeded "
+            f"between the checkpoint captures ({len(self.maturation_gate)} "
+            "job(s))",
+            approximate=False,
+        )
+        self._assert_maturation_events_attributable()
+
+    def _maturation_gate_params(self) -> dict[str, Any]:
+        if self.maturation_gate is None:
+            return {}
+        return {"maturation_gate": sorted(self.maturation_gate)}
+
+    def _maturation_gate_filter(self) -> str:
+        return "" if self.maturation_gate is None else MATURATION_GATE_FILTER_SQL
+
+    def _assert_maturation_events_attributable(self) -> None:
+        """Gated replay must be able to name every maturation write's job.
+
+        Live maturation events carry ``maturation_job_<id>_...`` refs; an
+        event claiming maturation provenance without a parseable job id
+        cannot be placed on either side of the capture boundary, so the
+        reconstruction refuses loudly instead of guessing.
+        """
+
+        self.cur.execute(
+            """
+            SELECT id FROM world_events
+            WHERE (
+                    source::text = 'maturation'
+                    OR (
+                        source::text = 'retrograde'
+                        AND payload ->> 'source' = 'maturation'
+                    )
+                  )
+              AND (
+                    payload ->> 'retrograde_event_ref' IS NULL
+                    OR payload ->> 'retrograde_event_ref'
+                        !~ '^maturation_job_[0-9]+'
+                  )
+            ORDER BY id
+            """
+        )
+        orphans = [_row_value(row, 0) for row in self.cur.fetchall()]
+        if orphans:
+            raise ValueError(
+                "Gated maturation replay found events with maturation "
+                f"provenance but no parseable maturation_job ref: {orphans}"
+            )
+
     # -- forward scalar replay ----------------------------------------------
 
     def replay(self, base_checkpoint_id: Optional[int] = None) -> ReplayResult:
@@ -500,6 +615,7 @@ class _Replayer:
             base_checkpoint_chunk_id=base_chunk,
             state={},
         )
+        self._resolve_maturation_gate(base_state, result)
         if "entities" in self.missing_base_sections:
             result.add_note(
                 "entities",
@@ -1013,6 +1129,7 @@ class _Replayer:
         maturation_activity_window = MATURATION_PROJECT_START_WINDOW_SQL.format(
             column="(activity.row ->> 'source_chunk_id')::bigint"
         )
+        maturation_gate_filter = self._maturation_gate_filter()
         self.cur.execute(
             f"""
             SELECT DISTINCT chunk_id FROM (
@@ -1034,6 +1151,7 @@ class _Replayer:
                                 LIKE 'maturation_job_%%'
                         )
                       )
+                  {maturation_gate_filter}
                 UNION
                 SELECT (activity.row ->> 'source_chunk_id')::bigint
                 FROM world_events
@@ -1044,12 +1162,14 @@ class _Replayer:
                   AND payload ->> 'retrograde_event_ref'
                         LIKE 'maturation_job_%%'
                   AND {maturation_activity_window}
+                  {maturation_gate_filter}
             ) w ORDER BY chunk_id
             """,
             {
                 "base": base_chunk,
                 "target": self.target_chunk_id,
                 "started_types": list(MATURATION_PROJECT_STARTED_TYPES),
+                **self._maturation_gate_params(),
             },
         )
         return [_row_value(row, 0) for row in self.cur.fetchall()]
@@ -1087,12 +1207,14 @@ class _Replayer:
                     LIKE 'maturation_job_%%'
               AND (activity.row ->> 'source_chunk_id')::bigint = %(chunk)s
               AND {maturation_activity_window}
+              {self._maturation_gate_filter()}
             ORDER BY world_events.id, activity.ordinal
             """,
             {
                 "chunk": chunk_id,
                 "base": base_chunk,
                 "target": self.target_chunk_id,
+                **self._maturation_gate_params(),
             },
         )
         applied_count = 0
@@ -1417,6 +1539,7 @@ class _Replayer:
                             LIKE 'maturation_job_%%'
                     )
                   )
+              {self._maturation_gate_filter()}
             ORDER BY id
             """,
             {
@@ -1424,6 +1547,7 @@ class _Replayer:
                 "base": base_chunk,
                 "target": self.target_chunk_id,
                 "started_types": list(MATURATION_PROJECT_STARTED_TYPES),
+                **self._maturation_gate_params(),
             },
         )
         event_rows = self.cur.fetchall()
@@ -2497,15 +2621,22 @@ def reconstruct_state_at_sync(
     chunk_id: int,
     *,
     base_checkpoint_id: Optional[int] = None,
+    target_checkpoint_id: Optional[int] = None,
 ) -> ReplayResult:
     """Reconstruct the full mutable state surface as of ``chunk_id``.
 
     ``base_checkpoint_id`` pins the starting checkpoint (used by verify to
     force replay across a window that ends at a stored checkpoint); by
     default the latest checkpoint at or before ``chunk_id`` is used.
+    ``target_checkpoint_id`` names the stored checkpoint the result will be
+    compared against, enabling the issue-#552 applied-at gate for
+    asynchronously persisted maturation writes; arbitrary chunk
+    reconstruction leaves it None and keeps the chunk-window boundary.
     """
 
-    return _Replayer(cur, chunk_id).replay(base_checkpoint_id)
+    return _Replayer(cur, chunk_id, target_checkpoint_id=target_checkpoint_id).replay(
+        base_checkpoint_id
+    )
 
 
 def _values_equal(expected: Any, actual: Any) -> bool:
@@ -2712,7 +2843,10 @@ def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:
             )
             continue
         result = reconstruct_state_at_sync(
-            cur, target_chunk, base_checkpoint_id=base_id
+            cur,
+            target_chunk,
+            base_checkpoint_id=base_id,
+            target_checkpoint_id=target_id,
         )
         stored = _load_checkpoint_state(cur, target_id)
         missing_sections = _missing_checkpoint_sections(

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -450,6 +450,12 @@ class _Replayer:
         # Resolved in replay() once the base document is loaded; None means
         # legacy chunk-window behavior (issue #552).
         self.maturation_gate: Optional[frozenset[int]] = None
+        # Requesting chunks of persisted jobs OUTSIDE the target's control
+        # set: their tag/claim/relationship writes carry window-interior
+        # chunk attribution but were invisible at the target capture, and
+        # those row kinds carry no job provenance to gate on — their rows
+        # are marked presence-uncertain instead.
+        self.delayed_maturation_chunks: frozenset[int] = frozenset()
 
     # -- base checkpoint ---------------------------------------------------
 
@@ -522,6 +528,7 @@ class _Replayer:
     def _resolve_maturation_gate(
         self,
         base_state: dict[str, Any],
+        base_chunk: int,
         result: ReplayResult,
     ) -> None:
         """Resolve the job-membership gate from the checkpoint documents.
@@ -559,7 +566,84 @@ class _Replayer:
             "job(s))",
             approximate=False,
         )
-        self._assert_maturation_events_attributable()
+        self._assert_maturation_events_attributable(base_chunk)
+        self._resolve_delayed_maturation_chunks(target_ids, base_chunk, result)
+
+    def _resolve_delayed_maturation_chunks(
+        self,
+        target_ids: list[Any],
+        base_chunk: int,
+        result: ReplayResult,
+    ) -> None:
+        """Find window chunks polluted by writes invisible at the target.
+
+        A persisted job absent from the TARGET's control set committed after
+        the target capture. Its project/activity events are gated by job id,
+        but its tag, claim, secret, and relationship rows carry only
+        requesting-chunk attribution — no job provenance — so every such
+        row inside the window is marked presence-uncertain rather than
+        guessed at (PR #586 review: gate every maturation-attributed replay
+        source).
+        """
+
+        self.cur.execute(
+            """
+            SELECT DISTINCT requesting_chunk_id
+            FROM orrery_maturation_jobs
+            WHERE (result_manifest ->> 'persisted')::boolean
+              AND NOT (id = ANY(%(target_ids)s::bigint[]))
+              AND requesting_chunk_id >= %(base)s
+              AND requesting_chunk_id <= %(target)s
+            ORDER BY requesting_chunk_id
+            """,
+            {
+                "target_ids": [int(v) for v in target_ids],
+                "base": base_chunk,
+                "target": self.target_chunk_id,
+            },
+        )
+        chunks = frozenset(_row_value(row, 0) for row in self.cur.fetchall())
+        self.delayed_maturation_chunks = chunks
+        if chunks:
+            result.add_note(
+                "_maturation_gate",
+                "delayed maturation persistence detected at requesting "
+                f"chunk(s) {sorted(chunks)}; tag/claim/secret/relationship "
+                "rows attributed there are presence-uncertain for this pair",
+                approximate=True,
+            )
+
+    def _mark_delayed_maturation_rows(self, result: ReplayResult) -> None:
+        """Mark rows chunk-attributed to delayed maturation persistence."""
+
+        chunks = self.delayed_maturation_chunks
+        if not chunks:
+            return
+        for section in (
+            "entity_tags",
+            "entity_pair_tags",
+            "claim_awareness",
+            "backstory_secrets",
+        ):
+            key_fn = _section_key_fn(section)
+            for row in result.state.get(section, []):
+                if row.get("source_chunk_id") in chunks:
+                    result.uncertain_rows.add((section, str(key_fn(row))))
+        self.cur.execute(
+            """
+            SELECT DISTINCT relationship_table, old_row
+            FROM relationship_versions
+            WHERE source_chunk_id = ANY(%(chunks)s::bigint[])
+            """,
+            {"chunks": sorted(chunks)},
+        )
+        for relationship_table, old_row_json in self.cur.fetchall():
+            columns = RELATIONSHIP_KEY_COLUMNS.get(relationship_table)
+            old_row = _as_document(old_row_json)
+            if columns is None or not isinstance(old_row, dict):
+                continue
+            key = tuple(old_row.get(column) for column in columns)
+            result.uncertain_rows.add((relationship_table, str(key)))
 
     def _maturation_gate_params(self) -> dict[str, Any]:
         if self.maturation_gate is None:
@@ -569,19 +653,24 @@ class _Replayer:
     def _maturation_gate_filter(self) -> str:
         return "" if self.maturation_gate is None else MATURATION_GATE_FILTER_SQL
 
-    def _assert_maturation_events_attributable(self) -> None:
+    def _assert_maturation_events_attributable(self, base_chunk: int) -> None:
         """Gated replay must be able to name every maturation write's job.
 
         Live maturation events carry ``maturation_job_<id>_...`` refs; an
         event claiming maturation provenance without a parseable job id
         cannot be placed on either side of the capture boundary, so the
-        reconstruction refuses loudly instead of guessing.
+        reconstruction refuses loudly instead of guessing. The scan is
+        windowed to this pair's maturation range — an orphan elsewhere in
+        history must not abort verification of an unrelated, healthy pair
+        (PR #586 review finding).
         """
 
         self.cur.execute(
             """
             SELECT id FROM world_events
-            WHERE (
+            WHERE tick_chunk_id >= %(base)s
+              AND tick_chunk_id < %(target)s
+              AND (
                     source::text = 'maturation'
                     OR (
                         source::text = 'retrograde'
@@ -594,7 +683,8 @@ class _Replayer:
                         !~ '^maturation_job_[0-9]+'
                   )
             ORDER BY id
-            """
+            """,
+            {"base": base_chunk, "target": self.target_chunk_id},
         )
         orphans = [_row_value(row, 0) for row in self.cur.fetchall()]
         if orphans:
@@ -615,7 +705,7 @@ class _Replayer:
             base_checkpoint_chunk_id=base_chunk,
             state={},
         )
-        self._resolve_maturation_gate(base_state, result)
+        self._resolve_maturation_gate(base_state, base_chunk, result)
         if "entities" in self.missing_base_sections:
             result.add_note(
                 "entities",
@@ -771,6 +861,7 @@ class _Replayer:
 
         for table in RELATIONSHIP_KEY_COLUMNS:
             self._unwind_relationships(table, result)
+        self._mark_delayed_maturation_rows(result)
         return result
 
     def _replay_claim_awareness(

--- a/tests/test_orrery/test_reconstruction.py
+++ b/tests/test_orrery/test_reconstruction.py
@@ -28,6 +28,7 @@ from nexus.agents.logon.apex_schema import (
 )
 from nexus.agents.orrery.reconstruction import (
     CHECKPOINT_SECTIONS,
+    MATURATION_JOBS_CONTROL_KEY,
     capture_state_checkpoint_sync,
     set_commit_chunk_attribution_sync,
 )
@@ -69,7 +70,10 @@ def test_checkpoint_captures_every_section_and_is_idempotent() -> None:
             state = cur.fetchone()[0]
             if isinstance(state, str):
                 state = json.loads(state)
-            assert set(state) == set(CHECKPOINT_SECTIONS)
+            assert set(state) == set(CHECKPOINT_SECTIONS) | {
+                MATURATION_JOBS_CONTROL_KEY
+            }
+            assert isinstance(state[MATURATION_JOBS_CONTROL_KEY], list)
 
             cur.execute("SELECT count(*) FROM entity_tags WHERE cleared_at IS NULL")
             active_tags = cur.fetchone()[0]

--- a/tests/test_orrery/test_replay.py
+++ b/tests/test_orrery/test_replay.py
@@ -853,6 +853,23 @@ def test_runtime_maturation_death_replays_without_drift() -> None:
             changed_fields, cause_payload = cur.fetchone()
             assert changed_fields == ["entities.is_active"]
             assert cause_payload["applied_entity_activity"] == [projection]
+            # The #552 gate keys maturation replay on job manifests recorded
+            # in the persistence transaction; the fixture models that
+            # provenance so the death projection stays inside the gate.
+            cur.execute(
+                """
+                INSERT INTO orrery_maturation_jobs (
+                    id, entity_id, entity_kind, entity_subtype_id,
+                    entity_name, slot, requesting_chunk_id, declaration,
+                    state, result_manifest
+                ) VALUES (
+                    545001, %s, 'character', 1, 'Death Probe', 'test', %s,
+                    '{}'::jsonb, 'succeeded'::orrery_job_state,
+                    '{"schema_version": "orrery_retrograde_maturation_manifest.v1", "persisted": true}'::jsonb
+                )
+                """,
+                (entity_id, source_chunk),
+            )
             target_id = capture_state_checkpoint_sync(
                 cur, chunk_id=target_chunk, label="manual"
             )

--- a/tests/test_orrery/test_retrograde_persistence.py
+++ b/tests/test_orrery/test_retrograde_persistence.py
@@ -905,6 +905,9 @@ class FakeRetrogradePersistenceCursor:
             self._result = [{"id": int(params[2])}]
         elif "SELECT to_regclass" in sql:
             self._result = [{"checkpoint_table": "backstory_secrets"}]
+        elif "jsonb_build_object" in sql:
+            # #552 single-statement capture: one coherent document.
+            self._result = [{"doc": {}}]
         elif "jsonb_agg(to_jsonb(t))" in sql:
             self._result = [{"state": []}]
         elif "FROM orrery_maturation_jobs" in sql and "persisted" in sql:

--- a/tests/test_orrery/test_retrograde_persistence.py
+++ b/tests/test_orrery/test_retrograde_persistence.py
@@ -907,6 +907,9 @@ class FakeRetrogradePersistenceCursor:
             self._result = [{"checkpoint_table": "backstory_secrets"}]
         elif "jsonb_agg(to_jsonb(t))" in sql:
             self._result = [{"state": []}]
+        elif "FROM orrery_maturation_jobs" in sql and "persisted" in sql:
+            # Issue #552 checkpoint control key: no succeeded jobs in fixture.
+            self._result = [{"coalesce": []}]
         elif "INSERT INTO state_checkpoints" in sql:
             self._result = [{"id": 904}]
         else:

--- a/tests/test_orrery/test_retrograde_projects_live.py
+++ b/tests/test_orrery/test_retrograde_projects_live.py
@@ -1419,11 +1419,14 @@ def test_delayed_maturation_write_is_gated_out_of_checkpoint_replay(
     actor_id, _actor = db["characters"][0]
     with db["conn"].cursor() as cur:
         base_time = _next_world_time(cur)
-        request_chunk = _fabricate_chunk(cur, base_time)
+        base_chunk = _fabricate_chunk(cur, base_time)
         base_id = capture_state_checkpoint_sync(
-            cur, chunk_id=request_chunk, label="manual"
+            cur, chunk_id=base_chunk, label="manual"
         )
         assert base_id is not None
+        # The requesting chunk sits strictly inside the window so both the
+        # inverse event window and the base-exclusive tag window cover it.
+        request_chunk = _fabricate_chunk(cur, base_time + timedelta(hours=1))
         target_chunk = _fabricate_chunk(cur, base_time + timedelta(hours=2))
         target_id = capture_state_checkpoint_sync(
             cur, chunk_id=target_chunk, label="manual"
@@ -1446,6 +1449,23 @@ def test_delayed_maturation_write_is_gated_out_of_checkpoint_replay(
             job_id=552001,
         )
 
+        # A delayed worker's pair-tag write carries only requesting-chunk
+        # attribution (no job provenance); replay's chunk-window arm reads
+        # the table directly, so the pair must skip the row as
+        # presence-uncertain instead of reporting phantom drift.
+        other_id, _other = db["characters"][3]
+        cur.execute("SELECT id FROM pair_tags ORDER BY id LIMIT 1")
+        pair_tag_id = cur.fetchone()[0]
+        cur.execute(
+            """
+            INSERT INTO entity_pair_tags (
+                subject_entity_id, object_entity_id, pair_tag_id,
+                source_kind, source_chunk_id
+            ) VALUES (%s, %s, %s, 'retrograde', %s)
+            """,
+            (actor_id, other_id, pair_tag_id, request_chunk),
+        )
+
         result = reconstruct_state_at_sync(
             cur,
             target_chunk,
@@ -1455,6 +1475,20 @@ def test_delayed_maturation_write_is_gated_out_of_checkpoint_replay(
         assert any(
             "gated on jobs" in note for note in result.notes.get("_maturation_gate", [])
         )
+        assert any(
+            "delayed maturation persistence" in note
+            for note in result.notes.get("_maturation_gate", [])
+        )
+
+        pair = [
+            verdict
+            for verdict in verify_checkpoints_sync(cur)
+            if verdict.base_checkpoint_id == base_id
+            and verdict.target_checkpoint_id == target_id
+        ]
+        assert len(pair) == 1
+        assert pair[0].drifts == []
+        assert pair[0].skipped_unreproducible >= 1
 
         with pytest.raises(ValueError, match="missing its required applied"):
             reconstruct_state_at_sync(cur, target_chunk, base_checkpoint_id=base_id)

--- a/tests/test_orrery/test_retrograde_projects_live.py
+++ b/tests/test_orrery/test_retrograde_projects_live.py
@@ -1357,7 +1357,12 @@ def _insert_succeeded_maturation_job(
             slot, requesting_chunk_id, declaration, state, result_manifest
         )
         SELECT %s, %s, 'character', c.id, c.name, 'test', %s, '{}'::jsonb,
-               'succeeded'::orrery_job_state, '{"schema_version": "orrery_retrograde_maturation_manifest.v1", "persisted": true}'::jsonb
+               'succeeded'::orrery_job_state,
+               jsonb_build_object(
+                   'schema_version',
+                   'orrery_retrograde_maturation_manifest.v1',
+                   'persisted', true
+               )
         FROM characters c WHERE c.entity_id = %s
         """,
         (job_id, actor_entity_id, requesting_chunk_id, actor_entity_id),

--- a/tests/test_orrery/test_retrograde_projects_live.py
+++ b/tests/test_orrery/test_retrograde_projects_live.py
@@ -862,6 +862,14 @@ def test_maturation_project_replays_exactly_and_hydrates_continuation(
         assert base_id is not None
 
         request_chunk = _fabricate_chunk(cur, base_time + timedelta(hours=1))
+        # The #552 gate keys maturation replay on job manifests recorded in
+        # the persistence transaction; the fixture models that provenance.
+        _insert_succeeded_maturation_job(
+            cur,
+            job_id=531004,
+            actor_entity_id=actor_id,
+            requesting_chunk_id=request_chunk,
+        )
         manifest = _persist_maturation_expansion(
             cur,
             packet=packet,
@@ -955,6 +963,14 @@ def test_maturation_start_at_base_chunk_replays_without_drift(
         )
         assert base_id is not None
 
+        # The #552 gate keys maturation replay on job manifests recorded in
+        # the persistence transaction; the fixture models that provenance.
+        _insert_succeeded_maturation_job(
+            cur,
+            job_id=531006,
+            actor_entity_id=actor_id,
+            requesting_chunk_id=base_chunk,
+        )
         manifest = _persist_maturation_expansion(
             cur,
             packet=packet,
@@ -1320,3 +1336,209 @@ def _apply_project_advance(
         need_tuning=load_need_tuning(),
         project_policy=coerce_project_policy(project_settings),
     )
+
+
+def _insert_succeeded_maturation_job(
+    cur: Any,
+    *,
+    job_id: int,
+    actor_entity_id: int,
+    requesting_chunk_id: int,
+) -> None:
+    """Fabricate a succeeded worker job row (delayed-persistence stand-in)."""
+    cur.execute(
+        "DELETE FROM orrery_maturation_jobs WHERE entity_id = %s",
+        (actor_entity_id,),
+    )
+    cur.execute(
+        """
+        INSERT INTO orrery_maturation_jobs (
+            id, entity_id, entity_kind, entity_subtype_id, entity_name,
+            slot, requesting_chunk_id, declaration, state, result_manifest
+        )
+        SELECT %s, %s, 'character', c.id, c.name, 'test', %s, '{}'::jsonb,
+               'succeeded'::orrery_job_state, '{"schema_version": "orrery_retrograde_maturation_manifest.v1", "persisted": true}'::jsonb
+        FROM characters c WHERE c.entity_id = %s
+        """,
+        (job_id, actor_entity_id, requesting_chunk_id, actor_entity_id),
+    )
+
+
+def _insert_malformed_maturation_start(
+    cur: Any,
+    *,
+    tick_chunk_id: int,
+    actor_entity_id: int,
+    job_id: int,
+) -> None:
+    """A maturation-started event whose missing `applied` projection raises
+    loudly if replay ever reads it — the tripwire proving gate behavior."""
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type, tick_chunk_id, actor_entity_id, world_layer,
+            source, changed_fields, payload
+        ) VALUES (
+            'build_venture_started', %s, %s,
+            'primary'::world_layer_type,
+            'retrograde'::event_source_kind,
+            ARRAY['character_project_states'],
+            %s::jsonb
+        )
+        """,
+        (
+            tick_chunk_id,
+            actor_entity_id,
+            json.dumps(
+                {
+                    "source": "maturation",
+                    "retrograde_event_ref": f"maturation_job_{job_id}_ev_probe",
+                }
+            ),
+        ),
+    )
+
+
+def test_delayed_maturation_write_is_gated_out_of_checkpoint_replay(
+    project_db: dict[str, Any],
+) -> None:
+    """Issue #552 acceptance: request chunk A, checkpoint captured before the
+    worker write, then a delayed maturation persistence — the checkpoint
+    reconstructs WITHOUT the late rows.
+
+    The event's missing `applied` projection raises if replay reads it, so
+    a clean gated reconstruction proves exclusion; the ungated call keeps
+    the legacy chunk-window boundary and still trips.
+    """
+    db = project_db
+    actor_id, _actor = db["characters"][0]
+    with db["conn"].cursor() as cur:
+        base_time = _next_world_time(cur)
+        request_chunk = _fabricate_chunk(cur, base_time)
+        base_id = capture_state_checkpoint_sync(
+            cur, chunk_id=request_chunk, label="manual"
+        )
+        assert base_id is not None
+        target_chunk = _fabricate_chunk(cur, base_time + timedelta(hours=2))
+        target_id = capture_state_checkpoint_sync(
+            cur, chunk_id=target_chunk, label="manual"
+        )
+        assert target_id is not None
+
+        # Delayed worker persistence: job + started event land AFTER the
+        # target capture, attributed to the requesting chunk inside the
+        # replay window.
+        _insert_succeeded_maturation_job(
+            cur,
+            job_id=552001,
+            actor_entity_id=actor_id,
+            requesting_chunk_id=request_chunk,
+        )
+        _insert_malformed_maturation_start(
+            cur,
+            tick_chunk_id=request_chunk,
+            actor_entity_id=actor_id,
+            job_id=552001,
+        )
+
+        result = reconstruct_state_at_sync(
+            cur,
+            target_chunk,
+            base_checkpoint_id=base_id,
+            target_checkpoint_id=target_id,
+        )
+        assert any(
+            "gated on jobs" in note for note in result.notes.get("_maturation_gate", [])
+        )
+
+        with pytest.raises(ValueError, match="missing its required applied"):
+            reconstruct_state_at_sync(cur, target_chunk, base_checkpoint_id=base_id)
+
+
+def test_between_capture_maturation_job_still_replays_under_gate(
+    project_db: dict[str, Any],
+) -> None:
+    """A job that became visible-succeeded between the captures is INSIDE the
+    gate — the gate must not over-exclude (base-inclusive behavior for
+    writes committed before the target checkpoint, per acceptance)."""
+    db = project_db
+    actor_id, _actor = db["characters"][1]
+    with db["conn"].cursor() as cur:
+        base_time = _next_world_time(cur)
+        request_chunk = _fabricate_chunk(cur, base_time)
+        base_id = capture_state_checkpoint_sync(
+            cur, chunk_id=request_chunk, label="manual"
+        )
+        assert base_id is not None
+
+        _insert_succeeded_maturation_job(
+            cur,
+            job_id=552002,
+            actor_entity_id=actor_id,
+            requesting_chunk_id=request_chunk,
+        )
+        _insert_malformed_maturation_start(
+            cur,
+            tick_chunk_id=request_chunk,
+            actor_entity_id=actor_id,
+            job_id=552002,
+        )
+
+        target_chunk = _fabricate_chunk(cur, base_time + timedelta(hours=2))
+        target_id = capture_state_checkpoint_sync(
+            cur, chunk_id=target_chunk, label="manual"
+        )
+        assert target_id is not None
+
+        with pytest.raises(ValueError, match="missing its required applied"):
+            reconstruct_state_at_sync(
+                cur,
+                target_chunk,
+                base_checkpoint_id=base_id,
+                target_checkpoint_id=target_id,
+            )
+
+
+def test_checkpoints_without_control_key_keep_legacy_window(
+    project_db: dict[str, Any],
+) -> None:
+    """Cross-era pairs (documents predating the control key) keep the
+    chunk-window boundary and note the approximation."""
+    db = project_db
+    actor_id, _actor = db["characters"][2]
+    with db["conn"].cursor() as cur:
+        base_time = _next_world_time(cur)
+        request_chunk = _fabricate_chunk(cur, base_time)
+        base_id = capture_state_checkpoint_sync(
+            cur, chunk_id=request_chunk, label="manual"
+        )
+        target_chunk = _fabricate_chunk(cur, base_time + timedelta(hours=2))
+        target_id = capture_state_checkpoint_sync(
+            cur, chunk_id=target_chunk, label="manual"
+        )
+        cur.execute(
+            "UPDATE state_checkpoints SET state = state - '_maturation_jobs_succeeded' "
+            "WHERE id IN (%s, %s)",
+            (base_id, target_id),
+        )
+
+        _insert_succeeded_maturation_job(
+            cur,
+            job_id=552003,
+            actor_entity_id=actor_id,
+            requesting_chunk_id=request_chunk,
+        )
+        _insert_malformed_maturation_start(
+            cur,
+            tick_chunk_id=request_chunk,
+            actor_entity_id=actor_id,
+            job_id=552003,
+        )
+
+        with pytest.raises(ValueError, match="missing its required applied"):
+            reconstruct_state_at_sync(
+                cur,
+                target_chunk,
+                base_checkpoint_id=base_id,
+                target_checkpoint_id=target_id,
+            )


### PR DESCRIPTION
Closes #552 — the timing race Sol filed: runtime maturation persistence is detached from its requesting chunk, so an interval checkpoint captured **before** a delayed worker transaction gets that worker's expansion projected into it by later verification (and the projected stub can be absent from the replay working set entirely). Chunk-keyed windows cannot express "committed after the capture."

## Custody decision (the issue's investigation ask)

**Applied-at lives in the checkpoint document.** Each capture records the set of maturation jobs whose expansion writes are visible in the capture transaction (`_maturation_jobs_succeeded`, underscore-prefixed and absent from `CHECKPOINT_SECTIONS`, so verification never diffs it as state). MVCC makes the set exact by construction — whatever the SELECT sees is precisely what the section snapshots saw. No migration, no timestamps, no clock comparisons.

Two subtleties the investigation surfaced:
- **The membership predicate is `result_manifest.persisted`**, recorded by the worker in the SAME transaction as its writes — NOT `state = 'succeeded'`, which flips in a later transaction after embedding and would open a race band where a capture sees the writes but not the membership.
- The `target ∖ base` rule also retires a **latent double-apply**: a job persisted before the base capture had its writes in the base document AND replayed again through the inverse chunk window.

## Boundary regimes (per acceptance)

- **Checkpoint-targeted reconstruction** (verify now passes `target_checkpoint_id`): include a maturation write iff its job ∈ target set ∖ base set.
- **Arbitrary chunk reconstruction** and **cross-era pairs** (documents predating the key): legacy chunk-window boundary, noted as approximate.
- Gated replay refuses loudly on maturation events without a parseable `maturation_job_<id>` ref (unattributable provenance).

## Verification

- Acceptance regression exactly as specified: request chunk A → checkpoint captured → delayed job+event insertion → gated reconstruction clean (the event's missing `applied` projection is a tripwire that raises if replay ever reads it), ungated reconstruction still trips (distinct regimes proven in one test).
- No-over-exclusion regression (between-capture jobs replay) + cross-era fallback regression.
- Three existing maturation-drift fixtures now model job provenance — their missing job rows were exactly the fabricated-provenance the gate exists to catch (manifests satisfy the migration-078 v1 trigger).
- **Standing oracle green: `replay_state.py --slot 5 --verify` — all four checkpoint pairs ok** (pre-fix documents, cross-era path).
- Suites: orrery+config 1,056 passed dry; **1,294 passed under NEXUS_RUN_POSTGRES=1**; mypy/black/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ