### PR TITLE
Default the openai role to Terra (owner ruling)

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -23,7 +23,9 @@ default_slot_model = "TEST"
 # outright for that model (e.g. temperature on reasoning-class models).
 # Config load refuses any consumer section that configures one of them.
 [global.model.api_models.openai]
-roles = { default = "gpt-5.5" }
+# Terra as default (owner, 2026-07-27): GPT-5.5's API rates equal Sol's
+# while Terra is half price — 5.5 stays selectable but earns no default.
+roles = { default = "gpt-5.6-terra" }
 models = [
     { id = "o3", label = "o3", unsupported_params = ["temperature", "top_p"] },
     { id = "gpt-5.5", label = "GPT-5.5", unsupported_params = ["temperature", "top_p"] },


### PR DESCRIPTION
One-line role flip: `@openai.default` → `gpt-5.6-terra`. GPT-5.5's API rates equal Sol's ($5/$30) while Terra is half price ($2.50/$15) — a dominated default. 5.5 remains registered and selectable. The role propagates to `gaia_model`, the wizard default, and the display default in one edit (the supported path per the registry comment). Config suite green (75 passed); the resolution tests assert against the role, so they follow automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ