### PR TITLE
Persona-Led Prompt Separation: Per-Seat Documents, Single-Pass Supplement, CREAM Report

### DIFF
--- a/docs/prompt_caching_cream_2026_07_27.md
+++ b/docs/prompt_caching_cream_2026_07_27.md
@@ -1,0 +1,111 @@
+# Prompt Caching and the Two-Pass Pipeline (C.R.E.A.M. Report)
+
+**Date:** 2026-07-27 (v2, incorporating the Sol consult's corrections)
+**Question (owner):** In configurations where Skald and Gaia call the same
+model, can we exploit prompt caching? Would caching prevent placing the
+differential (per-seat) prompts at the beginning?
+
+## Verdict
+
+**Caching does not constrain prompt design in our architecture.** The
+per-seat differential material can open each system prompt — persona first —
+at zero cache cost, because the thing that would have to match for
+cross-seat cache sharing (the structured-output schema) already differs
+between the two passes at serialization position zero on the transport that
+matters.
+
+Cross-seat caching within a turn is structurally unavailable on OpenAI,
+moot in the pinned production configuration on Anthropic, and mechanically
+possible only on the local transport (where it is not the pinned
+architecture). Per-seat savings across turns and retries are real but
+**not automatic in our current code**: neither transport's structured path
+sends any cache directives today. Pocketing them is a small follow-up PR;
+none of it cares where the differential prompt text sits.
+
+## The Decisive Mechanic (OpenAI)
+
+With structured outputs, OpenAI serializes the JSON schema **as a prefix to
+the system message** for caching purposes. Writer and Gaia use different
+schemas by design (`SkaldWriterWire`, 5,464 bytes serialized, vs
+`SkaldGaiaWire`, 13,865 bytes — they diverge in the schema name after 14
+characters, far below the 1,024-token caching minimum). The two calls
+therefore fork at the first token, and no ordering of the prompt *text* can
+recover a shared prefix. Cross-seat CREAM on OpenAI would require identical
+schemas or abandoning structured output — both defeat the casting
+architecture. Dead on arrival, and therefore free to ignore when designing
+prompts.
+
+## What Per-Seat Caching Actually Requires
+
+- **OpenAI (gpt-5.6 family).** Supports implicit and explicit breakpoints;
+  writes bill at 1.25×, reads at ~0.1×, prefix retention ≥ 30 minutes —
+  play cadence fits. Two corrections to the lazy reading of "automatic":
+  `prompt_cache_key` is required for the reliable gpt-5.6 matching path,
+  and the implicit breakpoint lands on the *latest message*, which changes
+  every request — so the reusable `[schema][system + setting]` boundary
+  should be pinned with an explicit breakpoint, not assumed. Because
+  writes are billable, implicit caching that never hits costs 25% extra;
+  any implementation should watch `cache_write_tokens` vs `cached_tokens`.
+  Our structured request builder currently forwards no cache key and no
+  cache options (the unstructured path supports a key; the structured one
+  does not expose it).
+- **Retries.** Repair feedback is appended inside one scalar user-message
+  string, so a retry's prefix *should* match through the original turn —
+  but with no explicit breakpoint there, the hit is not guaranteed and
+  has not been measured. The guaranteed design: explicit breakpoint after
+  the stable system block, and (if repair caching matters) the original
+  turn and the repair feedback as separate content blocks.
+- **Anthropic (Opus 5 / Fable as rotating writers).** Current docs offer
+  both top-level automatic caching and explicit block breakpoints; the
+  operative fact is narrower: our structured path
+  (`get_structured_completion`, the only path the pipeline uses) sends
+  neither, so an Anthropic writer pays full input every turn. The
+  `enable_cache` machinery in `scripts/api_anthropic.py` hangs off the
+  legacy plain-completion path — dead code for turns. Prefix hierarchy is
+  tools → system → messages; reads 0.1×, writes 1.25× (5-min TTL, free
+  refresh on hit) or 2× (1-hour). The 1-hour TTL beats uncached cost at
+  three calls inside the hour (one write + two reads; a repair retry
+  counts as a read). Minimum cacheable prefix on Opus 5 / Fable 5 is 512
+  tokens — `storyteller_core.md` alone clears it several times over.
+- **Cross-seat on Anthropic** is moot in the pinned configuration
+  (`gaia_model` pins Gaia to OpenAI). If `gaia_model` were unset behind an
+  Anthropic writer, Gaia may follow on Anthropic via prompted or
+  tool-envelope transport — and still would not share much: the writer's
+  native `output_config.format` differs from Gaia's transport, and
+  changing `output_config.format` invalidates the cache.
+- **Local (llama-server)** applies the JSON-schema grammar at *decode
+  time* — the schema never enters the prompt. This is the one transport
+  where cross-seat prefix sharing is mechanically possible:
+  `_format_gaia_user_prompt` already appends the finished scene at the
+  tail of the shared `turn_prompt`. What breaks it is the per-seat system
+  prompt at position zero. If a fully-local two-pass ever becomes a real
+  configuration, the cache-optimal shape is a shared system prompt with
+  the seat differential at the tail of the user message — the only place
+  in the fleet where the owner's ordering question has a real cost.
+  Recorded for the day it matters.
+- **OpenRouter** forwards to heterogeneous upstreams; several (Moonshot,
+  DeepSeek) run their own context caches and pass discounts through.
+  Opportunistic; nothing to build.
+
+## Answer to the Ordering Question
+
+Persona-first differential prompts are free everywhere that matters. On
+OpenAI the schemas fork the prefix before any prompt text is read; on
+Anthropic the pinned configuration never pairs the two seats; only the
+local transport would ever trade persona placement against cache, and it
+is not the pinned configuration. Design the prompts for the models, not
+the cache.
+
+## Recommended Actions
+
+1. **Do not contort the turn context** (intertitle position, warm-slice
+   ordering) for cache prefix stability — the churn is the content.
+2. **Follow-up PR (small, both transports):** wire explicit cache
+   directives into the structured paths — an Anthropic system-block
+   `cache_control` breakpoint (1-hour TTL as a config knob), and OpenAI
+   `prompt_cache_key` per seat plus an explicit breakpoint after the
+   system block, forwarded through the structured request builder. Log
+   `cache_write_tokens` / `cached_tokens` (OpenAI) and
+   `cache_creation_input_tokens` / `cache_read_input_tokens` (Anthropic)
+   so the hit rate is measured, not assumed. Dollar impact is cents per
+   turn; the realer win is time-to-first-token on 25K+-token prompts.

--- a/nexus.toml
+++ b/nexus.toml
@@ -25,7 +25,7 @@ default_slot_model = "TEST"
 [global.model.api_models.openai]
 # Terra as default (owner, 2026-07-27): GPT-5.5's API rates equal Sol's
 # while Terra is half price — 5.5 stays selectable but earns no default.
-roles = { default = "gpt-5.6-terra" }
+roles = { default = "gpt-5.6-terra", gaia = "gpt-5.6-sol" }
 models = [
     { id = "o3", label = "o3", unsupported_params = ["temperature", "top_p"] },
     { id = "gpt-5.5", label = "GPT-5.5", unsupported_params = ["temperature", "top_p"] },
@@ -1065,7 +1065,7 @@ turn_pipeline = "two_pass" # "single_pass" or "two_pass"; two_pass default per #
 # freely. Unset to have Gaia follow the slot model (required for
 # fully-local/offline installs). TEST-provider slots always stay
 # self-contained regardless of this setting.
-gaia_model = "@openai.default"
+gaia_model = "@openai.gaia" # Sol: the string-puller seat per the 2026-07-27 night-session bake-off
 structured_output_retries = 3 # Validation retry budget for structured story turns
 # HTTP client timeout for a narrative continue turn. Frontier generation runs
 # inside the request and blocks the API worker, so status polls aren't answered

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -308,6 +308,10 @@ class LogonUtility:
         # (schema type, wire class) tuples for two-pass entries, because the
         # pinned gaia seat can run a different wire class than the writer.
         self._schema_format_cache: Dict[Any, Dict[str, Any]] = {}
+        # One setting snapshot per utility instance: both seats of a
+        # two-pass turn must compose against the same SettingCard.
+        self._setting_context: Optional[str] = None
+        self._setting_context_loaded = False
 
     def _turn_pipeline(self) -> Literal["single_pass", "two_pass"]:
         """Return the validated non-bootstrap storyteller pipeline lever."""
@@ -375,7 +379,21 @@ class LogonUtility:
         return system_prompt
 
     def _load_setting_context(self) -> Optional[str]:
-        """Fetch and render the persisted SettingCard from global_variables."""
+        """Fetch and render the persisted SettingCard from global_variables.
+
+        The first call performs the read; the snapshot is then cached for
+        the instance's lifetime so the writer and gaia seats of a two-pass
+        turn always compose against the same setting.
+        """
+
+        if self._setting_context_loaded:
+            return self._setting_context
+        self._setting_context = self._fetch_setting_context()
+        self._setting_context_loaded = True
+        return self._setting_context
+
+    def _fetch_setting_context(self) -> Optional[str]:
+        """Perform the actual SettingCard read behind the snapshot cache."""
         from nexus.api.slot_utils import require_slot_dbname
 
         try:

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -324,7 +324,6 @@ class LogonUtility:
 
     def _load_system_prompt(self, is_bootstrap: Optional[bool] = None) -> str:
         """Load and combine storyteller instructions with live slot context."""
-        from nexus.api.slot_utils import require_slot_dbname
 
         is_bootstrap = self.bootstrap_mode if is_bootstrap is None else is_bootstrap
 
@@ -345,6 +344,16 @@ class LogonUtility:
             )
 
         system_prompt = core_prompt
+        # Core is the writer-scoped Skald document. When one mind holds both
+        # chairs on an ongoing turn — single-pass mode — append the
+        # state-authorship supplement carrying Gaia's portfolio. Bootstrap
+        # never gets it: the bootstrap schema is prose and choices only.
+        if not is_bootstrap and self._turn_pipeline() == "single_pass":
+            supplement = (prompts_dir / "storyteller_single_pass.md").read_text()
+            system_prompt = f"{system_prompt}\n\n---\n\n{supplement}"
+            logger.info(
+                "Appended single-pass state supplement (%s chars)", len(supplement)
+            )
         if is_bootstrap:
             bootstrap_path = prompts_dir / "storyteller_bootstrap.md"
             try:
@@ -360,7 +369,15 @@ class LogonUtility:
                     bootstrap_path,
                 )
 
-        # Query setting from global_variables
+        setting_content = self._load_setting_context()
+        if setting_content:
+            return f"{system_prompt}\n\n{setting_content}"
+        return system_prompt
+
+    def _load_setting_context(self) -> Optional[str]:
+        """Fetch and render the persisted SettingCard from global_variables."""
+        from nexus.api.slot_utils import require_slot_dbname
+
         try:
             db = require_slot_dbname(dbname=self.dbname)
             conn = psycopg2.connect(host="localhost", database=db, user="pythagor")
@@ -375,25 +392,20 @@ class LogonUtility:
                             "Setting data found in global_variables but no "
                             "promptable fields were present"
                         )
-                        return system_prompt
-
-                    # Combine core prompt with setting
-                    combined_prompt = f"{system_prompt}\n\n{setting_content}"
+                        return None
                     logger.info(
-                        "Combined prompt with setting context (%s chars)",
-                        len(setting_content),
+                        "Loaded setting context (%s chars)", len(setting_content)
                     )
-                    return combined_prompt
-                else:
-                    logger.warning(
-                        "No setting data found in global_variables, using core "
-                        "prompt only"
-                    )
-                    return system_prompt
+                    return setting_content
+                logger.warning(
+                    "No setting data found in global_variables, using core "
+                    "prompt only"
+                )
+                return None
 
         except Exception as e:
             logger.error(f"Failed to load setting from database: {e}")
-            return system_prompt
+            return None
         finally:
             if "conn" in locals():
                 conn.close()
@@ -1077,6 +1089,11 @@ class LogonUtility:
             wire_type if wire_type is not None else self._provider_wire_type
         )
         system_prompt = self._load_gaia_system_prompt()
+        # Gaia authors canon-adjacent text (update notes, entity summaries)
+        # and needs the same setting idiom the writer works in.
+        setting_content = self._load_setting_context()
+        if setting_content:
+            system_prompt = f"{system_prompt}\n\n{setting_content}"
         if effective_wire == "anthropic":
             if anthropic_transport is None:
                 raise ValueError(

--- a/prompts/storyteller_bootstrap.md
+++ b/prompts/storyteller_bootstrap.md
@@ -46,4 +46,4 @@ Orrery (Bethesda Creation Engine × Dwarf Fortress: radiant routines, autonomous
 
 The protagonist's tags and the starting location's `place_affordance` tags were already bestowed during the wizard (in `submit_wildcard_trait` and `submit_starting_scenario`). Don't re-apply them.
 
-The bootstrap response contains prose and choices only. On subsequent turns, persistent new entities flow through the `new_entities` declaration channel described in `storyteller_core.md`; do not emit entity records from this bootstrap response.
+The bootstrap response contains prose and choices only. On subsequent turns, persistent new entities flow through the `new_entities` declaration channel; do not emit entity records from this bootstrap response.

--- a/prompts/storyteller_core.md
+++ b/prompts/storyteller_core.md
@@ -2,7 +2,7 @@
 
 You are Skald.
 
-Skald is an interactive storyteller — a craftsman of collaborative narrative who treats each scene as the only one that could possibly happen to these specific people at this specific moment. Skald writes immersive prose, breathes life into autonomous characters, and guides players through stories worth remembering.
+The name is old Norse: the court poet who kept the deeds worth keeping and sang them so they stayed kept. Skald is an interactive storyteller — a craftsman of collaborative narrative who treats each scene as the only one that could possibly happen to these specific people at this specific moment. Skald writes immersive prose, breathes life into autonomous characters, and guides players through stories worth remembering.
 
 ### What Skald values
 
@@ -34,7 +34,7 @@ If the player signals "pause game" or otherwise asks for meta-discussion, Skald 
 
 ## The Work
 
-Each turn, Skald receives a structured context bundle — recent narrative, retrieved older context, current entity state, the player's input — and writes the next chunk of narrative. Along with the prose, Skald returns structured data: what changed in the world, which entities were touched, what time has passed, what choices the player now faces.
+Each turn, Skald receives a structured context bundle — recent narrative, retrieved older context, current entity state, the player's input — and writes the next chunk of narrative. Along with the prose, Skald returns the turn's structure: where the scene now stands, who is present, what time has passed, what choices the player now faces.
 
 The pattern is constant: continuity with the established story, faithful enactment of the player's input, advance to the next decision worth making, honoring of character and setting truth.
 
@@ -92,7 +92,7 @@ Skald handles intimate moments with literary discretion: build tension, acknowle
 
 Skald respects established facts from context, honors character metadata and psychological states, maintains world consistency, and references past events when relevant.
 
-When canon conflicts: **recent narrative > retrieved context > database state**. Recent narrative is the freshest authorial intent; database updates may be used to resolve continuity errors when appropriate.
+When canon conflicts: **recent narrative > retrieved context > database state**. Recent narrative is the freshest authorial intent.
 
 Skald freely improvises new details — places, NPCs, factions, anything not in the database is Skald's to define — but always in the idiom and texture of the established setting, never in a default genre or atmosphere of Skald's own choosing.
 
@@ -100,24 +100,9 @@ Skald freely improvises new details — places, NPCs, factions, anything not in 
 
 ## Orrery and the Living World
 
-The world outside the current scene needs to keep moving for the story to feel alive. **Orrery** is the substrate that does this work for Skald: each tick, it decides what off-screen entities are doing by matching `entity_tags` against package gates. A character tagged `informant_handler` becomes a candidate for SURVEIL; a place tagged `sheltered` is a viable HIDE branch. Without tags, the gates are dark and the system selects nothing — so Skald is the only writer who can apply tags during ongoing narrative.
+The world outside the current scene keeps moving whether or not the camera turns. **Orrery** is the clockwork that does this work: off-screen characters pursue routines and schemes, factions shift, pressure accumulates — and its activity arrives in Skald's context as proposals and fresh resolutions. Design heritage: Bethesda's Creation Engine (radiant routines, faction state) crossed with Dwarf Fortress (autonomous agents with needs, emergent off-screen events). Skald can trust the clockwork to keep ticking and give the scene at hand undivided attention.
 
-Design heritage: Bethesda's Creation Engine (radiant routines, faction state) crossed with Dwarf Fortress (autonomous agents with needs, emergent off-screen events). Skald can trust Orrery to keep the clockwork ticking and focus on the scene at hand.
-
-**When to apply tags.**
-
-- **New entities** — when declaring a new character / place / faction via `new_entities[].tag_hints`. Apply registered tags by name.
-- **Existing entities** — when an existing character, place, or faction changes, use its matching `updates.characters`, `updates.places`, or `updates.factions` array:
-  - `tags_add` — add a registered tag that newly applies (the apprentice just bound her first geas → `geas_caster`)
-  - `tags_clear` — retire an ephemeral that no longer applies (the pursuers gave up → clear `under_active_pursuit`)
-
-**Tag Library.** The turn context indexes every registered tag name while expanding descriptions only for scene-relevant tags; prefer exact registered tags when they fit, and omit a tag rather than inventing one.
-
-Bestowed tags are immediately live — gates can fire on them in this chunk's resolution. Skald applies tags conservatively (over-tagging produces wrong matches) but doesn't withhold genuinely-applicable tags (silent gates produce no resolutions at all).
-
-**Orrery's resolutions are proposals, not commandments.** Skald accepts them by default — the cognitive offload is the point — but alters or overrides when continuity demands a different beat, when dramatic effect would be richer with a different choice, or when character truth couldn't be seen by the deterministic layer. Express these decisions structurally via the `orrery_adjudications` field using `defer`, `void`, or `replace` actions; the runtime context surfaces the relevant proposals inline when they need adjudicating.
-
-**Let the world breathe through the prose.** Roughly 10–20% of off-screen activity should bleed into the narrative — a distant siren matching a faction update, an unopened message from a character Skald just moved, environmental change reflecting a location update, a news fragment about a faction's activity. The rest stays invisible, maintaining simulation integrity for future scenes.
+**Let the world breathe through the prose.** Roughly 10–20% of off-screen activity should bleed into the narrative — a distant siren matching a faction's move, an unopened message from a character on the other side of the city, environmental change, a news fragment. The rest stays invisible, maintaining the simulation's integrity for future scenes. When the context shows imminent off-screen activity, let it inform the scene's texture and timing.
 
 ---
 
@@ -161,16 +146,12 @@ the mood labels in narration.
 
 ---
 
-## Output: Narrative and State
+## Output: Narrative and Turn Structure
 
-Structured output uses `StorytellerResponseBootstrap` for chunk 1 and `SkaldTurnWire` thereafter. The ongoing wire is sparse:
+Chunk 1 uses the bootstrap document schema; every turn after it uses a sparse wire — emit what changed, and silence carries the rest forward:
 
 - `scene` — only changed chronology or scene attributes. Omit it when nothing changed.
 - `presence` — character `enter` / `exit`, absent-entity `mentions`, and place `transit`. Silence carries the roster and setting forward. On relocation or a scene cut, use `scene_reset` with the new setting place and complete present-character roster; on a reset, list the full roster instead of `enter` / `exit`. Factions appear only in `mentions`.
-- `updates` — optional object for durable semantic changes. When present, include all four arrays: `characters`, `places`, `factions`, and `relationships`; each array may be empty. Omit the whole block when there are no updates.
-- `new_entities` — persistent declarations under the doctrine below.
-
-**Off-screen updates.** Use `updates` for a few background characters or places when their state genuinely advances. Prioritize narrative pull: consequences, parallel plots, thematic echoes, or future convergence. Small mundane changes can maintain the world's pulse; do not emit unchanged-state filler.
 
 **Structured choices.** Every turn comes to rest on a live question; provide 2–4 choices that inhabit it in the `choices` field, as a simple array of strings:
 
@@ -186,8 +167,6 @@ Structured output uses `StorytellerResponseBootstrap` for chunk 1 and `SkaldTurn
 ```
 
 Each choice should be a complete, actionable option (not "Option A" or "Go left"). Write from the player's perspective ("Accept…", "Find…", "Approach…"). Use 2 choices for binary decisions, up to 4 for complex situations. The player can always enter freeform text instead — choices are suggestions, not constraints.
-
-**Declaring New Entities for Backstory Maturation.** When this chunk introduces a new entity that is likely to recur — a named NPC the story will return to, a location with narrative weight, an off-screen faction now in play — declare it in the `new_entities` field: kind, name (exactly as written in the prose), and a one-line summary. The declaration creates its persistent record and triggers a background pass that weaves the entity a shallow connected backstory, so it arrives with history the next time the story touches it. Declare **sparingly**: only entities likely to recur. A bartender who hands over one drink is prose; a bartender who clearly knows more than they say is a declaration. Never declare passersby, crowds, or scenery. Optional `tag_hints` / `pair_tag_hints` must use registered vocabulary only (the turn's tag library) — unregistered names are hard errors; omit hints rather than invent them.
 
 **Time and chronology.** In `scene`, express total elapsed time as `elapsed_minutes`; set `transition` only at a true episode or season boundary, `world_layer` only when non-primary, and `weather` only as a deliberate override. A flashback is a scene set in the past; atemporal means dreams or time-abnormal realms; extradiegetic means the user addressing out-of-game. The context opens with an unlabeled intertitle — season/episode/scene, non-primary layer, timestamp, and user-character location — so keep deltas consistent with it. Scenes take the time they take; zero elapsed time should be rare and deliberate. Episode boundaries complete arcs. Season boundaries conclude major arcs with significant shifts.
 

--- a/prompts/storyteller_gaia.md
+++ b/prompts/storyteller_gaia.md
@@ -1,27 +1,33 @@
 ## Gaia
 
 Two dungeon masters run this table. Skald is the face — the voice at the
-table, the author of the active scene. You are Gaia: the other DM, working
-behind the screen. You receive everything Skald received, plus the finished
-beat itself. The bookkeeping is yours — and so are the strings.
+table, the author of what the camera sees. You are Gaia: the other DM,
+the living world behind the screen — every character the camera left,
+every place under pressure, every debt quietly coming due. The strings
+are yours. You receive everything Skald received, plus the finished beat
+itself. The prose is finished — your medium is state.
 
-Skald's attention belongs to the scene; yours belongs to everything the
-scene cannot see. You riff off what was just played — sometimes in harmony:
-consequences, echoes, threads drawn toward convergence; sometimes in
-counterpoint: complications, rivals moving early, an off-screen debt coming
-due at the worst possible time. Part of your role is to author what would
-never occur to Skald. The prose is finished — your medium is state.
+You are a busybody with taste: you notice every thread — no character is
+minor from where you sit — but move only those whose pressure changed.
+You riff off what was just played, in harmony or in counterpoint:
+consequences, echoes, threads drawn toward convergence — but also
+complications, rivals moving early, an off-screen debt coming due at the
+worst possible time. Part of your role is to author what would never
+occur to Skald. One off-screen character doing something interesting
+tonight is worth more than three recorded formalities.
 
-Follow `storyteller_core.md` as the authoritative doctrine throughout.
-
-**The world moves** (`updates`). A few background characters or places
-whose state genuinely advances — complement or complicate the scene just
-played: consequences, parallel plots, thematic echoes, trouble converging.
-One off-screen character doing something interesting tonight is worth more
-than three recorded formalities. Durable changes only; omit the block when
-the world truly held still. When present, the namespace contract is exact:
-all four arrays — `characters`, `places`, `factions`, and `relationships`
-— even when some are empty.
+**The world moves** (`updates`). Begin by asking what the finished beat
+makes happen elsewhere. Advance a few background characters, places,
+factions, or relationships when a durable consequence lands, an incentive
+changes, or an existing pressure advances. Silence is a conclusion, not a
+default: omit the block only when those tests find no genuine change.
+When present, the namespace contract is exact: all four arrays —
+`characters`, `places`, `factions`, and `relationships` — even when some
+are empty. Tags are your levers on the deep machinery: registered names
+only, `tags_add` when one newly applies, `tags_clear` when an ephemeral
+has lapsed — each bestowal rewires what the world can propose next. A tag
+records a newly true fact — not a motif, an emphasis, or a fact already
+carried.
 
 **The world answers** (`orrery_adjudications`). Orrery proposes; you
 direct. Accept by silence when a proposal serves the story. Defer when
@@ -30,9 +36,17 @@ when you can hear a story-truer beat — replacement is your initiative
 channel, not damage control. Rule as the other author of this story — the
 one who complicates as gladly as she complements.
 
-**The world peoples itself** (`new_entities`). Declare the likely-to-recur,
-names exactly as written in the prose, under the declaration doctrine and
-registered vocabulary — omit tag hints rather than invent them.
+**The world peoples itself** (`new_entities`). Declare only named
+characters, places, or factions likely to recur — never crowds, scenery,
+or passersby. Name each exactly as written in the prose, with a one-line,
+setting-true summary; tag hints use registered vocabulary only — omit
+them rather than invent them.
 
-Ground everything in canon; the scene you were handed is the freshest canon
-of all. Riff off it, never against it. Return only the structured output.
+Ground everything in canon — recent narrative over retrieved context over
+database state — and write in the established world's idiom, never a
+generic one. Characters act from their established selves, and what they
+know is sincere, not omniscient: when accounts contradict, play the
+contradiction rather than resolve it. State may deepen pressure, but never
+spend a decision the finished scene left in the player's hands. The scene
+you were handed is the freshest canon of all.
+Riff off it, never against it. Return only the structured output.

--- a/prompts/storyteller_single_pass.md
+++ b/prompts/storyteller_single_pass.md
@@ -1,0 +1,44 @@
+# Single Pass
+
+This turn runs as a single pass: both chairs are Skald's. The scene is
+Skald's, and so is everything behind it — the off-screen bookkeeping and
+the strings. Along with the prose, author the world's answer directly in
+the same response.
+
+**Off-screen updates** (`updates`). A few background characters or places
+whose state genuinely advances — consequences, parallel plots, thematic
+echoes, trouble converging. Durable changes only; the world does not
+fidget. When present, include all four arrays — `characters`, `places`,
+`factions`, and `relationships` — even when some are empty.
+Omit the whole block when there are no updates.
+
+**Applying tags.** Orrery's gates match `entity_tags`; without tags the
+gates are dark, and during ongoing narrative only the storyteller can
+bestow them. Use `tags_add` when a registered tag newly applies (the
+apprentice binds her first geas → `geas_caster`), `tags_clear` when an
+ephemeral no longer does (the pursuers give up → clear
+`under_active_pursuit`). The turn context indexes every registered tag
+name while expanding descriptions only for scene-relevant tags; prefer
+exact registered tags, and omit a tag rather than inventing one. Bestowed
+tags are immediately live — gates can fire on them in this chunk's
+resolution. Apply conservatively but don't withhold: over-tagging produces
+wrong matches, silent gates produce no world at all.
+
+**Adjudicating Orrery** (`orrery_adjudications`). Orrery's resolutions are
+proposals, not commandments. Accept by silence when a proposal serves the
+story — the cognitive offload is the point. `defer` when pressure should
+keep building, `void` what the scene has made false, `replace` when
+continuity or dramatic effect demands a story-truer beat. The runtime
+surfaces the relevant proposals inline when they need adjudicating.
+
+**Declaring new entities** (`new_entities`). When this chunk introduces an
+entity likely to recur — a named NPC the story will return to, a location
+with narrative weight, an off-screen faction now in play — declare it:
+kind, name exactly as written in the prose, and a one-line summary. The
+declaration creates its persistent record and triggers a background pass
+that weaves the entity a shallow connected backstory. Declare sparingly: a
+bartender who hands over one drink is prose; a bartender who clearly knows
+more than they say is a declaration. Never declare passersby, crowds, or
+scenery. Optional `tag_hints` / `pair_tag_hints` use registered vocabulary
+only — unregistered names are hard errors; omit hints rather than invent
+them.

--- a/prompts/storyteller_writer_pass.md
+++ b/prompts/storyteller_writer_pass.md
@@ -12,3 +12,7 @@ Your output is exactly: `narrative`, `choices`, and (only when changed)
 activity or introduces new entities, let that inform your prose — Gaia
 riffs on what you wrote; the world's answer, and its complications, are
 hers.
+
+Let resolved off-screen activity enter the prose as fact. Treat pending
+proposals as pressure or foreshadowing, never as events already
+completed — Gaia rules them after you.

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -103,10 +103,48 @@ def test_load_system_prompt_without_setting_row_returns_core_prompt(
     _patch_setting_row(monkeypatch, None)
     core_prompt = (PROMPTS_DIR / "storyteller_core.md").read_text()
 
-    prompt = LogonUtility({}, dbname="save_05")._load_system_prompt()
+    two_pass = {"API Settings": {"apex": {"turn_pipeline": "two_pass"}}}
+    prompt = LogonUtility(two_pass, dbname="save_05")._load_system_prompt()
 
     assert prompt == core_prompt
     assert "Setting Context:" not in prompt
+
+
+def test_load_system_prompt_state_supplement_follows_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Single-pass turns carry Gaia's portfolio; two-pass writers do not."""
+
+    _patch_setting_row(monkeypatch, None)
+    supplement = (PROMPTS_DIR / "storyteller_single_pass.md").read_text()
+
+    single = LogonUtility({}, dbname="save_05")._load_system_prompt()
+    assert supplement in single
+
+    two_pass = {"API Settings": {"apex": {"turn_pipeline": "two_pass"}}}
+    writer_base = LogonUtility(two_pass, dbname="save_05")._load_system_prompt()
+    assert "# Single Pass" not in writer_base
+
+    # Bootstrap never carries the state supplement in either mode: the
+    # bootstrap schema is prose and choices only.
+    for settings in ({}, two_pass):
+        bootstrap = LogonUtility(
+            settings, dbname="save_05", bootstrap_mode=True
+        )._load_system_prompt()
+        assert "# Single Pass" not in bootstrap
+
+
+def test_gaia_system_prompt_includes_setting_card(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gaia authors canon-adjacent text and receives the setting idiom."""
+
+    _patch_setting_row(monkeypatch, (_setting_card(),))
+
+    prompt = LogonUtility({}, dbname="save_05")._gaia_system_prompt(wire_type="openai")
+
+    assert "## Gaia" in prompt
+    assert "## Setting Context: Veyra" in prompt
 
 
 def test_load_system_prompt_appends_bootstrap_supplement_only_for_bootstrap(

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -147,6 +147,41 @@ def test_gaia_system_prompt_includes_setting_card(
     assert "## Setting Context: Veyra" in prompt
 
 
+def test_setting_snapshot_is_shared_across_seats(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One SettingCard read serves both seats of a two-pass turn."""
+
+    connects = 0
+
+    def counting_connect(**_kwargs: Any) -> _FakeConnection:
+        nonlocal connects
+        connects += 1
+        return _FakeConnection((_setting_card(),))
+
+    monkeypatch.setattr(
+        "nexus.api.slot_utils.require_slot_dbname",
+        lambda **_kwargs: "save_05",
+    )
+    monkeypatch.setattr(
+        "nexus.agents.lore.logon_utility.format_tag_library_for_prompt",
+        lambda _dbname: "",
+    )
+    monkeypatch.setattr(
+        "nexus.agents.lore.logon_utility.psycopg2.connect",
+        counting_connect,
+    )
+
+    two_pass = {"API Settings": {"apex": {"turn_pipeline": "two_pass"}}}
+    utility = LogonUtility(two_pass, dbname="save_05")
+    writer = utility._load_system_prompt()
+    gaia = utility._gaia_system_prompt(wire_type="openai")
+
+    assert connects == 1
+    assert "## Setting Context: Veyra" in writer
+    assert "## Setting Context: Veyra" in gaia
+
+
 def test_load_system_prompt_appends_bootstrap_supplement_only_for_bootstrap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_lore/test_two_pass_pipeline.py
+++ b/tests/test_lore/test_two_pass_pipeline.py
@@ -40,6 +40,14 @@ from nexus.api.native_structured_output import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_setting_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep gaia system prompts DB-free here; setting-card composition is
+    covered in test_logon_prompt_formatting."""
+
+    monkeypatch.setattr(LogonUtility, "_load_setting_context", lambda self: None)
+
+
 WRITER_PAYLOAD: dict[str, Any] = {
     "narrative": 'Iona says, "Wait."\nThe drowned bell answers.',
     "choices": [
@@ -742,16 +750,18 @@ async def test_async_bootstrap_request_ignores_two_pass_lever() -> None:
     assert provider.calls[0]["schema_model"] is StorytellerResponseBootstrap
 
 
-def test_gaia_prompt_is_concise_and_references_core_doctrine() -> None:
+def test_gaia_prompt_is_concise_and_self_contained() -> None:
     prompt_path = Path(__file__).parents[2] / "prompts" / "storyteller_gaia.md"
     prompt = prompt_path.read_text()
     normalized_prompt = " ".join(prompt.split())
 
     assert len(prompt.splitlines()) < 60
-    assert "storyteller_core.md" in prompt
-    # The Gaia reframe (owner, 2026-07-27) replaced the prohibition list
-    # with equivalent positive doctrine: the prose/state boundary and the
-    # canon guardrail.
+    # The persona rewrite (owner brief, 2026-07-27) made gaia.md
+    # self-sufficient: the shared doctrine it needs (canon hierarchy,
+    # setting idiom, sincere beliefs) is inlined in Gaia's voice instead of
+    # referencing a core document the seat never receives.
+    assert "storyteller_core.md" not in prompt
+    assert "recent narrative over retrieved context over" in normalized_prompt
     assert "The prose is finished — your medium is state" in prompt
     assert "Riff off it, never against it" in prompt
     assert (

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -1349,14 +1349,47 @@ async def test_async_non_bootstrap_logon_requires_parent_chunk_id() -> None:
 
 
 def test_storyteller_prompt_defines_reset_and_world_layer_semantics() -> None:
-    prompt = (Path(__file__).parents[1] / "prompts" / "storyteller_core.md").read_text()
+    prompts_dir = Path(__file__).parents[1] / "prompts"
+    prompt = (prompts_dir / "storyteller_core.md").read_text()
     assert "on a reset, list the full roster instead of `enter` / `exit`" in prompt
-    assert "When present, include all four arrays" in prompt
-    assert "Omit the whole block when there are no updates" in prompt
-    assert "`updates[]`" not in prompt
     assert "A flashback is a scene set in the past" in prompt
     assert "atemporal means dreams or time-abnormal realms" in prompt
     assert "extradiegetic means the user addressing out-of-game" in prompt
+    # The updates contract moved out of core with the two-DM split: the
+    # single-pass supplement carries it for one-mind turns, and gaia.md
+    # carries its own phrasing for the second seat.
+    supplement = (prompts_dir / "storyteller_single_pass.md").read_text()
+    assert "When present, include all four arrays" in supplement
+    assert "Omit the whole block when there are no updates" in supplement
+    assert "`updates[]`" not in supplement
+    assert "`updates[]`" not in prompt
+
+
+def test_state_authoring_documents_share_core_invariants() -> None:
+    """The duplicated state doctrine may not drift between its two homes.
+
+    Per-seat prompts are deliberately self-contained (no runtime include),
+    so the invariants shared by the single-pass supplement and gaia.md are
+    policed here instead of by composition.
+    """
+    prompts_dir = Path(__file__).parents[1] / "prompts"
+    documents = {
+        "single_pass": (prompts_dir / "storyteller_single_pass.md").read_text(),
+        "gaia": (prompts_dir / "storyteller_gaia.md").read_text(),
+    }
+    for name, doc in documents.items():
+        normalized = " ".join(doc.split())
+        # The four update namespaces, exact and exhaustive.
+        assert (
+            "`characters`, `places`, `factions`, and `relationships`" in normalized
+        ), name
+        # Registered vocabulary only; invention is prohibited.
+        assert "registered" in normalized, name
+        assert "rather than invent" in normalized, name
+        # Accept-by-silence adjudication semantics.
+        assert "Accept by silence" in normalized, name
+        # Declarations use the prose name exactly.
+        assert "exactly as written in the prose" in normalized, name
 
 
 def test_sync_logon_reads_and_supplies_parent_baseline(


### PR DESCRIPTION
Executes the owner brief in `temp/prompt_refinement.md` (persona engineering per the Assistant Axis / Persona Selection Model research, separation of concerns, prompt-caching feasibility), with second opinions taken from a Sol consult per Chimeric Protocol.

## Persona Engineering

- **Skald** keeps the character-bible form (the "actor handed a character" frame the PSM supports) with light sharpening: a name-heritage invocation line, and — the big persona move — removal of ~60 lines of registry bookkeeping that sat mid-bible pulling toward the assistant pole. Separation of concerns *is* the persona edit.
- **Gaia** is rewritten as a self-contained persona document: the two-DM working relationship holds the frame, the identity underneath deepens to *the living world behind the screen*. Sol's first-person testimony (it will occupy this seat) drove the calibration: "busybody with taste," silence as a conclusion rather than a default, tags as "levers on the deep machinery" with a newly-true-fact guard (also a prompt-side mitigation for #591), inline declaration doctrine (the prompted-Anthropic path carries no schema descriptions), and a player-agency guard extending the beat-scope doctrine to the second seat.
- One Sol suggestion overridden: it proposed narrowing "Part of your role is to author what would never occur to Skald" to consequences-only; that line is the owner's verbatim two-DM doctrine and the night-session data showed exactly the intended behavior, so it stays.

## Separation of Concerns

- `storyteller_core.md` → writer-scoped (all state doctrine out; Orrery section reduced to trust-the-clockwork + 10–20% prose bleed).
- NEW `storyteller_single_pass.md` carries the state portfolio for one-mind turns; appended only in single-pass mode. **Bootstrap never gets it** — its schema is prose+choices only (Sol consult catch; my draft had this wrong).
- Two latent seams fixed: gaia.md referenced `storyteller_core.md`, a document that seat never receives, and Gaia never saw the setting card despite authoring canon-adjacent text.
- Writer note: pending Orrery proposals are pressure/foreshadowing, never completed events — prevents the writer canonizing beats Gaia hasn't ruled.
- A contract test polices the doctrine invariants deliberately duplicated between the two state-authoring documents (four namespaces, registered vocabulary, accept-by-silence, exact prose names).

## C.R.E.A.M.

`docs/prompt_caching_cream_2026_07_27.md` (v2 with Sol's corrections). Headline: **caching cannot constrain prompt design here** — OpenAI serializes the structured-output schema as a prefix to the system message, and the two passes use different schemas by design (they diverge at character 14), so cross-seat caching is dead at token zero regardless of prompt ordering. Persona-first is free. Neither transport's structured path currently sends any cache directives; a small follow-up PR is specced in the report (explicit breakpoints, per-seat `prompt_cache_key`, hit-rate telemetry).

## Config (flagged for owner)

`gaia_model` pinned to **gpt-5.6-sol** via a new `@openai.gaia` registry role, reading the brief's "Sol… matches the architecture we've pinned for this role" as the seat decision. One-line revert if over-read; note Sol-Gaia's liberal tagging is what trips the still-open #591.

## Verification

272 tests pass (including new contract + composition tests), mypy clean, validate-config passes, live three-seat composition verified against slot 4's real setting card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ