### PR TITLE
Gateway Test-Port Lane: NEXUS_GATEWAY_PORT with Isolated State

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -155,11 +155,16 @@ processes, and they fail loudly in other profiles.
   available.
 - `NEXUS_GATEWAY_PORT=<port>` runs the gateway on an alternate port with
   fully isolated state (`state_dir/gateway-<port>/`), so an agent or test
-  session coexists with the desktop app's instance on one checkout. An
-  override instance borrows a healthy fixed-port sibling (the mock
-  provider) instead of refusing, and `nexus down` under the override stops
-  only the override instance. The desktop shell never sets this — its
-  `runtimeOrigin` is pinned to the configured port.
+  session coexists with the desktop app's instance on one checkout.
+  Fixed-port siblings (the mock provider) always belong to the default
+  instance: an override instance borrows one only when the default state
+  ledger proves the listener is managed (live pidfile on that port, and
+  healthy), skips it loudly when it is not running, and never spawns its
+  own — so the default stack starts cleanly in either order. A foreign
+  listener answering the health path is still refused; overrides equal to
+  a configured sibling port are rejected at startup. `nexus down` under
+  the override stops only the override instance. The desktop shell never
+  sets this — its `runtimeOrigin` is pinned to the configured port.
 
 ## CLI Surface
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -151,6 +151,15 @@ processes, and they fail loudly in other profiles.
   Ctrl+C. `./iris` is a thin alias for exactly this.
 - `nexus up` refuses ports held by unmanaged processes and refuses to
   double-start; partial startups are rolled back so `up` is all-or-nothing.
+  The refusal identifies the listener (pid, age, command) when `lsof` is
+  available.
+- `NEXUS_GATEWAY_PORT=<port>` runs the gateway on an alternate port with
+  fully isolated state (`state_dir/gateway-<port>/`), so an agent or test
+  session coexists with the desktop app's instance on one checkout. An
+  override instance borrows a healthy fixed-port sibling (the mock
+  provider) instead of refusing, and `nexus down` under the override stops
+  only the override instance. The desktop shell never sets this — its
+  `runtimeOrigin` is pinned to the configured port.
 
 ## CLI Surface
 

--- a/nexus.toml
+++ b/nexus.toml
@@ -1151,7 +1151,7 @@ follow_poll_seconds = 0.5 # poll interval for `nexus logs -f`
 # argv template — {python} is the current interpreter; no shell in the path
 command = ["{python}", "-m", "uvicorn", "nexus.api.narrative:app", "--host", "{host}", "--port", "{port}"]
 host = "127.0.0.1"
-port = 8002
+port = 8002 # the desktop shell's runtimeOrigin pins this; agent/test shells export NEXUS_GATEWAY_PORT for an isolated-state instance on another port
 health_path = "/health"
 autorestart = "on-failure"  # honored by the foreground supervisor only
 

--- a/nexus/api/runtime_status.py
+++ b/nexus/api/runtime_status.py
@@ -25,6 +25,7 @@ from nexus.runtime.contract import (
     NEXUS_AUTH_HEADER,
     RUNTIME_CONFIG_ENV,
     RUNTIME_STATUS_PATH,
+    gateway_port_override,
 )
 
 
@@ -75,7 +76,12 @@ def build_runtime_status() -> Dict[str, Any]:
     if runtime and runtime.profile == "local":
         gateway = runtime.services.get("gateway")
         if gateway:
-            status["services"]["gateway"]["port"] = gateway.port
+            # A NEXUS_GATEWAY_PORT instance inherits the override in its
+            # environment; report the port actually serving this request,
+            # not the configured default.
+            status["services"]["gateway"]["port"] = (
+                gateway_port_override() or gateway.port
+            )
         mock = runtime.services.get("mock_openai")
         test_provider = settings.global_.model.api_models.get("test")
         mock_enabled = (

--- a/nexus/runtime/contract.py
+++ b/nexus/runtime/contract.py
@@ -28,3 +28,34 @@ RUNTIME_STATUS_PATH = "/runtime/status"
 # /runtime/status reports the profile/ports of the config that actually
 # launched it (test harnesses point this at temp configs).
 RUNTIME_CONFIG_ENV = "NEXUS_RUNTIME_CONFIG"
+
+# Environment seam: run the gateway on an alternate port with isolated
+# runtime state (pidfiles/logs under a per-port subdirectory). This is the
+# designated lane for agent and test sessions, so a live-testing gateway can
+# never squat the desktop app's configured port — the collision that
+# motivated it was an orphaned test gateway from a dead session holding
+# :8002. The desktop shell never sets this; interactive test shells export
+# it before `nexus up`.
+GATEWAY_PORT_ENV = "NEXUS_GATEWAY_PORT"
+
+
+def gateway_port_override() -> "int | None":
+    """Parse the gateway port override from the environment.
+
+    Returns None when unset; raises ValueError loudly on garbage so a typo
+    can never silently fall back to the configured port.
+    """
+    import os
+
+    raw = os.environ.get(GATEWAY_PORT_ENV)
+    if raw is None or raw.strip() == "":
+        return None
+    try:
+        port = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{GATEWAY_PORT_ENV} must be an integer port, got {raw!r}"
+        ) from exc
+    if not 1 <= port <= 65535:
+        raise ValueError(f"{GATEWAY_PORT_ENV} must be 1-65535, got {port}")
+    return port

--- a/nexus/runtime/supervisor.py
+++ b/nexus/runtime/supervisor.py
@@ -35,8 +35,10 @@ from nexus.config.settings_models import (
     Settings,
 )
 from nexus.runtime.contract import (
+    GATEWAY_PORT_ENV,
     RUNTIME_CONFIG_ENV,
     RUNTIME_STATUS_PATH,
+    gateway_port_override,
 )
 from nexus.runtime.remote_auth import build_runtime_request_auth
 
@@ -96,6 +98,40 @@ def _port_open(host: str, port: int, timeout: float = 0.5) -> bool:
         return sock.connect_ex((host, port)) == 0
 
 
+def _describe_port_occupant(port: int) -> Optional[str]:
+    """Best-effort identity of the process listening on a local port.
+
+    Diagnostics only: returns ``"pid=<pid> elapsed=<etime> <command>"`` via
+    lsof+ps on POSIX hosts, or None when the tools are unavailable or the
+    listener cannot be resolved. Never raises.
+    """
+    if os.name != "posix":  # pragma: no cover - Windows host path
+        return None
+    try:
+        lsof = subprocess.run(
+            ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        pids = lsof.stdout.split()
+        if not pids:
+            return None
+        ps = subprocess.run(
+            ["ps", "-o", "pid=,etime=,command=", "-p", pids[0]],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        described = " ".join(ps.stdout.split())
+        if not described:
+            return None
+        pid, etime, *command = described.split(" ", 2)
+        return f"pid={pid} elapsed={etime} {' '.join(command)}"
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
 def _tail_lines(path: Path, count: int) -> List[str]:
     if not path.exists():
         return []
@@ -124,6 +160,23 @@ class Supervisor:
         self.root = repo_root()
         state_dir = Path(self.runtime.state_dir)
         self.state_dir = state_dir if state_dir.is_absolute() else self.root / state_dir
+        # NEXUS_GATEWAY_PORT: run this instance's gateway on an alternate
+        # port with fully isolated state (pidfiles, logs, slot bookkeeping),
+        # so agent/test sessions and the desktop app can coexist on one
+        # checkout without ever contending for the configured port.
+        try:
+            self._gateway_port_override = gateway_port_override()
+        except ValueError as exc:
+            raise RuntimeError_(str(exc)) from exc
+        if self._gateway_port_override is not None:
+            gateway = self.runtime.services.get("gateway")
+            if gateway is None:
+                raise RuntimeError_(
+                    f"{GATEWAY_PORT_ENV} is set but nexus.toml has no "
+                    "[runtime.services.gateway] to apply it to."
+                )
+            gateway.port = self._gateway_port_override
+            self.state_dir = self.state_dir / f"gateway-{gateway.port}"
 
     @classmethod
     def from_config(cls, config_path: Optional[Path] = None) -> "Supervisor":
@@ -298,10 +351,32 @@ class Supervisor:
         if existing:
             self._pidfile(name).unlink()  # stale pidfile from a dead process
         if _port_open(service.host, service.port):
+            if (
+                self._gateway_port_override is not None
+                and name != "gateway"
+                and self._probe(
+                    f"http://{service.host}:{service.port}{service.health_path}"
+                )
+            ):
+                # Override instances share healthy fixed-port siblings (the
+                # mock provider) with the default instance instead of
+                # refusing: the gateway is the isolated piece, and stopping
+                # this instance must not tear down the sibling it borrowed.
+                return {
+                    "attached": True,
+                    "service": name,
+                    "port": service.port,
+                    "host": service.host,
+                }
+            occupant = _describe_port_occupant(service.port)
+            listener = f" Listener: {occupant}." if occupant else ""
             raise RuntimeError_(
                 f"Port {service.port} is already in use by an unmanaged process; "
                 f"refusing to spawn '{name}'. Adjust [runtime.services.{name}] "
-                f"port or stop the other process."
+                f"port or stop the other process.{listener} If the listener is "
+                "a stale NEXUS service from a dead session, kill that pid. "
+                f"Agent/test shells should export {GATEWAY_PORT_ENV} to run on "
+                "a separate port with isolated state."
             )
         pid = self._spawn(name, service, slot, detached=detached)
         self._await_healthy(name, service, pid)
@@ -353,7 +428,12 @@ class Supervisor:
                     name, service, resolved_slot, detached=not foreground
                 )
                 started[name] = record
-                if echo:
+                if echo and record.get("attached"):
+                    print(
+                        f"attached to existing {name} on "
+                        f"http://{service.host}:{service.port}"
+                    )
+                elif echo:
                     print(
                         f"started {name} (pid {record['pid']}) on "
                         f"http://{service.host}:{service.port}"

--- a/nexus/runtime/supervisor.py
+++ b/nexus/runtime/supervisor.py
@@ -168,6 +168,10 @@ class Supervisor:
             self._gateway_port_override = gateway_port_override()
         except ValueError as exc:
             raise RuntimeError_(str(exc)) from exc
+        # The default instance's state dir stays visible under an override:
+        # it is the ownership ledger for fixed-port siblings (see
+        # _start_service's borrow path).
+        self._base_state_dir = self.state_dir
         if self._gateway_port_override is not None:
             gateway = self.runtime.services.get("gateway")
             if gateway is None:
@@ -175,6 +179,14 @@ class Supervisor:
                     f"{GATEWAY_PORT_ENV} is set but nexus.toml has no "
                     "[runtime.services.gateway] to apply it to."
                 )
+            for name, service in self.runtime.services.items():
+                if name != "gateway" and service.port == self._gateway_port_override:
+                    raise RuntimeError_(
+                        f"{GATEWAY_PORT_ENV}={self._gateway_port_override} "
+                        f"collides with [runtime.services.{name}] port "
+                        f"{service.port}; pick a port no service is "
+                        "configured on."
+                    )
             gateway.port = self._gateway_port_override
             self.state_dir = self.state_dir / f"gateway-{gateway.port}"
 
@@ -240,6 +252,27 @@ class Supervisor:
 
     def _write_pidfile(self, name: str, record: Dict[str, Any]) -> None:
         self._pidfile(name).write_text(json.dumps(record, indent=2))
+
+    def _sibling_owned_by_default(
+        self, name: str, service: RuntimeServiceSettings
+    ) -> bool:
+        """True when the default instance's ledger owns this service's port.
+
+        The proof is the default state dir's pidfile: a live pid recorded on
+        exactly the configured port. A foreign process answering the health
+        path does not qualify — health alone is not ownership.
+        """
+        path = self._base_state_dir / f"{name}.pid.json"
+        if not path.exists():
+            return False
+        try:
+            record = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return False
+        return (
+            _pid_alive(int(record.get("pid", -1)))
+            and int(record.get("port", -1)) == service.port
+        )
 
     # ------------------------------------------------------------------
     # Spawning
@@ -350,24 +383,36 @@ class Supervisor:
             )
         if existing:
             self._pidfile(name).unlink()  # stale pidfile from a dead process
-        if _port_open(service.host, service.port):
-            if (
-                self._gateway_port_override is not None
-                and name != "gateway"
-                and self._probe(
-                    f"http://{service.host}:{service.port}{service.health_path}"
-                )
+        if self._gateway_port_override is not None and name != "gateway":
+            # Fixed-port siblings (the mock provider) belong to the default
+            # instance. An override instance borrows one only when the
+            # default state ledger proves the listener is the managed
+            # sibling — pidfile alive, same port, healthy — and never
+            # spawns its own, so a later default `nexus up` always finds
+            # its ports either free or owned by its own pidfiles.
+            if self._sibling_owned_by_default(name, service) and self._probe(
+                f"http://{service.host}:{service.port}{service.health_path}"
             ):
-                # Override instances share healthy fixed-port siblings (the
-                # mock provider) with the default instance instead of
-                # refusing: the gateway is the isolated piece, and stopping
-                # this instance must not tear down the sibling it borrowed.
                 return {
                     "attached": True,
                     "service": name,
                     "port": service.port,
                     "host": service.host,
                 }
+            if not _port_open(service.host, service.port):
+                return {
+                    "skipped": True,
+                    "service": name,
+                    "port": service.port,
+                    "host": service.host,
+                    "reason": (
+                        "fixed-port sibling is not running; start the "
+                        "default stack if this instance needs it"
+                    ),
+                }
+            # Port open but not verifiably ours: fall through to the
+            # unmanaged-port refusal below.
+        if _port_open(service.host, service.port):
             occupant = _describe_port_occupant(service.port)
             listener = f" Listener: {occupant}." if occupant else ""
             raise RuntimeError_(
@@ -433,6 +478,8 @@ class Supervisor:
                         f"attached to existing {name} on "
                         f"http://{service.host}:{service.port}"
                     )
+                elif echo and record.get("skipped"):
+                    print(f"skipped {name}: {record['reason']}")
                 elif echo:
                     print(
                         f"started {name} (pid {record['pid']}) on "

--- a/nexus/runtime/supervisor.py
+++ b/nexus/runtime/supervisor.py
@@ -126,8 +126,13 @@ def _describe_port_occupant(port: int) -> Optional[str]:
         described = " ".join(ps.stdout.split())
         if not described:
             return None
-        pid, etime, *command = described.split(" ", 2)
-        return f"pid={pid} elapsed={etime} {' '.join(command)}"
+        parts = described.split(" ", 2)
+        if len(parts) < 2:
+            # A process that exited between the lsof snapshot and the ps
+            # call can leave a truncated line; diagnostics never raise.
+            return None
+        command = parts[2] if len(parts) == 3 else ""
+        return f"pid={parts[0]} elapsed={parts[1]} {command}".rstrip()
     except (OSError, subprocess.SubprocessError):
         return None
 

--- a/tests/test_runtime/test_supervisor_live.py
+++ b/tests/test_runtime/test_supervisor_live.py
@@ -251,6 +251,76 @@ def test_gateway_port_override_garbage_is_loud(tmp_path):
     assert not _port_open("127.0.0.1", GATEWAY_PORT)
 
 
+def test_gateway_port_override_first_then_default_stack(tmp_path):
+    """Reverse order: override-first skips siblings, so default still owns them."""
+    config = _write_config(tmp_path)
+    override_env = {"NEXUS_GATEWAY_PORT": str(OVERRIDE_GATEWAY_PORT)}
+    try:
+        first = _cli("up", config=config, env_extra=override_env)
+        assert first["_returncode"] == 0, first
+        # No default stack yet: the fixed-port sibling is skipped, never
+        # spawned into the override's isolated state.
+        assert first["services"]["mock_openai"].get("skipped") is True
+        assert _port_open("127.0.0.1", OVERRIDE_GATEWAY_PORT)
+        assert not _port_open("127.0.0.1", MOCK_PORT)
+
+        # The default stack then starts cleanly and owns its siblings.
+        base = _cli("up", config=config)
+        assert base["_returncode"] == 0, base
+        assert base["services"]["mock_openai"].get("pid")
+        assert _port_open("127.0.0.1", GATEWAY_PORT)
+        assert _port_open("127.0.0.1", MOCK_PORT)
+    finally:
+        _cli("down", config=config, env_extra=override_env)
+        _down(config)
+
+
+def test_override_refuses_foreign_healthy_listener_on_sibling_port(tmp_path):
+    """Health 200 alone is not ownership; a foreign listener is still refused."""
+    config = _write_config(tmp_path)
+    override_env = {"NEXUS_GATEWAY_PORT": str(OVERRIDE_GATEWAY_PORT)}
+    foreign = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+                "class H(BaseHTTPRequestHandler):\n"
+                "    def do_GET(self):\n"
+                "        self.send_response(200)\n"
+                "        self.end_headers()\n"
+                "        self.wfile.write(b'ok')\n"
+                "    def log_message(self, *a):\n"
+                "        pass\n"
+                f"HTTPServer(('127.0.0.1', {MOCK_PORT}), H).serve_forever()\n"
+            ),
+        ],
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while not _port_open("127.0.0.1", MOCK_PORT):
+            assert time.monotonic() < deadline, "foreign listener never bound"
+            time.sleep(0.1)
+        result = _cli("up", config=config, env_extra=override_env)
+        assert result["_returncode"] == 1
+        assert "already in use by an unmanaged process" in result["error"]
+        # All-or-nothing: the already-started override gateway rolled back.
+        assert not _port_open("127.0.0.1", OVERRIDE_GATEWAY_PORT)
+    finally:
+        foreign.terminate()
+        foreign.wait(timeout=10)
+        _cli("down", config=config, env_extra=override_env)
+
+
+def test_gateway_port_override_sibling_collision_is_loud(tmp_path):
+    """An override equal to another service's port is a config error."""
+    config = _write_config(tmp_path)
+    result = _cli("up", config=config, env_extra={"NEXUS_GATEWAY_PORT": str(MOCK_PORT)})
+    assert result["_returncode"] == 1
+    assert "collides with [runtime.services.mock_openai]" in result["error"]
+    assert not _port_open("127.0.0.1", MOCK_PORT)
+
+
 def test_mock_openai_auto_gating_follows_test_provider(tmp_path):
     """enabled='auto' spawns the mock only while TEST is in the registry."""
     with_test = _write_config(tmp_path, include_test_provider=True)

--- a/tests/test_runtime/test_supervisor_live.py
+++ b/tests/test_runtime/test_supervisor_live.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import socket
 import subprocess
 import sys
@@ -30,6 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 GATEWAY_PORT = 8032
 MOCK_PORT = 5133
 EXTERNAL_GATEWAY_PORT = 8034
+OVERRIDE_GATEWAY_PORT = 8036
 TEST_SLOT = 5
 
 pytestmark = pytest.mark.requires_postgres
@@ -68,9 +70,16 @@ def _write_config(
     return path
 
 
-def _cli(*args: str, config: Path, timeout: float = 120) -> dict:
+def _cli(
+    *args: str,
+    config: Path,
+    timeout: float = 120,
+    env_extra: dict | None = None,
+) -> dict:
     env = dict(os.environ)
     env["PYTHONPATH"] = str(REPO_ROOT)
+    if env_extra:
+        env.update(env_extra)
     completed = subprocess.run(
         [sys.executable, "-m", "nexus.cli", "--json", *args, "--config", str(config)],
         capture_output=True,
@@ -181,11 +190,65 @@ def test_up_refuses_port_held_by_unmanaged_process(tmp_path):
         result = _cli("up", config=config)
         assert result["_returncode"] == 1
         assert "already in use by an unmanaged process" in result["error"]
+        # The refusal identifies the squatter (this pytest process) and
+        # points test shells at the isolated-port lane.
+        if shutil.which("lsof"):
+            assert "Listener: pid=" in result["error"]
+        assert "NEXUS_GATEWAY_PORT" in result["error"]
         state_dir = tmp_path / "state"
         assert not list(state_dir.glob("*.pid.json"))
     finally:
         blocker.close()
         _down(config)
+
+
+def test_gateway_port_override_coexists_with_default_instance(tmp_path):
+    """NEXUS_GATEWAY_PORT runs an isolated-state gateway beside the default."""
+    config = _write_config(tmp_path)
+    override_env = {"NEXUS_GATEWAY_PORT": str(OVERRIDE_GATEWAY_PORT)}
+    try:
+        base = _cli("up", config=config)
+        assert base["_returncode"] == 0
+
+        result = _cli("up", config=config, env_extra=override_env)
+        assert result["_returncode"] == 0
+        assert result["services"]["gateway"]["port"] == OVERRIDE_GATEWAY_PORT
+        # The fixed-port sibling is borrowed from the default instance, not
+        # respawned and not refused.
+        assert result["services"]["mock_openai"].get("attached") is True
+        assert _port_open("127.0.0.1", OVERRIDE_GATEWAY_PORT)
+        assert _port_open("127.0.0.1", GATEWAY_PORT)
+
+        # Isolated state: each instance keeps its own pidfiles.
+        override_state = tmp_path / "state" / f"gateway-{OVERRIDE_GATEWAY_PORT}"
+        assert (override_state / "gateway.pid.json").exists()
+        assert (tmp_path / "state" / "gateway.pid.json").exists()
+
+        # The override instance reports the port actually serving requests.
+        status = requests.get(
+            f"http://127.0.0.1:{OVERRIDE_GATEWAY_PORT}/runtime/status",
+            timeout=10,
+        ).json()
+        assert status["services"]["gateway"]["port"] == OVERRIDE_GATEWAY_PORT
+
+        # Downing the override instance leaves the default stack running.
+        down = _cli("down", config=config, env_extra=override_env)
+        assert set(down["stopped"]) == {"gateway"}
+        assert not _port_open("127.0.0.1", OVERRIDE_GATEWAY_PORT)
+        assert _port_open("127.0.0.1", GATEWAY_PORT)
+        assert _port_open("127.0.0.1", MOCK_PORT)
+    finally:
+        _cli("down", config=config, env_extra=override_env)
+        _down(config)
+
+
+def test_gateway_port_override_garbage_is_loud(tmp_path):
+    """A malformed override refuses to start anything, with a clear error."""
+    config = _write_config(tmp_path)
+    result = _cli("up", config=config, env_extra={"NEXUS_GATEWAY_PORT": "styrofoam"})
+    assert result["_returncode"] == 1
+    assert "NEXUS_GATEWAY_PORT must be an integer port" in result["error"]
+    assert not _port_open("127.0.0.1", GATEWAY_PORT)
 
 
 def test_mock_openai_auto_gating_follows_test_provider(tmp_path):


### PR DESCRIPTION
This morning's "Runtime unavailable" was an orphaned agent-session gateway holding :8002 (pid orphaned to PPID 1, 13h42m old) — the supervisor's unmanaged-port guard worked as designed but couldn't say what it was refusing over, and nothing prevented agent test servers from squatting the app's port in the first place.

## What This Builds

**The designated test lane (owner's "separate port for testing").** `NEXUS_GATEWAY_PORT=<port>` makes `nexus up` bind the gateway there with fully isolated runtime state — pidfiles, logs, and slot bookkeeping under `state_dir/gateway-<port>/`. An agent session on :8012 and the desktop app on :8002 coexist on one checkout; `nexus down` in the override shell stops only the override instance. Fixed-port siblings (the mock provider) are borrowed when already healthy rather than refused, since the gateway is the isolated piece. Garbage values fail loud (JSON error, nothing spawned). `/runtime/status` reports the port actually serving the request.

**Actionable refusals.** The unmanaged-port error now identifies the listener via lsof/ps — `Listener: pid=88287 elapsed=13:42:08 …uvicorn nexus.api.narrative:app…` — and tells test shells about the lane. This morning's mystery becomes a one-glance diagnosis.

**Deliberately NOT built: automatic alternate port for the app** (owner's other floated option). The Tauri shell's `runtimeOrigin` is hardcoded to the configured port, so a supervisor-side fallback would bring the gateway up where the webview isn't looking. Doing it properly means teaching the desktop shell to discover the port from the `up` JSON first; with the lane eliminating the collision class, deferred unless still wanted.

## Verification

All live, no mocks (`NEXUS_RUN_POSTGRES=1 pytest tests/test_runtime`, 28 passed): a new test runs two real gateways side by side (override + default), asserts the borrowed sibling, isolated pidfiles, truthful `/runtime/status`, and that downing the override leaves the default stack running; the existing refusal test now asserts listener identification; a garbage-value test asserts loud failure with nothing spawned. Docs: `docs/runtime.md` + the `nexus-cli` skill picked up the agent doctrine (export the lane before live-testing, always `nexus down` before session end).

Mypy: the 15 reported errors in supervisor/runtime_status are byte-identical on origin/main (missing requests stubs + platform attrs baseline); this diff adds zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7JLuuGzH37uY5YwY17hvJ