### PR TITLE
Fix storyteller tag reapplications and deduplicate Orrery reads

### DIFF
--- a/nexus/agents/logon/orrery_tag_validation.py
+++ b/nexus/agents/logon/orrery_tag_validation.py
@@ -13,7 +13,7 @@ output validator can hand issues back to the model while it still owns the turn.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from difflib import get_close_matches
 import logging
 from typing import Any, FrozenSet, List, Mapping, Optional, Tuple
@@ -39,6 +39,9 @@ class StorytellerVocabulary:
     tag_names_by_kind: Mapping[str, FrozenSet[str]]
     pair_tag_names: FrozenSet[str]
     event_types: FrozenSet[str]
+    tag_reapplication_policies_by_kind: Mapping[str, Mapping[str, str]] = field(
+        default_factory=dict
+    )
 
 
 def read_storyteller_vocabulary(dbname: str) -> StorytellerVocabulary:
@@ -49,15 +52,27 @@ def read_storyteller_vocabulary(dbname: str) -> StorytellerVocabulary:
         "place": set(),
         "faction": set(),
     }
+    policies_by_kind: dict[str, dict[str, str]] = {
+        "character": {},
+        "place": {},
+        "faction": {},
+    }
     for entry in read_tag_library(dbname):
         if entry.entity_kind in tags_by_kind:
             tags_by_kind[entry.entity_kind].add(entry.tag)
+            if entry.reapplication_policy is not None:
+                policies_by_kind[entry.entity_kind][
+                    entry.tag
+                ] = entry.reapplication_policy
     return StorytellerVocabulary(
         tag_names_by_kind={
             kind: frozenset(tag_names) for kind, tag_names in tags_by_kind.items()
         },
         pair_tag_names=frozenset(read_pair_tag_library(dbname)),
         event_types=frozenset(read_event_types(dbname)),
+        tag_reapplication_policies_by_kind={
+            kind: dict(policies) for kind, policies in policies_by_kind.items()
+        },
     )
 
 
@@ -130,6 +145,20 @@ def _validate_bestowal_against_vocabulary(
                         candidates=allowed_tags,
                         suggestion_limit=suggestion_limit,
                     )
+                )
+            elif (
+                field_name == "applied_tags"
+                and vocabulary.tag_reapplication_policies_by_kind.get(
+                    entity_kind, {}
+                ).get(tag_name)
+                == "extend_expiry"
+            ):
+                issues.append(
+                    f"{field_name}: Tag {tag_name!r} uses "
+                    "reapplication_policy='extend_expiry', which requires "
+                    "duration_override; storyteller tags_add cannot express "
+                    "duration_override. If the tag is already active, leave it "
+                    "unchanged; otherwise omit it."
                 )
     return issues
 
@@ -341,7 +370,9 @@ def build_storyteller_tag_validator(
                 "pair_tag_hints, use the exact registered pair-tag name; pair tags "
                 "may contain colons (e.g. 'contact:social'). For "
                 "replacement_event_type, use an exact registered event type. Drop "
-                "any value with no registered equivalent. Fix every listed "
+                "any value with no registered equivalent. A tags_add issue that "
+                "requires duration_override is not expressible on the storyteller "
+                "wire; omit that tag. Fix every listed "
                 f"path and resubmit the complete response:\n{formatted}"
             )
         return output

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -1016,9 +1016,22 @@ def _load_hostile_character_pairs(session: Any) -> Tuple[_EntityPair, ...]:
 
 def _load_institutional_pair_rows(
     session: Any,
+    *,
+    actor_ids: Optional[Iterable[int]] = None,
 ) -> Tuple[_InstitutionalPairRow, ...]:
     """Load active institutional edges for in-memory actor filtering."""
 
+    actor_id_list = sorted(set(actor_ids)) if actor_ids is not None else None
+    actor_filter = (
+        """
+                  AND (
+                        ept.subject_entity_id = ANY(:actor_ids)
+                        OR ept.object_entity_id = ANY(:actor_ids)
+                      )
+        """
+        if actor_id_list is not None
+        else ""
+    )
     return tuple(
         (
             int(row["subject_entity_id"]),
@@ -1028,7 +1041,7 @@ def _load_institutional_pair_rows(
         )
         for row in session.execute(
             text(
-                """
+                f"""
                 /* orrery:actor_faction_bindings_institutional_pair_tags */
                 SELECT DISTINCT
                        ept.subject_entity_id,
@@ -1047,8 +1060,10 @@ def _load_institutional_pair_rows(
                         pt.tag LIKE 'status:%'
                         OR pt.tag IN ('obligation', 'handles', 'authority_over')
                       )
+                  {actor_filter}
                 """
-            )
+            ),
+            {"actor_ids": actor_id_list} if actor_id_list is not None else {},
         ).mappings()
     )
 
@@ -1624,7 +1639,10 @@ def compose_actor_faction_bindings(
     institutional_rows = (
         composition_cache.institutional_pair_rows()
         if composition_cache is not None
-        else _load_institutional_pair_rows(session)
+        else _load_institutional_pair_rows(
+            session,
+            actor_ids=actor_id_set,
+        )
     )
     for subject_id, object_id, subject_kind, object_kind in institutional_rows:
         if subject_id in actor_id_set and object_kind == "faction":
@@ -2381,10 +2399,19 @@ def resolve_dry_run(
             )
         )
 
+    # Actor-candidate expiry historically uses the stored anchor clock even
+    # when world_time_override drives state what-if evaluation. Preserve that
+    # contract (and explain_dry_run parity) while reusing the normal anchor
+    # read when no override is present.
+    composition_world_time = (
+        state.world_time
+        if world_time_override is None
+        else _load_world_time(session, anchor_chunk_id=anchor_chunk_id)
+    )
     composition_cache = _CompositionSourceCache.load(
         session,
         anchor_chunk_id=anchor_chunk_id,
-        world_time=state.world_time,
+        world_time=composition_world_time,
     )
     drafts: list[OrreryResolutionDraft] = []
     scene_pressure_results: list[Resolution] = []

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -919,18 +919,323 @@ def _load_project_states(session: Any) -> dict[int, ProjectState]:
     return states
 
 
+_EntityPair = tuple[int, int]
+_InstitutionalPairRow = tuple[int, int, str, str]
+
+
+def _load_character_relationship_pairs(session: Any) -> Tuple[_EntityPair, ...]:
+    """Load the active character-relationship source once for route reuse."""
+
+    return tuple(
+        (
+            int(row["source_entity_id"]),
+            int(row["target_entity_id"]),
+        )
+        for row in session.execute(
+            text(
+                """
+                /* orrery:actor_target_bindings_character_relationships */
+                SELECT er.source_entity_id, er.target_entity_id
+                FROM entity_relationships_v er
+                JOIN entities es ON es.id = er.source_entity_id
+                JOIN entities et ON et.id = er.target_entity_id
+                WHERE er.relationship_scope = 'character'
+                  AND er.source_entity_id IS NOT NULL
+                  AND er.target_entity_id IS NOT NULL
+                  AND es.kind = 'character'
+                  AND et.kind = 'character'
+                  AND es.is_active = true
+                  AND et.is_active = true
+                """
+            )
+        ).mappings()
+    )
+
+
+def _load_social_contact_pairs(session: Any) -> Tuple[_EntityPair, ...]:
+    """Load active directed social-contact edges."""
+
+    return tuple(
+        (
+            int(row["source_entity_id"]),
+            int(row["target_entity_id"]),
+        )
+        for row in session.execute(
+            text(
+                """
+                /* orrery:actor_target_bindings_social_contacts */
+                SELECT ept.subject_entity_id AS source_entity_id,
+                       ept.object_entity_id AS target_entity_id
+                FROM entity_pair_tags ept
+                JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+                JOIN entities es ON es.id = ept.subject_entity_id
+                JOIN entities et ON et.id = ept.object_entity_id
+                WHERE pt.tag = 'contact:social'
+                  AND NOT pt.deprecated
+                  AND ept.cleared_at IS NULL
+                  AND es.kind = 'character'
+                  AND et.kind = 'character'
+                  AND es.is_active = true
+                  AND et.is_active = true
+                """
+            )
+        ).mappings()
+    )
+
+
+def _load_hostile_character_pairs(session: Any) -> Tuple[_EntityPair, ...]:
+    """Load active character-only hostility edges."""
+
+    return tuple(
+        (
+            int(row["source_entity_id"]),
+            int(row["target_entity_id"]),
+        )
+        for row in session.execute(
+            text(
+                """
+                /* orrery:actor_target_bindings_hostile_edges */
+                SELECT ept.subject_entity_id AS source_entity_id,
+                       ept.object_entity_id AS target_entity_id
+                FROM entity_pair_tags ept
+                JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+                JOIN entities es ON es.id = ept.subject_entity_id
+                JOIN entities et ON et.id = ept.object_entity_id
+                WHERE pt.tag IN ('hostile_to', 'hunting')
+                  AND NOT pt.deprecated
+                  AND ept.cleared_at IS NULL
+                  AND es.kind = 'character'
+                  AND et.kind = 'character'
+                  AND es.is_active = true
+                  AND et.is_active = true
+                """
+            )
+        ).mappings()
+    )
+
+
+def _load_institutional_pair_rows(
+    session: Any,
+) -> Tuple[_InstitutionalPairRow, ...]:
+    """Load active institutional edges for in-memory actor filtering."""
+
+    return tuple(
+        (
+            int(row["subject_entity_id"]),
+            int(row["object_entity_id"]),
+            str(row["subject_kind"]),
+            str(row["object_kind"]),
+        )
+        for row in session.execute(
+            text(
+                """
+                /* orrery:actor_faction_bindings_institutional_pair_tags */
+                SELECT DISTINCT
+                       ept.subject_entity_id,
+                       ept.object_entity_id,
+                       subject_entity.kind AS subject_kind,
+                       object_entity.kind AS object_kind
+                FROM entity_pair_tags ept
+                JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+                JOIN entities subject_entity
+                  ON subject_entity.id = ept.subject_entity_id
+                JOIN entities object_entity
+                  ON object_entity.id = ept.object_entity_id
+                WHERE ept.cleared_at IS NULL
+                  AND NOT pt.deprecated
+                  AND (
+                        pt.tag LIKE 'status:%'
+                        OR pt.tag IN ('obligation', 'handles', 'authority_over')
+                      )
+                """
+            )
+        ).mappings()
+    )
+
+
+def _load_actor_faction_roster_pairs(session: Any) -> Tuple[_EntityPair, ...]:
+    """Load active character/faction roster pairs."""
+
+    return tuple(
+        sorted(
+            {
+                (int(row["member_id"]), int(row["faction_id"]))
+                for row in session.execute(
+                    text(
+                        """
+                        /* orrery:actor_faction_bindings_rosters */
+                        SELECT DISTINCT
+                               CASE
+                                   WHEN subject_entity.kind = 'character'
+                                   THEN subject_entity.id
+                                   ELSE object_entity.id
+                               END AS member_id,
+                               CASE
+                                   WHEN subject_entity.kind = 'faction'
+                                   THEN subject_entity.id
+                                   ELSE object_entity.id
+                               END AS faction_id
+                        FROM entity_pair_tags ept
+                        JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+                        JOIN entities subject_entity
+                          ON subject_entity.id = ept.subject_entity_id
+                        JOIN entities object_entity
+                          ON object_entity.id = ept.object_entity_id
+                        WHERE pt.tag LIKE 'status:%'
+                          AND NOT pt.deprecated
+                          AND ept.cleared_at IS NULL
+                          AND subject_entity.is_active = true
+                          AND object_entity.is_active = true
+                          AND (
+                              (subject_entity.kind = 'character'
+                               AND object_entity.kind = 'faction')
+                              OR (subject_entity.kind = 'faction'
+                                  AND object_entity.kind = 'character')
+                          )
+                        """
+                    )
+                ).mappings()
+            }
+        )
+    )
+
+
+@dataclass
+class _CompositionSourceCache:
+    """One resolver tick's lazily hydrated binding-source candidates."""
+
+    session: Any
+    anchor_chunk_id: Optional[int]
+    world_time: Optional[datetime]
+    present_actor_ids: frozenset[int]
+    _character_relationship_pairs: Optional[Tuple[_EntityPair, ...]] = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
+    _social_contact_pairs: Optional[Tuple[_EntityPair, ...]] = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
+    _hostile_character_pairs: Optional[Tuple[_EntityPair, ...]] = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
+    _institutional_pair_rows: Optional[Tuple[_InstitutionalPairRow, ...]] = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
+    _actor_faction_roster_pairs: Optional[Tuple[_EntityPair, ...]] = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
+
+    @classmethod
+    def load(
+        cls,
+        session: Any,
+        *,
+        anchor_chunk_id: Optional[int],
+        world_time: Optional[datetime],
+    ) -> "_CompositionSourceCache":
+        """Create one tick cache and hydrate the shared presence boundary."""
+
+        return cls(
+            session=session,
+            anchor_chunk_id=anchor_chunk_id,
+            world_time=world_time,
+            present_actor_ids=frozenset(
+                _present_actor_ids_at_anchor(
+                    session,
+                    anchor_chunk_id=anchor_chunk_id,
+                )
+            ),
+        )
+
+    def validate_scope(
+        self,
+        session: Any,
+        *,
+        anchor_chunk_id: Optional[int],
+    ) -> None:
+        """Fail if a tick-local cache is accidentally reused out of scope."""
+
+        if self.session is not session or self.anchor_chunk_id != anchor_chunk_id:
+            raise ValueError("composition source cache belongs to a different tick")
+
+    def character_relationship_pairs(self) -> Tuple[_EntityPair, ...]:
+        if self._character_relationship_pairs is None:
+            self._character_relationship_pairs = _load_character_relationship_pairs(
+                self.session
+            )
+        return self._character_relationship_pairs
+
+    def social_contact_pairs(self) -> Tuple[_EntityPair, ...]:
+        if self._social_contact_pairs is None:
+            self._social_contact_pairs = _load_social_contact_pairs(self.session)
+        return self._social_contact_pairs
+
+    def hostile_character_pairs(self) -> Tuple[_EntityPair, ...]:
+        if self._hostile_character_pairs is None:
+            self._hostile_character_pairs = _load_hostile_character_pairs(self.session)
+        return self._hostile_character_pairs
+
+    def institutional_pair_rows(self) -> Tuple[_InstitutionalPairRow, ...]:
+        if self._institutional_pair_rows is None:
+            self._institutional_pair_rows = _load_institutional_pair_rows(self.session)
+        return self._institutional_pair_rows
+
+    def actor_faction_roster_pairs(self) -> Tuple[_EntityPair, ...]:
+        if self._actor_faction_roster_pairs is None:
+            self._actor_faction_roster_pairs = _load_actor_faction_roster_pairs(
+                self.session
+            )
+        return self._actor_faction_roster_pairs
+
+
+def _composition_present_actor_ids(
+    session: Any,
+    *,
+    anchor_chunk_id: Optional[int],
+    composition_cache: Optional[_CompositionSourceCache],
+) -> set[int]:
+    """Use cached scene presence or preserve the direct-call fallback read."""
+
+    if composition_cache is None:
+        return _present_actor_ids_at_anchor(
+            session,
+            anchor_chunk_id=anchor_chunk_id,
+        )
+    composition_cache.validate_scope(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+    )
+    return set(composition_cache.present_actor_ids)
+
+
 def compose_actor_bindings(
     session: Any,
     *,
     anchor_chunk_id: Optional[int],
     window_chunks: int,
+    composition_cache: Optional[_CompositionSourceCache] = None,
 ) -> Tuple[Bindings, ...]:
     """Compose ACTOR-only bindings for recently relevant off-screen characters."""
 
     actor_ids: set[int] = set()
-    current_world_time = _load_world_time(session, anchor_chunk_id=anchor_chunk_id)
-    present_actor_ids = _present_actor_ids_at_anchor(
-        session, anchor_chunk_id=anchor_chunk_id
+    current_world_time = (
+        composition_cache.world_time
+        if composition_cache is not None
+        else _load_world_time(session, anchor_chunk_id=anchor_chunk_id)
+    )
+    present_actor_ids = _composition_present_actor_ids(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        composition_cache=composition_cache,
     )
 
     if anchor_chunk_id is not None:
@@ -1080,6 +1385,7 @@ def compose_actor_target_bindings(
     target_presence: str = "offscreen",
     include_social_contacts: bool = False,
     include_hostile_edges: bool = False,
+    composition_cache: Optional[_CompositionSourceCache] = None,
 ) -> Tuple[Bindings, ...]:
     """Compose ACTOR+TARGET bindings from actors' relational neighborhoods.
 
@@ -1115,12 +1421,15 @@ def compose_actor_target_bindings(
             session,
             anchor_chunk_id=anchor_chunk_id,
             window_chunks=window_chunks,
+            composition_cache=composition_cache,
         )
         actor_id_set = {bindings[Slot.ACTOR] for bindings in actor_only}
     else:
         actor_id_set = set(actor_ids)
-    present_actor_ids = _present_actor_ids_at_anchor(
-        session, anchor_chunk_id=anchor_chunk_id
+    present_actor_ids = _composition_present_actor_ids(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        composition_cache=composition_cache,
     )
     actor_id_set -= present_actor_ids
     if not actor_id_set:
@@ -1150,83 +1459,43 @@ def compose_actor_target_bindings(
         ):
             pairs.add((target, source))
 
-    for row in session.execute(
-        text(
-            """
-            /* orrery:actor_target_bindings_character_relationships */
-            SELECT er.source_entity_id, er.target_entity_id
-            FROM entity_relationships_v er
-            JOIN entities es ON es.id = er.source_entity_id
-            JOIN entities et ON et.id = er.target_entity_id
-            WHERE er.relationship_scope = 'character'
-              AND er.source_entity_id IS NOT NULL
-              AND er.target_entity_id IS NOT NULL
-              AND es.kind = 'character'
-              AND et.kind = 'character'
-              AND es.is_active = true
-              AND et.is_active = true
-            """
-        )
-    ).mappings():
+    relationship_pairs = (
+        composition_cache.character_relationship_pairs()
+        if composition_cache is not None
+        else _load_character_relationship_pairs(session)
+    )
+    for source_id, target_id in relationship_pairs:
         add_candidate(
-            int(row["source_entity_id"]),
-            int(row["target_entity_id"]),
+            source_id,
+            target_id,
             reverse=True,
         )
 
     if include_social_contacts:
-        for row in session.execute(
-            text(
-                """
-                /* orrery:actor_target_bindings_social_contacts */
-                SELECT ept.subject_entity_id AS source_entity_id,
-                       ept.object_entity_id AS target_entity_id
-                FROM entity_pair_tags ept
-                JOIN pair_tags pt ON pt.id = ept.pair_tag_id
-                JOIN entities es ON es.id = ept.subject_entity_id
-                JOIN entities et ON et.id = ept.object_entity_id
-                WHERE pt.tag = 'contact:social'
-                  AND NOT pt.deprecated
-                  AND ept.cleared_at IS NULL
-                  AND es.kind = 'character'
-                  AND et.kind = 'character'
-                  AND es.is_active = true
-                  AND et.is_active = true
-                """
-            )
-        ).mappings():
+        social_pairs = (
+            composition_cache.social_contact_pairs()
+            if composition_cache is not None
+            else _load_social_contact_pairs(session)
+        )
+        for source_id, target_id in social_pairs:
             add_candidate(
-                int(row["source_entity_id"]),
-                int(row["target_entity_id"]),
+                source_id,
+                target_id,
                 reverse=False,
             )
 
     if include_hostile_edges:
-        for row in session.execute(
-            text(
-                """
-                /* orrery:actor_target_bindings_hostile_edges */
-                SELECT ept.subject_entity_id AS source_entity_id,
-                       ept.object_entity_id AS target_entity_id
-                FROM entity_pair_tags ept
-                JOIN pair_tags pt ON pt.id = ept.pair_tag_id
-                JOIN entities es ON es.id = ept.subject_entity_id
-                JOIN entities et ON et.id = ept.object_entity_id
-                WHERE pt.tag IN ('hostile_to', 'hunting')
-                  AND NOT pt.deprecated
-                  AND ept.cleared_at IS NULL
-                  AND es.kind = 'character'
-                  AND et.kind = 'character'
-                  AND es.is_active = true
-                  AND et.is_active = true
-                """
-            )
-        ).mappings():
+        hostile_pairs = (
+            composition_cache.hostile_character_pairs()
+            if composition_cache is not None
+            else _load_hostile_character_pairs(session)
+        )
+        for source_id, target_id in hostile_pairs:
             # Faction-endpoint hostility deliberately composes nothing until
             # an authored desire names that faction.
             add_candidate(
-                int(row["source_entity_id"]),
-                int(row["target_entity_id"]),
+                source_id,
+                target_id,
                 reverse=True,
             )
 
@@ -1241,6 +1510,7 @@ def compose_acquaintance_bindings(
     *,
     anchor_chunk_id: Optional[int],
     actor_ids: Iterable[int],
+    composition_cache: Optional[_CompositionSourceCache] = None,
 ) -> Tuple[Bindings, ...]:
     """Compose canonical off-screen stranger pairs sharing one place.
 
@@ -1250,8 +1520,10 @@ def compose_acquaintance_bindings(
     """
 
     actor_id_set = set(actor_ids)
-    present_actor_ids = _present_actor_ids_at_anchor(
-        session, anchor_chunk_id=anchor_chunk_id
+    present_actor_ids = _composition_present_actor_ids(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        composition_cache=composition_cache,
     )
     actor_id_set -= present_actor_ids
     if not actor_id_set:
@@ -1316,6 +1588,7 @@ def compose_actor_faction_bindings(
     include_rosters: bool = False,
     roster_reach: int = 2,
     orbit_distance: Optional[Mapping[tuple[int, int], int]] = None,
+    composition_cache: Optional[_CompositionSourceCache] = None,
 ) -> Tuple[Bindings, ...]:
     """Compose ACTOR+FACTION bindings from active institutional pair tags.
 
@@ -1332,12 +1605,15 @@ def compose_actor_faction_bindings(
             session,
             anchor_chunk_id=anchor_chunk_id,
             window_chunks=window_chunks,
+            composition_cache=composition_cache,
         )
         actor_id_set = {bindings[Slot.ACTOR] for bindings in actor_only}
     else:
         actor_id_set = set(actor_ids)
-    actor_id_set -= _present_actor_ids_at_anchor(
-        session, anchor_chunk_id=anchor_chunk_id
+    actor_id_set -= _composition_present_actor_ids(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        composition_cache=composition_cache,
     )
     if not actor_id_set:
         return ()
@@ -1345,83 +1621,23 @@ def compose_actor_faction_bindings(
         raise ValueError("roster_reach must be between 1 and 4")
 
     pairs: set[tuple[int, int]] = set()
-    for row in session.execute(
-        text(
-            """
-            /* orrery:actor_faction_bindings_institutional_pair_tags */
-            SELECT DISTINCT
-                   ept.subject_entity_id,
-                   ept.object_entity_id,
-                   subject_entity.kind AS subject_kind,
-                   object_entity.kind AS object_kind
-            FROM entity_pair_tags ept
-            JOIN pair_tags pt ON pt.id = ept.pair_tag_id
-            JOIN entities subject_entity
-              ON subject_entity.id = ept.subject_entity_id
-            JOIN entities object_entity
-              ON object_entity.id = ept.object_entity_id
-            WHERE ept.cleared_at IS NULL
-              AND NOT pt.deprecated
-              AND (
-                    pt.tag LIKE 'status:%'
-                    OR pt.tag IN ('obligation', 'handles', 'authority_over')
-                  )
-              AND (
-                    ept.subject_entity_id = ANY(:actor_ids)
-                    OR ept.object_entity_id = ANY(:actor_ids)
-                  )
-            """
-        ),
-        {"actor_ids": sorted(actor_id_set)},
-    ).mappings():
-        subject_id = int(row["subject_entity_id"])
-        object_id = int(row["object_entity_id"])
-        if subject_id in actor_id_set and row["object_kind"] == "faction":
+    institutional_rows = (
+        composition_cache.institutional_pair_rows()
+        if composition_cache is not None
+        else _load_institutional_pair_rows(session)
+    )
+    for subject_id, object_id, subject_kind, object_kind in institutional_rows:
+        if subject_id in actor_id_set and object_kind == "faction":
             pairs.add((subject_id, object_id))
-        if object_id in actor_id_set and row["subject_kind"] == "faction":
+        if object_id in actor_id_set and subject_kind == "faction":
             pairs.add((object_id, subject_id))
 
     if include_rosters:
         assert orbit_distance is not None
-        live_rosters = sorted(
-            {
-                (int(row["member_id"]), int(row["faction_id"]))
-                for row in session.execute(
-                    text(
-                        """
-                        /* orrery:actor_faction_bindings_rosters */
-                        SELECT DISTINCT
-                               CASE
-                                   WHEN subject_entity.kind = 'character'
-                                   THEN subject_entity.id
-                                   ELSE object_entity.id
-                               END AS member_id,
-                               CASE
-                                   WHEN subject_entity.kind = 'faction'
-                                   THEN subject_entity.id
-                                   ELSE object_entity.id
-                               END AS faction_id
-                        FROM entity_pair_tags ept
-                        JOIN pair_tags pt ON pt.id = ept.pair_tag_id
-                        JOIN entities subject_entity
-                          ON subject_entity.id = ept.subject_entity_id
-                        JOIN entities object_entity
-                          ON object_entity.id = ept.object_entity_id
-                        WHERE pt.tag LIKE 'status:%'
-                          AND NOT pt.deprecated
-                          AND ept.cleared_at IS NULL
-                          AND subject_entity.is_active = true
-                          AND object_entity.is_active = true
-                          AND (
-                              (subject_entity.kind = 'character'
-                               AND object_entity.kind = 'faction')
-                              OR (subject_entity.kind = 'faction'
-                                  AND object_entity.kind = 'character')
-                          )
-                        """
-                    )
-                ).mappings()
-            }
+        live_rosters = (
+            composition_cache.actor_faction_roster_pairs()
+            if composition_cache is not None
+            else _load_actor_faction_roster_pairs(session)
         )
         for actor_id in sorted(actor_id_set):
             for member_id, faction_id in live_rosters:
@@ -1451,6 +1667,7 @@ def compose_actor_target_faction_bindings(
     include_rosters: bool = False,
     roster_reach: int = 2,
     orbit_distance: Optional[Mapping[tuple[int, int], int]] = None,
+    composition_cache: Optional[_CompositionSourceCache] = None,
 ) -> Tuple[Bindings, ...]:
     """Compose the deterministic product of target and faction candidates."""
 
@@ -1461,6 +1678,7 @@ def compose_actor_target_faction_bindings(
                 session,
                 anchor_chunk_id=anchor_chunk_id,
                 window_chunks=window_chunks,
+                composition_cache=composition_cache,
             )
         }
     else:
@@ -1473,6 +1691,7 @@ def compose_actor_target_faction_bindings(
         target_presence=target_presence,
         include_social_contacts=include_social_contacts,
         include_hostile_edges=include_hostile_edges,
+        composition_cache=composition_cache,
     )
     faction_bindings = compose_actor_faction_bindings(
         session,
@@ -1482,6 +1701,7 @@ def compose_actor_target_faction_bindings(
         include_rosters=include_rosters,
         roster_reach=roster_reach,
         orbit_distance=orbit_distance,
+        composition_cache=composition_cache,
     )
     targets_by_actor: dict[int, set[int]] = {}
     for binding in target_bindings:
@@ -1516,6 +1736,7 @@ def compose_project_target_bindings(
     anchor_chunk_id: Optional[int],
     actor_ids: Iterable[int],
     target_presence: str = "offscreen",
+    composition_cache: Optional[_CompositionSourceCache] = None,
 ) -> Tuple[Bindings, ...]:
     """Bind character-project actors to their durable project target.
 
@@ -1526,8 +1747,10 @@ def compose_project_target_bindings(
 
     if target_presence not in {"offscreen", "present"}:
         raise ValueError("target_presence must be 'offscreen' or 'present'")
-    present_actor_ids = _present_actor_ids_at_anchor(
-        session, anchor_chunk_id=anchor_chunk_id
+    present_actor_ids = _composition_present_actor_ids(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        composition_cache=composition_cache,
     )
     actor_id_set = set(actor_ids) - present_actor_ids
     pairs: list[tuple[int, int]] = []
@@ -1554,11 +1777,14 @@ def compose_project_faction_bindings(
     state: WorldState,
     anchor_chunk_id: Optional[int],
     actor_ids: Iterable[int],
+    composition_cache: Optional[_CompositionSourceCache] = None,
 ) -> Tuple[Bindings, ...]:
     """Bind project actors to their immutable stored faction counterparty."""
 
-    present_actor_ids = _present_actor_ids_at_anchor(
-        session, anchor_chunk_id=anchor_chunk_id
+    present_actor_ids = _composition_present_actor_ids(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        composition_cache=composition_cache,
     )
     pairs: list[tuple[int, int]] = []
     for actor_id in sorted(set(actor_ids) - present_actor_ids):
@@ -1590,6 +1816,7 @@ def compose_actor_faction_routes(
     window_chunks: int,
     actor_ids: Iterable[int],
     composition_settings: Optional[Any] = None,
+    composition_cache: Optional[_CompositionSourceCache] = None,
 ) -> Tuple[tuple[Bindings, Tuple[Template, ...]], ...]:
     """Route institutional and stored-project faction bindings by template."""
 
@@ -1602,6 +1829,7 @@ def compose_actor_faction_routes(
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
         actor_ids=actor_id_set,
+        composition_cache=composition_cache,
     )
     roster_enabled, roster_reach = _roster_composition_settings(composition_settings)
     roster = (
@@ -1613,6 +1841,7 @@ def compose_actor_faction_routes(
             include_rosters=True,
             roster_reach=roster_reach,
             orbit_distance=state.orbit_distance,
+            composition_cache=composition_cache,
         )
         if roster_enabled and any(t.courts_factions for t in templates_tuple)
         else ()
@@ -1622,6 +1851,7 @@ def compose_actor_faction_routes(
         state=state,
         anchor_chunk_id=anchor_chunk_id,
         actor_ids=actor_id_set,
+        composition_cache=composition_cache,
     )
     institutional_pairs = {
         (binding[Slot.ACTOR], binding[Slot.FACTION]) for binding in institutional
@@ -1662,6 +1892,7 @@ def compose_actor_target_faction_routes(
     actor_ids: Iterable[int],
     target_presence: str = "offscreen",
     composition_settings: Optional[Any] = None,
+    composition_cache: Optional[_CompositionSourceCache] = None,
 ) -> Tuple[tuple[Bindings, Tuple[Template, ...]], ...]:
     """Route target-candidate products with institutional/project factions."""
 
@@ -1675,6 +1906,7 @@ def compose_actor_target_faction_routes(
         window_chunks=window_chunks,
         actor_ids=actor_id_set,
         target_presence=target_presence,
+        composition_cache=composition_cache,
     )
     social_targets = (
         compose_actor_target_bindings(
@@ -1684,6 +1916,7 @@ def compose_actor_target_faction_routes(
             actor_ids=actor_id_set,
             target_presence=target_presence,
             include_social_contacts=True,
+            composition_cache=composition_cache,
         )
         if any(template.starts_from_social_contact for template in templates_tuple)
         else ()
@@ -1699,6 +1932,7 @@ def compose_actor_target_faction_routes(
             actor_ids=actor_id_set,
             target_presence=target_presence,
             include_hostile_edges=True,
+            composition_cache=composition_cache,
         )
         if hostile_enabled
         and any(template.composes_from_hostility for template in templates_tuple)
@@ -1711,6 +1945,7 @@ def compose_actor_target_faction_routes(
             anchor_chunk_id=anchor_chunk_id,
             actor_ids=actor_id_set,
             target_presence=target_presence,
+            composition_cache=composition_cache,
         )
         if any(template.binds_project_target for template in templates_tuple)
         else ()
@@ -1720,6 +1955,7 @@ def compose_actor_target_faction_routes(
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
         actor_ids=actor_id_set,
+        composition_cache=composition_cache,
     )
     roster_enabled, roster_reach = _roster_composition_settings(composition_settings)
     roster_factions = (
@@ -1731,6 +1967,7 @@ def compose_actor_target_faction_routes(
             include_rosters=True,
             roster_reach=roster_reach,
             orbit_distance=state.orbit_distance,
+            composition_cache=composition_cache,
         )
         if roster_enabled and any(t.courts_factions for t in templates_tuple)
         else ()
@@ -1741,6 +1978,7 @@ def compose_actor_target_faction_routes(
             state=state,
             anchor_chunk_id=anchor_chunk_id,
             actor_ids=actor_id_set,
+            composition_cache=composition_cache,
         )
         if any(template.binds_project_faction for template in templates_tuple)
         else ()
@@ -1810,6 +2048,7 @@ def compose_actor_target_routes(
     actor_ids: Iterable[int],
     target_presence: str = "offscreen",
     composition_settings: Optional[Any] = None,
+    composition_cache: Optional[_CompositionSourceCache] = None,
 ) -> Tuple[tuple[Bindings, Tuple[Template, ...]], ...]:
     """Route each ACTOR/TARGET binding to its authorized template stack.
 
@@ -1839,6 +2078,7 @@ def compose_actor_target_routes(
         actor_ids=actor_id_set,
         target_presence=target_presence,
         include_social_contacts=False,
+        composition_cache=composition_cache,
     )
     add_routes(relationship_bindings, templates_tuple)
 
@@ -1853,6 +2093,7 @@ def compose_actor_target_routes(
             actor_ids=actor_id_set,
             target_presence=target_presence,
             include_social_contacts=True,
+            composition_cache=composition_cache,
         )
         add_routes(social_bindings, social_templates)
 
@@ -1869,6 +2110,7 @@ def compose_actor_target_routes(
             actor_ids=actor_id_set,
             target_presence=target_presence,
             include_hostile_edges=True,
+            composition_cache=composition_cache,
         )
         add_routes(hostile_bindings, hostile_templates)
 
@@ -1882,6 +2124,7 @@ def compose_actor_target_routes(
             session,
             anchor_chunk_id=anchor_chunk_id,
             actor_ids=actor_id_set,
+            composition_cache=composition_cache,
         )
         add_routes(acquaintance_bindings, acquaintance_templates)
 
@@ -1895,6 +2138,7 @@ def compose_actor_target_routes(
             anchor_chunk_id=anchor_chunk_id,
             actor_ids=actor_id_set,
             target_presence=target_presence,
+            composition_cache=composition_cache,
         )
         add_routes(project_bindings, project_templates)
 
@@ -2137,6 +2381,11 @@ def resolve_dry_run(
             )
         )
 
+    composition_cache = _CompositionSourceCache.load(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        world_time=state.world_time,
+    )
     drafts: list[OrreryResolutionDraft] = []
     scene_pressure_results: list[Resolution] = []
 
@@ -2144,6 +2393,7 @@ def resolve_dry_run(
         session,
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=window_chunks,
+        composition_cache=composition_cache,
     )
     actor_ids = {bindings[Slot.ACTOR] for bindings in actor_bindings}
     for bindings in actor_bindings:
@@ -2170,6 +2420,7 @@ def resolve_dry_run(
             actor_ids=actor_ids,
             target_presence="offscreen",
             composition_settings=composition_settings,
+            composition_cache=composition_cache,
         )
         for bindings, routed_templates in offscreen_routes:
             resolution = evaluate_stack(
@@ -2199,6 +2450,7 @@ def resolve_dry_run(
                 actor_ids=actor_ids,
                 target_presence="present",
                 composition_settings=composition_settings,
+                composition_cache=composition_cache,
             )
             for bindings, routed_templates in present_routes:
                 resolution = evaluate_stack(
@@ -2221,6 +2473,7 @@ def resolve_dry_run(
             window_chunks=window_chunks,
             actor_ids=actor_ids,
             composition_settings=composition_settings,
+            composition_cache=composition_cache,
         )
         offscreen_routes += faction_routes
         for bindings, routed_templates in faction_routes:
@@ -2245,6 +2498,7 @@ def resolve_dry_run(
             actor_ids=actor_ids,
             target_presence="offscreen",
             composition_settings=composition_settings,
+            composition_cache=composition_cache,
         )
         offscreen_routes += triple_routes
         for bindings, routed_templates in triple_routes:
@@ -2275,6 +2529,7 @@ def resolve_dry_run(
                 actor_ids=actor_ids,
                 target_presence="present",
                 composition_settings=composition_settings,
+                composition_cache=composition_cache,
             )
             present_routes += triple_pressure_routes
             for bindings, routed_templates in triple_pressure_routes:
@@ -2305,42 +2560,44 @@ def resolve_dry_run(
         for value in draft.bindings.values():
             if isinstance(value, int):
                 draft_entity_ids.add(value)
-    draft_entity_names = _load_entity_names(session, draft_entity_ids)
+
+    present_need_pressure_specs = _present_need_pressure_specs(
+        state,
+        present_actor_ids=set(composition_cache.present_actor_ids),
+        need_tuning=need_tuning,
+    )
+    pressure_entity_ids = _entity_ids_from_resolutions(scene_pressure_results) | {
+        spec["actor_entity_id"] for spec in present_need_pressure_specs
+    }
+    name_entity_ids = draft_entity_ids | pressure_entity_ids
+    if state.mood_enabled:
+        name_entity_ids.update(composition_cache.present_actor_ids)
+    entity_names = _load_entity_names(session, name_entity_ids)
+
     drafts = [
         replace(
             draft,
             binding_names={
-                slot: _entity_label(value, draft_entity_names)
+                slot: _entity_label(value, entity_names)
                 for slot, value in draft.bindings.items()
             },
             narrative_stub=_render_bound_text(
                 draft.narrative_stub,
                 draft.bindings,
-                draft_entity_names,
+                entity_names,
                 template_id=draft.template_id,
             ),
         )
         for draft in drafts
     ]
 
-    present_need_pressure_specs = _present_need_pressure_specs(
-        state,
-        present_actor_ids=_present_actor_ids_at_anchor(
-            session, anchor_chunk_id=anchor_chunk_id
-        ),
-        need_tuning=need_tuning,
-    )
-    pressure_entity_ids = _entity_ids_from_resolutions(scene_pressure_results) | {
-        spec["actor_entity_id"] for spec in present_need_pressure_specs
-    }
-    pressure_entity_names = _load_entity_names(session, pressure_entity_ids)
     scene_pressures = tuple(
-        _scene_pressure_from_resolution(resolution, pressure_entity_names)
+        _scene_pressure_from_resolution(resolution, entity_names)
         for resolution in scene_pressure_results
     ) + tuple(
         _scene_pressure_from_need_spec(
             spec,
-            pressure_entity_names,
+            entity_names,
             need_tuning=need_tuning,
         )
         for spec in present_need_pressure_specs
@@ -2361,18 +2618,14 @@ def resolve_dry_run(
             {"weather": state.weather, "time_of_day": state.time_of_day}
         )
     if state.mood_enabled:
-        present_actor_ids = _present_actor_ids_at_anchor(
-            session, anchor_chunk_id=anchor_chunk_id
-        )
-        present_names = _load_entity_names(session, present_actor_ids)
         moods = [
             {
                 "entity_id": entity_id,
-                "name": present_names[entity_id],
+                "name": entity_names[entity_id],
                 "mood": mood,
             }
-            for entity_id in sorted(present_actor_ids)
-            if entity_id in present_names
+            for entity_id in sorted(composition_cache.present_actor_ids)
+            if entity_id in entity_names
             if (mood := active_mood(state, {Slot.ACTOR: entity_id}, slot=Slot.ACTOR))
             is not None
         ]
@@ -2383,7 +2636,7 @@ def resolve_dry_run(
         actor_count=len(unique_actors),
         resolutions=tuple(drafts),
         scene_pressures=scene_pressures,
-        joint_beats=detect_joint_beats(drafts, draft_entity_names),
+        joint_beats=detect_joint_beats(drafts, entity_names),
         communication_graph=state.communication_graph,
         epistemics_settings={
             "enabled": epistemics_policy.enabled,

--- a/nexus/agents/orrery/tag_library.py
+++ b/nexus/agents/orrery/tag_library.py
@@ -37,6 +37,7 @@ class TagLibraryEntry:
     description: str
     category_description: str
     prompt_order: int
+    reapplication_policy: Optional[str] = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -109,7 +110,8 @@ def read_tag_library(
                     r.prompt_order,
                     t.tag,
                     t.is_ephemeral,
-                    t.description
+                    t.description,
+                    t.reapplication_policy::text AS reapplication_policy
                 FROM tag_category_registry r
                 JOIN tags t ON t.category = r.category
                 WHERE {' AND '.join(where)}
@@ -130,6 +132,11 @@ def read_tag_library(
                     description=str(row["description"] or ""),
                     category_description=str(row["category_description"] or ""),
                     prompt_order=int(row["prompt_order"]),
+                    reapplication_policy=(
+                        str(row["reapplication_policy"])
+                        if row.get("reapplication_policy") is not None
+                        else None
+                    ),
                 )
                 for row in cur.fetchall()
             ]

--- a/nexus/agents/orrery/tag_writer.py
+++ b/nexus/agents/orrery/tag_writer.py
@@ -21,6 +21,7 @@ scheduled-expiry column used by duration-bearing tags.
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import AbstractSet, Any, Literal, Optional, TypeAlias
@@ -30,6 +31,7 @@ from nexus.agents.orrery.tag_constants import CANONICAL_TAGS
 from nexus.agents.orrery.tag_library import VALID_ENTITY_KINDS
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
 
+logger = logging.getLogger(__name__)
 
 # Split the retired source-kind literal so grep checks catch live usage sites.
 _DISALLOWED_SOURCE_KINDS = frozenset({"auto_" "registered"})
@@ -665,6 +667,45 @@ async def _chunk_world_time_async(
     )
 
 
+def _has_current_entity_tag(cur: Any, *, entity_id: int, tag_id: int) -> bool:
+    """Return whether one entity/tag pair already has an uncleared row."""
+
+    cur.execute(
+        """
+        SELECT id
+        FROM entity_tags
+        WHERE entity_id = %s
+          AND tag_id = %s
+          AND cleared_at IS NULL
+        LIMIT 1
+        """,
+        (entity_id, tag_id),
+    )
+    return cur.fetchone() is not None
+
+
+async def _has_current_entity_tag_async(
+    conn: Any, *, entity_id: int, tag_id: int
+) -> bool:
+    """Asyncpg twin of ``_has_current_entity_tag``."""
+
+    return (
+        await conn.fetchval(
+            """
+            SELECT id
+            FROM entity_tags
+            WHERE entity_id = $1
+              AND tag_id = $2
+              AND cleared_at IS NULL
+            LIMIT 1
+            """,
+            entity_id,
+            tag_id,
+        )
+        is not None
+    )
+
+
 def _insert_entity_tag(
     cur: Any,
     *,
@@ -682,6 +723,19 @@ def _insert_entity_tag(
             f"Unsupported entity tag reapplication_policy={reapplication_policy!r}"
         )
     if reapplication_policy == "extend_expiry" and duration_override is None:
+        if source_kind == "skald_inline" and _has_current_entity_tag(
+            cur,
+            entity_id=entity_id,
+            tag_id=tag_id,
+        ):
+            logger.info(
+                "Ignoring storyteller reapplication of active extend_expiry "
+                "entity tag entity_id=%s tag_id=%s: the storyteller wire "
+                "cannot express duration_override",
+                entity_id,
+                tag_id,
+            )
+            return False
         raise ValueError(
             "reapplication_policy='extend_expiry' requires duration_override"
         )
@@ -796,6 +850,19 @@ async def _insert_entity_tag_async(
             f"Unsupported entity tag reapplication_policy={reapplication_policy!r}"
         )
     if reapplication_policy == "extend_expiry" and duration_override is None:
+        if source_kind == "skald_inline" and await _has_current_entity_tag_async(
+            conn,
+            entity_id=entity_id,
+            tag_id=tag_id,
+        ):
+            logger.info(
+                "Ignoring storyteller reapplication of active extend_expiry "
+                "entity tag entity_id=%s tag_id=%s: the storyteller wire "
+                "cannot express duration_override",
+                entity_id,
+                tag_id,
+            )
+            return False
         raise ValueError(
             "reapplication_policy='extend_expiry' requires duration_override"
         )

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -2954,6 +2954,109 @@ def test_resolve_dry_run_routes_present_targets_to_scene_pressures() -> None:
     assert "state_delta" not in pressure.to_dict()
 
 
+def test_resolve_dry_run_reuses_composition_sources_once_per_tick() -> None:
+    """Route fanout filters cached source rows instead of repeating SQL reads."""
+
+    pair_template = Template(
+        id="cached_pair_sources",
+        priority=10,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="Exercise every pair source.",
+        required_slots=(Slot.ACTOR, Slot.TARGET),
+        package_gate=ALWAYS,
+        branches=(
+            Branch(
+                label="Pair act",
+                conditions=ALWAYS,
+                narrative_stub="{actor} acts toward {target}.",
+                scene_pressure_stub="{actor} pressures {target}.",
+            ),
+        ),
+        present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
+        starts_from_social_contact=True,
+        composes_from_hostility=True,
+    )
+    triple_template = Template(
+        id="cached_triple_sources",
+        priority=10,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="Exercise pair and institutional source fanout.",
+        required_slots=(Slot.ACTOR, Slot.TARGET, Slot.FACTION),
+        package_gate=ALWAYS,
+        branches=(
+            Branch(
+                label="Triple act",
+                conditions=ALWAYS,
+                narrative_stub="{actor} acts toward {target} for {faction}.",
+                scene_pressure_stub="{actor} pressures {target} for {faction}.",
+            ),
+        ),
+        present_target_policy=PresentTargetPolicy.STORYTELLER_PRESSURE,
+        starts_from_social_contact=True,
+        composes_from_hostility=True,
+    )
+    session = FakeSession(
+        present_actor_rows=[{"entity_id": 2}],
+        actor_target_relationship_rows=[
+            {"source_entity_id": 1, "target_entity_id": 2},
+            {"source_entity_id": 1, "target_entity_id": 3},
+        ],
+        actor_target_social_contact_rows=[
+            {"source_entity_id": 1, "target_entity_id": 4},
+        ],
+        actor_target_hostile_edge_rows=[
+            {"source_entity_id": 1, "target_entity_id": 5},
+        ],
+        actor_faction_pair_tag_rows=[
+            {
+                "subject_entity_id": 1,
+                "object_entity_id": 9,
+                "subject_kind": "character",
+                "object_kind": "faction",
+            }
+        ],
+        entity_name_rows=[
+            {"id": 1, "name": "Mara"},
+            {"id": 2, "name": "Vale"},
+            {"id": 3, "name": "Iris"},
+            {"id": 4, "name": "Joryn"},
+            {"id": 5, "name": "Brena"},
+            {"id": 9, "name": "The Sluice Guild"},
+        ],
+    )
+
+    proposal = resolve_dry_run(
+        session,
+        (pair_template, triple_template),
+        anchor_chunk_id=100,
+        window_chunks=30,
+        composition_settings={"hostile_source_enabled": True},
+    )
+
+    offscreen_targets = {
+        draft.bindings["target"]
+        for draft in proposal.resolutions
+        if "target" in draft.bindings
+    }
+    present_targets = {
+        pressure.bindings["target"] for pressure in proposal.scene_pressures
+    }
+    assert {3, 4, 5} <= offscreen_targets
+    assert present_targets == {2}
+
+    def query_count(tag: str) -> int:
+        marker = f"/* orrery:{tag} */"
+        return sum(marker in sql for sql in session.executed_sql)
+
+    assert query_count("present_actor_ids_at_anchor") == 1
+    assert query_count("actor_target_bindings_character_relationships") == 1
+    assert query_count("actor_target_bindings_social_contacts") == 1
+    assert query_count("actor_target_bindings_hostile_edges") == 1
+    assert query_count("actor_faction_bindings_institutional_pair_tags") == 1
+    assert query_count("anchor_world_time") == 1
+    assert query_count("entity_names") == 1
+
+
 def test_resolve_dry_run_routes_present_need_debt_to_scene_pressure() -> None:
     """On-screen actors get prompt-only need pressure, not resolutions."""
 

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -180,6 +180,8 @@ class FakeSession:
         self.max_chunk_id = max_chunk_id
         self.max_id_queries = 0
         self.world_time_queries = 0
+        self.actor_binding_world_times: list[object] = []
+        self.actor_faction_query_params: list[object] = []
         self.executed_sql: list[str] = []
 
     def __enter__(self):
@@ -266,6 +268,7 @@ class FakeSession:
             assert "JOIN entity_tags et" in sql
             assert "et.expires_at_world_time > :current_world_time" in sql
             assert _params["current_world_time"] in {None, self.world_time}
+            self.actor_binding_world_times.append(_params["current_world_time"])
             return FakeResult(self.ephemeral_actor_rows)
         if "/* orrery:actor_bindings_inbound_ephemeral_pair_tags */" in sql:
             assert "pt.is_ephemeral = true" in sql
@@ -305,6 +308,7 @@ class FakeSession:
             assert "'obligation', 'handles', 'authority_over'" in sql
             assert "ept.cleared_at IS NULL" in sql
             assert "NOT pt.deprecated" in sql
+            self.actor_faction_query_params.append(_params)
             return FakeResult(self.actor_faction_pair_tag_rows)
         if "/* orrery:actor_faction_bindings_rosters */" in sql:
             assert "pt.tag LIKE 'status:%'" in sql
@@ -2201,30 +2205,31 @@ def test_compose_actor_target_bindings_yields_both_directions() -> None:
 def test_compose_actor_faction_bindings_is_distinct_and_ordered() -> None:
     """Institutional edges are direction-agnostic, distinct, and ID-sorted."""
 
+    session = FakeSession(
+        chunk_ref_actor_rows=[{"entity_id": 1}],
+        actor_faction_pair_tag_rows=[
+            {
+                "subject_entity_id": 10,
+                "object_entity_id": 1,
+                "subject_kind": "faction",
+                "object_kind": "character",
+            },
+            {
+                "subject_entity_id": 1,
+                "object_entity_id": 9,
+                "subject_kind": "character",
+                "object_kind": "faction",
+            },
+            {
+                "subject_entity_id": 1,
+                "object_entity_id": 9,
+                "subject_kind": "character",
+                "object_kind": "faction",
+            },
+        ],
+    )
     bindings = compose_actor_faction_bindings(
-        FakeSession(
-            chunk_ref_actor_rows=[{"entity_id": 1}],
-            actor_faction_pair_tag_rows=[
-                {
-                    "subject_entity_id": 10,
-                    "object_entity_id": 1,
-                    "subject_kind": "faction",
-                    "object_kind": "character",
-                },
-                {
-                    "subject_entity_id": 1,
-                    "object_entity_id": 9,
-                    "subject_kind": "character",
-                    "object_kind": "faction",
-                },
-                {
-                    "subject_entity_id": 1,
-                    "object_entity_id": 9,
-                    "subject_kind": "character",
-                    "object_kind": "faction",
-                },
-            ],
-        ),
+        session,
         anchor_chunk_id=100,
         window_chunks=30,
     )
@@ -2232,6 +2237,10 @@ def test_compose_actor_faction_bindings_is_distinct_and_ordered() -> None:
     assert bindings == (
         {Slot.ACTOR: 1, Slot.FACTION: 9},
         {Slot.ACTOR: 1, Slot.FACTION: 10},
+    )
+    assert session.actor_faction_query_params == [{"actor_ids": [1]}]
+    assert any(
+        "ept.subject_entity_id = ANY(:actor_ids)" in sql for sql in session.executed_sql
     )
 
 
@@ -2747,6 +2756,70 @@ def test_enabled_composition_sources_keep_production_and_audit_in_parity() -> No
             ("roster_parity", (("actor", 1), ("faction", 9))),
         }
     )
+
+
+def test_resolve_and_explain_actor_expiry_use_anchor_clock_with_override() -> None:
+    """What-if state time must not split production and audit actor bindings."""
+
+    anchor_world_time = datetime(2073, 10, 31, 12, tzinfo=timezone.utc)
+    override_world_time = datetime(2073, 11, 2, 12, tzinfo=timezone.utc)
+    template = Template(
+        id="world_time_parity",
+        priority=10,
+        drive_band=DriveBand.PROJECT_IDENTITY,
+        blurb="Actor-expiry parity fixture.",
+        required_slots=(Slot.ACTOR,),
+        package_gate=ALWAYS,
+        branches=(Branch("act", ALWAYS, "{actor} acts."),),
+    )
+
+    def session() -> FakeSession:
+        return FakeSession(
+            world_time=anchor_world_time,
+            chunk_ref_actor_rows=[{"entity_id": 1}],
+            ephemeral_actor_rows=[{"entity_id": 2}],
+            active_entity_rows=[{"id": 1}, {"id": 2}],
+            entity_name_rows=[
+                {"id": 1, "name": "Mara"},
+                {"id": 2, "name": "Vale"},
+            ],
+        )
+
+    production_session = session()
+    audit_session = session()
+    proposal = resolve_dry_run(
+        production_session,
+        (template,),
+        anchor_chunk_id=100,
+        window_chunks=30,
+        world_time_override=override_world_time,
+    )
+    report = explain_dry_run(
+        audit_session,
+        (template,),
+        anchor_chunk_id=100,
+        window_chunks=30,
+        world_time_override=override_world_time,
+    )
+
+    production = {
+        (draft.template_id, draft.bindings["actor"]) for draft in proposal.resolutions
+    }
+    audited = {
+        (group.actor_stack.winner_id, group.actor_entity_id) for group in report.actors
+    }
+    assert (
+        audited
+        == production
+        == {
+            ("world_time_parity", 1),
+            ("world_time_parity", 2),
+        }
+    )
+    assert production_session.actor_binding_world_times == [anchor_world_time]
+    assert audit_session.actor_binding_world_times == [anchor_world_time]
+    assert production_session.world_time_queries == 1
+    assert audit_session.world_time_queries == 1
 
 
 def test_actor_target_routes_preserve_contact_only_recruitment_continuity() -> None:

--- a/tests/test_orrery/test_tag_library.py
+++ b/tests/test_orrery/test_tag_library.py
@@ -65,6 +65,27 @@ def test_read_pair_tag_library_uses_shared_connection(monkeypatch) -> None:
     assert tag_library.read_pair_tag_library("save_05") == ["hiding", "shelters"]
 
 
+def test_read_tag_library_captures_reapplication_policy(monkeypatch) -> None:
+    rows = [
+        {
+            "entity_kind": "character",
+            "category": "disposition",
+            "category_description": "Recent conduct.",
+            "prompt_order": 10,
+            "tag": "recently_protective",
+            "is_ephemeral": True,
+            "description": "Recently acted to protect someone.",
+            "reapplication_policy": "extend_expiry",
+        }
+    ]
+    monkeypatch.setattr(tag_library, "_connect", lambda _dbname: _Conn(rows))
+
+    entries = tag_library.read_tag_library("save_05")
+
+    assert len(entries) == 1
+    assert entries[0].reapplication_policy == "extend_expiry"
+
+
 def _fake_entries() -> list[tag_library.TagLibraryEntry]:
     return [
         tag_library.TagLibraryEntry(

--- a/tests/test_orrery/test_tag_writer.py
+++ b/tests/test_orrery/test_tag_writer.py
@@ -199,6 +199,23 @@ class FakeCursor:
             )
             self.rowcount = 1
             return
+        if sql_upper.startswith("SELECT ID") and "FROM ENTITY_TAGS" in sql_upper:
+            entity_id, tag_id = params
+            current = next(
+                (
+                    row
+                    for row in self.entity_tags
+                    if row["entity_id"] == entity_id
+                    and row["tag_id"] == tag_id
+                    and row["cleared_at"] is None
+                ),
+                None,
+            )
+            self._next_row = (
+                _FakeRow({"id": current["id"]}, ["id"]) if current is not None else None
+            )
+            self.rowcount = 1 if current is not None else 0
+            return
         if sql_upper.startswith("INSERT INTO ENTITY_TAGS"):
             (
                 entity_id,
@@ -513,6 +530,40 @@ def test_extend_expiry_policy_requires_duration_override():
         )
 
     assert cur.entity_tags == []
+
+
+def test_storyteller_extend_expiry_reapplication_without_duration_is_noop():
+    tag_id = hash("recently_protective") & 0xFFFFFF
+    original_expiry = _WORLD_TIME + timedelta(hours=1)
+    cur = FakeCursor(
+        tags=_registered(
+            ("recently_protective", "disposition", True, "extend_expiry"),
+        ),
+        entity_tags=[
+            {
+                "entity_id": 42,
+                "tag_id": tag_id,
+                "applied_at_world_time": _WORLD_TIME,
+                "expires_at_world_time": original_expiry,
+                "source_kind": "system",
+                "cleared_at": None,
+            }
+        ],
+    )
+
+    counters = apply_tag_bestowal(
+        cur,
+        entity_id=42,
+        entity_kind="character",
+        bestowal=OrreryTagBestowal(applied_tags=["recently_protective"]),
+        world_time=_WORLD_TIME + timedelta(minutes=15),
+        source_kind="skald_inline",
+    )
+
+    assert counters["applied"] == 0
+    assert len(cur.entity_tags) == 1
+    assert cur.entity_tags[0]["expires_at_world_time"] == original_expiry
+    assert cur.entity_tags[0]["source_kind"] == "system"
 
 
 def test_replace_policy_restamps_existing_open_row():

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -40,6 +40,12 @@ class FakeRegistryCursor:
             "human": (1, "bodyform", False, None),
             "perceptive": (2, "disposition", False, None),
             "haven": (3, "place_class", False, None),
+            "recently_protective": (
+                4,
+                "disposition",
+                True,
+                "extend_expiry",
+            ),
         }
         # tag -> (id, subject_kinds, object_kinds)
         self.pair_tags = {
@@ -128,12 +134,15 @@ class FakeRegistryConnection:
 def _test_vocabulary() -> StorytellerVocabulary:
     return StorytellerVocabulary(
         tag_names_by_kind={
-            "character": frozenset({"human", "perceptive"}),
+            "character": frozenset({"human", "perceptive", "recently_protective"}),
             "place": frozenset({"haven"}),
             "faction": frozenset({"loyalist"}),
         },
         pair_tag_names=frozenset({"protects", "contact:social", "status:junior"}),
         event_types=frozenset({"evade_pursuit", "slept"}),
+        tag_reapplication_policies_by_kind={
+            "character": {"recently_protective": "extend_expiry"},
+        },
     )
 
 
@@ -151,6 +160,12 @@ def _stub_storyteller_vocabulary_readers(
         lambda _dbname: [
             _tag_entry("character", "bodyform", "human"),
             _tag_entry("character", "disposition", "perceptive"),
+            _tag_entry(
+                "character",
+                "disposition",
+                "recently_protective",
+                reapplication_policy="extend_expiry",
+            ),
             _tag_entry("place", "place_class", "haven"),
             _tag_entry("faction", "ideology", "loyalist"),
         ],
@@ -349,6 +364,31 @@ def test_cached_catalog_validates_single_tags_per_kind_and_field(
     assert kind in issues[0]
 
 
+def test_cached_catalog_rejects_unexpressible_extend_expiry_add() -> None:
+    response = _storyteller_response(
+        updates=_updates_block(
+            characters=[
+                {
+                    "name": "Brena Tideloft",
+                    "tags_add": ["recently_protective"],
+                }
+            ]
+        )
+    )
+
+    issues = collect_orrery_tag_issues(
+        response,
+        FakeRegistryCursor(),
+        vocabulary=_test_vocabulary(),
+    )
+
+    assert len(issues) == 1
+    assert issues[0].startswith("updates.characters[0]: applied_tags:")
+    assert "reapplication_policy='extend_expiry'" in issues[0]
+    assert "storyteller tags_add cannot express duration_override" in issues[0]
+    assert "leave it unchanged" in issues[0]
+
+
 def test_new_entity_hint_issues_are_path_qualified_and_aggregated() -> None:
     response = _response(
         new_entities=[
@@ -433,6 +473,7 @@ def test_replacement_event_type_uses_cached_catalog() -> None:
             {
                 "proposal_id": "proposal-valid",
                 "action": "replace",
+                "replacement_state_delta": {},
                 "replacement_event_type": "slept",
             }
         ]
@@ -442,6 +483,7 @@ def test_replacement_event_type_uses_cached_catalog() -> None:
             {
                 "proposal_id": "proposal-invalid",
                 "action": "replace",
+                "replacement_state_delta": {},
                 "replacement_event_type": "invented_event",
             }
         ]
@@ -638,6 +680,40 @@ async def test_storyteller_validator_attributes_declaration_failure_to_model_ret
 
 
 @pytest.mark.asyncio
+async def test_storyteller_validator_retries_unexpressible_extend_expiry_add(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nexus.api import db_pool
+
+    monkeypatch.setattr(
+        db_pool,
+        "get_connection",
+        lambda _dbname: FakeRegistryConnection(FakeRegistryCursor()),
+    )
+    validator = build_storyteller_tag_validator("test_slot")
+    assert validator is not None
+
+    with pytest.raises(ModelRetry) as exc_info:
+        await validator(
+            SimpleNamespace(retry=0),
+            _storyteller_response(
+                updates=_updates_block(
+                    characters=[
+                        {
+                            "name": "Brena Tideloft",
+                            "tags_add": ["recently_protective"],
+                        }
+                    ]
+                )
+            ),
+        )
+
+    assert "updates.characters[0]" in exc_info.value.message
+    assert "requires duration_override" in exc_info.value.message
+    assert "omit that tag" in exc_info.value.message
+
+
+@pytest.mark.asyncio
 async def test_storyteller_validator_reads_each_catalog_once_per_attempt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -701,6 +777,7 @@ async def test_storyteller_validator_reads_each_catalog_once_per_attempt(
             {
                 "proposal_id": "proposal-1",
                 "action": "replace",
+                "replacement_state_delta": {},
                 "replacement_event_type": "slept",
             }
         ],
@@ -980,6 +1057,7 @@ def _retry_boundary_response(
                 {
                     "proposal_id": "proposal-1",
                     "action": "replace",
+                    "replacement_state_delta": {},
                     "replacement_event_type": ("slept" if valid else "sleptt"),
                 }
             ]
@@ -1151,7 +1229,13 @@ def test_validator_skipped_without_slot_database() -> None:
     assert build_storyteller_tag_validator("save_05") is not None
 
 
-def _tag_entry(entity_kind: str, category: str, tag: str) -> TagLibraryEntry:
+def _tag_entry(
+    entity_kind: str,
+    category: str,
+    tag: str,
+    *,
+    reapplication_policy: Optional[str] = None,
+) -> TagLibraryEntry:
     return TagLibraryEntry(
         entity_kind=entity_kind,
         category=category,
@@ -1160,4 +1244,5 @@ def _tag_entry(entity_kind: str, category: str, tag: str) -> TagLibraryEntry:
         description=f"{tag} description",
         category_description=f"{category} description",
         prompt_order=10,
+        reapplication_policy=reapplication_policy,
     )


### PR DESCRIPTION
## Summary

- carry tag reapplication policy into the per-attempt Storyteller vocabulary and return impossible `extend_expiry` additions to the model as a repairable retry
- make an already-active storyteller `extend_expiry` reapplication a logged no-op in both sync and async tag writers, while preserving the fail-fast error for first applications without duration
- reuse presence, world time, relationship, social-contact, hostile-edge, institutional, roster, and entity-name reads within one Orrery resolver tick
- retain direct composition-helper fallback reads and deterministic source-specific routing

Closes #591.
Closes #593.

## Root Cause

The storyteller wire cannot express `duration_override`, but generation-time validation only cached registered tag names. An `extend_expiry` tag therefore passed generation and failed during commit.

Separately, each resolver route family owned its source hydration. Off-screen, present-target, faction, and triple routes repeatedly issued identical SQL even though their filtering inputs were stable for the tick.

## Live Benchmark

Slot 5, anchor 147, 15 measured runs after warmup:

| Measurement | #593 baseline (`927ce653`) | This branch |
| --- | ---: | ---: |
| median | 57.83 ms | 43.11 ms |
| p95 | 72.20 ms | 52.87 ms |
| tagged SQL time | 40.81 ms | 32.73 ms |
| SQL reads | 57 | 39 |

All formerly repeated Orrery query tags executed once. The proposal remained 15 actors, 9 resolutions, 12 scene pressures, and 31 communication edges.

## Validation

- `poetry run pytest tests/test_orrery -q` — 985 passed, 318 skipped
- `poetry run pytest tests/test_orrery_tag_validation.py tests/test_orrery/test_tag_writer.py tests/test_orrery/test_tag_library.py -q` — 69 passed, 2 skipped
- `poetry run python scripts/replay_state.py --slot 5 --verify` — four checkpoint windows drift-free
- changed-source mypy, flake8, and Black checks pass
- full `poetry run pytest -q` — 1905 passed, 438 skipped, with two failures reproduced unchanged on `origin/main`:
  - `test_shipped_gaia_model_resolves_to_openai_registry_id`
  - `test_responses_non_wizard_skald_turn_route_is_unchanged`

No schema, migration, configuration, or canonical-data changes.

Codex (GPT-5)