### PR TITLE
Wizard: Share Traits-to-Wildcard Transition and Refuse Empty Continues

### DIFF
--- a/nexus/api/narrative_schemas.py
+++ b/nexus/api/narrative_schemas.py
@@ -8,7 +8,7 @@ serialization of API requests and responses.
 from datetime import datetime
 from typing import Dict, List, Optional, Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Re-export ChoiceSelection from shared module for backward compatibility
 from nexus.api.choice_handling import ChoiceSelection
@@ -276,6 +276,20 @@ class ChatRequest(BaseModel):
     # Trait selection operations (character phase, traits subphase)
     # 0 = confirm selection, 1-10 = toggle trait by ID
     trait_choice: Optional[int] = None
+
+    @model_validator(mode="after")
+    def validate_wizard_input(self) -> "ChatRequest":
+        """Reject blank conversational turns before any provider call."""
+        if (
+            not self.message.strip()
+            and not self.accept_fate
+            and self.trait_choice is None
+        ):
+            raise ValueError(
+                "Wizard message must be non-empty unless accept_fate or "
+                "trait_choice is provided."
+            )
+        return self
 
     @field_validator("model")
     @classmethod

--- a/nexus/api/wizard_agent.py
+++ b/nexus/api/wizard_agent.py
@@ -427,6 +427,7 @@ async def _submit_traits_impl(
         "phase_complete": phase_complete,
         "subphase_complete": True,
         "phase": ctx.deps.phase,
+        "subphase": "wildcard",
         "artifact_type": "submit_trait_selection",
         "data": response_data,
     }

--- a/nexus/api/wizard_chat.py
+++ b/nexus/api/wizard_chat.py
@@ -95,6 +95,25 @@ def wizard_model_lock_candidate(
     return bool(request_model and slot_model and request_model != slot_model)
 
 
+def _wizard_subphase_for_state(
+    phase: str,
+    *,
+    has_concept: bool,
+    has_traits: bool,
+    has_wildcard: bool,
+) -> str:
+    """Name the canonical wizard subphase represented by persisted state."""
+    if phase != "character":
+        return "none"
+    if not has_concept:
+        return "concept"
+    if not has_traits:
+        return "traits"
+    if not has_wildcard:
+        return "wildcard"
+    return "complete"
+
+
 def _hydrate_character_context(request: ChatRequest) -> Optional[Dict[str, Any]]:
     """Load character_state from cache if in character phase and no context provided."""
     if request.current_phase != "character" or request.context_data is not None:
@@ -249,10 +268,29 @@ async def new_story_chat_endpoint(request: ChatRequest):
         if request.current_phase is None:
             request.current_phase = state.wizard_state.phase
 
-        request.context_data = _hydrate_character_context(request)
+        state_phase = state.wizard_state.phase
+        state_subphase = _wizard_subphase_for_state(
+            state_phase,
+            has_concept=state.wizard_state.has_concept,
+            has_traits=state.wizard_state.has_traits,
+            has_wildcard=state.wizard_state.has_wildcard,
+        )
+
+        if request.trait_choice is not None and not (
+            state_phase == "character" and state_subphase == "traits"
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "trait_choice is only valid during phase 'character', "
+                    "subphase 'traits'; current wizard state is phase "
+                    f"'{state_phase}', subphase '{state_subphase}'. Send a "
+                    "non-empty message to continue the current wizard step."
+                ),
+            )
 
         # Handle trait toggle/confirm operations (no LLM call needed)
-        if request.trait_choice is not None and request.current_phase == "character":
+        if request.trait_choice is not None:
             from nexus.api.new_story_cache import (
                 confirm_trait_selection,
                 get_selected_trait_count,
@@ -312,6 +350,17 @@ async def new_story_chat_endpoint(request: ChatRequest):
                         f"Invalid trait_choice: {request.trait_choice}. Must be 0-10."
                     ),
                 )
+
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "trait_choice could not be applied because wizard state changed; "
+                    f"last observed phase was '{state_phase}', subphase "
+                    f"'{state_subphase}'. Reload the wizard state before retrying."
+                ),
+            )
+
+        request.context_data = _hydrate_character_context(request)
 
         dev_mode = request.dev
         if request.message:

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -1166,8 +1166,38 @@ def _apply_traits_to_wildcard_transition(
     if model:
         intro_payload["model"] = model
 
-    intro_response = _api_post(url, json=intro_payload, timeout=120)
+    recovery_command = (
+        f'nexus continue --slot {slot} --user-text "Continue to the wildcard step."'
+    )
+    try:
+        intro_response = _api_post(url, json=intro_payload, timeout=120)
+    except requests.exceptions.RequestException as exc:
+        result["intro_error"] = {
+            "detail": str(exc),
+            "status_code": None,
+        }
+        result["intro_recovery_command"] = recovery_command
+        result["message"] = (
+            f"{result.get('message') or 'Traits confirmed.'} Traits were saved, "
+            "but the wildcard introduction could not be loaded. Retry with: "
+            f"{recovery_command}"
+        )
+        return
+
     if not intro_response.ok:
+        detail = intro_response.text.strip() or (
+            f"Wildcard intro request failed with HTTP {intro_response.status_code}."
+        )
+        result["intro_error"] = {
+            "detail": detail,
+            "status_code": intro_response.status_code,
+        }
+        result["intro_recovery_command"] = recovery_command
+        result["message"] = (
+            f"{result.get('message') or 'Traits confirmed.'} Traits were saved, "
+            "but the wildcard introduction could not be loaded. Retry with: "
+            f"{recovery_command}"
+        )
         return
 
     intro_data = intro_response.json()

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -1139,6 +1139,44 @@ def _generation_timeout_seconds() -> int:
     return load_settings().apex.generation_timeout_seconds
 
 
+def _apply_traits_to_wildcard_transition(
+    *,
+    url: str,
+    slot: int,
+    data: Dict[str, Any],
+    result: Dict[str, Any],
+    model: Optional[str],
+) -> None:
+    """Fetch and attach the wildcard intro after trait confirmation."""
+    if not (
+        data.get("subphase_complete")
+        and data.get("phase") == "character"
+        and data.get("subphase") == "wildcard"
+    ):
+        return
+
+    intro_payload = {
+        "slot": slot,
+        "message": (
+            "[SYSTEM] Phase character subphase traits complete. "
+            "Proceeding to wildcard. Please introduce the next subphase."
+        ),
+        "current_phase": "character",
+    }
+    if model:
+        intro_payload["model"] = model
+
+    intro_response = _api_post(url, json=intro_payload, timeout=120)
+    if not intro_response.ok:
+        return
+
+    intro_data = intro_response.json()
+    result["next_phase_intro"] = intro_data.get("message")
+    result["choices"] = intro_data.get("choices", [])
+    result["phase"] = intro_data.get("phase") or "character"
+    result["subphase"] = "wildcard"
+
+
 def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
     """
     Advance the story (wizard or narrative).
@@ -1266,39 +1304,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                     response.raise_for_status()
                     data = response.json()
 
-                    # Check if confirmed traits need a wildcard intro.
-                    if data.get("subphase_complete"):
-                        next_subphase = data.get("subphase")  # Should be "wildcard"
-                        if next_subphase:
-                            # Request Skald intro for next subphase
-                            intro_payload = {
-                                "slot": args.slot,
-                                "message": (
-                                    "[SYSTEM] Phase character subphase traits "
-                                    f"complete. Proceeding to {next_subphase}. "
-                                    "Please introduce the next subphase."
-                                ),
-                                "current_phase": "character",
-                            }
-                            if model_to_use:
-                                intro_payload["model"] = model_to_use
-
-                            intro_response = _api_post(
-                                url, json=intro_payload, timeout=120
-                            )
-                            if intro_response.ok:
-                                intro_data = intro_response.json()
-                                return {
-                                    "success": True,
-                                    "message": data.get("message", ""),
-                                    "next_phase_intro": intro_data.get("message"),
-                                    "choices": intro_data.get("choices", []),
-                                    "phase": "character",
-                                    "subphase": next_subphase,
-                                }
-
-                    # Return for toggles or if the intro request failed.
-                    return {
+                    result = {
                         "success": True,
                         "message": data.get("message", ""),
                         "phase": data.get("phase"),
@@ -1307,6 +1313,14 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                         "can_confirm": data.get("can_confirm", False),
                         "subphase_complete": data.get("subphase_complete", False),
                     }
+                    _apply_traits_to_wildcard_transition(
+                        url=url,
+                        slot=args.slot,
+                        data=data,
+                        result=result,
+                        model=model_to_use,
+                    )
+                    return result
 
                 # Resolve --choice to user text if provided (non-trait mode)
                 user_text = args.user_text or ""
@@ -1334,6 +1348,14 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                         "success": False,
                         "error": "Cannot combine --dev with --accept-fate.",
                     }
+                if not user_text.strip() and not args.accept_fate:
+                    return {
+                        "success": False,
+                        "error": (
+                            "Wizard continue requires non-empty text, --choice, "
+                            "or --accept-fate."
+                        ),
+                    }
                 if args.dev:
                     payload["dev"] = True
                 if model_to_use:
@@ -1355,7 +1377,16 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                     "trait_menu": data.get("trait_menu"),
                     "can_confirm": data.get("can_confirm", False),
                     "subphase": data.get("subphase"),
+                    "subphase_complete": data.get("subphase_complete", False),
                 }
+
+                _apply_traits_to_wildcard_transition(
+                    url=url,
+                    slot=args.slot,
+                    data=data,
+                    result=result,
+                    model=model_to_use,
+                )
 
                 # Auto-transition: if phase completed, trigger next phase intro
                 if data.get("phase_complete"):

--- a/tests/test_api/test_wizard_chat_validation.py
+++ b/tests/test_api/test_wizard_chat_validation.py
@@ -1,9 +1,44 @@
 """Request-boundary validation for wizard chat turns."""
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from nexus.api.slot_state import SlotState, WizardState
 from nexus.api.wizard_chat import router
+
+
+def _client_with_wizard_state(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    phase: str,
+    has_concept: bool,
+    has_traits: bool,
+    has_wildcard: bool,
+) -> TestClient:
+    """Mount the real endpoint with a deterministic persisted-state boundary."""
+    from nexus.api import slot_state
+
+    state = SlotState(
+        slot=4,
+        is_empty=False,
+        is_wizard_mode=True,
+        wizard_state=WizardState(
+            phase=phase,
+            thread_id="thread-test",
+            choices=[],
+            has_concept=has_concept,
+            has_traits=has_traits,
+            has_wildcard=has_wildcard,
+        ),
+        narrative_state=None,
+        model="TEST",
+    )
+    monkeypatch.setattr(slot_state, "get_slot_state", lambda _slot: state)
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
 
 
 def test_wizard_chat_rejects_blank_message_locally() -> None:
@@ -36,3 +71,47 @@ def test_wizard_chat_allows_blank_accept_fate_action() -> None:
     request = ChatRequest(slot=4, message="", accept_fate=True)
 
     assert request.accept_fate is True
+
+
+def test_repeated_trait_confirmation_reports_wildcard_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A confirmation repeated after trait commit must never reach inference."""
+    client = _client_with_wizard_state(
+        monkeypatch,
+        phase="character",
+        has_concept=True,
+        has_traits=True,
+        has_wildcard=False,
+    )
+
+    response = client.post(
+        "/api/story/new/chat",
+        json={"slot": 4, "message": "", "trait_choice": 0},
+    )
+
+    assert response.status_code == 409
+    assert "phase 'character', subphase 'wildcard'" in response.json()["detail"]
+    assert "non-empty message" in response.json()["detail"]
+
+
+def test_trait_choice_outside_character_reports_current_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A trait action during another phase must fail before provider setup."""
+    client = _client_with_wizard_state(
+        monkeypatch,
+        phase="setting",
+        has_concept=False,
+        has_traits=False,
+        has_wildcard=False,
+    )
+
+    response = client.post(
+        "/api/story/new/chat",
+        json={"slot": 4, "message": "", "trait_choice": 1},
+    )
+
+    assert response.status_code == 409
+    assert "phase 'setting', subphase 'none'" in response.json()["detail"]
+    assert "non-empty message" in response.json()["detail"]

--- a/tests/test_api/test_wizard_chat_validation.py
+++ b/tests/test_api/test_wizard_chat_validation.py
@@ -1,0 +1,38 @@
+"""Request-boundary validation for wizard chat turns."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.api.wizard_chat import router
+
+
+def test_wizard_chat_rejects_blank_message_locally() -> None:
+    """Blank conversation input must fail before reaching a model provider."""
+    app = FastAPI()
+    app.include_router(router)
+
+    response = TestClient(app).post(
+        "/api/story/new/chat",
+        json={"slot": 4, "message": "   "},
+    )
+
+    assert response.status_code == 422
+    assert "Wizard message must be non-empty" in response.text
+
+
+def test_wizard_chat_allows_blank_deterministic_trait_action() -> None:
+    """Trait toggles and confirmation intentionally carry no user message."""
+    from nexus.api.narrative_schemas import ChatRequest
+
+    request = ChatRequest(slot=4, message="", trait_choice=0)
+
+    assert request.trait_choice == 0
+
+
+def test_wizard_chat_allows_blank_accept_fate_action() -> None:
+    """Accept-fate requests use a local synthetic prompt instead of a message."""
+    from nexus.api.narrative_schemas import ChatRequest
+
+    request = ChatRequest(slot=4, message="", accept_fate=True)
+
+    assert request.accept_fate is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,11 +15,16 @@ class DummyResponse:
     """Minimal requests.Response double for CLI tests."""
 
     def __init__(
-        self, payload: dict[str, Any], ok: bool = True, text: str = ""
+        self,
+        payload: dict[str, Any],
+        ok: bool = True,
+        text: str = "",
+        status_code: int = 200,
     ) -> None:
         self.payload = payload
         self.ok = ok
         self.text = text
+        self.status_code = status_code
 
     def json(self) -> dict[str, Any]:
         """Return response JSON."""
@@ -230,6 +235,72 @@ def test_deterministic_trait_confirmation_exposes_wildcard_intro(monkeypatch) ->
     assert posts[0]["message"] == ""
     assert posts[0]["trait_choice"] == 0
     assert "Proceeding to wildcard" in posts[1]["message"]
+
+
+def test_trait_confirmation_intro_failure_exposes_recovery(monkeypatch) -> None:
+    """A failed wildcard intro must preserve success and name a retry command."""
+    posts: list[dict[str, Any]] = []
+
+    def fake_get(url: str, **kwargs: Any) -> DummyResponse:
+        assert url.endswith("/api/slot/5/state")
+        return DummyResponse(
+            {
+                "is_empty": False,
+                "is_wizard_mode": True,
+                "phase": "character",
+                "subphase": "traits",
+                "trait_menu": [{"id": 1, "name": "allies"}],
+                "can_confirm": True,
+            }
+        )
+
+    def fake_post(url: str, json: dict[str, Any], **kwargs: Any) -> DummyResponse:
+        assert url.endswith("/api/story/new/chat")
+        posts.append(json)
+        if len(posts) == 1:
+            return DummyResponse(
+                {
+                    "message": "Generating artifact...",
+                    "phase": "character",
+                    "subphase": "wildcard",
+                    "subphase_complete": True,
+                    "phase_complete": False,
+                    "artifact_type": "submit_trait_selection",
+                }
+            )
+        return DummyResponse(
+            {},
+            ok=False,
+            text='{"detail":"Wildcard intro unavailable"}',
+            status_code=503,
+        )
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+    monkeypatch.setattr(cli.requests, "post", fake_post)
+
+    result = cli.run_continue(
+        Namespace(
+            slot=5,
+            model=None,
+            user_text="Exactly those three: 1, 2, 3.",
+            choice=None,
+            accept_fate=False,
+            dev=False,
+        )
+    )
+
+    recovery_command = (
+        'nexus continue --slot 5 --user-text "Continue to the wildcard step."'
+    )
+    assert result["success"] is True
+    assert result["intro_error"] == {
+        "detail": '{"detail":"Wildcard intro unavailable"}',
+        "status_code": 503,
+    }
+    assert result["intro_recovery_command"] == recovery_command
+    assert "Traits were saved" in result["message"]
+    assert recovery_command in result["message"]
+    assert len(posts) == 2
 
 
 @pytest.mark.parametrize("confirmation_path", ["free-text", "deterministic"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,8 @@ import sys
 from argparse import Namespace
 from typing import Any
 
+import pytest
+
 from nexus import cli
 from nexus.cli import _is_terminal_generation_status
 
@@ -101,6 +103,175 @@ def test_continue_posts_choice_to_backend_without_preapproving(
     assert payload["choice"] == 1
     assert payload["accept_fate"] is False
     assert payload["user_text"] == ""
+
+
+def test_free_text_trait_confirmation_exposes_wildcard_intro(monkeypatch) -> None:
+    """Free-text trait submission should immediately return the next action."""
+    posts: list[dict[str, Any]] = []
+
+    def fake_get(url: str, **kwargs: Any) -> DummyResponse:
+        assert url.endswith("/api/slot/5/state")
+        return DummyResponse(
+            {
+                "is_empty": False,
+                "is_wizard_mode": True,
+                "phase": "character",
+                "subphase": "traits",
+                "trait_menu": [{"id": 1, "name": "allies"}],
+                "can_confirm": True,
+            }
+        )
+
+    def fake_post(url: str, json: dict[str, Any], **kwargs: Any) -> DummyResponse:
+        assert url.endswith("/api/story/new/chat")
+        posts.append(json)
+        if len(posts) == 1:
+            return DummyResponse(
+                {
+                    "message": "Generating artifact...",
+                    "phase": "character",
+                    "subphase": "wildcard",
+                    "subphase_complete": True,
+                    "phase_complete": False,
+                    "artifact_type": "submit_trait_selection",
+                }
+            )
+        return DummyResponse(
+            {
+                "message": "What singular gift or burden defines Mara?",
+                "choices": ["A storm answers her anger."],
+                "phase": "character",
+            }
+        )
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+    monkeypatch.setattr(cli.requests, "post", fake_post)
+
+    result = cli.run_continue(
+        Namespace(
+            slot=5,
+            model=None,
+            user_text="Exactly those three: 1, 2, 3.",
+            choice=None,
+            accept_fate=False,
+            dev=False,
+        )
+    )
+
+    assert result["success"] is True
+    assert result["subphase_complete"] is True
+    assert result["subphase"] == "wildcard"
+    assert result["next_phase_intro"] == "What singular gift or burden defines Mara?"
+    assert result["choices"] == ["A storm answers her anger."]
+    assert len(posts) == 2
+    assert posts[0]["message"] == "Exactly those three: 1, 2, 3."
+    assert "Proceeding to wildcard" in posts[1]["message"]
+
+
+def test_deterministic_trait_confirmation_exposes_wildcard_intro(monkeypatch) -> None:
+    """Choice-based trait confirmation should retain its wildcard transition."""
+    posts: list[dict[str, Any]] = []
+
+    def fake_get(url: str, **kwargs: Any) -> DummyResponse:
+        assert url.endswith("/api/slot/5/state")
+        return DummyResponse(
+            {
+                "is_empty": False,
+                "is_wizard_mode": True,
+                "phase": "character",
+                "subphase": "traits",
+                "trait_menu": [{"id": 1, "name": "allies"}],
+                "can_confirm": True,
+            }
+        )
+
+    def fake_post(url: str, json: dict[str, Any], **kwargs: Any) -> DummyResponse:
+        assert url.endswith("/api/story/new/chat")
+        posts.append(json)
+        if len(posts) == 1:
+            return DummyResponse(
+                {
+                    "message": "Traits confirmed. Moving to wildcard definition.",
+                    "phase": "character",
+                    "subphase": "wildcard",
+                    "subphase_complete": True,
+                }
+            )
+        return DummyResponse(
+            {
+                "message": "Name the exception that makes Mara unforgettable.",
+                "choices": ["She remembers futures that never happened."],
+                "phase": "character",
+            }
+        )
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+    monkeypatch.setattr(cli.requests, "post", fake_post)
+
+    result = cli.run_continue(
+        Namespace(
+            slot=5,
+            model=None,
+            user_text=None,
+            choice=0,
+            accept_fate=False,
+            dev=False,
+        )
+    )
+
+    assert result["success"] is True
+    assert result["subphase_complete"] is True
+    assert result["subphase"] == "wildcard"
+    assert result["next_phase_intro"] == (
+        "Name the exception that makes Mara unforgettable."
+    )
+    assert result["choices"] == ["She remembers futures that never happened."]
+    assert len(posts) == 2
+    assert posts[0]["message"] == ""
+    assert posts[0]["trait_choice"] == 0
+    assert "Proceeding to wildcard" in posts[1]["message"]
+
+
+@pytest.mark.parametrize("confirmation_path", ["free-text", "deterministic"])
+def test_plain_continue_after_trait_confirmation_stays_local(
+    monkeypatch, confirmation_path: str
+) -> None:
+    """Neither trait-confirmation route may lead to an empty provider message."""
+
+    def fake_get(url: str, **kwargs: Any) -> DummyResponse:
+        assert url.endswith("/api/slot/5/state")
+        return DummyResponse(
+            {
+                "is_empty": False,
+                "is_wizard_mode": True,
+                "phase": "character",
+                "subphase": "wildcard",
+                "choices": ["Define Mara's impossible inheritance."],
+                "confirmation_path": confirmation_path,
+            }
+        )
+
+    def fail_post(*args: Any, **kwargs: Any) -> DummyResponse:
+        raise AssertionError("Plain wizard continue must not make an API POST")
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+    monkeypatch.setattr(cli.requests, "post", fail_post)
+
+    result = cli.run_continue(
+        Namespace(
+            slot=5,
+            model=None,
+            user_text=None,
+            choice=None,
+            accept_fate=False,
+            dev=False,
+        )
+    )
+
+    assert result == {
+        "success": False,
+        "error": "Wizard continue requires non-empty text, --choice, or --accept-fate.",
+    }
 
 
 class FakeWizardCache:

--- a/tests/test_wizard_agent.py
+++ b/tests/test_wizard_agent.py
@@ -272,6 +272,8 @@ async def test_submit_trait_selection_advances_state(monkeypatch):
     result = ctx.deps.last_tool_result
     assert result["artifact_type"] == "submit_trait_selection"
     assert result["phase_complete"] is False
+    assert result["subphase_complete"] is True
+    assert result["subphase"] == "wildcard"
 
 
 @pytest.mark.asyncio

--- a/tests/test_wizard_live.py
+++ b/tests/test_wizard_live.py
@@ -35,7 +35,8 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 # Phase configurations for testing
-# Note: Phase 3 (traits) is deterministic with accept_fate, so not tested here
+# Trait accept_fate is deterministic, while free-text confirmation still uses
+# live inference and is covered by the normal-flow test below.
 PHASE_CONFIGS: Dict[str, Dict[str, Any]] = {
     "setting": {
         "phase": "setting",
@@ -50,6 +51,31 @@ PHASE_CONFIGS: Dict[str, Dict[str, Any]] = {
         },
         "expected_tool": "submit_character_concept",
         "prompt": "Create a reluctant hero - a former soldier haunted by past decisions.",
+    },
+    "traits": {
+        "phase": "character",
+        "context_data": {
+            "setting": {"genre": "fantasy", "world_name": "Valdoria"},
+            "character_state": {
+                "concept": {
+                    "name": "Kael Stormwind",
+                    "archetype": "Reluctant Hero",
+                    "background": "A former soldier haunted by past decisions.",
+                    "appearance": "Weathered, scarred, and dressed for the road.",
+                    "suggested_traits": ["allies", "contacts", "patron"],
+                    "trait_rationales": {
+                        "allies": "Fellow deserters still answer his calls.",
+                        "contacts": "Old scouts pass him guarded intelligence.",
+                        "patron": "A hidden noble finances his search for justice.",
+                    },
+                }
+            },
+        },
+        "expected_tool": "submit_trait_selection",
+        "prompt": (
+            "Confirm exactly these three traits now: allies, contacts, and patron. "
+            "Use the stated rationales and submit the selection."
+        ),
     },
     "wildcard": {
         "phase": "character",
@@ -217,7 +243,9 @@ async def test_accept_fate_forces_tool_call(
 
 @pytest.mark.live
 @pytest.mark.asyncio
-@pytest.mark.parametrize("phase_name", ["setting", "concept", "wildcard", "seed"])
+@pytest.mark.parametrize(
+    "phase_name", ["setting", "concept", "traits", "wildcard", "seed"]
+)
 async def test_normal_flow_allows_wizard_response(phase_name: str, mock_db_functions):
     """
     Sanity check: accept_fate=False should allow WizardResponse.
@@ -242,9 +270,14 @@ async def test_normal_flow_allows_wizard_response(phase_name: str, mock_db_funct
         model=model,
     )
 
-    # With accept_fate=False, either WizardResponse or tool call is valid
-    # (the model may choose to call the tool or present options)
+    # Free-text trait confirmation must submit the selected traits. Other
+    # phases may either respond conversationally or submit their artifact.
     assert result.output is not None, "Should have some output"
+    if phase_name == "traits":
+        assert isinstance(result.output, DeferredToolRequests)
+        assert context.last_tool_name == config["expected_tool"]
+        assert context.last_tool_result is not None
+        assert context.last_tool_result["subphase"] == "wildcard"
 
     output_type = type(result.output).__name__
     logger.info(f"✓ {phase_name}/accept_fate=False: Got {output_type}")


### PR DESCRIPTION
Fixes #598 (midnight adversarial QA finding 1).

## Fix
- `_submit_traits_impl()` emits `subphase="wildcard"` so clients need not infer the destination.
- CLI: transition logic extracted to `_apply_traits_to_wildcard_transition()` and applied on **both** the deterministic and free-text confirmation routes (previously only `--choice` got the wildcard intro).
- CLI: plain wizard `continue` with no text/choice/accept-fate returns a local actionable error without POSTing.
- API: `ChatRequest` model-validator rejects blank conversational turns locally (422) while permitting deterministic `accept_fate`/`trait_choice` turns — the upstream OpenAI 400→500 conversion is unreachable for this class.

## Tests
CLI transition coverage for both routes plus plain-follow-up behavior; backend transition-signal assertion; local 422 validation tests; and the live wizard matrix extended with a real free-text `submit_trait_selection` phase — 13 live tests passed (4:36, registry-role models). 41 unit/API tests passed; black clean; new surfaces mypy-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fs3R2bgfcWPiU4QgToRxo