### PR TITLE
Retrograde: Thread Typed Cold-Start Relationship Constraints (Option 0)

### DIFF
--- a/migrations/097_trait_cold_start_relationship_constraints.sql
+++ b/migrations/097_trait_cold_start_relationship_constraints.sql
@@ -1,0 +1,14 @@
+-- Persist player-authored cold-start relationship boundaries beside each trait.
+
+ALTER TABLE assets.traits
+    ADD COLUMN IF NOT EXISTS cold_start_relationships TEXT NOT NULL DEFAULT 'allowed';
+
+ALTER TABLE assets.traits
+    DROP CONSTRAINT IF EXISTS traits_cold_start_relationships_check;
+
+ALTER TABLE assets.traits
+    ADD CONSTRAINT traits_cold_start_relationships_check
+    CHECK (cold_start_relationships IN ('allowed', 'forbidden'));
+
+COMMENT ON COLUMN assets.traits.cold_start_relationships IS
+    'Whether setup may materialize a preexisting relationship row for this trait';

--- a/migrations/097_trait_cold_start_relationship_constraints.sql
+++ b/migrations/097_trait_cold_start_relationship_constraints.sql
@@ -4,11 +4,25 @@ ALTER TABLE assets.traits
     ADD COLUMN IF NOT EXISTS cold_start_relationships TEXT NOT NULL DEFAULT 'allowed';
 
 ALTER TABLE assets.traits
+    ADD COLUMN IF NOT EXISTS preexisting_relationship_targets JSONB
+    NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE assets.traits
     DROP CONSTRAINT IF EXISTS traits_cold_start_relationships_check;
 
 ALTER TABLE assets.traits
     ADD CONSTRAINT traits_cold_start_relationships_check
     CHECK (cold_start_relationships IN ('allowed', 'forbidden'));
 
+ALTER TABLE assets.traits
+    DROP CONSTRAINT IF EXISTS traits_preexisting_relationship_targets_check;
+
+ALTER TABLE assets.traits
+    ADD CONSTRAINT traits_preexisting_relationship_targets_check
+    CHECK (jsonb_typeof(preexisting_relationship_targets) = 'array');
+
 COMMENT ON COLUMN assets.traits.cold_start_relationships IS
-    'Whether setup may materialize a preexisting relationship row for this trait';
+    'Whether setup may materialize preexisting relationship or pair-tag rows for this trait';
+
+COMMENT ON COLUMN assets.traits.preexisting_relationship_targets IS
+    'Player-explicit preexisting relationship target names captured by trait confirmation';

--- a/nexus/agents/orrery/pair_tag_registry.py
+++ b/nexus/agents/orrery/pair_tag_registry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Mapping, Sequence
 
 
 PairTagSeedRow = tuple[str, list[str], list[str], bool, str]
@@ -103,3 +103,24 @@ PAIR_TAG_SEED: Sequence[PairTagSeedRow] = (
         "Subject teaches or trains the target.",
     ),
 )
+
+
+# Prompt-time semantic classification for every seed-eligible pair-tag above.
+# The database registry stores kind constraints and lifecycle metadata, but it
+# has no category column for pair tags. Retrograde therefore carries this
+# explicit companion metadata and fails enumeration when a newly registered
+# built-in row is missing a classification.
+PAIR_TAG_SEMANTIC_CATEGORIES: Mapping[str, frozenset[str]] = {
+    "knows_location": frozenset({"location_knowledge"}),
+    "can_access": frozenset({"access"}),
+    "claims": frozenset({"domain"}),
+    "resides_at": frozenset({"residence"}),
+    "operates_from": frozenset({"operational_base"}),
+    "originates_from": frozenset({"origin"}),
+    "hunting": frozenset({"adversarial"}),
+    "handles": frozenset({"contact", "patronage"}),
+    "obligation": frozenset({"obligation"}),
+    "authority_over": frozenset({"patronage"}),
+    "protects": frozenset({"affiliative", "dependency", "patronage"}),
+    "mentors": frozenset({"affiliative", "patronage"}),
+}

--- a/nexus/agents/orrery/retrograde_expansion.py
+++ b/nexus/agents/orrery/retrograde_expansion.py
@@ -11,7 +11,6 @@ from nexus.agents.logon.apex_schema import Coordinates
 from nexus.agents.orrery.geo_authoring import geo_prompt_from_context
 from nexus.agents.orrery.retrograde_junctions import resolve_junctions
 from nexus.agents.orrery.retrograde_packet import (
-    COLD_START_RELATIONSHIP_TYPES_BY_TRAIT,
     CORE_ENTITIES_HEADING,
     NAMED_SEED_NPCS_HEADING,
 )
@@ -642,6 +641,7 @@ def render_expansion_prompt(
         "selected_candidates": selected_candidates,
         "selected_junctions": selected_junctions,
         "trait_constraints": seed_generation_request.get("trait_constraints", []),
+        "protagonist_identity": seed_generation_request.get("protagonist_identity", {}),
         "core_prompt_sections": (
             seed_generation_request.get("prompt_sections", [])[:4]
         ),
@@ -718,6 +718,10 @@ def validate_expansion_plan(
         selected_seed_ids=list(candidates.selected_seed_ids),
     )
     geo_authoring = packet.get("geo_authoring")
+    (
+        forbidden_relationship_traits,
+        forbidden_pair_tag_traits,
+    ) = _forbidden_cold_start_mechanics(seed_generation_request)
     issues = _expansion_contract_issues(
         response=response,
         selected_seed_ids=selected_seed_ids,
@@ -726,10 +730,9 @@ def validate_expansion_plan(
         candidates_by_id={
             candidate.seed_id: candidate for candidate in candidates.candidates
         },
-        forbidden_relationship_traits=_forbidden_relationship_traits(
-            seed_generation_request
-        ),
-        protagonist_ref=_packet_protagonist_ref(packet),
+        forbidden_relationship_traits=forbidden_relationship_traits,
+        forbidden_pair_tag_traits=forbidden_pair_tag_traits,
+        protagonist_identity=_packet_protagonist_identity(packet),
         known_entity_keys=_packet_known_entity_keys(packet),
         max_new_entity_stubs=_budget_entity_stub_cap(seed_generation_request),
     )
@@ -831,12 +834,19 @@ def _expansion_contract_issues(
     selected_junctions: list[dict[str, Any]],
     vocabulary: SeedEligibleVocabulary,
     candidates_by_id: Mapping[str, Any],
-    forbidden_relationship_traits: Mapping[str, str],
-    protagonist_ref: Optional[str],
+    forbidden_relationship_traits: Mapping[str, set[str]],
+    forbidden_pair_tag_traits: Mapping[str, set[str]],
+    protagonist_identity: Mapping[str, Any],
     known_entity_keys: Optional[set[tuple[str, str]]] = None,
     max_new_entity_stubs: Optional[int] = None,
 ) -> list[str]:
     issues: list[str] = []
+    issues.extend(
+        _protagonist_duplicate_ref_issues(
+            response=response,
+            protagonist_identity=protagonist_identity,
+        )
+    )
     issues.extend(
         _new_entity_budget_issues(
             response=response,
@@ -917,6 +927,8 @@ def _expansion_contract_issues(
                 pair_definitions=pair_definitions,
                 event_refs=event_refs,
                 status_edge_counts=status_edge_counts,
+                forbidden_pair_tag_traits=forbidden_pair_tag_traits,
+                protagonist_identity=protagonist_identity,
             )
         )
 
@@ -928,7 +940,7 @@ def _expansion_contract_issues(
                 relationship_types=relationship_types,
                 event_refs=event_refs,
                 forbidden_relationship_traits=forbidden_relationship_traits,
-                protagonist_ref=protagonist_ref,
+                protagonist_identity=protagonist_identity,
             )
         )
 
@@ -1116,6 +1128,66 @@ def _collect_plan_entity_keys(
     return keys
 
 
+def _protagonist_normalized_refs(
+    protagonist_identity: Mapping[str, Any],
+) -> tuple[Optional[str], set[str]]:
+    """Return the canonical normalized ref and all explicitly known aliases."""
+
+    canonical_value = protagonist_identity.get("canonical_ref")
+    if not canonical_value:
+        return None, set()
+    canonical_ref = normalize_entity_ref(str(canonical_value))
+    aliases = {
+        normalize_entity_ref(str(alias))
+        for alias in protagonist_identity.get("known_aliases") or ()
+        if str(alias).strip()
+    }
+    return canonical_ref, aliases
+
+
+def _ref_matches_protagonist(
+    entity_ref: str,
+    protagonist_identity: Mapping[str, Any],
+) -> bool:
+    """Match canonical name, known aliases, and strict name-token subsets."""
+
+    canonical_ref, aliases = _protagonist_normalized_refs(protagonist_identity)
+    if canonical_ref is None:
+        return False
+    normalized_ref = normalize_entity_ref(entity_ref)
+    if normalized_ref == canonical_ref or normalized_ref in aliases:
+        return True
+    canonical_tokens = frozenset(canonical_ref.split())
+    candidate_tokens = frozenset(normalized_ref.split())
+    return bool(candidate_tokens) and candidate_tokens < canonical_tokens
+
+
+def _protagonist_duplicate_ref_issues(
+    *,
+    response: RetrogradeExpansionPlanResponse,
+    protagonist_identity: Mapping[str, Any],
+) -> list[str]:
+    """Refuse alias/subset refs that would stage a second protagonist row."""
+
+    canonical_ref, _aliases = _protagonist_normalized_refs(protagonist_identity)
+    if canonical_ref is None:
+        return []
+    duplicate_refs = sorted(
+        normalized_ref
+        for entity_kind, normalized_ref in _collect_plan_entity_keys(response)
+        if entity_kind == "character"
+        and normalized_ref != canonical_ref
+        and _ref_matches_protagonist(normalized_ref, protagonist_identity)
+    )
+    if not duplicate_refs:
+        return []
+    return [
+        "protagonist_duplicate_stub_forbidden: character refs are aliases or "
+        "strict name-token subsets of the protagonist and may not mint a second "
+        f"character row: {duplicate_refs}"
+    ]
+
+
 def _packet_known_entity_keys(packet: Mapping[str, Any]) -> set[tuple[str, str]]:
     """First-class starting entity keys known to the Retrograde packet.
 
@@ -1156,19 +1228,49 @@ def _packet_known_entity_keys(packet: Mapping[str, Any]) -> set[tuple[str, str]]
     return keys
 
 
-def _packet_protagonist_ref(packet: Mapping[str, Any]) -> Optional[str]:
-    """Return the protagonist's exact prompt-local name from a packet."""
+def _packet_protagonist_identity(packet: Mapping[str, Any]) -> dict[str, Any]:
+    """Return canonical and known alias refs for the packet protagonist."""
+
+    def coerce(value: Any) -> Optional[dict[str, Any]]:
+        if not isinstance(value, Mapping):
+            return None
+        canonical_ref = value.get("canonical_ref")
+        if not canonical_ref:
+            return None
+        aliases = value.get("known_aliases") or []
+        if not isinstance(aliases, list):
+            raise RetrogradeExpansionValidationError(
+                "packet protagonist_identity.known_aliases must be a list"
+            )
+        return {
+            "canonical_ref": str(canonical_ref),
+            "known_aliases": [str(alias) for alias in aliases if str(alias).strip()],
+        }
 
     scaffolds = packet.get("candidate_scaffolds")
     if isinstance(scaffolds, Mapping):
+        identity = coerce(scaffolds.get("protagonist_identity"))
+        if identity is not None:
+            return identity
         for card in scaffolds.get("core_entities") or ():
             if isinstance(card, Mapping) and card.get("role") == "protagonist":
                 name = card.get("name")
                 if name:
-                    return str(name)
+                    details = card.get("details")
+                    aliases = (
+                        details.get("known_aliases", [])
+                        if isinstance(details, Mapping)
+                        else []
+                    )
+                    return (
+                        coerce({"canonical_ref": name, "known_aliases": aliases}) or {}
+                    )
 
     seed_generation_request = packet.get("seed_generation_request")
     if isinstance(seed_generation_request, Mapping):
+        identity = coerce(seed_generation_request.get("protagonist_identity"))
+        if identity is not None:
+            return identity
         for section in seed_generation_request.get("prompt_sections") or ():
             if not isinstance(section, Mapping):
                 continue
@@ -1178,27 +1280,45 @@ def _packet_protagonist_ref(packet: Mapping[str, Any]) -> Optional[str]:
                 if isinstance(card, Mapping) and card.get("role") == "protagonist":
                     name = card.get("name")
                     if name:
-                        return str(name)
-    return None
+                        details = card.get("details")
+                        aliases = (
+                            details.get("known_aliases", [])
+                            if isinstance(details, Mapping)
+                            else []
+                        )
+                        return (
+                            coerce({"canonical_ref": name, "known_aliases": aliases})
+                            or {}
+                        )
+    return {}
 
 
-def _forbidden_relationship_traits(
+def _forbidden_cold_start_mechanics(
     seed_generation_request: Mapping[str, Any],
-) -> dict[str, str]:
-    """Map forbidden mechanical relationship types back to their source trait."""
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Index packet-materialized blocked mechanics back to source traits."""
 
-    forbidden: dict[str, str] = {}
+    relationship_traits: dict[str, set[str]] = {}
+    pair_tag_traits: dict[str, set[str]] = {}
     for constraint in seed_generation_request.get("trait_constraints") or ():
         if not isinstance(constraint, Mapping):
             continue
         if constraint.get("cold_start_relationships") != "forbidden":
             continue
         trait = str(constraint.get("trait") or "")
-        for relationship_type in COLD_START_RELATIONSHIP_TYPES_BY_TRAIT.get(
-            trait, frozenset()
+        if (
+            "blocked_relationship_types" not in constraint
+            or "blocked_pair_tags" not in constraint
         ):
-            forbidden[relationship_type] = trait
-    return forbidden
+            raise RetrogradeExpansionValidationError(
+                "cold_start_constraint_unmaterialized: forbidden trait "
+                f"{trait!r} is missing vocabulary-derived blocked sets"
+            )
+        for relationship_type in constraint.get("blocked_relationship_types") or ():
+            relationship_traits.setdefault(str(relationship_type), set()).add(trait)
+        for pair_tag in constraint.get("blocked_pair_tags") or ():
+            pair_tag_traits.setdefault(str(pair_tag), set()).add(trait)
+    return relationship_traits, pair_tag_traits
 
 
 def _budget_entity_stub_cap(
@@ -1289,6 +1409,8 @@ def _pair_tag_plan_issues(
     pair_definitions: Mapping[str, Mapping[str, Any]],
     event_refs: set[str],
     status_edge_counts: Mapping[tuple[str, str, str, str], int],
+    forbidden_pair_tag_traits: Mapping[str, set[str]],
+    protagonist_identity: Mapping[str, Any],
 ) -> list[str]:
     issues: list[str] = []
     prefix = f"pair tag {pair_plan.tag!r}"
@@ -1326,6 +1448,29 @@ def _pair_tag_plan_issues(
             f"{pair_plan.subject_ref!r} -> {pair_plan.object_ref!r}; plan only "
             "the final standing and express the status arc in event_plan"
         )
+    constrained_traits = forbidden_pair_tag_traits.get(pair_plan.tag, set())
+    involves_protagonist = (
+        pair_plan.subject_kind == "character"
+        and _ref_matches_protagonist(
+            pair_plan.subject_ref,
+            protagonist_identity,
+        )
+    ) or (
+        pair_plan.object_kind == "character"
+        and _ref_matches_protagonist(
+            pair_plan.object_ref,
+            protagonist_identity,
+        )
+    )
+    if constrained_traits and involves_protagonist:
+        issues.append(
+            "cold_start_relationships_forbidden: "
+            f"pair tag {pair_plan.tag!r} involving protagonist "
+            f"{protagonist_identity.get('canonical_ref')!r} violates trait(s) "
+            f"{sorted(constrained_traits)!r} cold_start_relationships='forbidden'; "
+            "retain any supporting backstory event but remove the mechanical "
+            "pair-tag row"
+        )
     return issues
 
 
@@ -1335,8 +1480,8 @@ def _relationship_plan_issues(
     entity_kinds: set[str],
     relationship_types: set[str],
     event_refs: set[str],
-    forbidden_relationship_traits: Mapping[str, str],
-    protagonist_ref: Optional[str],
+    forbidden_relationship_traits: Mapping[str, set[str]],
+    protagonist_identity: Mapping[str, Any],
 ) -> list[str]:
     issues: list[str] = []
     prefix = f"relationship {relationship_plan.relationship_type!r}"
@@ -1366,23 +1511,34 @@ def _relationship_plan_issues(
             f"{prefix} references unknown source_event_ref "
             f"{relationship_plan.source_event_ref!r}"
         )
-    constrained_trait = forbidden_relationship_traits.get(
-        relationship_plan.relationship_type
+    constrained_traits = forbidden_relationship_traits.get(
+        relationship_plan.relationship_type,
+        set(),
     )
-    relationship_refs = {
-        normalize_entity_ref(relationship_plan.subject_ref),
-        normalize_entity_ref(relationship_plan.object_ref),
-    }
+    involves_protagonist = (
+        relationship_plan.subject_kind == "character"
+        and _ref_matches_protagonist(
+            relationship_plan.subject_ref,
+            protagonist_identity,
+        )
+    ) or (
+        relationship_plan.object_kind == "character"
+        and _ref_matches_protagonist(
+            relationship_plan.object_ref,
+            protagonist_identity,
+        )
+    )
     if (
-        constrained_trait is not None
-        and protagonist_ref is not None
-        and normalize_entity_ref(protagonist_ref) in relationship_refs
+        constrained_traits
+        and protagonist_identity.get("canonical_ref")
+        and involves_protagonist
     ):
         issues.append(
             "cold_start_relationships_forbidden: "
             f"relationship {relationship_plan.relationship_type!r} involving "
-            f"protagonist {protagonist_ref!r} violates trait "
-            f"{constrained_trait!r} cold_start_relationships='forbidden'; "
+            f"protagonist {protagonist_identity.get('canonical_ref')!r} violates "
+            f"trait(s) {sorted(constrained_traits)!r} "
+            "cold_start_relationships='forbidden'; "
             "retain any supporting backstory event but remove the mechanical "
             "relationship row"
         )
@@ -1624,9 +1780,9 @@ def _hard_validation_rules() -> list[str]:
         ),
         (
             "A trait with cold_start_relationships='forbidden' prohibits its "
-            "matching relationship mechanic when either endpoint is the "
-            "protagonist. Keep permissible backstory events; omit only the "
-            "forbidden relationship row."
+            "blocked relationship and pair-tag mechanics when either endpoint "
+            "is the protagonist or a listed alias. Keep permissible backstory "
+            "events; omit only the forbidden mechanical row."
         ),
         (
             "project_plan may carry only a woven selected seed's exact "
@@ -1712,6 +1868,7 @@ def _seed_vocabulary(value: Any) -> SeedEligibleVocabulary:
         "multi_entity_tag_definitions",
         "event_types",
         "relationship_types",
+        "relationship_type_definitions",
     )
     missing = [key for key in required_keys if key not in vocabulary]
     if missing:

--- a/nexus/agents/orrery/retrograde_expansion.py
+++ b/nexus/agents/orrery/retrograde_expansion.py
@@ -11,6 +11,7 @@ from nexus.agents.logon.apex_schema import Coordinates
 from nexus.agents.orrery.geo_authoring import geo_prompt_from_context
 from nexus.agents.orrery.retrograde_junctions import resolve_junctions
 from nexus.agents.orrery.retrograde_packet import (
+    COLD_START_RELATIONSHIP_TYPES_BY_TRAIT,
     CORE_ENTITIES_HEADING,
     NAMED_SEED_NPCS_HEADING,
 )
@@ -640,6 +641,7 @@ def render_expansion_prompt(
         "selected_seed_ids": candidates.selected_seed_ids,
         "selected_candidates": selected_candidates,
         "selected_junctions": selected_junctions,
+        "trait_constraints": seed_generation_request.get("trait_constraints", []),
         "core_prompt_sections": (
             seed_generation_request.get("prompt_sections", [])[:4]
         ),
@@ -724,6 +726,10 @@ def validate_expansion_plan(
         candidates_by_id={
             candidate.seed_id: candidate for candidate in candidates.candidates
         },
+        forbidden_relationship_traits=_forbidden_relationship_traits(
+            seed_generation_request
+        ),
+        protagonist_ref=_packet_protagonist_ref(packet),
         known_entity_keys=_packet_known_entity_keys(packet),
         max_new_entity_stubs=_budget_entity_stub_cap(seed_generation_request),
     )
@@ -792,10 +798,19 @@ def generate_expansion_with_skald(
             ) from exc
 
     provider.output_validator = _validate_output
-    response, _llm_response = provider.get_structured_completion(
-        prompt,
-        RetrogradeExpansionWireResponse,
-    )
+    try:
+        response, _llm_response = provider.get_structured_completion(
+            prompt,
+            RetrogradeExpansionWireResponse,
+        )
+    except RuntimeError as exc:
+        last_error = exc.__cause__
+        if isinstance(last_error, ModelRetry):
+            raise RuntimeError(
+                "Retrograde expansion exhausted validation retries: "
+                f"{last_error.message}"
+            ) from exc
+        raise
     if not isinstance(response, RetrogradeExpansionPlanResponse):
         raise TypeError(
             "Skald expansion call returned "
@@ -816,6 +831,8 @@ def _expansion_contract_issues(
     selected_junctions: list[dict[str, Any]],
     vocabulary: SeedEligibleVocabulary,
     candidates_by_id: Mapping[str, Any],
+    forbidden_relationship_traits: Mapping[str, str],
+    protagonist_ref: Optional[str],
     known_entity_keys: Optional[set[tuple[str, str]]] = None,
     max_new_entity_stubs: Optional[int] = None,
 ) -> list[str]:
@@ -910,6 +927,8 @@ def _expansion_contract_issues(
                 entity_kinds=entity_kinds,
                 relationship_types=relationship_types,
                 event_refs=event_refs,
+                forbidden_relationship_traits=forbidden_relationship_traits,
+                protagonist_ref=protagonist_ref,
             )
         )
 
@@ -1137,6 +1156,51 @@ def _packet_known_entity_keys(packet: Mapping[str, Any]) -> set[tuple[str, str]]
     return keys
 
 
+def _packet_protagonist_ref(packet: Mapping[str, Any]) -> Optional[str]:
+    """Return the protagonist's exact prompt-local name from a packet."""
+
+    scaffolds = packet.get("candidate_scaffolds")
+    if isinstance(scaffolds, Mapping):
+        for card in scaffolds.get("core_entities") or ():
+            if isinstance(card, Mapping) and card.get("role") == "protagonist":
+                name = card.get("name")
+                if name:
+                    return str(name)
+
+    seed_generation_request = packet.get("seed_generation_request")
+    if isinstance(seed_generation_request, Mapping):
+        for section in seed_generation_request.get("prompt_sections") or ():
+            if not isinstance(section, Mapping):
+                continue
+            if section.get("heading") != CORE_ENTITIES_HEADING:
+                continue
+            for card in section.get("items") or ():
+                if isinstance(card, Mapping) and card.get("role") == "protagonist":
+                    name = card.get("name")
+                    if name:
+                        return str(name)
+    return None
+
+
+def _forbidden_relationship_traits(
+    seed_generation_request: Mapping[str, Any],
+) -> dict[str, str]:
+    """Map forbidden mechanical relationship types back to their source trait."""
+
+    forbidden: dict[str, str] = {}
+    for constraint in seed_generation_request.get("trait_constraints") or ():
+        if not isinstance(constraint, Mapping):
+            continue
+        if constraint.get("cold_start_relationships") != "forbidden":
+            continue
+        trait = str(constraint.get("trait") or "")
+        for relationship_type in COLD_START_RELATIONSHIP_TYPES_BY_TRAIT.get(
+            trait, frozenset()
+        ):
+            forbidden[relationship_type] = trait
+    return forbidden
+
+
 def _budget_entity_stub_cap(
     seed_generation_request: Mapping[str, Any],
 ) -> Optional[int]:
@@ -1271,6 +1335,8 @@ def _relationship_plan_issues(
     entity_kinds: set[str],
     relationship_types: set[str],
     event_refs: set[str],
+    forbidden_relationship_traits: Mapping[str, str],
+    protagonist_ref: Optional[str],
 ) -> list[str]:
     issues: list[str] = []
     prefix = f"relationship {relationship_plan.relationship_type!r}"
@@ -1299,6 +1365,26 @@ def _relationship_plan_issues(
         issues.append(
             f"{prefix} references unknown source_event_ref "
             f"{relationship_plan.source_event_ref!r}"
+        )
+    constrained_trait = forbidden_relationship_traits.get(
+        relationship_plan.relationship_type
+    )
+    relationship_refs = {
+        normalize_entity_ref(relationship_plan.subject_ref),
+        normalize_entity_ref(relationship_plan.object_ref),
+    }
+    if (
+        constrained_trait is not None
+        and protagonist_ref is not None
+        and normalize_entity_ref(protagonist_ref) in relationship_refs
+    ):
+        issues.append(
+            "cold_start_relationships_forbidden: "
+            f"relationship {relationship_plan.relationship_type!r} involving "
+            f"protagonist {protagonist_ref!r} violates trait "
+            f"{constrained_trait!r} cold_start_relationships='forbidden'; "
+            "retain any supporting backstory event but remove the mechanical "
+            "relationship row"
         )
     return issues
 
@@ -1535,6 +1621,12 @@ def _hard_validation_rules() -> list[str]:
         (
             "relationship mechanics currently support only character->character "
             "rows; express faction/place pressure through events or pair tags."
+        ),
+        (
+            "A trait with cold_start_relationships='forbidden' prohibits its "
+            "matching relationship mechanic when either endpoint is the "
+            "protagonist. Keep permissible backstory events; omit only the "
+            "forbidden relationship row."
         ),
         (
             "project_plan may carry only a woven selected seed's exact "

--- a/nexus/agents/orrery/retrograde_expansion.py
+++ b/nexus/agents/orrery/retrograde_expansion.py
@@ -22,6 +22,7 @@ from nexus.agents.orrery.retrograde_seed_candidates import (
 from nexus.agents.orrery.retrograde_vocabulary import (
     ENTITY_REF_MAX_LENGTH,
     SeedEligibleVocabulary,
+    fold_entity_ref_for_identity,
     normalize_entity_ref,
 )
 
@@ -1149,17 +1150,20 @@ def _ref_matches_protagonist(
     entity_ref: str,
     protagonist_identity: Mapping[str, Any],
 ) -> bool:
-    """Match canonical name, known aliases, and strict name-token subsets."""
+    """Match canonical name, aliases, and name-token subsets or permutations."""
 
     canonical_ref, aliases = _protagonist_normalized_refs(protagonist_identity)
     if canonical_ref is None:
         return False
-    normalized_ref = normalize_entity_ref(entity_ref)
-    if normalized_ref == canonical_ref or normalized_ref in aliases:
+    folded_ref = fold_entity_ref_for_identity(entity_ref)
+    folded_canonical = fold_entity_ref_for_identity(canonical_ref)
+    if folded_ref == folded_canonical or folded_ref in {
+        fold_entity_ref_for_identity(alias) for alias in aliases
+    }:
         return True
-    canonical_tokens = frozenset(canonical_ref.split())
-    candidate_tokens = frozenset(normalized_ref.split())
-    return bool(candidate_tokens) and candidate_tokens < canonical_tokens
+    canonical_tokens = frozenset(folded_canonical.split())
+    candidate_tokens = frozenset(folded_ref.split())
+    return bool(candidate_tokens) and candidate_tokens <= canonical_tokens
 
 
 def _protagonist_duplicate_ref_issues(

--- a/nexus/agents/orrery/retrograde_packet.py
+++ b/nexus/agents/orrery/retrograde_packet.py
@@ -22,6 +22,14 @@ WEIRD_LEVELS = frozenset({"low", "medium", "high"})
 # silent heading drift would empty that set and hard-block valid expansions.
 CORE_ENTITIES_HEADING = "Core entities"
 NAMED_SEED_NPCS_HEADING = "Named seed NPCs"
+COLD_START_RELATIONSHIP_TYPES_BY_TRAIT: Mapping[str, frozenset[str]] = {
+    "allies": frozenset({"ally"}),
+    "contacts": frozenset({"contact"}),
+    "patron": frozenset({"patron"}),
+    "dependents": frozenset({"dependent"}),
+    "enemies": frozenset({"enemy"}),
+    "obligations": frozenset({"obligation"}),
+}
 SEED_BUDGETS: Mapping[str, Mapping[str, int]] = {
     "low": {"generate_candidates": 6, "select_target": 3, "deferred_secret_cap": 1},
     "medium": {"generate_candidates": 9, "select_target": 4, "deferred_secret_cap": 2},
@@ -225,6 +233,9 @@ def build_seed_generation_request(
         "coverage_functions": list(RETROGRADE_COVERAGE_FUNCTIONS),
         "candidate_graph": candidate_graph,
         "selection_rubric": _selection_rubric(level),
+        "trait_constraints": list(
+            _mapping(candidate_scaffolds.get("trait_hooks")).get("constraints") or []
+        ),
         "prompt_sections": _seed_prompt_sections(candidate_scaffolds),
         "candidate_response_schema": seed_candidate_response_schema(),
         "candidate_output_schema": {
@@ -381,6 +392,11 @@ def _selection_rubric(level: str) -> dict[str, Any]:
             (
                 "Reject seeds that require unregistered tags, recursive entity "
                 "expansion, or timeline contortions."
+            ),
+            (
+                "Reject candidates whose mechanical_hints would violate any "
+                "trait constraint, while allowing backstory events that do not "
+                "materialize the forbidden relationship row."
             ),
             "Prefer fewer, sharper surviving seeds over a busy history web.",
         ],
@@ -554,6 +570,7 @@ def _candidate_scaffolds(
         "trait_hooks": {
             "selected_traits": selected_traits,
             "rationales": trait_selection.get("trait_rationales") or {},
+            "constraints": trait_selection.get("trait_constraints") or [],
             "wildcard": {
                 "name": wildcard.get("wildcard_name"),
                 "description": wildcard.get("wildcard_description"),
@@ -661,10 +678,22 @@ def _trait_prompt_items(value: Any) -> list[dict[str, Any]]:
     hooks = _mapping(value)
     selected_traits = hooks.get("selected_traits") or []
     rationales = _mapping(hooks.get("rationales"))
+    constraints = {
+        str(constraint.get("trait")): constraint.get(
+            "cold_start_relationships", "allowed"
+        )
+        for constraint in hooks.get("constraints") or []
+        if isinstance(constraint, Mapping) and constraint.get("trait")
+    }
     wildcard = _mapping(hooks.get("wildcard"))
 
     items: list[dict[str, Any]] = [
-        {"kind": "trait", "name": trait, "rationale": rationales.get(str(trait))}
+        {
+            "kind": "trait",
+            "name": trait,
+            "rationale": rationales.get(str(trait)),
+            "cold_start_relationships": constraints.get(str(trait), "allowed"),
+        }
         for trait in selected_traits
         if trait
     ]

--- a/nexus/agents/orrery/retrograde_packet.py
+++ b/nexus/agents/orrery/retrograde_packet.py
@@ -22,13 +22,15 @@ WEIRD_LEVELS = frozenset({"low", "medium", "high"})
 # silent heading drift would empty that set and hard-block valid expansions.
 CORE_ENTITIES_HEADING = "Core entities"
 NAMED_SEED_NPCS_HEADING = "Named seed NPCs"
-COLD_START_RELATIONSHIP_TYPES_BY_TRAIT: Mapping[str, frozenset[str]] = {
-    "allies": frozenset({"ally"}),
+COLD_START_RELATIONSHIP_CATEGORIES_BY_TRAIT: Mapping[str, frozenset[str]] = {
+    "allies": frozenset({"affiliative"}),
     "contacts": frozenset({"contact"}),
-    "patron": frozenset({"patron"}),
-    "dependents": frozenset({"dependent"}),
-    "enemies": frozenset({"enemy"}),
+    "patron": frozenset({"patronage"}),
+    "dependents": frozenset({"dependency"}),
+    "enemies": frozenset({"adversarial"}),
     "obligations": frozenset({"obligation"}),
+    "status": frozenset({"status"}),
+    "domain": frozenset({"domain"}),
 }
 SEED_BUDGETS: Mapping[str, Mapping[str, int]] = {
     "low": {"generate_candidates": 6, "select_target": 3, "deferred_secret_cap": 1},
@@ -108,6 +110,15 @@ def build_retrograde_dry_run_packet(
         initial_location=initial_location,
         trait_compile_inputs=trait_compile_inputs,
     )
+    trait_hooks = dict(_mapping(candidate_scaffolds.get("trait_hooks")))
+    trait_hooks["constraints"] = _materialize_trait_constraints(
+        trait_hooks.get("constraints"),
+        vocabulary=vocabulary,
+    )
+    candidate_scaffolds = {
+        **candidate_scaffolds,
+        "trait_hooks": trait_hooks,
+    }
     if settings.orrery is None:
         raise ValueError("settings.orrery is required for Retrograde budgets")
     junction_count = getattr(
@@ -218,6 +229,10 @@ def build_seed_generation_request(
         graph_settings=graph_settings,
         junction_count=junction_count,
     )
+    trait_constraints = _materialize_trait_constraints(
+        _mapping(candidate_scaffolds.get("trait_hooks")).get("constraints"),
+        vocabulary=vocabulary,
+    )
 
     return {
         "schema_version": SEED_REQUEST_SCHEMA_VERSION,
@@ -233,8 +248,9 @@ def build_seed_generation_request(
         "coverage_functions": list(RETROGRADE_COVERAGE_FUNCTIONS),
         "candidate_graph": candidate_graph,
         "selection_rubric": _selection_rubric(level),
-        "trait_constraints": list(
-            _mapping(candidate_scaffolds.get("trait_hooks")).get("constraints") or []
+        "trait_constraints": trait_constraints,
+        "protagonist_identity": dict(
+            _mapping(candidate_scaffolds.get("protagonist_identity"))
         ),
         "prompt_sections": _seed_prompt_sections(candidate_scaffolds),
         "candidate_response_schema": seed_candidate_response_schema(),
@@ -394,9 +410,10 @@ def _selection_rubric(level: str) -> dict[str, Any]:
                 "expansion, or timeline contortions."
             ),
             (
-                "Reject candidates whose mechanical_hints would violate any "
-                "trait constraint, while allowing backstory events that do not "
-                "materialize the forbidden relationship row."
+                "Reject candidates whose relationship or pair-tag mechanical_hints "
+                "appear in a forbidden constraint's explicit blocked sets and "
+                "involve the protagonist. Backstory events without those rows "
+                "remain allowed."
             ),
             "Prefer fewer, sharper surviving seeds over a busy history web.",
         ],
@@ -518,6 +535,7 @@ def _candidate_scaffolds(
     trait_selection = _mapping(character.get("trait_selection"))
     wildcard = _mapping(character.get("wildcard"))
     selected_traits = list(trait_selection.get("selected_traits") or ())
+    protagonist_identity = _protagonist_identity(concept.get("name"))
 
     return {
         "core_entities": [
@@ -529,6 +547,7 @@ def _candidate_scaffolds(
                 details={
                     "archetype": concept.get("archetype"),
                     "appearance": concept.get("appearance"),
+                    "known_aliases": protagonist_identity["known_aliases"],
                 },
             ),
             _compact_card(
@@ -560,6 +579,7 @@ def _candidate_scaffolds(
             for name in seed.get("key_npcs", [])
             if name
         ],
+        "protagonist_identity": protagonist_identity,
         "pressure_axes": [
             _axis("stakes", seed.get("stakes")),
             _axis("tension_source", seed.get("tension_source")),
@@ -679,9 +699,7 @@ def _trait_prompt_items(value: Any) -> list[dict[str, Any]]:
     selected_traits = hooks.get("selected_traits") or []
     rationales = _mapping(hooks.get("rationales"))
     constraints = {
-        str(constraint.get("trait")): constraint.get(
-            "cold_start_relationships", "allowed"
-        )
+        str(constraint.get("trait")): constraint
         for constraint in hooks.get("constraints") or []
         if isinstance(constraint, Mapping) and constraint.get("trait")
     }
@@ -692,7 +710,17 @@ def _trait_prompt_items(value: Any) -> list[dict[str, Any]]:
             "kind": "trait",
             "name": trait,
             "rationale": rationales.get(str(trait)),
-            "cold_start_relationships": constraints.get(str(trait), "allowed"),
+            "cold_start_relationships": _mapping(constraints.get(str(trait))).get(
+                "cold_start_relationships", "allowed"
+            ),
+            "blocked_relationship_types": list(
+                _mapping(constraints.get(str(trait))).get(
+                    "blocked_relationship_types", []
+                )
+            ),
+            "blocked_pair_tags": list(
+                _mapping(constraints.get(str(trait))).get("blocked_pair_tags", [])
+            ),
         }
         for trait in selected_traits
         if trait
@@ -700,6 +728,77 @@ def _trait_prompt_items(value: Any) -> list[dict[str, Any]]:
     if wildcard:
         items.append({"kind": "wildcard", **dict(wildcard)})
     return items
+
+
+def _materialize_trait_constraints(
+    value: Any,
+    *,
+    vocabulary: SeedEligibleVocabulary,
+) -> list[dict[str, Any]]:
+    """Resolve forbidden trait categories to registered mechanical primitives."""
+
+    if not value:
+        return []
+
+    relationship_definitions = {
+        str(definition["relationship_type"]): set(definition["semantic_categories"])
+        for definition in vocabulary["relationship_type_definitions"]
+    }
+    pair_definitions = {
+        str(definition["tag"]): set(definition["semantic_categories"])
+        for definition in vocabulary["multi_entity_tag_definitions"]
+    }
+
+    materialized: list[dict[str, Any]] = []
+    for raw_constraint in value or ():
+        if not isinstance(raw_constraint, Mapping):
+            raise ValueError("Trait constraints must be mapping objects")
+        trait = str(raw_constraint.get("trait") or "")
+        policy = str(raw_constraint.get("cold_start_relationships") or "allowed")
+        if not trait:
+            raise ValueError("Trait constraint is missing trait")
+        categories = COLD_START_RELATIONSHIP_CATEGORIES_BY_TRAIT.get(trait)
+        if policy == "forbidden" and not categories:
+            raise ValueError(
+                "Forbidden cold-start relationship trait has no semantic "
+                f"category mapping: {trait!r}"
+            )
+        blocked_relationship_types = sorted(
+            relationship_type
+            for relationship_type, primitive_categories in relationship_definitions.items()
+            if categories and primitive_categories & set(categories)
+        )
+        blocked_pair_tags = sorted(
+            pair_tag
+            for pair_tag, primitive_categories in pair_definitions.items()
+            if categories and primitive_categories & set(categories)
+        )
+        constraint = {
+            key: item
+            for key, item in raw_constraint.items()
+            if key not in {"blocked_relationship_types", "blocked_pair_tags"}
+        }
+        constraint["cold_start_relationships"] = policy
+        constraint["blocked_relationship_types"] = (
+            blocked_relationship_types if policy == "forbidden" else []
+        )
+        constraint["blocked_pair_tags"] = (
+            blocked_pair_tags if policy == "forbidden" else []
+        )
+        materialized.append(constraint)
+    return materialized
+
+
+def _protagonist_identity(name: Any) -> dict[str, Any]:
+    """Build prompt-visible canonical and natural alias refs for the protagonist."""
+
+    canonical_ref = " ".join(str(name or "").split())
+    tokens = canonical_ref.split()
+    known_aliases = [tokens[0]] if len(tokens) > 1 else []
+    return {
+        "canonical_ref": canonical_ref,
+        "known_aliases": known_aliases,
+    }
 
 
 def _axis(kind: str, text: Any) -> dict[str, Any]:

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -30,6 +30,7 @@ from nexus.agents.orrery.retrograde_markers import (
     RETROGRADE_PROLOGUE_MARKER,
 )
 from nexus.agents.orrery.retrograde_vocabulary import (
+    fold_entity_ref_for_identity,
     normalize_entity_ref,
     relationship_type_default_emotional_valence,
 )
@@ -2822,18 +2823,22 @@ def _protagonist_duplicate_stub_blockers(
 
     if protagonist_identity is None:
         return []
-    canonical_ref = normalize_entity_ref(protagonist_identity.name)
-    canonical_tokens = frozenset(canonical_ref.split())
-    alias_refs = {normalize_entity_ref(alias) for alias in protagonist_identity.aliases}
+    folded_canonical = fold_entity_ref_for_identity(protagonist_identity.name)
+    canonical_tokens = frozenset(folded_canonical.split())
+    alias_refs = {
+        fold_entity_ref_for_identity(alias) for alias in protagonist_identity.aliases
+    }
     duplicate_refs: list[str] = []
     for row in entity_stub_rows:
         if row.get("status") != "would_insert" or row.get("entity_kind") != "character":
             continue
         entity_ref = str(row.get("entity_ref") or "")
-        normalized_ref = normalize_entity_ref(entity_ref)
-        candidate_tokens = frozenset(normalized_ref.split())
-        if normalized_ref in alias_refs or (
-            candidate_tokens and candidate_tokens < canonical_tokens
+        folded_ref = fold_entity_ref_for_identity(entity_ref)
+        candidate_tokens = frozenset(folded_ref.split())
+        if (
+            folded_ref in alias_refs
+            or folded_ref == folded_canonical
+            or (candidate_tokens and candidate_tokens <= canonical_tokens)
         ):
             duplicate_refs.append(entity_ref)
     if not duplicate_refs:
@@ -2842,8 +2847,9 @@ def _protagonist_duplicate_stub_blockers(
         {
             "id": "protagonist_duplicate_stub_forbidden",
             "reason": (
-                "Retrograde may not create a character stub whose normalized "
-                "name is a protagonist alias or strict name-token subset: "
+                "Retrograde may not create a character stub whose folded "
+                "name is a protagonist alias, name-token subset, or "
+                "permutation: "
                 f"{sorted(set(duplicate_refs))}; canonical protagonist is "
                 f"{protagonist_identity.name!r}"
             ),

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -29,7 +29,10 @@ from nexus.agents.orrery.retrograde_expansion import (
 from nexus.agents.orrery.retrograde_markers import (
     RETROGRADE_PROLOGUE_MARKER,
 )
-from nexus.agents.orrery.retrograde_vocabulary import normalize_entity_ref
+from nexus.agents.orrery.retrograde_vocabulary import (
+    normalize_entity_ref,
+    relationship_type_default_emotional_valence,
+)
 from nexus.agents.orrery.status_family import STATUS_TAGS, level_from_status_tag
 from nexus.agents.orrery.substrate import ProjectPolicy, coerce_project_policy
 from nexus.agents.orrery.tag_writer import apply_status_pair_tag_bestowal
@@ -102,6 +105,15 @@ class _ProjectRefDecision:
     winning_seed_id: Optional[str] = None
 
 
+@dataclass(frozen=True, slots=True)
+class _PersistedProtagonistIdentity:
+    """Canonical protagonist name plus aliases loaded from normalized tables."""
+
+    character_id: int
+    name: str
+    aliases: frozenset[str]
+
+
 def build_retrograde_persistence_plan(
     cur: Any,
     *,
@@ -158,6 +170,9 @@ def build_retrograde_persistence_plan(
             )
     existing_prologue_id = _find_prologue_chunk_id(cur)
     entity_index = _load_entity_index(cur)
+    protagonist_identity = (
+        _load_persisted_protagonist_identity(cur) if create_missing_entities else None
+    )
     project_ref_decisions = (
         _arbitrate_project_refs(
             expansion,
@@ -212,13 +227,16 @@ def build_retrograde_persistence_plan(
         project_event_origin=project_event_origin,
         project_event_ref_prefix=project_event_ref_prefix,
         project_log_context=project_log_context,
+        protagonist_identity=protagonist_identity,
     )
     if dry_run:
         return manifest
 
     blockers = list(manifest["execute_blockers"])
     if blockers:
-        formatted = "; ".join(blocker["reason"] for blocker in blockers)
+        formatted = "; ".join(
+            f"{blocker['id']}: {blocker['reason']}" for blocker in blockers
+        )
         raise ValueError(f"Retrograde expansion is not safe to execute: {formatted}")
 
     inserted_stub_keys = _insert_missing_entity_stubs(
@@ -262,6 +280,7 @@ def build_retrograde_persistence_plan(
         project_event_origin=project_event_origin,
         project_event_ref_prefix=project_event_ref_prefix,
         project_log_context=project_log_context,
+        protagonist_identity=protagonist_identity,
     )
 
 
@@ -295,6 +314,7 @@ def _build_plan(
     project_event_origin: str,
     project_event_ref_prefix: Optional[str],
     project_log_context: Optional[str],
+    protagonist_identity: Optional[_PersistedProtagonistIdentity],
 ) -> dict[str, Any]:
     counters: Counter[str] = Counter()
     reference_issues: list[dict[str, Any]] = []
@@ -311,6 +331,12 @@ def _build_plan(
         create_missing_entities=create_missing_entities,
         inserted_stub_keys=inserted_stub_keys,
         project_ref_decisions=project_ref_decisions,
+    )
+    execute_blockers.extend(
+        _protagonist_duplicate_stub_blockers(
+            entity_stub_rows=entity_stub_rows,
+            protagonist_identity=protagonist_identity,
+        )
     )
     creatable_refs = frozenset(
         (row["entity_kind"], normalize_entity_ref(row["entity_ref"]))
@@ -2615,6 +2641,37 @@ def _load_entity_index(cur: Any) -> dict[tuple[str, str], list[_EntityRecord]]:
     return index
 
 
+def _load_persisted_protagonist_identity(
+    cur: Any,
+) -> Optional[_PersistedProtagonistIdentity]:
+    """Load the canonical player character and normalized alias rows."""
+
+    cur.execute(
+        """
+        /* orrery:retrograde:protagonist_identity */
+        SELECT c.id, c.name, ca.alias
+        FROM global_variables gv
+        JOIN characters c ON c.id = gv.user_character
+        LEFT JOIN character_aliases ca ON ca.character_id = c.id
+        WHERE gv.id = TRUE
+        ORDER BY ca.alias
+        """
+    )
+    rows = cur.fetchall()
+    if not rows:
+        return None
+    character_id = int(_row_value(rows[0], "id", 0))
+    name = str(_row_value(rows[0], "name", 1))
+    aliases = frozenset(
+        str(alias) for row in rows if (alias := _row_value(row, "alias", 2)) is not None
+    )
+    return _PersistedProtagonistIdentity(
+        character_id=character_id,
+        name=name,
+        aliases=aliases,
+    )
+
+
 def _load_event_types(cur: Any) -> set[str]:
     cur.execute(
         """
@@ -2754,6 +2811,44 @@ def _plan_entity_stubs(
             row["candidates"] = [_entity_record_json(match) for match in matches]
         rows.append(row)
     return rows
+
+
+def _protagonist_duplicate_stub_blockers(
+    *,
+    entity_stub_rows: Sequence[Mapping[str, Any]],
+    protagonist_identity: Optional[_PersistedProtagonistIdentity],
+) -> list[dict[str, str]]:
+    """Block new character stubs that alias or abbreviate the protagonist."""
+
+    if protagonist_identity is None:
+        return []
+    canonical_ref = normalize_entity_ref(protagonist_identity.name)
+    canonical_tokens = frozenset(canonical_ref.split())
+    alias_refs = {normalize_entity_ref(alias) for alias in protagonist_identity.aliases}
+    duplicate_refs: list[str] = []
+    for row in entity_stub_rows:
+        if row.get("status") != "would_insert" or row.get("entity_kind") != "character":
+            continue
+        entity_ref = str(row.get("entity_ref") or "")
+        normalized_ref = normalize_entity_ref(entity_ref)
+        candidate_tokens = frozenset(normalized_ref.split())
+        if normalized_ref in alias_refs or (
+            candidate_tokens and candidate_tokens < canonical_tokens
+        ):
+            duplicate_refs.append(entity_ref)
+    if not duplicate_refs:
+        return []
+    return [
+        {
+            "id": "protagonist_duplicate_stub_forbidden",
+            "reason": (
+                "Retrograde may not create a character stub whose normalized "
+                "name is a protagonist alias or strict name-token subset: "
+                f"{sorted(set(duplicate_refs))}; canonical protagonist is "
+                f"{protagonist_identity.name!r}"
+            ),
+        }
+    ]
 
 
 def _collect_expansion_entity_refs(
@@ -3050,23 +3145,7 @@ def _relationship_extra_data(
 
 
 def _default_emotional_valence(relationship_type: str) -> str:
-    positive = {
-        "ally",
-        "chosen_kin",
-        "companion",
-        "family",
-        "friend",
-        "guardian",
-        "mentor",
-        "romantic",
-        "ward",
-    }
-    negative = {"captor", "enemy", "rival"}
-    if relationship_type in positive:
-        return "+3|trusting"
-    if relationship_type in negative:
-        return "-3|resentful"
-    return "0|neutral"
+    return relationship_type_default_emotional_valence(relationship_type)
 
 
 def _source_kind_blockers(cur: Any) -> list[dict[str, str]]:

--- a/nexus/agents/orrery/retrograde_seed_candidates.py
+++ b/nexus/agents/orrery/retrograde_seed_candidates.py
@@ -543,6 +543,7 @@ def render_seed_generation_prompt(
         "candidate_graph": seed_generation_request.get("candidate_graph", {}),
         "selection_rubric": seed_generation_request.get("selection_rubric", {}),
         "trait_constraints": seed_generation_request.get("trait_constraints", []),
+        "protagonist_identity": seed_generation_request.get("protagonist_identity", {}),
         "project_intent_policy": seed_generation_request.get(
             "project_intent_policy",
             {
@@ -1409,6 +1410,7 @@ def _seed_vocabulary(value: Any) -> SeedEligibleVocabulary:
         "multi_entity_tag_definitions",
         "event_types",
         "relationship_types",
+        "relationship_type_definitions",
     )
     missing = [key for key in required_keys if key not in vocabulary]
     if missing:
@@ -1513,6 +1515,7 @@ def render_seed_selection_prompt(
         "budget": seed_generation_request.get("budget", {}),
         "selection_rubric": seed_generation_request.get("selection_rubric", {}),
         "trait_constraints": seed_generation_request.get("trait_constraints", []),
+        "protagonist_identity": seed_generation_request.get("protagonist_identity", {}),
         "weird_policy": seed_generation_request.get("weird_policy", {}),
         "attachment_contract": (
             seed_generation_request.get("candidate_graph", {}) or {}
@@ -1533,9 +1536,11 @@ def render_seed_selection_prompt(
         "coverage functions, honor their claimed dangling edges with "
         "conviction rather than lip service, and would take real creative "
         "work to weave into the story — merge-difficulty is value, not "
-        "risk. Reject seeds that ignore their claimed edges or whose "
-        "mechanical hints violate a trait constraint. A backstory event alone "
-        "does not violate a relationship constraint.\n"
+        "risk. Reject seeds that ignore their claimed edges or whose mechanical "
+        "hints violate a trait constraint: specifically, relationship or pair-tag "
+        "hints in a forbidden trait's explicit blocked sets that involve the "
+        "protagonist or an alias. A backstory event alone does not violate a "
+        "relationship constraint.\n"
         "Resolved junction seed pairs are atomic: select both member seeds "
         "or reject both. A pair consumes two ordinary selection slots.\n"
         "Every non-selected candidate must appear in rejected_seed_ids.\n\n"

--- a/nexus/agents/orrery/retrograde_seed_candidates.py
+++ b/nexus/agents/orrery/retrograde_seed_candidates.py
@@ -542,6 +542,7 @@ def render_seed_generation_prompt(
         "coverage_functions": seed_generation_request.get("coverage_functions", []),
         "candidate_graph": seed_generation_request.get("candidate_graph", {}),
         "selection_rubric": seed_generation_request.get("selection_rubric", {}),
+        "trait_constraints": seed_generation_request.get("trait_constraints", []),
         "project_intent_policy": seed_generation_request.get(
             "project_intent_policy",
             {
@@ -1511,6 +1512,7 @@ def render_seed_selection_prompt(
         ),
         "budget": seed_generation_request.get("budget", {}),
         "selection_rubric": seed_generation_request.get("selection_rubric", {}),
+        "trait_constraints": seed_generation_request.get("trait_constraints", []),
         "weird_policy": seed_generation_request.get("weird_policy", {}),
         "attachment_contract": (
             seed_generation_request.get("candidate_graph", {}) or {}
@@ -1531,7 +1533,9 @@ def render_seed_selection_prompt(
         "coverage functions, honor their claimed dangling edges with "
         "conviction rather than lip service, and would take real creative "
         "work to weave into the story — merge-difficulty is value, not "
-        "risk. Reject seeds that ignore their claimed edges.\n"
+        "risk. Reject seeds that ignore their claimed edges or whose "
+        "mechanical hints violate a trait constraint. A backstory event alone "
+        "does not violate a relationship constraint.\n"
         "Resolved junction seed pairs are atomic: select both member seeds "
         "or reject both. A pair consumes two ordinary selection slots.\n"
         "Every non-selected candidate must appear in rejected_seed_ids.\n\n"

--- a/nexus/agents/orrery/retrograde_vocabulary.py
+++ b/nexus/agents/orrery/retrograde_vocabulary.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Literal, TypedDict
+from typing import Iterable, Literal, Mapping, TypedDict
 
 from nexus.agents.orrery.catalog import collect_template_vocabulary
-from nexus.agents.orrery.pair_tag_registry import PAIR_TAG_SEED
+from nexus.agents.orrery.pair_tag_registry import (
+    PAIR_TAG_SEED,
+    PAIR_TAG_SEMANTIC_CATEGORIES,
+)
 from nexus.agents.orrery.status_family import STATUS_LEVELS, status_tag_for_level
 from nexus.agents.orrery.substrate import EntityKind, Slot
 from nexus.agents.orrery.tag_library import (
@@ -48,6 +51,15 @@ class PairTagPrimitive(TypedDict):
     subject_kinds: list[str]
     object_kinds: list[str]
     is_ephemeral: bool
+    semantic_categories: list[str]
+
+
+class RelationshipTypePrimitive(TypedDict):
+    """One relationship type with the missing registry semantics made explicit."""
+
+    relationship_type: str
+    semantic_categories: list[str]
+    default_emotional_valence: str
 
 
 SeedTagPolicy = Literal["stable_seed", "event_anchored", "prompt_visible_only"]
@@ -84,6 +96,7 @@ class SeedEligibleVocabulary(TypedDict):
     event_type_categories: dict[str, str]
     place_classes: list[str]
     relationship_types: list[str]
+    relationship_type_definitions: list[RelationshipTypePrimitive]
 
 
 # Seed-eligible vs prompt-visible category split (issue #300, settled in M4).
@@ -140,6 +153,38 @@ EVENT_ANCHORED_TAG_CATEGORIES: frozenset[str] = frozenset(
 RUNTIME_ONLY_TAG_CATEGORY_PREFIX = "orrery_"
 
 
+# ``character_relationships.relationship_type`` is free text and has no
+# registry table. This companion registry makes the valence/category metadata
+# used by persistence and cold-start constraints explicit. Enumeration refuses
+# a template relationship type that is absent here, preventing a newly added
+# adversarial primitive from silently bypassing player constraints.
+RELATIONSHIP_TYPE_DEFINITIONS: Mapping[str, tuple[str, frozenset[str]]] = {
+    "ally": ("+3|trusting", frozenset({"affiliative"})),
+    "asset": ("0|neutral", frozenset({"contact"})),
+    "captor": ("-3|resentful", frozenset({"adversarial", "patronage"})),
+    "chosen_kin": ("+3|trusting", frozenset({"affiliative", "dependency"})),
+    "companion": ("+3|trusting", frozenset({"affiliative"})),
+    "comrade": ("0|neutral", frozenset({"affiliative"})),
+    "enemy": ("-3|resentful", frozenset({"adversarial"})),
+    "family": ("+3|trusting", frozenset({"affiliative", "dependency"})),
+    "friend": ("+3|trusting", frozenset({"affiliative"})),
+    "guardian": (
+        "+3|trusting",
+        frozenset({"affiliative", "dependency", "patronage"}),
+    ),
+    "handler": ("0|neutral", frozenset({"contact", "patronage"})),
+    "lover": ("0|neutral", frozenset({"affiliative"})),
+    "mentor": ("+3|trusting", frozenset({"affiliative", "patronage"})),
+    "partner": ("0|neutral", frozenset({"affiliative"})),
+    "patron": ("0|neutral", frozenset({"patronage"})),
+    "rival": ("-3|resentful", frozenset({"adversarial"})),
+    "romantic": ("+3|trusting", frozenset({"affiliative"})),
+    "romantic_partner": ("0|neutral", frozenset({"affiliative"})),
+    "spouse": ("0|neutral", frozenset({"affiliative", "dependency"})),
+    "ward": ("+3|trusting", frozenset({"dependency"})),
+}
+
+
 def enumerate_seed_eligible_vocabulary(
     dbname: str | None = None,
 ) -> SeedEligibleVocabulary:
@@ -175,6 +220,10 @@ def enumerate_seed_eligible_vocabulary(
         | set(registry_vocab["registered_single_entity_tags"])
     )
     pair_tag_definitions = _load_pair_tag_definitions()
+    relationship_types = _sorted_strings(template_vocab["relationship_types"])
+    relationship_type_definitions = _load_relationship_type_definitions(
+        relationship_types
+    )
 
     return {
         "entity_kinds": sorted(kind.value for kind in EntityKind),
@@ -203,7 +252,8 @@ def enumerate_seed_eligible_vocabulary(
         "event_types": event_types,
         "event_type_categories": event_type_categories,
         "place_classes": _sorted_strings(template_vocab["place_classes"]),
-        "relationship_types": _sorted_strings(template_vocab["relationship_types"]),
+        "relationship_types": relationship_types,
+        "relationship_type_definitions": relationship_type_definitions,
     }
 
 
@@ -334,12 +384,18 @@ def _load_pair_tag_definitions() -> list[PairTagPrimitive]:
         is_ephemeral,
         _description,
     ) in PAIR_TAG_SEED:
+        semantic_categories = PAIR_TAG_SEMANTIC_CATEGORIES.get(str(tag))
+        if not semantic_categories:
+            raise ValueError(
+                "Seed-eligible pair tag is missing semantic classification: " f"{tag!r}"
+            )
         definitions.append(
             {
                 "tag": str(tag),
                 "subject_kinds": [str(kind) for kind in subject_kinds],
                 "object_kinds": [str(kind) for kind in object_kinds],
                 "is_ephemeral": bool(is_ephemeral),
+                "semantic_categories": sorted(semantic_categories),
             }
         )
     definitions.extend(
@@ -348,10 +404,52 @@ def _load_pair_tag_definitions() -> list[PairTagPrimitive]:
             "subject_kinds": ["character", "faction"],
             "object_kinds": ["faction"],
             "is_ephemeral": False,
+            "semantic_categories": ["status"],
         }
         for level in STATUS_LEVELS
     )
     return sorted(definitions, key=lambda item: item["tag"])
+
+
+def _load_relationship_type_definitions(
+    relationship_types: Iterable[str],
+) -> list[RelationshipTypePrimitive]:
+    """Return complete relationship metadata, refusing unclassified types."""
+
+    definitions: list[RelationshipTypePrimitive] = []
+    for relationship_type in sorted(str(value) for value in relationship_types):
+        metadata = RELATIONSHIP_TYPE_DEFINITIONS.get(relationship_type)
+        if metadata is None:
+            raise ValueError(
+                "Seed-eligible relationship type is missing semantic and "
+                f"valence classification: {relationship_type!r}"
+            )
+        default_valence, semantic_categories = metadata
+        if default_valence.startswith("-") and "adversarial" not in semantic_categories:
+            raise ValueError(
+                "Negative-valence seed-eligible relationship type is not "
+                f"classified as adversarial: {relationship_type!r}"
+            )
+        definitions.append(
+            {
+                "relationship_type": relationship_type,
+                "semantic_categories": sorted(semantic_categories),
+                "default_emotional_valence": default_valence,
+            }
+        )
+    return definitions
+
+
+def relationship_type_default_emotional_valence(relationship_type: str) -> str:
+    """Return the canonical setup valence for a classified relationship type."""
+
+    metadata = RELATIONSHIP_TYPE_DEFINITIONS.get(str(relationship_type))
+    if metadata is None:
+        raise ValueError(
+            "Relationship type is missing semantic and valence classification: "
+            f"{relationship_type!r}"
+        )
+    return metadata[0]
 
 
 def _sorted_strings(values: Iterable[object]) -> list[str]:

--- a/nexus/agents/orrery/retrograde_vocabulary.py
+++ b/nexus/agents/orrery/retrograde_vocabulary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import unicodedata
 from typing import Iterable, Literal, Mapping, TypedDict
 
 from nexus.agents.orrery.catalog import collect_template_vocabulary
@@ -42,6 +43,20 @@ def normalize_entity_ref(value: str) -> str:
     """
 
     return " ".join(value.split()).casefold()
+
+
+def fold_entity_ref_for_identity(value: str) -> str:
+    """Aggressively fold a ref for protagonist-identity comparison ONLY.
+
+    Adds diacritic stripping on top of ``normalize_entity_ref`` so accent or
+    token-order variants of the protagonist's name cannot mint a second
+    protagonist row. Never use this for general ref resolution: two distinct
+    characters may legitimately differ only by diacritics.
+    """
+
+    decomposed = unicodedata.normalize("NFKD", value)
+    stripped = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    return normalize_entity_ref(stripped)
 
 
 class PairTagPrimitive(TypedDict):

--- a/nexus/agents/orrery/tag_library.py
+++ b/nexus/agents/orrery/tag_library.py
@@ -7,7 +7,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from hashlib import sha256
 import os
-import re
 from typing import Iterator, Literal, Optional, Sequence
 
 import psycopg2
@@ -19,10 +18,9 @@ from nexus.agents.orrery.resolver import (
     load_anchor_world_time,
     load_current_entity_tags,
 )
-from nexus.api.slot_utils import get_slot_db_url
+from nexus.api.slot_utils import get_slot_db_url, require_slot_dbname
 
 VALID_ENTITY_KINDS = frozenset({"character", "faction", "place"})
-_SLOT_DB_RE = re.compile(r"^save_0[1-5]$")
 EntityKind = Literal["character", "faction", "place"]
 
 
@@ -660,9 +658,4 @@ def _resolve_dbname(dbname: Optional[str]) -> str:
             resolved = f"save_{int(slot):02d}"
         else:
             resolved = os.environ.get("PGDATABASE", "")
-    if not _SLOT_DB_RE.match(resolved):
-        raise ValueError(
-            "Orrery tag library requires a slot database name "
-            f"(save_01..save_05), got {resolved!r}"
-        )
-    return resolved
+    return require_slot_dbname(dbname=resolved)

--- a/nexus/api/new_story_cache.py
+++ b/nexus/api/new_story_cache.py
@@ -15,7 +15,7 @@ import logging
 import os
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Mapping, Optional
 
 from nexus.api.db_pool import get_connection
 from nexus.api.trait_compiler_schemas import canonical_trait_name
@@ -70,6 +70,27 @@ def _trait_rationale(
         or (rationales.get("reputation") if storage_name == "fame" else None)
         or ""
     )
+
+
+def _trait_constraint_map(value: Any) -> Dict[str, str]:
+    """Index TraitSelection constraint rows by canonical trait name."""
+
+    if not isinstance(value, list):
+        return {}
+    constraints: Dict[str, str] = {}
+    for entry in value:
+        if not isinstance(entry, Mapping):
+            continue
+        trait_name = entry.get("trait")
+        relationship_policy = entry.get("cold_start_relationships", "allowed")
+        if trait_name in VALID_TRAITS and relationship_policy in {
+            "allowed",
+            "forbidden",
+        }:
+            constraints[canonical_trait_name(str(trait_name))] = str(
+                relationship_policy
+            )
+    return constraints
 
 
 def _parse_pg_array(value: Any) -> List[str]:
@@ -136,6 +157,7 @@ class SuggestedTrait:
 
     trait: str
     rationale: str
+    cold_start_relationships: Literal["allowed", "forbidden"] = "allowed"
 
 
 @dataclass
@@ -282,6 +304,13 @@ class WizardCache:
         # Build trait data from suggested_traits (which are the selected ones)
         selected = [st.trait for st in self.character.suggested_traits]
         rationales = {st.trait: st.rationale for st in self.character.suggested_traits}
+        constraints = [
+            {
+                "trait": st.trait,
+                "cold_start_relationships": st.cold_start_relationships,
+            }
+            for st in self.character.suggested_traits
+        ]
 
         return {
             "concept": {
@@ -295,6 +324,7 @@ class WizardCache:
             "trait_selection": {
                 "selected_traits": selected,
                 "trait_rationales": rationales,
+                "trait_constraints": constraints,
             },
             "wildcard": {
                 "wildcard_name": self.character.wildcard_name,
@@ -391,7 +421,7 @@ def read_cache(dbname: Optional[str] = None) -> Optional[WizardCache]:
             # Load trait data from assets.traits
             cur.execute(
                 """
-                SELECT id, name, rationale, is_selected
+                SELECT id, name, rationale, is_selected, cold_start_relationships
                 FROM assets.traits
                 ORDER BY id
                 """
@@ -400,7 +430,12 @@ def read_cache(dbname: Optional[str] = None) -> Optional[WizardCache]:
 
             # Build trait info for CharacterData
             selected_traits = [
-                SuggestedTrait(trait=r["name"], rationale=r["rationale"] or "")
+                SuggestedTrait(
+                    trait=r["name"],
+                    rationale=r["rationale"] or "",
+                    cold_start_relationships=r.get("cold_start_relationships")
+                    or "allowed",
+                )
                 for r in traits_rows
                 if r["is_selected"] and r["id"] <= 10
             ]
@@ -663,7 +698,9 @@ def confirm_trait_selection(dbname: Optional[str]) -> List[str]:
 
             # Clear rationales for non-selected traits
             cur.execute(
-                "UPDATE assets.traits SET rationale = NULL WHERE is_selected = FALSE AND id <= 10"
+                "UPDATE assets.traits SET rationale = NULL, "
+                "cold_start_relationships = 'allowed' "
+                "WHERE is_selected = FALSE AND id <= 10"
             )
 
             # Set confirmation flag in cache
@@ -793,7 +830,8 @@ def write_suggested_traits(
         with conn.cursor() as cur:
             # First deselect all optional traits (not wildcard)
             cur.execute(
-                "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL WHERE id <= 10"
+                "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL, "
+                "cold_start_relationships = 'allowed' WHERE id <= 10"
             )
 
             # Select and set rationale for each suggested trait
@@ -830,7 +868,8 @@ def clear_suggested_traits(dbname: Optional[str] = None) -> None:
     with get_connection(dbname) as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL WHERE id <= 10"
+                "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL, "
+                "cold_start_relationships = 'allowed' WHERE id <= 10"
             )
     logger.info(
         "Cleared trait selections in %s", dbname or os.environ.get("PGDATABASE")
@@ -959,7 +998,8 @@ def clear_cache(dbname: Optional[str] = None) -> None:
             cur.execute("DELETE FROM assets.new_story_creator WHERE id = TRUE")
             # Reset traits: deselect optional traits, clear rationales, reset wildcard name
             cur.execute(
-                "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL WHERE id <= 10"
+                "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL, "
+                "cold_start_relationships = 'allowed' WHERE id <= 10"
             )
             cur.execute(
                 "UPDATE assets.traits SET name = 'wildcard', rationale = NULL WHERE id = 11"
@@ -1054,7 +1094,8 @@ def clear_character_phase(dbname: Optional[str] = None) -> None:
             # Reset traits: deselect all (except wildcard), clear rationales, reset wildcard name
             cur.execute(
                 """
-                UPDATE assets.traits SET is_selected = FALSE, rationale = NULL WHERE id <= 10;
+                UPDATE assets.traits SET is_selected = FALSE, rationale = NULL,
+                    cold_start_relationships = 'allowed' WHERE id <= 10;
                 UPDATE assets.traits SET name = 'wildcard', rationale = NULL WHERE id = 11;
                 """
             )
@@ -1122,7 +1163,8 @@ def clear_setting_phase(dbname: Optional[str] = None) -> None:
             # Reset traits to defaults
             cur.execute(
                 """
-                UPDATE assets.traits SET is_selected = FALSE, rationale = NULL WHERE id <= 10;
+                UPDATE assets.traits SET is_selected = FALSE, rationale = NULL,
+                    cold_start_relationships = 'allowed' WHERE id <= 10;
                 UPDATE assets.traits SET name = 'wildcard', rationale = NULL WHERE id = 11;
                 """
             )
@@ -1166,7 +1208,7 @@ def write_cache(
 
             # Build the update dynamically based on what's provided
             updates = ["updated_at = NOW()"]
-            params = []
+            params: List[Any] = []
 
             if thread_id is not None:
                 updates.append("thread_id = %s")
@@ -1246,10 +1288,15 @@ def write_cache(
                 if traits:
                     selected = traits.get("selected_traits", [])
                     rationales = traits.get("trait_rationales", {})
+                    constraints = _trait_constraint_map(
+                        traits.get("trait_constraints", [])
+                    )
                     if len(selected) == 3:
                         # Clear previous selections, then set new ones
                         cur.execute(
-                            "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL WHERE id <= 10"
+                            "UPDATE assets.traits SET is_selected = FALSE, "
+                            "rationale = NULL, cold_start_relationships = 'allowed' "
+                            "WHERE id <= 10"
                         )
                         for trait_name in selected:
                             storage_name = canonical_trait_name(trait_name)
@@ -1261,10 +1308,16 @@ def write_cache(
                             cur.execute(
                                 """
                                 UPDATE assets.traits
-                                SET is_selected = TRUE, rationale = %s
+                                SET is_selected = TRUE,
+                                    rationale = %s,
+                                    cold_start_relationships = %s
                                 WHERE name = %s
                                 """,
-                                (rationale, storage_name),
+                                (
+                                    rationale,
+                                    constraints.get(storage_name, "allowed"),
+                                    storage_name,
+                                ),
                             )
                             _ensure_trait_update_matched(
                                 cur,

--- a/nexus/api/new_story_cache.py
+++ b/nexus/api/new_story_cache.py
@@ -72,24 +72,33 @@ def _trait_rationale(
     )
 
 
-def _trait_constraint_map(value: Any) -> Dict[str, str]:
+def _trait_constraint_map(value: Any) -> Dict[str, Dict[str, Any]]:
     """Index TraitSelection constraint rows by canonical trait name."""
 
     if not isinstance(value, list):
         return {}
-    constraints: Dict[str, str] = {}
+    constraints: Dict[str, Dict[str, Any]] = {}
     for entry in value:
         if not isinstance(entry, Mapping):
             continue
         trait_name = entry.get("trait")
         relationship_policy = entry.get("cold_start_relationships", "allowed")
-        if trait_name in VALID_TRAITS and relationship_policy in {
-            "allowed",
-            "forbidden",
-        }:
-            constraints[canonical_trait_name(str(trait_name))] = str(
-                relationship_policy
-            )
+        named_targets = entry.get("preexisting_relationship_targets") or []
+        if (
+            trait_name in VALID_TRAITS
+            and relationship_policy
+            in {
+                "allowed",
+                "forbidden",
+            }
+            and isinstance(named_targets, list)
+        ):
+            constraints[canonical_trait_name(str(trait_name))] = {
+                "cold_start_relationships": str(relationship_policy),
+                "preexisting_relationship_targets": [
+                    str(target) for target in named_targets if str(target).strip()
+                ],
+            }
     return constraints
 
 
@@ -158,6 +167,7 @@ class SuggestedTrait:
     trait: str
     rationale: str
     cold_start_relationships: Literal["allowed", "forbidden"] = "allowed"
+    preexisting_relationship_targets: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -308,6 +318,9 @@ class WizardCache:
             {
                 "trait": st.trait,
                 "cold_start_relationships": st.cold_start_relationships,
+                "preexisting_relationship_targets": list(
+                    st.preexisting_relationship_targets
+                ),
             }
             for st in self.character.suggested_traits
         ]
@@ -421,7 +434,8 @@ def read_cache(dbname: Optional[str] = None) -> Optional[WizardCache]:
             # Load trait data from assets.traits
             cur.execute(
                 """
-                SELECT id, name, rationale, is_selected, cold_start_relationships
+                SELECT id, name, rationale, is_selected, cold_start_relationships,
+                       preexisting_relationship_targets
                 FROM assets.traits
                 ORDER BY id
                 """
@@ -435,6 +449,9 @@ def read_cache(dbname: Optional[str] = None) -> Optional[WizardCache]:
                     rationale=r["rationale"] or "",
                     cold_start_relationships=r.get("cold_start_relationships")
                     or "allowed",
+                    preexisting_relationship_targets=list(
+                        r.get("preexisting_relationship_targets") or []
+                    ),
                 )
                 for r in traits_rows
                 if r["is_selected"] and r["id"] <= 10
@@ -699,7 +716,8 @@ def confirm_trait_selection(dbname: Optional[str]) -> List[str]:
             # Clear rationales for non-selected traits
             cur.execute(
                 "UPDATE assets.traits SET rationale = NULL, "
-                "cold_start_relationships = 'allowed' "
+                "cold_start_relationships = 'allowed', "
+                "preexisting_relationship_targets = '[]'::jsonb "
                 "WHERE is_selected = FALSE AND id <= 10"
             )
 
@@ -831,7 +849,8 @@ def write_suggested_traits(
             # First deselect all optional traits (not wildcard)
             cur.execute(
                 "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL, "
-                "cold_start_relationships = 'allowed' WHERE id <= 10"
+                "cold_start_relationships = 'allowed', "
+                "preexisting_relationship_targets = '[]'::jsonb WHERE id <= 10"
             )
 
             # Select and set rationale for each suggested trait
@@ -869,7 +888,8 @@ def clear_suggested_traits(dbname: Optional[str] = None) -> None:
         with conn.cursor() as cur:
             cur.execute(
                 "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL, "
-                "cold_start_relationships = 'allowed' WHERE id <= 10"
+                "cold_start_relationships = 'allowed', "
+                "preexisting_relationship_targets = '[]'::jsonb WHERE id <= 10"
             )
     logger.info(
         "Cleared trait selections in %s", dbname or os.environ.get("PGDATABASE")
@@ -999,7 +1019,8 @@ def clear_cache(dbname: Optional[str] = None) -> None:
             # Reset traits: deselect optional traits, clear rationales, reset wildcard name
             cur.execute(
                 "UPDATE assets.traits SET is_selected = FALSE, rationale = NULL, "
-                "cold_start_relationships = 'allowed' WHERE id <= 10"
+                "cold_start_relationships = 'allowed', "
+                "preexisting_relationship_targets = '[]'::jsonb WHERE id <= 10"
             )
             cur.execute(
                 "UPDATE assets.traits SET name = 'wildcard', rationale = NULL WHERE id = 11"
@@ -1095,7 +1116,8 @@ def clear_character_phase(dbname: Optional[str] = None) -> None:
             cur.execute(
                 """
                 UPDATE assets.traits SET is_selected = FALSE, rationale = NULL,
-                    cold_start_relationships = 'allowed' WHERE id <= 10;
+                    cold_start_relationships = 'allowed',
+                    preexisting_relationship_targets = '[]'::jsonb WHERE id <= 10;
                 UPDATE assets.traits SET name = 'wildcard', rationale = NULL WHERE id = 11;
                 """
             )
@@ -1164,7 +1186,8 @@ def clear_setting_phase(dbname: Optional[str] = None) -> None:
             cur.execute(
                 """
                 UPDATE assets.traits SET is_selected = FALSE, rationale = NULL,
-                    cold_start_relationships = 'allowed' WHERE id <= 10;
+                    cold_start_relationships = 'allowed',
+                    preexisting_relationship_targets = '[]'::jsonb WHERE id <= 10;
                 UPDATE assets.traits SET name = 'wildcard', rationale = NULL WHERE id = 11;
                 """
             )
@@ -1295,7 +1318,8 @@ def write_cache(
                         # Clear previous selections, then set new ones
                         cur.execute(
                             "UPDATE assets.traits SET is_selected = FALSE, "
-                            "rationale = NULL, cold_start_relationships = 'allowed' "
+                            "rationale = NULL, cold_start_relationships = 'allowed', "
+                            "preexisting_relationship_targets = '[]'::jsonb "
                             "WHERE id <= 10"
                         )
                         for trait_name in selected:
@@ -1305,17 +1329,26 @@ def write_cache(
                                 trait_name=trait_name,
                                 storage_name=storage_name,
                             )
+                            constraint = constraints.get(storage_name, {})
                             cur.execute(
                                 """
                                 UPDATE assets.traits
                                 SET is_selected = TRUE,
                                     rationale = %s,
-                                    cold_start_relationships = %s
+                                    cold_start_relationships = %s,
+                                    preexisting_relationship_targets = %s::jsonb
                                 WHERE name = %s
                                 """,
                                 (
                                     rationale,
-                                    constraints.get(storage_name, "allowed"),
+                                    constraint.get(
+                                        "cold_start_relationships", "allowed"
+                                    ),
+                                    json.dumps(
+                                        constraint.get(
+                                            "preexisting_relationship_targets", []
+                                        )
+                                    ),
                                     storage_name,
                                 ),
                             )

--- a/nexus/api/new_story_db_mapper.py
+++ b/nexus/api/new_story_db_mapper.py
@@ -768,6 +768,11 @@ class NewStoryDatabaseMapper:
         for trait in character.get_trait_entries():
             extra_data[trait.name] = trait.description
 
+        extra_data["trait_constraints"] = [
+            constraint.model_dump(mode="json")
+            for constraint in character.trait_constraints
+        ]
+
         # Add required wildcard trait
         extra_data["wildcard"] = {
             "name": character.wildcard_name,

--- a/nexus/api/new_story_flow.py
+++ b/nexus/api/new_story_flow.py
@@ -34,6 +34,56 @@ logger = logging.getLogger("nexus.api.new_story_flow")
 MOCK_WIZARD_MODEL = "TEST"
 
 
+def build_transition_data_from_cache(cache: Any) -> "TransitionData":
+    """Hydrate the canonical transition package through wizard-cache adapters."""
+
+    from nexus.api.new_story_schemas import (
+        CharacterCreationState,
+        CharacterSheet,
+        LayerDefinition,
+        PlaceProfile,
+        SettingCard,
+        StorySeed,
+        TransitionData,
+        ZoneDefinition,
+    )
+
+    character_draft = cache.get_character_dict()
+    setting_draft = cache.get_setting_dict()
+    seed_draft = cache.get_seed_dict()
+    layer_draft = cache.get_layer_dict()
+    zone_draft = cache.get_zone_dict()
+    location_draft = cache.get_initial_location()
+    if any(
+        value is None
+        for value in (
+            character_draft,
+            setting_draft,
+            seed_draft,
+            layer_draft,
+            zone_draft,
+            location_draft,
+            cache.base_timestamp,
+        )
+    ):
+        raise ValueError("Wizard cache is incomplete for transition hydration")
+
+    character_state = CharacterCreationState.model_validate(character_draft)
+    character_sheet = character_state.to_character_sheet()
+    return TransitionData.model_validate(
+        {
+            "setting": SettingCard.model_validate(setting_draft),
+            "character": CharacterSheet.model_validate(character_sheet.model_dump()),
+            "seed": StorySeed.model_validate(seed_draft),
+            "layer": LayerDefinition.model_validate(layer_draft),
+            "zone": ZoneDefinition.model_validate(zone_draft),
+            "location": PlaceProfile.model_validate(location_draft),
+            "base_timestamp": cache.base_timestamp,
+            "thread_id": cache.thread_id or "",
+        }
+    )
+
+
 def resolve_setup_model(
     slot_model: Optional[str],
     *,

--- a/nexus/api/new_story_schemas.py
+++ b/nexus/api/new_story_schemas.py
@@ -469,6 +469,23 @@ class TraitRationales(BaseModel):
         return {k: v for k, v in self.model_dump().items() if v is not None}
 
 
+class TraitConstraint(BaseModel):
+    """One selected trait's explicit cold-start materialization constraint."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    trait: TraitName = Field(..., description="Selected trait this constraint governs")
+    cold_start_relationships: Literal["allowed", "forbidden"] = Field(
+        default="allowed",
+        description=(
+            "Whether setup may create preexisting mechanical relationship rows "
+            "for this trait. Use 'forbidden' when the player says the relationship "
+            "may arise only during future play, such as no preexisting personal "
+            "nemesis. Backstory events without a relationship row remain allowed."
+        ),
+    )
+
+
 class TraitSuggestion(BaseModel):
     """Suggested trait with explicit rationale."""
 
@@ -530,7 +547,9 @@ class CharacterConceptSubmission(BaseModel):
     def to_character_concept(self) -> "CharacterConcept":
         """Convert tool submission into the internal CharacterConcept schema."""
         suggested_names = [item.name for item in self.suggested_traits]
-        rationales = {item.name: item.rationale for item in self.suggested_traits}
+        rationales: Dict[str, str] = {
+            str(item.name): item.rationale for item in self.suggested_traits
+        }
         return CharacterConcept(
             archetype=self.archetype,
             background=self.background,
@@ -578,7 +597,7 @@ class CharacterConcept(BaseModel):
         description="3 trait names that would create interesting story tensions for this character",
     )
     trait_rationales: TraitRationales = Field(
-        default_factory=TraitRationales,
+        default_factory=lambda: TraitRationales.model_validate({}),
         description="Rationales for each suggested trait explaining why it fits this character",
     )
 
@@ -629,6 +648,14 @@ class TraitSelection(BaseModel):
         default_factory=list,
         description="The 3 traits Skald pre-selected as fitting for this character",
     )
+    trait_constraints: List[TraitConstraint] = Field(
+        default_factory=list,
+        max_length=3,
+        description=(
+            "Per-trait setup constraints inferred from the player's wording. "
+            "Omitted traits default to allowing cold-start relationship rows."
+        ),
+    )
 
     @field_validator("selected_traits")
     @classmethod
@@ -637,6 +664,20 @@ class TraitSelection(BaseModel):
         if len(set(v)) != 3:
             raise ValueError("Must select exactly 3 unique traits")
         return v
+
+    @model_validator(mode="after")
+    def validate_trait_constraints(self) -> "TraitSelection":
+        """Keep constraints unique and scoped to the confirmed selection."""
+
+        constrained_traits = [constraint.trait for constraint in self.trait_constraints]
+        if len(constrained_traits) != len(set(constrained_traits)):
+            raise ValueError("Trait constraints must name unique traits")
+        unselected = sorted(set(constrained_traits) - set(self.selected_traits))
+        if unselected:
+            raise ValueError(
+                f"Trait constraints reference unselected traits: {unselected}"
+            )
+        return self
 
 
 class WildcardTrait(BaseModel):
@@ -740,6 +781,9 @@ class CharacterCreationState(BaseModel):
             if not self.wildcard:
                 missing.append("wildcard")
             raise ValueError(f"Cannot assemble CharacterSheet - missing: {missing}")
+        assert self.concept is not None
+        assert self.trait_selection is not None
+        assert self.wildcard is not None
 
         # Build trait entries
         trait_entries: List[CharacterTrait] = []
@@ -959,24 +1003,24 @@ class PlaceExtraData(BaseModel):
 
     atmosphere: Optional[str] = Field(None, description="Mood and feeling of the place")
     resources: List[str] = Field(
-        default_factory=list, max_items=5, description="Available resources"
+        default_factory=list, max_length=5, description="Available resources"
     )
     dangers: List[str] = Field(
-        default_factory=list, max_items=5, description="Known threats or hazards"
+        default_factory=list, max_length=5, description="Known threats or hazards"
     )
     ruler: Optional[str] = Field(None, description="Who controls or governs this place")
     factions: List[str] = Field(
-        default_factory=list, max_items=5, description="Active factions or groups"
+        default_factory=list, max_length=5, description="Active factions or groups"
     )
     culture: Optional[str] = Field(
         None, description="Cultural characteristics and customs"
     )
     economy: Optional[str] = Field(None, description="Economic base and activities")
     nearby_landmarks: List[str] = Field(
-        default_factory=list, max_items=5, description="Nearby notable locations"
+        default_factory=list, max_length=5, description="Nearby notable locations"
     )
     rumors: List[str] = Field(
-        default_factory=list, max_items=3, description="Current rumors or gossip"
+        default_factory=list, max_length=3, description="Current rumors or gossip"
     )
 
 
@@ -1018,7 +1062,7 @@ class PlaceProfile(BaseModel):
     # Inhabitants (stored as text array in database)
     inhabitants: List[str] = Field(
         default_factory=list,
-        max_items=10,
+        max_length=10,
         description="Who lives, works, or frequents this location",
     )
 
@@ -1129,7 +1173,7 @@ class SpecificLocation(BaseModel):
     smells: Optional[str] = Field(None, description="What can be smelled")
 
     # Access and movement
-    entrances: List[str] = Field(..., min_items=1, description="How to enter/exit")
+    entrances: List[str] = Field(..., min_length=1, description="How to enter/exit")
     connected_areas: List[str] = Field(
         default_factory=list, description="Adjacent areas"
     )
@@ -1142,13 +1186,13 @@ class SpecificLocation(BaseModel):
         default_factory=list, description="Who's typically here"
     )
     objects: List[str] = Field(
-        ..., min_items=1, description="Notable objects or furniture"
+        ..., min_length=1, description="Notable objects or furniture"
     )
     lighting: Literal["dark", "dim", "normal", "bright", "variable"] = Field("normal")
 
     # Activity
     typical_activities: List[str] = Field(
-        ..., min_items=1, description="What happens here"
+        ..., min_length=1, description="What happens here"
     )
     busy_times: Optional[str] = Field(
         None, description="When this location is most active"

--- a/nexus/api/new_story_schemas.py
+++ b/nexus/api/new_story_schemas.py
@@ -318,6 +318,47 @@ class CharacterTrait(BaseModel):
     )
 
 
+class TraitConstraint(BaseModel):
+    """One selected trait's explicit cold-start materialization constraint."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    trait: TraitName = Field(..., description="Selected trait this constraint governs")
+    cold_start_relationships: Literal["allowed", "forbidden"] = Field(
+        default="allowed",
+        description=(
+            "Whether setup may create preexisting mechanical relationship or "
+            "pair-tag rows for this trait. Use 'forbidden' when the player says "
+            "the relationship may arise only during future play, such as no "
+            "preexisting personal nemesis. Backstory events without a mechanical "
+            "relationship remain allowed."
+        ),
+    )
+    preexisting_relationship_targets: List[str] = Field(
+        default_factory=list,
+        max_length=8,
+        description=(
+            "Concrete people or factions the player explicitly established as "
+            "preexisting targets for this trait. Never invent entries."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def reject_forbidden_named_targets(self) -> "TraitConstraint":
+        """A named setup target contradicts a future-opposition-only boundary."""
+
+        if (
+            self.cold_start_relationships == "forbidden"
+            and self.preexisting_relationship_targets
+        ):
+            raise ValueError(
+                f"Trait {self.trait!r} cannot forbid cold-start relationships "
+                "while naming preexisting relationship targets: "
+                f"{self.preexisting_relationship_targets}"
+            )
+        return self
+
+
 class CharacterSheet(BaseModel):
     """
     Character definition following Mind's Eye Theatre trait philosophy.
@@ -392,14 +433,31 @@ class CharacterSheet(BaseModel):
             "Traits without structured inputs remain prose-only remainders."
         ),
     )
+    trait_constraints: List[TraitConstraint] = Field(
+        default_factory=list,
+        max_length=3,
+        description=(
+            "Confirmed per-trait cold-start constraints carried into transition "
+            "materialization."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_unique_traits(self) -> "CharacterSheet":
-        """Ensure trait names are unique across the three slots."""
+        """Ensure traits and their cold-start constraints stay aligned."""
+
         names = [self.trait_1.name, self.trait_2.name, self.trait_3.name]
         if len(set(names)) != 3:
             raise ValueError(
                 "Trait names must be unique across trait_1/trait_2/trait_3."
+            )
+        constrained_traits = [constraint.trait for constraint in self.trait_constraints]
+        if len(constrained_traits) != len(set(constrained_traits)):
+            raise ValueError("Trait constraints must name unique traits")
+        unselected = sorted(set(constrained_traits) - set(names))
+        if unselected:
+            raise ValueError(
+                f"Trait constraints reference unselected traits: {unselected}"
             )
         return self
 
@@ -467,23 +525,6 @@ class TraitRationales(BaseModel):
     def to_dict(self) -> Dict[str, str]:
         """Convert to dict with only non-None values."""
         return {k: v for k, v in self.model_dump().items() if v is not None}
-
-
-class TraitConstraint(BaseModel):
-    """One selected trait's explicit cold-start materialization constraint."""
-
-    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
-
-    trait: TraitName = Field(..., description="Selected trait this constraint governs")
-    cold_start_relationships: Literal["allowed", "forbidden"] = Field(
-        default="allowed",
-        description=(
-            "Whether setup may create preexisting mechanical relationship rows "
-            "for this trait. Use 'forbidden' when the player says the relationship "
-            "may arise only during future play, such as no preexisting personal "
-            "nemesis. Backstory events without a relationship row remain allowed."
-        ),
-    )
 
 
 class TraitSuggestion(BaseModel):
@@ -813,6 +854,7 @@ class CharacterCreationState(BaseModel):
             trait_3=trait_entries[2],
             orrery_tags=self.wildcard.orrery_tags,
             trait_compile_inputs=self.trait_compile_inputs,
+            trait_constraints=self.trait_selection.trait_constraints,
         )
 
 

--- a/nexus/api/trait_compiler.py
+++ b/nexus/api/trait_compiler.py
@@ -46,6 +46,7 @@ from nexus.api.trait_compiler_schemas import (
     TraitRelationshipDrift,
     UnresolvedTrait,
     canonical_trait_name,
+    suppress_cold_start_relationship_inputs,
 )
 
 
@@ -159,6 +160,13 @@ def compile_character_traits(
     """
 
     inputs = _coerce_inputs(trait_compile_inputs or character.trait_compile_inputs)
+    forbidden_traits = {
+        canonical_trait_name(str(constraint.trait))
+        for constraint in character.trait_constraints
+        if constraint.cold_start_relationships == "forbidden"
+    }
+    inputs = suppress_cold_start_relationship_inputs(inputs, forbidden_traits)
+    suppressed_traits = set(inputs.suppressed_cold_start_relationship_traits)
     result = TraitCompileResult(
         character_id=character_id,
         character_entity_id=character_entity_id,
@@ -178,6 +186,21 @@ def compile_character_traits(
     for trait in trait_entries:
         trait_name = str(trait.name)
         canonical_trait = canonical_trait_name(trait_name)
+        if canonical_trait in suppressed_traits:
+            _add_remainder(
+                result,
+                trait=trait_name,
+                reason_code=(TraitCompileReasonCode.COLD_START_RELATIONSHIPS_FORBIDDEN),
+                message=(
+                    "Setup-time relationship and pair-tag materialization was "
+                    "suppressed by the confirmed trait constraint."
+                ),
+                details={
+                    "cold_start_relationships": "forbidden",
+                    "suppressed_trait_input": canonical_trait,
+                },
+            )
+            continue
         if canonical_trait == "resources":
             _compile_single_entity_level(
                 cur,

--- a/nexus/api/trait_compiler_schemas.py
+++ b/nexus/api/trait_compiler_schemas.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, Iterable, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -15,6 +15,18 @@ FameLevel = Literal["obscure", "known", "renowned", "legendary"]
 PairTagDirection = Literal["protagonist_to_target", "target_to_protagonist"]
 PatronFunction = Literal["mentors", "sponsors", "protects", "authority_over"]
 ObligationCounterpartyKind = Literal["character", "faction"]
+RELATIONSHIP_BEARING_TRAIT_FIELDS = frozenset(
+    {
+        "status",
+        "allies",
+        "contacts",
+        "enemies",
+        "domain",
+        "patron",
+        "dependents",
+        "obligations",
+    }
+)
 
 
 def canonical_trait_name(trait_name: str) -> str:
@@ -36,6 +48,7 @@ class TraitCompileReasonCode(str, Enum):
     REGISTRY_MISSING_TAG = "registry_missing_tag"
     REGISTRY_MISSING_PAIR_TAG = "registry_missing_pair_tag"
     RELATIONSHIP_PAIR_CONFLICT = "relationship_pair_conflict"
+    COLD_START_RELATIONSHIPS_FORBIDDEN = "cold_start_relationships_forbidden"
 
 
 class SingleEntityTraitInput(BaseModel):
@@ -301,6 +314,33 @@ class TraitCompileInputs(BaseModel):
     patron: Optional[PatronTraitInput] = None
     dependents: Optional[DependentsTraitInput] = None
     obligations: Optional[ObligationsTraitInput] = None
+    suppressed_cold_start_relationship_traits: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Selected traits whose setup-time relationship and pair-tag inputs "
+            "were suppressed by an explicit cold-start constraint."
+        ),
+    )
+
+
+def suppress_cold_start_relationship_inputs(
+    inputs: TraitCompileInputs,
+    forbidden_traits: Iterable[str],
+) -> TraitCompileInputs:
+    """Remove mintable relationship inputs and record the suppressed traits."""
+
+    suppressed = sorted(
+        {
+            canonical_trait_name(str(trait))
+            for trait in forbidden_traits
+            if canonical_trait_name(str(trait)) in RELATIONSHIP_BEARING_TRAIT_FIELDS
+        }
+    )
+    updates: Dict[str, Any] = {
+        trait: None for trait in suppressed if trait in TraitCompileInputs.model_fields
+    }
+    updates["suppressed_cold_start_relationship_traits"] = suppressed
+    return inputs.model_copy(update=updates)
 
 
 class AppliedTag(BaseModel):

--- a/nexus/api/trait_input_derivation.py
+++ b/nexus/api/trait_input_derivation.py
@@ -26,8 +26,10 @@ from pydantic import BaseModel, ConfigDict, create_model
 from nexus.agents.orrery.status_family import STATUS_LEVELS
 from nexus.api.trait_compiler import FAME_TAGS, RESOURCE_TAGS
 from nexus.api.trait_compiler_schemas import (
+    RELATIONSHIP_BEARING_TRAIT_FIELDS,
     TraitCompileInputs,
     canonical_trait_name,
+    suppress_cold_start_relationship_inputs,
 )
 
 if TYPE_CHECKING:
@@ -61,6 +63,33 @@ def selected_canonical_traits(character: "CharacterSheet") -> List[str]:
 
     return [
         canonical_trait_name(str(trait.name)) for trait in character.get_trait_entries()
+    ]
+
+
+def forbidden_cold_start_relationship_traits(
+    character: "CharacterSheet",
+) -> List[str]:
+    """Return selected traits whose setup-time relations are forbidden."""
+
+    return sorted(
+        {
+            canonical_trait_name(str(constraint.trait))
+            for constraint in character.trait_constraints
+            if constraint.cold_start_relationships == "forbidden"
+            and canonical_trait_name(str(constraint.trait))
+            in RELATIONSHIP_BEARING_TRAIT_FIELDS
+        }
+    )
+
+
+def traits_requiring_derived_inputs(character: "CharacterSheet") -> List[str]:
+    """Return selected fields the model may populate after constraints apply."""
+
+    forbidden = set(forbidden_cold_start_relationship_traits(character))
+    return [
+        trait
+        for trait in selected_canonical_traits(character)
+        if trait not in forbidden
     ]
 
 
@@ -211,8 +240,11 @@ def render_trait_input_prompt(
         raise FileNotFoundError(f"Trait input deriver prompt not found: {PROMPT_PATH}")
     instructions = PROMPT_PATH.read_text()
 
+    forbidden_traits = forbidden_cold_start_relationship_traits(character)
     payload = {
         "selected_traits": selected_canonical_traits(character),
+        "traits_to_compile": traits_requiring_derived_inputs(character),
+        "forbidden_cold_start_relationship_traits": forbidden_traits,
         "character": {
             "name": character.name,
             "summary": character.summary,
@@ -263,7 +295,8 @@ def derive_trait_compile_inputs(
 
     from nexus.api.native_structured_output import build_native_structured_provider
 
-    selected = selected_canonical_traits(character)
+    selected = traits_requiring_derived_inputs(character)
+    forbidden_traits = forbidden_cold_start_relationship_traits(character)
     prompt = render_trait_input_prompt(character=character, setting=setting)
     schema_model = selected_trait_compile_inputs_model(selected)
 
@@ -298,7 +331,7 @@ def derive_trait_compile_inputs(
             "Trait input derivation returned "
             f"{type(output).__name__}, expected TraitCompileInputs"
         )
-    return output
+    return suppress_cold_start_relationship_inputs(output, forbidden_traits)
 
 
 def ensure_trait_compile_inputs(
@@ -324,9 +357,13 @@ def ensure_trait_compile_inputs(
 
     character = transition_data.character
     if character.trait_compile_inputs is not None:
+        character.trait_compile_inputs = suppress_cold_start_relationship_inputs(
+            character.trait_compile_inputs,
+            forbidden_cold_start_relationship_traits(character),
+        )
         logger.info(
             "Slot %s character already has trait_compile_inputs; skipping "
-            "derivation",
+            "derivation after enforcing cold-start constraints",
             slot,
         )
         return None
@@ -360,4 +397,7 @@ def ensure_trait_compile_inputs(
         "derived": True,
         "model": model_name,
         "traits": derived_traits,
+        "suppressed_cold_start_relationship_traits": list(
+            derived.suppressed_cold_start_relationship_traits
+        ),
     }

--- a/nexus/api/wizard_chat.py
+++ b/nexus/api/wizard_chat.py
@@ -38,19 +38,18 @@ from nexus.api.new_story_cache import (
     read_cache,
     write_wizard_choices,
 )
-from nexus.api.new_story_flow import perform_transition_with_retrograde, record_drafts
+from nexus.api.new_story_flow import (
+    build_transition_data_from_cache,
+    perform_transition_with_retrograde,
+    record_drafts,
+)
 from nexus.api.new_story_generator import generate_set_design
 from nexus.api.new_story_schemas import (
-    SettingCard,
-    CharacterSheet,
-    StorySeed,
-    LayerDefinition,
-    ZoneDefinition,
-    PlaceProfile,
     CharacterCreationState,
+    SettingCard,
+    StorySeed,
     TraitSelection,
     TraitRationales,
-    TransitionData,
     WizardResponse,
 )
 from nexus.api.pydantic_ai_utils import build_message_history, build_pydantic_ai_model
@@ -990,21 +989,7 @@ async def transition_to_narrative_endpoint(request: TransitionRequest):
 
     # Build TransitionData from cache
     try:
-        # Get character dict and assemble CharacterSheet from CharacterCreationState
-        char_draft = cache.get_character_dict()
-        state = CharacterCreationState(**char_draft)
-        char_sheet = state.to_character_sheet().model_dump()
-
-        transition_data = TransitionData(
-            setting=SettingCard(**cache.get_setting_dict()),
-            character=CharacterSheet(**char_sheet),
-            seed=StorySeed(**cache.get_seed_dict()),
-            layer=LayerDefinition(**cache.get_layer_dict()),
-            zone=ZoneDefinition(**cache.get_zone_dict()),
-            location=PlaceProfile(**cache.get_initial_location()),
-            base_timestamp=cache.base_timestamp,
-            thread_id=cache.thread_id or "",
-        )
+        transition_data = build_transition_data_from_cache(cache)
     except ValidationError as e:
         # Fail loudly per user directive
         logger.error(f"Validation error building TransitionData: {e}")

--- a/prompts/storyteller_new.md
+++ b/prompts/storyteller_new.md
@@ -167,7 +167,7 @@ Respond to whatever the player offers:
 
 For each selected trait, ask one evocative follow-up that grounds it in specifics. The question should be vivid and particular to the trait's nature: who are these people, what is this place, what does this mean in practice? Keep exchanges brief unless the player is clearly eager to elaborate.
 
-When the user confirms their 3 trait selections, call `submit_trait_selection` to lock in the choices and proceed to wildcard definition. In that same tool call, encode any explicit future-only relationship boundary as a per-trait constraint: if the player says a relationship must not preexist (for example, "no preexisting personal nemesis"), set that trait's `cold_start_relationships` to `forbidden`; otherwise omit the constraint or use `allowed`. This does not prohibit backstory events or future opposition.
+When the user confirms their 3 trait selections, call `submit_trait_selection` to lock in the choices and proceed to wildcard definition. In that same tool call, encode any explicit future-only relationship boundary as a per-trait constraint: if the player says a relationship must not preexist (for example, "no preexisting personal nemesis"), set that trait's `cold_start_relationships` to `forbidden`; otherwise omit the constraint or use `allowed`. Put only player-established preexisting people or factions in `preexisting_relationship_targets`, never invented names. A trait cannot both forbid cold-start relationships and name a preexisting target; the tool will reject that contradiction loudly. This does not prohibit backstory events or future opposition.
 
 ### 2.3: Wildcard Definition → `submit_wildcard_trait`
 

--- a/prompts/storyteller_new.md
+++ b/prompts/storyteller_new.md
@@ -167,7 +167,7 @@ Respond to whatever the player offers:
 
 For each selected trait, ask one evocative follow-up that grounds it in specifics. The question should be vivid and particular to the trait's nature: who are these people, what is this place, what does this mean in practice? Keep exchanges brief unless the player is clearly eager to elaborate.
 
-When the user confirms their 3 trait selections, call `submit_trait_selection` to lock in the choices and proceed to wildcard definition.
+When the user confirms their 3 trait selections, call `submit_trait_selection` to lock in the choices and proceed to wildcard definition. In that same tool call, encode any explicit future-only relationship boundary as a per-trait constraint: if the player says a relationship must not preexist (for example, "no preexisting personal nemesis"), set that trait's `cold_start_relationships` to `forbidden`; otherwise omit the constraint or use `allowed`. This does not prohibit backstory events or future opposition.
 
 ### 2.3: Wildcard Definition → `submit_wildcard_trait`
 

--- a/prompts/trait_input_deriver.md
+++ b/prompts/trait_input_deriver.md
@@ -14,6 +14,10 @@ mechanical state (relationship rows, pair-tags, stub entities).
    targets have no database rows, so the compiler records them as prose
    remainders either way. Provide named targets for them only when the
    prose names concrete people (the names seed world-history coverage).
+   `traits_to_compile` is the authoritative subset after player constraints.
+   Never derive an input or invent a target for a trait listed in
+   `forbidden_cold_start_relationship_traits`; the transition records that
+   trait as a structured suppression remainder instead.
 2. Never set any database id field (`character_id`, `character_entity_id`,
    `place_id`, `place_entity_id`, `counterparty_id`, `counterparty_entity_id`,
    `scope_faction_entity_id`). This is a brand-new world: there are no existing

--- a/tests/fixtures/slot3_midnight_qa_wizard_cache.json
+++ b/tests/fixtures/slot3_midnight_qa_wizard_cache.json
@@ -1,0 +1,94 @@
+{
+  "source": {
+    "slot": 3,
+    "qa_date": "2026-07-28",
+    "story": "The Frozen Clock"
+  },
+  "setting": {
+    "genre": "thriller",
+    "secondary_genres": ["contemporary", "mystery"],
+    "world_name": "Dunlow County, Arkansas",
+    "time_period": "October 2026",
+    "tech_level": "modern",
+    "magic_exists": false,
+    "magic_description": null,
+    "political_structure": "A conventional U.S. county government with elected judges, a county clerk, sheriff's office, and emergency management.",
+    "major_conflict": "At 10:48 a.m., a cyberattack disrupts the courthouse as flash-floodwater breaches the lower level and an evacuation order gives everyone twelve minutes to leave.",
+    "tone": "dark",
+    "themes": ["institutional fragility", "duty under pressure", "evidence and truth", "triage", "public trust"],
+    "cultural_notes": "Dunlow is a river-county seat where courthouse favors are remembered longer than official rulings and plain language matters during emergencies.",
+    "language_notes": "Official speech favors clipped emergency phrasing: confirmed, unconfirmed, hold position, and egress route.",
+    "geographic_scope": "local",
+    "diegetic_artifact": "DUNLOW COUNTY EMERGENCY MANAGEMENT: At 10:48 a.m. the courthouse enters a compound cyberattack and flood emergency. Preserve life over property and records; relay verified information with source and time."
+  },
+  "character": {
+    "concept": {
+      "name": "Jules Mercer",
+      "archetype": "Injured freelance court reporter trapped in a failing courthouse evacuation",
+      "background": "Jules became a court reporter because precise records gave them a way to work within institutions that too often mistake access needs for incompetence. Profoundly deaf, they communicate through ASL and lip-reading and cannot hear alarms, radios, footsteps, voices behind them, or off-screen sounds. They are covering civil hearing DC-26-184 because the freelance fee matters for rent, but they will not risk a life merely to preserve a transcript.",
+      "appearance": "Jules is a 38-year-old brown-skinned person with close-cropped black hair and rain-darkened charcoal courthouse clothes. Their left forearm is immobilized in a bright orange rigid splint, while their usable right hand is ink-stained.",
+      "suggested_traits": ["status", "enemies", "obligations"],
+      "trait_rationales": {
+        "status": "Jules's status is strictly procedural: they are the contract reporter assigned to civil hearing DC-26-184, with no special authority or access.",
+        "enemies": "Jules begins with no preexisting personal nemesis. This trait foregrounds opposition that may arise only if an adverse party or attacker reacts to what Jules actually witnesses or carries during play.",
+        "obligations": "Jules needs the DC-26-184 fee to make rent and is professionally bound to an accurate record, but neither obligation outweighs immediate human safety."
+      }
+    },
+    "trait_selection": {
+      "selected_traits": ["status", "enemies", "obligations"],
+      "trait_rationales": {
+        "status": "Jules's status is strictly procedural: they are the contract reporter assigned to civil hearing DC-26-184, with no special authority or access.",
+        "enemies": "Jules begins with no preexisting personal nemesis. This trait foregrounds opposition that may arise only if an adverse party or attacker reacts to what Jules actually witnesses or carries during play.",
+        "obligations": "Jules needs the DC-26-184 fee to make rent and is professionally bound to an accurate record, but neither obligation outweighs immediate human safety."
+      },
+      "suggested_by_llm": ["status", "enemies", "obligations"],
+      "trait_constraints": [
+        {"trait": "enemies", "cold_start_relationships": "forbidden"}
+      ]
+    },
+    "wildcard": {
+      "wildcard_name": "Verification Habit",
+      "wildcard_description": "Using their usable right hand, Jules writes an exact timestamp, floor or room, visible source, and CONFIRMED or UNCONFIRMED on the paper evacuation map before relying on any claim."
+    }
+  },
+  "seed": {
+    "story_seed": {
+      "seed_type": "crisis",
+      "title": "The Frozen Clock",
+      "situation": "At 10:48 a.m. in Civil Hearing Room 2B, the wall clock freezes and a silent evacuation alert appears. Exactly six people are present, and the stenotype transcript remains in Jules's case, but no document is worth a life.",
+      "hook": "A twelve-minute evacuation begins with conflicting, incomplete visible information: the courthouse is under cyberattack, water has affected the basement, and no one knows which routes or messages can be trusted.",
+      "immediate_goal": "Understand the visible evacuation instruction, account for the five other people in Room 2B, and reach a safe exit without treating unverified claims as fact.",
+      "stakes": "Six people may be delayed, separated, injured, or directed into danger; preserving later evidence cannot take priority over survival.",
+      "tension_source": "Jules cannot hear alarms or off-screen sounds, their splinted wrist limits signing and grip, technology is failing, and access routes may be compromised.",
+      "weather": "Heavy rain outside; basement flooding is confirmed, while water above the basement requires evidence.",
+      "key_npcs": ["Judge Mara Venn", "Bailiff Theo Pike", "Lena Ortiz", "Grant Shaw", "Nia Bell"],
+      "secrets": "No villain is preselected. Any later opposition to Jules must arise from what they actually witness, record, or carry during the evacuation, not from a preexisting personal enemy.",
+      "base_timestamp": {"year": 2026, "month": 5, "day": 14, "hour": 6, "minute": 48}
+    },
+    "layer": {
+      "name": "Earth",
+      "type": "planet",
+      "description": "A modern Earth where rain-lashed local institutions and fragile public systems can turn routine civic life into a crisis."
+    },
+    "zone": {
+      "name": "Dunlow County, Arkansas",
+      "summary": "A fictional Arkansas county centered on its aging county seat and vulnerable to abrupt autumn flash flooding."
+    },
+    "initial_location": {
+      "name": "Civil Hearing Room 2B, Dunlow County Courthouse",
+      "place_type": "fixed_location",
+      "summary": "A wood-paneled civil courtroom on the courthouse second floor with a wall clock stalled at 10:48 a.m. and a monitor showing a silent evacuation alert.",
+      "history": "Hearing Room 2B handles civil disputes, probate matters, and administrative hearings.",
+      "current_status": "Six people are caught in an evacuation as heavy rain floods the basement and the alert provides no audible guidance.",
+      "secrets": "The alert's exact wording, sender, and timestamp could establish what hazard officials believed existed.",
+      "inhabitants": ["Jules Mercer", "Judge Mara Venn", "Bailiff Theo Pike", "Lena Ortiz", "Grant Shaw", "Nia Bell"],
+      "latitude": 34.7445,
+      "longitude": -92.2896,
+      "extra_data": {
+        "atmosphere": "Claustrophobic civic formality ruptured by silent technological failure.",
+        "culture": "Formal county-courthouse procedure and institutional hierarchy.",
+        "rumors": ["The evacuation warning may concern more than floodwater."]
+      }
+    }
+  }
+}

--- a/tests/test_issue_601_wizard_live.py
+++ b/tests/test_issue_601_wizard_live.py
@@ -120,10 +120,10 @@ async def test_live_trait_confirmation_persists_and_threads_constraint() -> None
     assert context.last_tool_result is not None
     submitted = context.last_tool_result["data"]["character_state"]["trait_selection"]
     submitted_constraints = {
-        row["trait"]: row["cold_start_relationships"]
-        for row in submitted["trait_constraints"]
+        row["trait"]: row for row in submitted["trait_constraints"]
     }
-    assert submitted_constraints["enemies"] == "forbidden"
+    assert submitted_constraints["enemies"]["cold_start_relationships"] == "forbidden"
+    assert submitted_constraints["enemies"]["preexisting_relationship_targets"] == []
 
     hydrated = read_cache(DBNAME)
     assert hydrated is not None
@@ -136,17 +136,27 @@ async def test_live_trait_confirmation_persists_and_threads_constraint() -> None
         weird_level="low",
     )
     packet_constraints = {
-        row["trait"]: row["cold_start_relationships"]
+        row["trait"]: row
         for row in packet["candidate_scaffolds"]["trait_hooks"]["constraints"]
     }
-    assert packet_constraints["enemies"] == "forbidden"
+    assert packet_constraints["enemies"]["cold_start_relationships"] == "forbidden"
+    assert packet_constraints["enemies"]["blocked_relationship_types"] == [
+        "captor",
+        "enemy",
+        "rival",
+    ]
+    assert packet_constraints["enemies"]["blocked_pair_tags"] == ["hunting"]
     request_constraints = {
-        row["trait"]: row["cold_start_relationships"]
+        row["trait"]: row
         for row in packet["seed_generation_request"]["trait_constraints"]
     }
-    assert request_constraints["enemies"] == "forbidden"
+    assert request_constraints["enemies"] == packet_constraints["enemies"]
     selection_prompt = render_seed_selection_prompt(
         seed_generation_request=packet["seed_generation_request"],
         candidates_payload={"candidates": []},
     )
     assert '"cold_start_relationships": "forbidden"' in selection_prompt
+    assert '"blocked_relationship_types": [' in selection_prompt
+    assert '"rival"' in selection_prompt
+    assert '"blocked_pair_tags": [' in selection_prompt
+    assert '"hunting"' in selection_prompt

--- a/tests/test_issue_601_wizard_live.py
+++ b/tests/test_issue_601_wizard_live.py
@@ -1,0 +1,152 @@
+"""Live structured-call and hydrated-packet proof for issue #601."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic_ai.tools import DeferredToolRequests
+
+from nexus.agents.orrery.retrograde_packet import build_retrograde_dry_run_packet
+from nexus.agents.orrery.retrograde_seed_candidates import (
+    render_seed_selection_prompt,
+)
+from nexus.agents.orrery.retrograde_vocabulary import (
+    enumerate_seed_eligible_vocabulary,
+)
+from nexus.api.new_story_cache import read_cache, write_cache, write_suggested_traits
+from nexus.api.pydantic_ai_utils import build_pydantic_ai_model
+from nexus.api.slot_utils import slot_dbname
+from nexus.api.wizard_agent import WizardContext, get_wizard_agent
+from nexus.config import load_settings, resolve_model_ref
+
+SLOT = int(os.environ.get("NEXUS_ISSUE_601_TEST_SLOT", "0"))
+DBNAME = slot_dbname(SLOT) if SLOT in {1, 2, 3, 4} else ""
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.live_llm,
+    pytest.mark.requires_postgres,
+    pytest.mark.skipif(
+        os.environ.get("NEXUS_ISSUE_601_LIVE") != "1"
+        or not DBNAME
+        or os.environ.get("NEXUS_CONFIRM_DISPOSABLE_DB") != DBNAME,
+        reason=(
+            "Set NEXUS_ISSUE_601_LIVE=1, choose disposable slot 1-4 with "
+            "NEXUS_ISSUE_601_TEST_SLOT, and confirm its database name with "
+            "NEXUS_CONFIRM_DISPOSABLE_DB."
+        ),
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_live_trait_confirmation_persists_and_threads_constraint() -> None:
+    """The registry-selected wizard model types the live QA rationale in one call."""
+
+    from nexus.api.save_slots import upsert_slot
+    from scripts.new_story_setup import create_slot_schema_only
+
+    fixture = json.loads(
+        (
+            Path(__file__).parent / "fixtures" / "slot3_midnight_qa_wizard_cache.json"
+        ).read_text()
+    )
+    model_ref = os.environ.get("NEXUS_ISSUE_601_MODEL", "@openai.default")
+    model_name = resolve_model_ref(model_ref)
+
+    create_slot_schema_only(SLOT, source_db="NEXUS_template", force=True)
+    upsert_slot(SLOT, model=model_name, dbname=DBNAME)
+    character = fixture["character"]
+    seed = fixture["seed"]
+    write_cache(
+        thread_id="issue_601_live_trait_confirmation",
+        setting_draft=fixture["setting"],
+        character_draft={
+            "concept": character["concept"],
+            "wildcard": character["wildcard"],
+        },
+        selected_seed=seed["story_seed"],
+        layer_draft=seed["layer"],
+        zone_draft=seed["zone"],
+        initial_location=seed["initial_location"],
+        base_timestamp="2026-05-14T10:48:00+00:00",
+        target_slot=SLOT,
+        dbname=DBNAME,
+    )
+    write_suggested_traits(
+        DBNAME,
+        [
+            {
+                "trait": trait,
+                "rationale": character["concept"]["trait_rationales"][trait],
+            }
+            for trait in character["concept"]["suggested_traits"]
+        ],
+    )
+
+    context = WizardContext(
+        slot=SLOT,
+        cache=read_cache(DBNAME),
+        phase="character",
+        thread_id="issue_601_live_trait_confirmation",
+        model=model_name,
+        context_data={
+            "setting": fixture["setting"],
+            "character_state": {"concept": character["concept"]},
+        },
+        accept_fate=False,
+        dev_mode=False,
+        history_len=1,
+        user_turns=1,
+        assistant_turns=1,
+    )
+    agent: Any = get_wizard_agent(context)
+    result = await agent.run(
+        (
+            "Confirm Status, Enemies, and Obligations exactly. Enemies must not "
+            "invent a preexisting personal nemesis: opposition may arise only "
+            "because of what Jules witnesses or carries during play."
+        ),
+        deps=context,
+        model=build_pydantic_ai_model(model_name),
+    )
+
+    assert isinstance(result.output, DeferredToolRequests)
+    assert context.last_tool_name == "submit_trait_selection"
+    assert context.last_tool_result is not None
+    submitted = context.last_tool_result["data"]["character_state"]["trait_selection"]
+    submitted_constraints = {
+        row["trait"]: row["cold_start_relationships"]
+        for row in submitted["trait_constraints"]
+    }
+    assert submitted_constraints["enemies"] == "forbidden"
+
+    hydrated = read_cache(DBNAME)
+    assert hydrated is not None
+    packet = build_retrograde_dry_run_packet(
+        slot=SLOT,
+        dbname=DBNAME,
+        cache=hydrated,
+        vocabulary=enumerate_seed_eligible_vocabulary(dbname=DBNAME),
+        settings=load_settings(),
+        weird_level="low",
+    )
+    packet_constraints = {
+        row["trait"]: row["cold_start_relationships"]
+        for row in packet["candidate_scaffolds"]["trait_hooks"]["constraints"]
+    }
+    assert packet_constraints["enemies"] == "forbidden"
+    request_constraints = {
+        row["trait"]: row["cold_start_relationships"]
+        for row in packet["seed_generation_request"]["trait_constraints"]
+    }
+    assert request_constraints["enemies"] == "forbidden"
+    selection_prompt = render_seed_selection_prompt(
+        seed_generation_request=packet["seed_generation_request"],
+        candidates_payload={"candidates": []},
+    )
+    assert '"cold_start_relationships": "forbidden"' in selection_prompt

--- a/tests/test_new_story_cache.py
+++ b/tests/test_new_story_cache.py
@@ -150,7 +150,13 @@ def test_write_cache_marks_three_selected_traits_confirmed(monkeypatch) -> None:
         "traits_confirmed = TRUE" in sql for sql, _params in fake_conn.cursor_obj.calls
     )
     assert any(
-        params == ("Powerful people want her silenced.", "forbidden", "enemies")
+        params
+        == (
+            "Powerful people want her silenced.",
+            "forbidden",
+            "[]",
+            "enemies",
+        )
         for _sql, params in fake_conn.cursor_obj.calls
     )
 
@@ -175,7 +181,7 @@ def test_write_cache_canonicalizes_legacy_reputation_trait(monkeypatch) -> None:
     )
 
     assert any(
-        params == ("Her name has started to travel.", "allowed", "fame")
+        params == ("Her name has started to travel.", "allowed", "[]", "fame")
         for _sql, params in fake_conn.cursor_obj.calls
     )
 
@@ -202,7 +208,7 @@ def test_write_cache_preserves_rationale_across_fame_alias(
     )
 
     assert any(
-        params == ("Her name has started to travel.", "allowed", "fame")
+        params == ("Her name has started to travel.", "allowed", "[]", "fame")
         for _sql, params in fake_conn.cursor_obj.calls
     )
 

--- a/tests/test_new_story_cache.py
+++ b/tests/test_new_story_cache.py
@@ -1,5 +1,7 @@
 """Tests for the normalized new-story setup cache."""
 
+from typing import Any
+
 from nexus.api.new_story_cache import (
     CharacterData,
     SuggestedTrait,
@@ -11,7 +13,7 @@ import nexus.api.new_story_cache as cache_module
 
 class FakeCursor:
     def __init__(self) -> None:
-        self.calls = []
+        self.calls: list[tuple[str, Any]] = []
         self.rowcount = 1
 
     def __enter__(self):
@@ -20,7 +22,7 @@ class FakeCursor:
     def __exit__(self, *_exc):
         return False
 
-    def execute(self, sql, params=None):
+    def execute(self, sql: str, params: Any = None) -> None:
         self.calls.append((sql, params))
         self.rowcount = 1
 
@@ -114,7 +116,9 @@ def test_row_to_cache_reads_character_orrery_tags() -> None:
 
     assert cache.character.orrery_tags == bestowal
     assert cache.character.trait_compile_result == compile_result
-    assert cache.get_character_dict()["wildcard"]["orrery_tags"] == bestowal
+    character_dict = cache.get_character_dict()
+    assert character_dict is not None
+    assert character_dict["wildcard"]["orrery_tags"] == bestowal
 
 
 def test_write_cache_marks_three_selected_traits_confirmed(monkeypatch) -> None:
@@ -132,12 +136,22 @@ def test_write_cache_marks_three_selected_traits_confirmed(monkeypatch) -> None:
                     "enemies": "Powerful people want her silenced.",
                     "obligations": "A dying archivist gave her one last charge.",
                 },
+                "trait_constraints": [
+                    {
+                        "trait": "enemies",
+                        "cold_start_relationships": "forbidden",
+                    }
+                ],
             }
         },
     )
 
     assert any(
         "traits_confirmed = TRUE" in sql for sql, _params in fake_conn.cursor_obj.calls
+    )
+    assert any(
+        params == ("Powerful people want her silenced.", "forbidden", "enemies")
+        for _sql, params in fake_conn.cursor_obj.calls
     )
 
 
@@ -161,7 +175,7 @@ def test_write_cache_canonicalizes_legacy_reputation_trait(monkeypatch) -> None:
     )
 
     assert any(
-        params == ("Her name has started to travel.", "fame")
+        params == ("Her name has started to travel.", "allowed", "fame")
         for _sql, params in fake_conn.cursor_obj.calls
     )
 
@@ -188,7 +202,7 @@ def test_write_cache_preserves_rationale_across_fame_alias(
     )
 
     assert any(
-        params == ("Her name has started to travel.", "fame")
+        params == ("Her name has started to travel.", "allowed", "fame")
         for _sql, params in fake_conn.cursor_obj.calls
     )
 

--- a/tests/test_new_story_schemas.py
+++ b/tests/test_new_story_schemas.py
@@ -225,7 +225,11 @@ class TestNewStorySchemas:
 
         dumped = selection.model_dump(mode="json")
         assert dumped["trait_constraints"] == [
-            {"trait": "enemies", "cold_start_relationships": "forbidden"}
+            {
+                "trait": "enemies",
+                "cold_start_relationships": "forbidden",
+                "preexisting_relationship_targets": [],
+            }
         ]
 
     def test_trait_selection_defaults_unstated_relationships_to_allowed(self):
@@ -257,6 +261,26 @@ class TestNewStorySchemas:
                     TraitConstraint(
                         trait="enemies", cold_start_relationships="forbidden"
                     )
+                ],
+            )
+
+    def test_trait_selection_rejects_forbidden_named_target_contradiction(self):
+        """A future-only boundary cannot affirm a setup relationship target."""
+
+        with pytest.raises(ValidationError, match="cannot forbid.*Doctor Voss"):
+            TraitSelection(
+                selected_traits=["status", "patron", "obligations"],
+                trait_rationales=TraitRationales(
+                    status="Jules has a narrow procedural role.",
+                    patron="Doctor Voss is an explicitly established patron.",
+                    obligations="The transcript fee matters, but lives matter more.",
+                ),
+                trait_constraints=[
+                    {
+                        "trait": "patron",
+                        "cold_start_relationships": "forbidden",
+                        "preexisting_relationship_targets": ["Doctor Voss"],
+                    }
                 ],
             )
 

--- a/tests/test_new_story_schemas.py
+++ b/tests/test_new_story_schemas.py
@@ -29,6 +29,9 @@ from nexus.api.new_story_schemas import (
     TransitionData,
     Genre,
     TechLevel,
+    TraitConstraint,
+    TraitRationales,
+    TraitSelection,
     StorySeedType,
     PlaceExtraData,
     WildcardTrait,
@@ -204,6 +207,58 @@ class TestNewStorySchemas:
             character.trait_2.name,
             character.trait_3.name,
         }
+
+    def test_trait_selection_types_future_only_relationship_constraint(self):
+        """Trait confirmation preserves an explicit no-preexisting-row boundary."""
+
+        selection = TraitSelection(
+            selected_traits=["status", "enemies", "obligations"],
+            trait_rationales=TraitRationales(
+                status="Jules has a narrow procedural role.",
+                enemies="No preexisting personal nemesis; opposition arises in play.",
+                obligations="The transcript fee matters, but lives matter more.",
+            ),
+            trait_constraints=[
+                TraitConstraint(trait="enemies", cold_start_relationships="forbidden")
+            ],
+        )
+
+        dumped = selection.model_dump(mode="json")
+        assert dumped["trait_constraints"] == [
+            {"trait": "enemies", "cold_start_relationships": "forbidden"}
+        ]
+
+    def test_trait_selection_defaults_unstated_relationships_to_allowed(self):
+        """Existing selections keep current behavior when no boundary is stated."""
+
+        selection = TraitSelection(
+            selected_traits=["status", "enemies", "obligations"],
+            trait_rationales=TraitRationales(
+                status="A narrow procedural role.",
+                enemies="The player delegates adversary invention.",
+                obligations="A professional duty.",
+            ),
+        )
+
+        assert selection.trait_constraints == []
+
+    def test_trait_selection_rejects_constraint_for_unselected_trait(self):
+        """A model cannot attach a boundary to a trait it did not confirm."""
+
+        with pytest.raises(ValidationError, match="unselected traits"):
+            TraitSelection(
+                selected_traits=["status", "resources", "obligations"],
+                trait_rationales=TraitRationales(
+                    status="A narrow procedural role.",
+                    resources="The player delegates asset invention.",
+                    obligations="A professional duty.",
+                ),
+                trait_constraints=[
+                    TraitConstraint(
+                        trait="enemies", cold_start_relationships="forbidden"
+                    )
+                ],
+            )
 
     def test_character_state_strips_legacy_orrery_tag_proposals(self):
         """Persisted wizard state may predate the locked Orrery vocabulary."""

--- a/tests/test_orrery/test_retrograde_constraints_pg.py
+++ b/tests/test_orrery/test_retrograde_constraints_pg.py
@@ -1,12 +1,13 @@
-"""Real-PostgreSQL regression for issue #601 materialization enforcement."""
+"""Real cache-to-transition PostgreSQL regressions for issue #601."""
 
 from __future__ import annotations
 
 import copy
+import json
 import os
 from pathlib import Path
+from typing import Any, Iterator, Mapping, Optional
 import uuid
-from typing import Any, Iterator
 
 import psycopg2
 from psycopg2 import sql
@@ -16,8 +17,9 @@ import pytest
 from nexus.agents.orrery.retrograde_expansion import (
     RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION,
     RetrogradeExpansionValidationError,
+    validate_expansion_plan,
 )
-from nexus.agents.orrery.retrograde_packet import build_seed_generation_request
+from nexus.agents.orrery.retrograde_packet import build_retrograde_dry_run_packet
 from nexus.agents.orrery.retrograde_persistence import (
     build_retrograde_persistence_plan,
 )
@@ -28,26 +30,40 @@ from nexus.agents.orrery.retrograde_vocabulary import (
     SeedEligibleVocabulary,
     enumerate_seed_eligible_vocabulary,
 )
+from nexus.api.new_story_cache import read_cache, write_cache
+from nexus.api.new_story_db_mapper import NewStoryDatabaseMapper
+from nexus.api.new_story_flow import build_transition_data_from_cache
+from nexus.api.db_pool import close_all_pools
+from nexus.api.slot_utils import VALID_DBNAMES
+from nexus.api.trait_compiler_schemas import TraitCompileInputs
+from nexus.api.trait_input_derivation import ensure_trait_compile_inputs
+from nexus.config import load_settings
 
 pytestmark = pytest.mark.requires_postgres
 
+FIXTURE_PATH = (
+    Path(__file__).parents[1] / "fixtures" / "slot3_midnight_qa_wizard_cache.json"
+)
 
-def _connect(dbname: str) -> Any:
-    return psycopg2.connect(
-        dbname=dbname,
-        user=os.environ.get("PGUSER", "pythagor"),
-        host=os.environ.get("PGHOST", "localhost"),
-        port=os.environ.get("PGPORT", "5432"),
-    )
+
+def _connect(dbname: str, *, dict_cursor: bool = False) -> Any:
+    kwargs: dict[str, Any] = {
+        "dbname": dbname,
+        "user": os.environ.get("PGUSER", "pythagor"),
+        "host": os.environ.get("PGHOST", "localhost"),
+        "port": os.environ.get("PGPORT", "5432"),
+    }
+    if dict_cursor:
+        kwargs["cursor_factory"] = RealDictCursor
+    return psycopg2.connect(**kwargs)
 
 
 @pytest.fixture()
-def disposable_cursor() -> Iterator[Any]:
+def disposable_dbname() -> Iterator[str]:
     """Yield a current-template clone and remove it after the regression."""
 
     dbname = f"nexus_test_issue_601_{uuid.uuid4().hex[:12]}"
-    admin = None
-    conn = None
+    admin: Any = None
     try:
         try:
             admin = _connect("postgres")
@@ -61,23 +77,19 @@ def disposable_cursor() -> Iterator[Any]:
                     sql.Identifier("NEXUS_template"),
                 )
             )
-        conn = _connect(dbname)
-        with conn.cursor(cursor_factory=RealDictCursor) as cur:
-            migration = (
-                Path(__file__).parents[2]
-                / "migrations"
-                / "097_trait_cold_start_relationship_constraints.sql"
-            )
-            cur.execute(migration.read_text())
-            cur.execute(
-                "UPDATE global_variables SET base_timestamp = %s WHERE id = TRUE",
-                ("2026-05-14T10:48:00+00:00",),
-            )
-            yield cur
+        with _connect(dbname) as conn:
+            with conn.cursor() as cur:
+                migration = (
+                    Path(__file__).parents[2]
+                    / "migrations"
+                    / "097_trait_cold_start_relationship_constraints.sql"
+                )
+                cur.execute(migration.read_text())
+        VALID_DBNAMES.add(dbname)
+        yield dbname
     finally:
-        if conn is not None:
-            conn.rollback()
-            conn.close()
+        close_all_pools()
+        VALID_DBNAMES.discard(dbname)
         if admin is not None:
             with admin.cursor() as cur:
                 cur.execute(
@@ -91,120 +103,104 @@ def disposable_cursor() -> Iterator[Any]:
             admin.close()
 
 
-def test_persistence_keeps_dispute_event_without_enemy_row(
-    disposable_cursor: Any,
-) -> None:
-    """The real persistence path retains Voss's event and mints no PC enemy row."""
+def _fixture_payload() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text())
 
-    cur = disposable_cursor
-    vocabulary = enumerate_seed_eligible_vocabulary()
-    event_type = (
-        "backstory_secret_authored"
-        if "backstory_secret_authored" in vocabulary["event_types"]
+
+def _hydrate_fixture(
+    dbname: str,
+    *,
+    fixture: Optional[Mapping[str, Any]] = None,
+) -> Any:
+    """Write the checked-in artifact through normalized cache persistence."""
+
+    payload = copy.deepcopy(dict(fixture or _fixture_payload()))
+    character = payload["character"]
+    seed = payload["seed"]
+    write_cache(
+        thread_id="issue_601_postgres_regression",
+        setting_draft=payload["setting"],
+        character_draft=character,
+        selected_seed=seed["story_seed"],
+        layer_draft=seed["layer"],
+        zone_draft=seed["zone"],
+        initial_location=seed["initial_location"],
+        base_timestamp="2026-05-14T10:48:00+00:00",
+        target_slot=3,
+        dbname=dbname,
+    )
+    cache = read_cache(dbname)
+    assert cache is not None
+    assert cache.current_phase() == "ready"
+    return cache
+
+
+def _build_transition_and_packet(
+    dbname: str,
+    cache: Any,
+    *,
+    trait_inputs: TraitCompileInputs,
+) -> tuple[Any, dict[str, Any], SeedEligibleVocabulary]:
+    """Use production hydration, typed-input gating, and packet construction."""
+
+    transition = build_transition_data_from_cache(cache)
+    transition.character.trait_compile_inputs = trait_inputs
+    ensure_trait_compile_inputs(
+        transition,
+        slot=3,
+        model_name="@provider.unused_existing_input",
+        max_tokens=1,
+        retries=1,
+    )
+    vocabulary = enumerate_seed_eligible_vocabulary(dbname=dbname)
+    constrained_inputs = transition.character.trait_compile_inputs
+    assert constrained_inputs is not None
+    packet = build_retrograde_dry_run_packet(
+        slot=3,
+        dbname=dbname,
+        cache=cache,
+        vocabulary=vocabulary,
+        settings=load_settings(),
+        weird_level="low",
+        trait_compile_inputs=constrained_inputs.model_dump(
+            mode="json",
+            exclude_none=True,
+        ),
+    )
+    return transition, packet, vocabulary
+
+
+def _event_type(vocabulary: SeedEligibleVocabulary) -> str:
+    preferred = "backstory_secret_authored"
+    return (
+        preferred
+        if preferred in vocabulary["event_types"]
         else vocabulary["event_types"][0]
     )
-    packet = _packet(vocabulary)
-    seed_response = _seed_response(vocabulary, event_type=event_type)
-    violating = _expansion(vocabulary, event_type=event_type, include_enemy=True)
-
-    with pytest.raises(
-        RetrogradeExpansionValidationError,
-        match="cold_start_relationships_forbidden.*enemy.*Jules Mercer.*enemies",
-    ):
-        build_retrograde_persistence_plan(
-            cur,
-            packet=packet,
-            seed_candidate_response=seed_response,
-            expansion_plan_payload=violating,
-            slot=3,
-            dbname="disposable_issue_601",
-            dry_run=False,
-            create_missing_entities=True,
-            summaries_enabled=False,
-        )
-
-    repaired = copy.deepcopy(violating)
-    repaired["relationship_plan"] = []
-    manifest = build_retrograde_persistence_plan(
-        cur,
-        packet=packet,
-        seed_candidate_response=seed_response,
-        expansion_plan_payload=repaired,
-        slot=3,
-        dbname="disposable_issue_601",
-        dry_run=False,
-        create_missing_entities=True,
-        summaries_enabled=False,
-    )
-
-    cur.execute(
-        """
-        SELECT count(*) AS count
-        FROM character_relationships cr
-        JOIN characters subject ON subject.id = cr.character1_id
-        JOIN characters object_character ON object_character.id = cr.character2_id
-        WHERE cr.relationship_type = 'enemy'
-          AND (subject.name = 'Jules Mercer' OR object_character.name = 'Jules Mercer')
-        """
-    )
-    assert cur.fetchone()["count"] == 0
-    cur.execute(
-        """
-        SELECT payload ->> 'retrograde_event_ref' AS event_ref
-        FROM world_events
-        WHERE source = 'retrograde'
-          AND payload ->> 'retrograde_event_ref' = 'e_voss_practice_dispute'
-        """
-    )
-    assert cur.fetchone()["event_ref"] == "e_voss_practice_dispute"
-    assert manifest["counters"]["events_inserted"] == 1
-    assert manifest["counters"]["relationships_inserted"] == 0
-
-
-def _packet(vocabulary: SeedEligibleVocabulary) -> dict[str, Any]:
-    scaffolds = {
-        "core_entities": [
-            {
-                "kind": "character",
-                "role": "protagonist",
-                "name": "Jules Mercer",
-                "summary": "A court reporter who begins with no personal nemesis.",
-            },
-            {
-                "kind": "character",
-                "role": "seed_npc",
-                "name": "Della Voss",
-                "summary": "A deceased accessibility auditor with sealed records.",
-            },
-        ],
-        "named_seed_npcs": [],
-        "pressure_axes": [],
-        "trait_hooks": {
-            "selected_traits": ["status", "enemies", "obligations"],
-            "rationales": {
-                "enemies": "No preexisting personal nemesis; opposition arises in play."
-            },
-            "constraints": [
-                {"trait": "enemies", "cold_start_relationships": "forbidden"}
-            ],
-        },
-    }
-    request = build_seed_generation_request(
-        candidate_scaffolds=scaffolds,
-        vocabulary=vocabulary,
-        weird={"level": "low", "genre": "thriller", "raw_midpoint": 0.2},
-    )
-    request["candidate_graph"] = {}
-    return {
-        "candidate_scaffolds": scaffolds,
-        "seed_generation_request": request,
-        "seed_eligible_vocabulary": vocabulary,
-    }
 
 
 def _seed_response(
-    vocabulary: SeedEligibleVocabulary, *, event_type: str
+    packet: Mapping[str, Any],
+    vocabulary: SeedEligibleVocabulary,
 ) -> dict[str, Any]:
+    request = packet["seed_generation_request"]
+    dangling_edges = request["candidate_graph"]["dangling_edges"]
+    claimed_edges: list[dict[str, Any]] = []
+    if dangling_edges:
+        edge = dangling_edges[0]
+        endpoint_name = {
+            "character": "Della Voss",
+            "faction": "Dunlow Court Registry",
+            "place": "Courthouse Archive Annex",
+        }[edge["open_endpoint_kind"]]
+        claimed_edges.append(
+            {
+                "edge_id": edge["edge_id"],
+                "open_endpoint_name": endpoint_name,
+                "open_endpoint_kind": edge["open_endpoint_kind"],
+            }
+        )
+    event_type = _event_type(vocabulary)
     return {
         "schema_version": SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION,
         "candidates": [
@@ -219,8 +215,11 @@ def _seed_response(
                         {
                             "event_ref": "e_voss_practice_dispute",
                             "event_type": event_type,
-                            "summary": "Voss challenged a practice Jules later inherited.",
-                            "participating_entities": ["Jules Mercer", "Della Voss"],
+                            "summary": "Voss challenged a practice Jules inherited.",
+                            "participating_entities": [
+                                "Jules Mercer",
+                                "Della Voss",
+                            ],
                         }
                     ],
                     "single_entity_tags": [],
@@ -228,7 +227,7 @@ def _seed_response(
                     "relationships": [],
                 },
                 "defer_or_reject_if": [],
-                "claimed_edges": [],
+                "claimed_edges": claimed_edges,
             }
         ],
         "selected_seed_ids": ["seed_paper_enemy"],
@@ -239,20 +238,35 @@ def _seed_response(
 def _expansion(
     vocabulary: SeedEligibleVocabulary,
     *,
-    event_type: str,
-    include_enemy: bool,
+    relationship_type: Optional[str] = None,
+    pair_tag: Optional[str] = None,
+    protagonist_ref: str = "Jules Mercer",
 ) -> dict[str, Any]:
-    relationships = []
-    if include_enemy:
-        relationships.append(
+    event_type = _event_type(vocabulary)
+    relationship_plan: list[dict[str, Any]] = []
+    if relationship_type is not None:
+        relationship_plan.append(
             {
-                "subject_ref": "Jules Mercer",
+                "subject_ref": protagonist_ref,
                 "subject_kind": "character",
-                "relationship_type": "enemy",
+                "relationship_type": relationship_type,
                 "object_ref": "Della Voss",
                 "object_kind": "character",
                 "source_event_ref": "e_voss_practice_dispute",
                 "rationale": "The sealed dispute leaves a paper trail.",
+            }
+        )
+    pair_tag_plan: list[dict[str, Any]] = []
+    if pair_tag is not None:
+        pair_tag_plan.append(
+            {
+                "subject_ref": "Della Voss",
+                "subject_kind": "character",
+                "tag": pair_tag,
+                "object_ref": protagonist_ref,
+                "object_kind": "character",
+                "source_event_ref": "e_voss_practice_dispute",
+                "rationale": "The mechanical edge would predate play.",
             }
         )
     return {
@@ -276,7 +290,7 @@ def _expansion(
                         "role": "actor",
                     },
                     {
-                        "entity_ref": "Jules Mercer",
+                        "entity_ref": protagonist_ref,
                         "entity_kind": "character",
                         "role": "target",
                     },
@@ -292,8 +306,8 @@ def _expansion(
             }
         ],
         "entity_tag_plan": [],
-        "pair_tag_plan": [],
-        "relationship_plan": relationships,
+        "pair_tag_plan": pair_tag_plan,
+        "relationship_plan": relationship_plan,
         "death_plan": [],
         "project_plan": [],
         "thread_plan": [
@@ -315,3 +329,315 @@ def _expansion(
             "explanation": "Runtime fills the canonical anchor.",
         },
     }
+
+
+def test_real_cache_packet_and_transition_keep_event_without_adversarial_rows(
+    disposable_dbname: str,
+) -> None:
+    """The live QA event persists while all enemy-class mechanics are refused."""
+
+    cache = _hydrate_fixture(disposable_dbname)
+    transition, packet, vocabulary = _build_transition_and_packet(
+        disposable_dbname,
+        cache,
+        trait_inputs=TraitCompileInputs.model_validate(
+            {"enemies": {"targets": [{"name": "Della Voss"}]}}
+        ),
+    )
+    constraints = packet["seed_generation_request"]["trait_constraints"]
+    enemy_constraint = next(row for row in constraints if row["trait"] == "enemies")
+    assert enemy_constraint["blocked_relationship_types"] == [
+        "captor",
+        "enemy",
+        "rival",
+    ]
+    assert enemy_constraint["blocked_pair_tags"] == ["hunting"]
+    assert (
+        transition.character.trait_compile_inputs.enemies is None
+        if transition.character.trait_compile_inputs is not None
+        else False
+    )
+
+    seed_response = _seed_response(packet, vocabulary)
+    for relationship_type in ("enemy", "rival", "captor"):
+        with pytest.raises(
+            RetrogradeExpansionValidationError,
+            match=(
+                "cold_start_relationships_forbidden.*" f"{relationship_type}.*enemies"
+            ),
+        ):
+            validate_expansion_plan(
+                payload=_expansion(
+                    vocabulary,
+                    relationship_type=relationship_type,
+                ),
+                packet=packet,
+                seed_candidate_response=seed_response,
+            )
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="cold_start_relationships_forbidden.*hunting.*enemies",
+    ):
+        validate_expansion_plan(
+            payload=_expansion(vocabulary, pair_tag="hunting"),
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="protagonist_duplicate_stub_forbidden.*jules",
+    ):
+        validate_expansion_plan(
+            payload=_expansion(
+                vocabulary,
+                relationship_type="rival",
+                protagonist_ref="Jules",
+            ),
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+
+    repaired = _expansion(vocabulary)
+    validated = validate_expansion_plan(
+        payload=repaired,
+        packet=packet,
+        seed_candidate_response=seed_response,
+    )
+    assert validated.event_plan[0].event_ref == "e_voss_practice_dispute"
+    assert validated.relationship_plan == []
+    assert validated.pair_tag_plan == []
+
+    manifest_holder: dict[str, Any] = {}
+
+    def persist(cur: Any) -> None:
+        manifest_holder["manifest"] = build_retrograde_persistence_plan(
+            cur,
+            packet=packet,
+            seed_candidate_response=seed_response,
+            expansion_plan_payload=repaired,
+            slot=3,
+            dbname=disposable_dbname,
+            dry_run=False,
+            create_missing_entities=True,
+            summaries_enabled=False,
+        )
+
+    NewStoryDatabaseMapper(dbname=disposable_dbname).perform_transition(
+        transition,
+        in_transaction=persist,
+    )
+    manifest = manifest_holder["manifest"]
+
+    with _connect(disposable_dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, entity_id
+                FROM characters
+                WHERE name = 'Jules Mercer'
+                """
+            )
+            protagonist = cur.fetchone()
+            assert protagonist is not None
+            cur.execute(
+                """
+                SELECT count(*) AS count
+                FROM character_relationships cr
+                WHERE (cr.character1_id = %s OR cr.character2_id = %s)
+                  AND cr.relationship_type IN ('enemy', 'rival', 'captor')
+                """,
+                (protagonist["id"], protagonist["id"]),
+            )
+            assert cur.fetchone()["count"] == 0
+            cur.execute(
+                """
+                SELECT count(*) AS count
+                FROM entity_pair_tags ept
+                JOIN pair_tags pt ON pt.id = ept.pair_tag_id
+                WHERE pt.tag = 'hunting'
+                  AND (
+                      ept.subject_entity_id = %s
+                      OR ept.object_entity_id = %s
+                  )
+                  AND ept.cleared_at IS NULL
+                """,
+                (protagonist["entity_id"], protagonist["entity_id"]),
+            )
+            assert cur.fetchone()["count"] == 0
+            cur.execute(
+                """
+                SELECT payload ->> 'retrograde_event_ref' AS event_ref
+                FROM world_events
+                WHERE source = 'retrograde'
+                  AND payload ->> 'retrograde_event_ref'
+                      = 'e_voss_practice_dispute'
+                """
+            )
+            assert cur.fetchone()["event_ref"] == "e_voss_practice_dispute"
+            cur.execute(
+                """
+                SELECT extra_data -> 'trait_compile_result'
+                       -> 'prose_only_remainders' AS remainders
+                FROM characters
+                WHERE id = %s
+                """,
+                (protagonist["id"],),
+            )
+            remainders = cur.fetchone()["remainders"]
+            enemy_remainder = next(
+                row for row in remainders if row["trait"] == "enemies"
+            )
+            assert (
+                enemy_remainder["reason_code"] == "cold_start_relationships_forbidden"
+            )
+
+    assert manifest["counters"]["events_inserted"] == 1
+    assert manifest["counters"]["relationships_inserted"] == 0
+    assert manifest["counters"]["pair_tags_inserted"] == 0
+
+
+def test_real_cache_compiler_gate_suppresses_all_named_target_materialization(
+    disposable_dbname: str,
+) -> None:
+    """Forbidden typed inputs create only #605-style structured remainders."""
+
+    fixture = _fixture_payload()
+    selected = ["patron", "dependents", "obligations"]
+    rationales = {
+        "patron": "No patron relationship may predate the opening scene.",
+        "dependents": "No dependent relationship may predate the opening scene.",
+        "obligations": "No obligation relationship may predate the opening scene.",
+    }
+    fixture["character"]["concept"]["suggested_traits"] = selected
+    fixture["character"]["concept"]["trait_rationales"] = rationales
+    fixture["character"]["trait_selection"] = {
+        "selected_traits": selected,
+        "trait_rationales": rationales,
+        "suggested_by_llm": selected,
+        "trait_constraints": [
+            {"trait": trait, "cold_start_relationships": "forbidden"}
+            for trait in selected
+        ],
+    }
+    cache = _hydrate_fixture(disposable_dbname, fixture=fixture)
+    transition, packet, _vocabulary = _build_transition_and_packet(
+        disposable_dbname,
+        cache,
+        trait_inputs=TraitCompileInputs.model_validate(
+            {
+                "patron": {
+                    "name": "Doctor Voss",
+                    "functions": ["mentors", "protects"],
+                },
+                "dependents": {"targets": [{"name": "Juno Reyes"}]},
+                "obligations": {
+                    "targets": [
+                        {
+                            "counterparty_kind": "character",
+                            "name": "Magistrate Hale",
+                        }
+                    ]
+                },
+            }
+        ),
+    )
+    assert {
+        row["trait"] for row in packet["seed_generation_request"]["trait_constraints"]
+    } == set(selected)
+    constrained_inputs = transition.character.trait_compile_inputs
+    assert constrained_inputs is not None
+    assert constrained_inputs.patron is None
+    assert constrained_inputs.dependents is None
+    assert constrained_inputs.obligations is None
+    assert constrained_inputs.suppressed_cold_start_relationship_traits == sorted(
+        selected
+    )
+
+    NewStoryDatabaseMapper(dbname=disposable_dbname).perform_transition(transition)
+
+    with _connect(disposable_dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT count(*) AS count
+                FROM characters
+                WHERE name IN ('Doctor Voss', 'Juno Reyes', 'Magistrate Hale')
+                """
+            )
+            assert cur.fetchone()["count"] == 0
+            cur.execute("SELECT count(*) AS count FROM character_relationships")
+            assert cur.fetchone()["count"] == 0
+            cur.execute("SELECT count(*) AS count FROM entity_pair_tags")
+            assert cur.fetchone()["count"] == 0
+            cur.execute(
+                """
+                SELECT extra_data -> 'trait_compile_result'
+                       -> 'prose_only_remainders' AS remainders
+                FROM characters
+                WHERE name = 'Jules Mercer'
+                """
+            )
+            remainders = cur.fetchone()["remainders"]
+            assert {(row["trait"], row["reason_code"]) for row in remainders} == {
+                ("patron", "cold_start_relationships_forbidden"),
+                ("dependents", "cold_start_relationships_forbidden"),
+                ("obligations", "cold_start_relationships_forbidden"),
+            }
+
+
+def test_persistence_refuses_database_alias_stub_even_without_packet_alias(
+    disposable_dbname: str,
+) -> None:
+    """The persistence wall reads character_aliases before staging stubs."""
+
+    cache = _hydrate_fixture(disposable_dbname)
+    transition, packet, vocabulary = _build_transition_and_packet(
+        disposable_dbname,
+        cache,
+        trait_inputs=TraitCompileInputs.model_validate(
+            {
+                "enemies": {"targets": [{"name": "Della Voss"}]},
+                "status": {
+                    "level": "junior",
+                    "scope_faction_name": "Dunlow County Circuit Court",
+                },
+            }
+        ),
+    )
+    seed_response = _seed_response(packet, vocabulary)
+    alias_expansion = _expansion(vocabulary, protagonist_ref="J.M.")
+    validate_expansion_plan(
+        payload=alias_expansion,
+        packet=packet,
+        seed_candidate_response=seed_response,
+    )
+
+    def persist(cur: Any) -> None:
+        cur.execute("SELECT user_character FROM global_variables WHERE id = TRUE")
+        protagonist_id = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO character_aliases (character_id, alias) VALUES (%s, %s)",
+            (protagonist_id, "J.M."),
+        )
+        build_retrograde_persistence_plan(
+            cur,
+            packet=packet,
+            seed_candidate_response=seed_response,
+            expansion_plan_payload=alias_expansion,
+            slot=3,
+            dbname=disposable_dbname,
+            dry_run=False,
+            create_missing_entities=True,
+            summaries_enabled=False,
+        )
+
+    with pytest.raises(ValueError, match="protagonist_duplicate_stub_forbidden"):
+        NewStoryDatabaseMapper(dbname=disposable_dbname).perform_transition(
+            transition,
+            in_transaction=persist,
+        )
+
+    with _connect(disposable_dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) AS count FROM characters WHERE name = 'J.M.'")
+            assert cur.fetchone()["count"] == 0

--- a/tests/test_orrery/test_retrograde_constraints_pg.py
+++ b/tests/test_orrery/test_retrograde_constraints_pg.py
@@ -1,0 +1,317 @@
+"""Real-PostgreSQL regression for issue #601 materialization enforcement."""
+
+from __future__ import annotations
+
+import copy
+import os
+from pathlib import Path
+import uuid
+from typing import Any, Iterator
+
+import psycopg2
+from psycopg2 import sql
+from psycopg2.extras import RealDictCursor
+import pytest
+
+from nexus.agents.orrery.retrograde_expansion import (
+    RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION,
+    RetrogradeExpansionValidationError,
+)
+from nexus.agents.orrery.retrograde_packet import build_seed_generation_request
+from nexus.agents.orrery.retrograde_persistence import (
+    build_retrograde_persistence_plan,
+)
+from nexus.agents.orrery.retrograde_seed_candidates import (
+    SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION,
+)
+from nexus.agents.orrery.retrograde_vocabulary import (
+    SeedEligibleVocabulary,
+    enumerate_seed_eligible_vocabulary,
+)
+
+pytestmark = pytest.mark.requires_postgres
+
+
+def _connect(dbname: str) -> Any:
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+@pytest.fixture()
+def disposable_cursor() -> Iterator[Any]:
+    """Yield a current-template clone and remove it after the regression."""
+
+    dbname = f"nexus_test_issue_601_{uuid.uuid4().hex[:12]}"
+    admin = None
+    conn = None
+    try:
+        try:
+            admin = _connect("postgres")
+        except psycopg2.Error as exc:
+            pytest.skip(f"PostgreSQL admin connection unavailable: {exc}")
+        admin.autocommit = True
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier("NEXUS_template"),
+                )
+            )
+        conn = _connect(dbname)
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            migration = (
+                Path(__file__).parents[2]
+                / "migrations"
+                / "097_trait_cold_start_relationship_constraints.sql"
+            )
+            cur.execute(migration.read_text())
+            cur.execute(
+                "UPDATE global_variables SET base_timestamp = %s WHERE id = TRUE",
+                ("2026-05-14T10:48:00+00:00",),
+            )
+            yield cur
+    finally:
+        if conn is not None:
+            conn.rollback()
+            conn.close()
+        if admin is not None:
+            with admin.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = %s AND pid <> pg_backend_pid()",
+                    (dbname,),
+                )
+                cur.execute(
+                    sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+                )
+            admin.close()
+
+
+def test_persistence_keeps_dispute_event_without_enemy_row(
+    disposable_cursor: Any,
+) -> None:
+    """The real persistence path retains Voss's event and mints no PC enemy row."""
+
+    cur = disposable_cursor
+    vocabulary = enumerate_seed_eligible_vocabulary()
+    event_type = (
+        "backstory_secret_authored"
+        if "backstory_secret_authored" in vocabulary["event_types"]
+        else vocabulary["event_types"][0]
+    )
+    packet = _packet(vocabulary)
+    seed_response = _seed_response(vocabulary, event_type=event_type)
+    violating = _expansion(vocabulary, event_type=event_type, include_enemy=True)
+
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="cold_start_relationships_forbidden.*enemy.*Jules Mercer.*enemies",
+    ):
+        build_retrograde_persistence_plan(
+            cur,
+            packet=packet,
+            seed_candidate_response=seed_response,
+            expansion_plan_payload=violating,
+            slot=3,
+            dbname="disposable_issue_601",
+            dry_run=False,
+            create_missing_entities=True,
+            summaries_enabled=False,
+        )
+
+    repaired = copy.deepcopy(violating)
+    repaired["relationship_plan"] = []
+    manifest = build_retrograde_persistence_plan(
+        cur,
+        packet=packet,
+        seed_candidate_response=seed_response,
+        expansion_plan_payload=repaired,
+        slot=3,
+        dbname="disposable_issue_601",
+        dry_run=False,
+        create_missing_entities=True,
+        summaries_enabled=False,
+    )
+
+    cur.execute(
+        """
+        SELECT count(*) AS count
+        FROM character_relationships cr
+        JOIN characters subject ON subject.id = cr.character1_id
+        JOIN characters object_character ON object_character.id = cr.character2_id
+        WHERE cr.relationship_type = 'enemy'
+          AND (subject.name = 'Jules Mercer' OR object_character.name = 'Jules Mercer')
+        """
+    )
+    assert cur.fetchone()["count"] == 0
+    cur.execute(
+        """
+        SELECT payload ->> 'retrograde_event_ref' AS event_ref
+        FROM world_events
+        WHERE source = 'retrograde'
+          AND payload ->> 'retrograde_event_ref' = 'e_voss_practice_dispute'
+        """
+    )
+    assert cur.fetchone()["event_ref"] == "e_voss_practice_dispute"
+    assert manifest["counters"]["events_inserted"] == 1
+    assert manifest["counters"]["relationships_inserted"] == 0
+
+
+def _packet(vocabulary: SeedEligibleVocabulary) -> dict[str, Any]:
+    scaffolds = {
+        "core_entities": [
+            {
+                "kind": "character",
+                "role": "protagonist",
+                "name": "Jules Mercer",
+                "summary": "A court reporter who begins with no personal nemesis.",
+            },
+            {
+                "kind": "character",
+                "role": "seed_npc",
+                "name": "Della Voss",
+                "summary": "A deceased accessibility auditor with sealed records.",
+            },
+        ],
+        "named_seed_npcs": [],
+        "pressure_axes": [],
+        "trait_hooks": {
+            "selected_traits": ["status", "enemies", "obligations"],
+            "rationales": {
+                "enemies": "No preexisting personal nemesis; opposition arises in play."
+            },
+            "constraints": [
+                {"trait": "enemies", "cold_start_relationships": "forbidden"}
+            ],
+        },
+    }
+    request = build_seed_generation_request(
+        candidate_scaffolds=scaffolds,
+        vocabulary=vocabulary,
+        weird={"level": "low", "genre": "thriller", "raw_midpoint": 0.2},
+    )
+    request["candidate_graph"] = {}
+    return {
+        "candidate_scaffolds": scaffolds,
+        "seed_generation_request": request,
+        "seed_eligible_vocabulary": vocabulary,
+    }
+
+
+def _seed_response(
+    vocabulary: SeedEligibleVocabulary, *, event_type: str
+) -> dict[str, Any]:
+    return {
+        "schema_version": SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION,
+        "candidates": [
+            {
+                "seed_id": "seed_paper_enemy",
+                "summary": "A sealed dispute survives Della Voss's death.",
+                "origin_friction": "medium",
+                "present_leaf_anchor": "The record may be discovered during play.",
+                "coverage_functions": ["hidden_truth", "trait_bound_hook"],
+                "mechanical_hints": {
+                    "events": [
+                        {
+                            "event_ref": "e_voss_practice_dispute",
+                            "event_type": event_type,
+                            "summary": "Voss challenged a practice Jules later inherited.",
+                            "participating_entities": ["Jules Mercer", "Della Voss"],
+                        }
+                    ],
+                    "single_entity_tags": [],
+                    "pair_tags": [],
+                    "relationships": [],
+                },
+                "defer_or_reject_if": [],
+                "claimed_edges": [],
+            }
+        ],
+        "selected_seed_ids": ["seed_paper_enemy"],
+        "rejected_seed_ids": [],
+    }
+
+
+def _expansion(
+    vocabulary: SeedEligibleVocabulary,
+    *,
+    event_type: str,
+    include_enemy: bool,
+) -> dict[str, Any]:
+    relationships = []
+    if include_enemy:
+        relationships.append(
+            {
+                "subject_ref": "Jules Mercer",
+                "subject_kind": "character",
+                "relationship_type": "enemy",
+                "object_ref": "Della Voss",
+                "object_kind": "character",
+                "source_event_ref": "e_voss_practice_dispute",
+                "rationale": "The sealed dispute leaves a paper trail.",
+            }
+        )
+    return {
+        "schema_version": RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION,
+        "selected_seed_ids": ["seed_paper_enemy"],
+        "event_plan": [
+            {
+                "event_ref": "e_voss_practice_dispute",
+                "seed_ids": ["seed_paper_enemy"],
+                "event_type": event_type,
+                "summary": (
+                    "A sealed professional dispute states that Della Voss "
+                    "challenged a transcript practice later inherited by Jules "
+                    "Mercer without their knowledge."
+                ),
+                "chronology": "recent_past",
+                "participants": [
+                    {
+                        "entity_ref": "Della Voss",
+                        "entity_kind": "character",
+                        "role": "actor",
+                    },
+                    {
+                        "entity_ref": "Jules Mercer",
+                        "entity_kind": "character",
+                        "role": "target",
+                    },
+                ],
+                "location_ref": None,
+                "changed_fields": ["sealed_record"],
+                "magnitude": 0.2,
+                "payload": {
+                    "record_status": (
+                        "Paper-trail conflict only, not a present adversary."
+                    )
+                },
+            }
+        ],
+        "entity_tag_plan": [],
+        "pair_tag_plan": [],
+        "relationship_plan": relationships,
+        "death_plan": [],
+        "project_plan": [],
+        "thread_plan": [
+            {
+                "seed_id": "seed_paper_enemy",
+                "status": "woven",
+                "event_refs": ["e_voss_practice_dispute"],
+                "present_leaf_anchor": "The sealed record may surface during play.",
+            }
+        ],
+        "coverage_notes": ["The event preserves texture without an enemy row."],
+        "commit_readiness": {
+            "writes": "none",
+            "planned_source": "retrograde",
+            "blocked_by": [
+                "pre_game_tick_chunk_id",
+                "event_source_kind_retrograde",
+            ],
+            "explanation": "Runtime fills the canonical anchor.",
+        },
+    }

--- a/tests/test_orrery/test_retrograde_expansion.py
+++ b/tests/test_orrery/test_retrograde_expansion.py
@@ -190,6 +190,43 @@ def test_expansion_rejects_protagonist_first_name_alias() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "variant_ref",
+    ["Mercer Jules", "JÚLES MERCER"],
+    ids=["token-permutation", "diacritic-variant"],
+)
+def test_expansion_rejects_protagonist_name_variants(variant_ref: str) -> None:
+    """Token permutations and diacritic variants cannot mint a second PC."""
+
+    vocabulary = _expansion_test_vocabulary()
+    packet = _packet(
+        vocabulary,
+        constraints=[{"trait": "enemies", "cold_start_relationships": "forbidden"}],
+        protagonist_name="Jules Mercer",
+    )
+    payload = _valid_expansion(vocabulary)
+    payload["relationship_plan"][0]["subject_ref"] = variant_ref
+    payload["relationship_plan"][0]["relationship_type"] = "rival"
+    seed_response = _seed_response_base(vocabulary)
+    edge = packet["seed_generation_request"]["candidate_graph"]["dangling_edges"][0]
+    for candidate in seed_response["candidates"]:
+        candidate["claimed_edges"] = [
+            {
+                "edge_id": edge["edge_id"],
+                "open_endpoint_name": "The Salt Ledger",
+                "open_endpoint_kind": edge["open_endpoint_kind"],
+            }
+        ]
+
+    with pytest.raises(RetrogradeExpansionValidationError) as excinfo:
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+    assert "protagonist_duplicate_stub_forbidden" in str(excinfo.value)
+
+
 def test_expansion_prompt_names_future_only_relationship_constraint() -> None:
     """R6 can repair a forbidden row because the typed constraint is visible."""
 

--- a/tests/test_orrery/test_retrograde_expansion.py
+++ b/tests/test_orrery/test_retrograde_expansion.py
@@ -52,10 +52,10 @@ def test_expansion_rejects_forbidden_pc_relationship_but_keeps_event() -> None:
     """A future-only enemy trait blocks only the mechanical cold-start row."""
 
     vocabulary = _expansion_test_vocabulary()
-    packet = _packet(vocabulary)
-    packet["seed_generation_request"]["trait_constraints"] = [
-        {"trait": "enemies", "cold_start_relationships": "forbidden"}
-    ]
+    packet = _packet(
+        vocabulary,
+        constraints=[{"trait": "enemies", "cold_start_relationships": "forbidden"}],
+    )
     payload = _valid_expansion(vocabulary)
     payload["relationship_plan"][0]["relationship_type"] = "enemy"
 
@@ -80,14 +80,124 @@ def test_expansion_rejects_forbidden_pc_relationship_but_keeps_event() -> None:
     assert repaired.event_plan[0].event_ref == "retro_event_001"
 
 
+def test_expansion_rejects_forbidden_enemy_rival_relationship() -> None:
+    """The adversarial class blocks registered rival rows for the PC."""
+
+    vocabulary = _expansion_test_vocabulary()
+    packet = _packet(
+        vocabulary,
+        constraints=[{"trait": "enemies", "cold_start_relationships": "forbidden"}],
+    )
+    payload = _valid_expansion(vocabulary)
+    payload["relationship_plan"][0]["relationship_type"] = "rival"
+
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="cold_start_relationships_forbidden.*rival.*enemies",
+    ):
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=_seed_response(vocabulary),
+        )
+
+
+def test_expansion_rejects_forbidden_enemy_captor_relationship() -> None:
+    """The adversarial class blocks registered captor rows for the PC."""
+
+    vocabulary = _expansion_test_vocabulary()
+    packet = _packet(
+        vocabulary,
+        constraints=[{"trait": "enemies", "cold_start_relationships": "forbidden"}],
+    )
+    payload = _valid_expansion(vocabulary)
+    payload["relationship_plan"][0]["relationship_type"] = "captor"
+
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="cold_start_relationships_forbidden.*captor.*enemies",
+    ):
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=_seed_response(vocabulary),
+        )
+
+
+def test_expansion_rejects_forbidden_enemy_hunting_pair_tag() -> None:
+    """The adversarial class blocks registered hunting edges for the PC."""
+
+    vocabulary = _expansion_test_vocabulary()
+    packet = _packet(
+        vocabulary,
+        constraints=[{"trait": "enemies", "cold_start_relationships": "forbidden"}],
+    )
+    payload = _valid_expansion(vocabulary)
+    payload["relationship_plan"] = []
+    payload["pair_tag_plan"] = [
+        {
+            "subject_ref": "Vale",
+            "subject_kind": "character",
+            "tag": "hunting",
+            "object_ref": "Mara",
+            "object_kind": "character",
+            "source_event_ref": "retro_event_001",
+        }
+    ]
+
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="cold_start_relationships_forbidden.*hunting.*enemies",
+    ):
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=_seed_response(vocabulary),
+        )
+
+
+def test_expansion_rejects_protagonist_first_name_alias() -> None:
+    """A first-name ref cannot bypass constraints or mint a second PC stub."""
+
+    vocabulary = _expansion_test_vocabulary()
+    packet = _packet(
+        vocabulary,
+        constraints=[{"trait": "enemies", "cold_start_relationships": "forbidden"}],
+        protagonist_name="Jules Mercer",
+    )
+    payload = _valid_expansion(vocabulary)
+    payload["relationship_plan"][0]["subject_ref"] = "Jules"
+    payload["relationship_plan"][0]["relationship_type"] = "rival"
+    seed_response = _seed_response_base(vocabulary)
+    edge = packet["seed_generation_request"]["candidate_graph"]["dangling_edges"][0]
+    for candidate in seed_response["candidates"]:
+        candidate["claimed_edges"] = [
+            {
+                "edge_id": edge["edge_id"],
+                "open_endpoint_name": "The Salt Ledger",
+                "open_endpoint_kind": edge["open_endpoint_kind"],
+            }
+        ]
+
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="protagonist_duplicate_stub_forbidden.*jules",
+    ):
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+
+
 def test_expansion_prompt_names_future_only_relationship_constraint() -> None:
     """R6 can repair a forbidden row because the typed constraint is visible."""
 
     vocabulary = _expansion_test_vocabulary()
-    packet = _packet(vocabulary)
-    packet["seed_generation_request"]["trait_constraints"] = [
-        {"trait": "enemies", "cold_start_relationships": "forbidden"}
-    ]
+    packet = _packet(
+        vocabulary,
+        constraints=[{"trait": "enemies", "cold_start_relationships": "forbidden"}],
+    )
 
     prompt = render_expansion_prompt(
         packet=packet,
@@ -1065,7 +1175,13 @@ def _expansion_test_vocabulary() -> SeedEligibleVocabulary:
     return vocabulary
 
 
-def _packet(vocabulary: SeedEligibleVocabulary) -> dict[str, Any]:
+def _packet(
+    vocabulary: SeedEligibleVocabulary,
+    *,
+    constraints: list[dict[str, Any]] | None = None,
+    protagonist_name: str = "Mara",
+) -> dict[str, Any]:
+    protagonist_tokens = protagonist_name.split()
     return {
         "seed_generation_request": build_seed_generation_request(
             candidate_scaffolds={
@@ -1073,13 +1189,19 @@ def _packet(vocabulary: SeedEligibleVocabulary) -> dict[str, Any]:
                     {
                         "kind": "character",
                         "role": "protagonist",
-                        "name": "Mara",
+                        "name": protagonist_name,
                         "summary": "Debt tracker.",
                     }
                 ],
                 "named_seed_npcs": [],
                 "pressure_axes": [],
-                "trait_hooks": {},
+                "trait_hooks": {"constraints": constraints or []},
+                "protagonist_identity": {
+                    "canonical_ref": protagonist_name,
+                    "known_aliases": (
+                        [protagonist_tokens[0]] if len(protagonist_tokens) > 1 else []
+                    ),
+                },
             },
             vocabulary=vocabulary,
             weird={"level": "medium", "genre": "cyberpunk", "raw_midpoint": 0.5},

--- a/tests/test_orrery/test_retrograde_expansion.py
+++ b/tests/test_orrery/test_retrograde_expansion.py
@@ -48,6 +48,56 @@ def test_expansion_plan_accepts_row_shaped_dry_run_output() -> None:
     assert response.event_plan[0].event_type == vocabulary["event_types"][0]
 
 
+def test_expansion_rejects_forbidden_pc_relationship_but_keeps_event() -> None:
+    """A future-only enemy trait blocks only the mechanical cold-start row."""
+
+    vocabulary = _expansion_test_vocabulary()
+    packet = _packet(vocabulary)
+    packet["seed_generation_request"]["trait_constraints"] = [
+        {"trait": "enemies", "cold_start_relationships": "forbidden"}
+    ]
+    payload = _valid_expansion(vocabulary)
+    payload["relationship_plan"][0]["relationship_type"] = "enemy"
+
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="cold_start_relationships_forbidden.*enemy.*Mara.*enemies",
+    ):
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=_seed_response(vocabulary),
+        )
+
+    payload["relationship_plan"] = []
+    repaired = validate_expansion_plan(
+        payload=payload,
+        packet=packet,
+        seed_candidate_response=_seed_response(vocabulary),
+    )
+
+    assert repaired.relationship_plan == []
+    assert repaired.event_plan[0].event_ref == "retro_event_001"
+
+
+def test_expansion_prompt_names_future_only_relationship_constraint() -> None:
+    """R6 can repair a forbidden row because the typed constraint is visible."""
+
+    vocabulary = _expansion_test_vocabulary()
+    packet = _packet(vocabulary)
+    packet["seed_generation_request"]["trait_constraints"] = [
+        {"trait": "enemies", "cold_start_relationships": "forbidden"}
+    ]
+
+    prompt = render_expansion_prompt(
+        packet=packet,
+        seed_candidate_response=_seed_response(vocabulary),
+    )
+
+    assert '"cold_start_relationships": "forbidden"' in prompt
+    assert "Keep permissible backstory events" in prompt
+
+
 def test_wire_expansion_response_omits_deterministic_fields() -> None:
     """Provider grammar excludes fields the runtime already knows."""
 

--- a/tests/test_orrery/test_retrograde_packet.py
+++ b/tests/test_orrery/test_retrograde_packet.py
@@ -52,7 +52,7 @@ class FakeRetrogradeCache:
             },
         }
 
-    def get_seed_dict(self) -> dict[str, object]:
+    def get_seed_dict(self) -> dict[str, object] | None:
         return {
             "seed_type": "inciting pressure",
             "title": "The Ledger Wakes",
@@ -125,11 +125,17 @@ def test_retrograde_packet_is_dry_run_and_selection_oriented() -> None:
         section for section in sections if section["heading"] == "Trait hooks"
     )
     assert trait_section["items"] == [
-        {"kind": "trait", "name": "resources", "rationale": "Money opens doors."},
+        {
+            "kind": "trait",
+            "name": "resources",
+            "rationale": "Money opens doors.",
+            "cold_start_relationships": "allowed",
+        },
         {
             "kind": "trait",
             "name": "status",
             "rationale": "The badge matters narrowly.",
+            "cold_start_relationships": "allowed",
         },
         {
             "kind": "wildcard",

--- a/tests/test_orrery/test_retrograde_packet.py
+++ b/tests/test_orrery/test_retrograde_packet.py
@@ -130,12 +130,16 @@ def test_retrograde_packet_is_dry_run_and_selection_oriented() -> None:
             "name": "resources",
             "rationale": "Money opens doors.",
             "cold_start_relationships": "allowed",
+            "blocked_relationship_types": [],
+            "blocked_pair_tags": [],
         },
         {
             "kind": "trait",
             "name": "status",
             "rationale": "The badge matters narrowly.",
             "cold_start_relationships": "allowed",
+            "blocked_relationship_types": [],
+            "blocked_pair_tags": [],
         },
         {
             "kind": "wildcard",
@@ -157,6 +161,46 @@ def test_retrograde_packet_is_dry_run_and_selection_oriented() -> None:
         {"kind": "character", "role": "seed_npc", "name": "Vale"}
     ]
     assert packet["vocabulary_summary"]["event_types"] > 0
+
+
+def test_packet_materializes_enemy_constraint_from_registered_vocabulary() -> None:
+    """The packet blocks the full adversarial class, including pair tags."""
+
+    class EnemiesForbiddenCache(FakeRetrogradeCache):
+        def get_character_dict(self) -> dict[str, object]:
+            character = super().get_character_dict()
+            character["trait_selection"] = {
+                "selected_traits": ["status", "enemies", "obligations"],
+                "trait_rationales": {
+                    "status": "The badge matters narrowly.",
+                    "enemies": "No preexisting personal nemesis.",
+                    "obligations": "A professional duty remains.",
+                },
+                "trait_constraints": [
+                    {
+                        "trait": "enemies",
+                        "cold_start_relationships": "forbidden",
+                    }
+                ],
+            }
+            return character
+
+    packet = build_retrograde_dry_run_packet(
+        slot=5,
+        dbname="save_05",
+        cache=EnemiesForbiddenCache(),
+        vocabulary=enumerate_seed_eligible_vocabulary(),
+        settings=load_settings(),
+        weird_level="low",
+    )
+
+    constraint = packet["seed_generation_request"]["trait_constraints"][0]
+    assert constraint["blocked_relationship_types"] == ["captor", "enemy", "rival"]
+    assert constraint["blocked_pair_tags"] == ["hunting"]
+    assert packet["seed_generation_request"]["protagonist_identity"] == {
+        "canonical_ref": "Mara",
+        "known_aliases": [],
+    }
 
 
 def test_retrograde_packet_budget_carries_entity_stub_cap() -> None:

--- a/tests/test_orrery/test_retrograde_persistence.py
+++ b/tests/test_orrery/test_retrograde_persistence.py
@@ -794,6 +794,8 @@ class FakeRetrogradePersistenceCursor:
                     }
                 )
             self._result = rows
+        elif "orrery:retrograde:protagonist_identity" in sql:
+            self._result = [{"id": 11, "name": "Mara", "alias": None}]
         elif "orrery:retrograde:event_types" in sql:
             event_types = self.vocabulary["event_types"]
             if self.omit_first_event_type:

--- a/tests/test_orrery/test_retrograde_seed_candidates.py
+++ b/tests/test_orrery/test_retrograde_seed_candidates.py
@@ -616,6 +616,25 @@ def test_seed_selection_prompt_surfaces_resolved_atomic_junction() -> None:
     assert "select both member seeds or reject both" in prompt
 
 
+def test_seed_selection_prompt_exposes_trait_constraint_and_taste_line() -> None:
+    """R5 rejects mechanical breaches without rejecting event texture."""
+
+    vocabulary = _seed_test_vocabulary()
+    seed_request, payload = _junction_case(vocabulary)
+    seed_request["trait_constraints"] = [
+        {"trait": "enemies", "cold_start_relationships": "forbidden"}
+    ]
+
+    prompt = render_seed_selection_prompt(
+        seed_generation_request=seed_request,
+        candidates_payload=payload,
+    )
+
+    assert '"cold_start_relationships": "forbidden"' in prompt
+    assert "mechanical hints violate a trait constraint" in prompt
+    assert "A backstory event alone does not violate" in prompt
+
+
 def _seed_test_vocabulary() -> SeedEligibleVocabulary:
     vocabulary = enumerate_seed_eligible_vocabulary()
     vocabulary["registered_single_entity_tags"] = [

--- a/tests/test_orrery/test_retrograde_vocabulary.py
+++ b/tests/test_orrery/test_retrograde_vocabulary.py
@@ -88,11 +88,38 @@ def test_seed_eligible_vocabulary_includes_pair_tag_kind_constraints() -> None:
     assert definitions["hunting"]["subject_kinds"] == ["character", "faction"]
     assert definitions["hunting"]["object_kinds"] == ["character"]
     assert definitions["hunting"]["is_ephemeral"] is True
+    assert definitions["hunting"]["semantic_categories"] == ["adversarial"]
     assert STATUS_TAGS <= set(definitions)
     for tag in STATUS_TAGS:
         assert definitions[tag]["subject_kinds"] == ["character", "faction"]
         assert definitions[tag]["object_kinds"] == ["faction"]
         assert definitions[tag]["is_ephemeral"] is False
+        assert definitions[tag]["semantic_categories"] == ["status"]
+
+
+def test_seed_relationship_types_carry_semantic_and_valence_metadata() -> None:
+    """Constraint classification is registered metadata, not string equality."""
+
+    vocabulary = enumerate_seed_eligible_vocabulary()
+    definitions = {
+        item["relationship_type"]: item
+        for item in vocabulary["relationship_type_definitions"]
+    }
+
+    for relationship_type in ("captor", "enemy", "rival"):
+        assert "adversarial" in definitions[relationship_type]["semantic_categories"]
+        assert definitions[relationship_type]["default_emotional_valence"].startswith(
+            "-"
+        )
+
+
+def test_unclassified_seed_relationship_type_fails_loudly() -> None:
+    """A new seed-eligible relation cannot silently bypass constraint classes."""
+
+    with pytest.raises(ValueError, match="missing semantic and valence"):
+        retrograde_vocabulary._load_relationship_type_definitions(
+            ["unclassified_future_threat"]
+        )
 
 
 def test_seed_eligible_vocabulary_classifies_registered_categories(

--- a/tests/test_trait_compiler.py
+++ b/tests/test_trait_compiler.py
@@ -10,7 +10,12 @@ from typing import Any, Optional
 
 import pytest
 
-from nexus.api.new_story_schemas import CharacterSheet, CharacterTrait, TraitName
+from nexus.api.new_story_schemas import (
+    CharacterSheet,
+    CharacterTrait,
+    TraitConstraint,
+    TraitName,
+)
 from nexus.api.trait_compiler import (
     apply_character_trait_compilation,
     compile_character_traits,
@@ -592,6 +597,7 @@ class TraitCompilerCursor:
 def _character(
     *trait_names: TraitName,
     inputs: TraitCompileInputs | None = None,
+    constraints: list[TraitConstraint] | None = None,
 ) -> CharacterSheet:
     traits = [
         CharacterTrait(name=trait_name, description=f"{trait_name} description")
@@ -609,6 +615,7 @@ def _character(
         trait_2=traits[1],
         trait_3=traits[2],
         trait_compile_inputs=inputs,
+        trait_constraints=constraints or [],
     )
 
 
@@ -631,6 +638,124 @@ def test_no_typed_inputs_returns_structured_remainders() -> None:
     assert {item.reason_code for item in result.prose_only_remainders} == {
         TraitCompileReasonCode.MISSING_STRUCTURED_TRAIT_INPUT
     }
+
+
+def test_forbidden_relationship_traits_never_reach_named_target_prepass() -> None:
+    """Patron/dependent/obligation targets become structured suppressions."""
+
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs.model_validate(
+        {
+            "patron": {
+                "name": "Doctor Voss",
+                "functions": ["mentors", "protects"],
+            },
+            "dependents": {"targets": [{"name": "Juno Reyes"}]},
+            "obligations": {
+                "targets": [
+                    {
+                        "counterparty_kind": "character",
+                        "name": "Magistrate Hale",
+                    }
+                ]
+            },
+        }
+    )
+    constraints = [
+        TraitConstraint.model_validate(
+            {"trait": trait, "cold_start_relationships": "forbidden"}
+        )
+        for trait in ("patron", "dependents", "obligations")
+    ]
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character(
+            "patron",
+            "dependents",
+            "obligations",
+            inputs=inputs,
+            constraints=constraints,
+        ),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert result.created_entities == []
+    assert result.created_relationships == []
+    assert result.applied_pair_tags == []
+    assert cur.characters == {
+        1: {"entity_id": 501, "name": "Mara"},
+        2: {"entity_id": 502, "name": "Bren"},
+    }
+    assert cur.character_relationships == []
+    assert cur.entity_pair_tags == []
+    assert {
+        (item.trait, item.reason_code) for item in result.prose_only_remainders
+    } == {
+        (
+            "patron",
+            TraitCompileReasonCode.COLD_START_RELATIONSHIPS_FORBIDDEN,
+        ),
+        (
+            "dependents",
+            TraitCompileReasonCode.COLD_START_RELATIONSHIPS_FORBIDDEN,
+        ),
+        (
+            "obligations",
+            TraitCompileReasonCode.COLD_START_RELATIONSHIPS_FORBIDDEN,
+        ),
+    }
+
+
+def test_forbidden_enemies_blocks_relationship_defaults() -> None:
+    """A pre-resolved enemy input cannot mint either mechanical layer."""
+
+    cur = TraitCompilerCursor()
+    inputs = TraitCompileInputs.model_validate(
+        {
+            "enemies": {
+                "targets": [
+                    {
+                        "character_id": 2,
+                        "character_entity_id": 502,
+                        "apply_pair_tag": True,
+                        "pair_tag": "hostile_to",
+                    }
+                ]
+            }
+        }
+    )
+
+    result = apply_character_trait_compilation(
+        cur,
+        character=_character(
+            "enemies",
+            "resources",
+            "domain",
+            inputs=inputs,
+            constraints=[
+                TraitConstraint(
+                    trait="enemies",
+                    cold_start_relationships="forbidden",
+                )
+            ],
+        ),
+        character_id=1,
+        character_entity_id=501,
+    )
+
+    assert result.created_relationships == []
+    assert result.applied_pair_tags == []
+    assert cur.character_relationships == []
+    assert cur.entity_pair_tags == []
+    enemy_remainder = next(
+        item for item in result.prose_only_remainders if item.trait == "enemies"
+    )
+    assert (
+        enemy_remainder.reason_code
+        == TraitCompileReasonCode.COLD_START_RELATIONSHIPS_FORBIDDEN
+    )
 
 
 def test_resources_and_reputation_compile_to_single_entity_tags() -> None:

--- a/tests/test_trait_compiler_integration.py
+++ b/tests/test_trait_compiler_integration.py
@@ -17,7 +17,12 @@ from typing import Any, Optional
 import psycopg2
 import pytest
 
-from nexus.api.new_story_schemas import CharacterSheet, CharacterTrait, TraitName
+from nexus.api.new_story_schemas import (
+    CharacterSheet,
+    CharacterTrait,
+    TraitConstraint,
+    TraitName,
+)
 from nexus.api.trait_compiler import (
     apply_character_trait_compilation,
     compile_character_traits,
@@ -123,7 +128,9 @@ def _install_valence_shadow(cur: Any) -> None:
 
 
 def _character_sheet(
-    *trait_names: TraitName, inputs: Optional[TraitCompileInputs]
+    *trait_names: TraitName,
+    inputs: Optional[TraitCompileInputs],
+    constraints: Optional[list[TraitConstraint]] = None,
 ) -> CharacterSheet:
     traits = [
         CharacterTrait(name=trait_name, description=f"{trait_name} trait prose")
@@ -144,6 +151,7 @@ def _character_sheet(
         trait_2=traits[1],
         trait_3=traits[2],
         trait_compile_inputs=inputs,
+        trait_constraints=constraints or [],
     )
 
 
@@ -960,6 +968,87 @@ def test_dependents_apply_and_dry_run_audit_on_save_05() -> None:
                 (character_id,),
             )
             assert cur.fetchall() == [("dependent", "+3|trusting", "protects")]
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+@pytest.mark.requires_postgres
+def test_forbidden_relationship_traits_have_dry_run_apply_parity_on_save_05() -> None:
+    """The constraint gate precedes #605 target pre-resolution in both modes."""
+
+    try:
+        conn = psycopg2.connect(dbname=TEST_DBNAME)
+    except psycopg2.Error as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"{TEST_DBNAME} PostgreSQL test database unavailable: {exc}")
+
+    try:
+        with conn.cursor() as cur:
+            _install_valence_shadow(cur)
+            character_id, character_entity_id = _insert_protagonist(cur)
+            inputs = TraitCompileInputs.model_validate(
+                {
+                    "patron": {
+                        "name": PATRON_NAME,
+                        "functions": ["mentors", "protects"],
+                    },
+                    "dependents": {"targets": [{"name": DEPENDENT_NAME}]},
+                    "obligations": {
+                        "targets": [
+                            {
+                                "counterparty_kind": "character",
+                                "name": OBLIGATION_CHARACTER_NAME,
+                            }
+                        ]
+                    },
+                }
+            )
+            constraints = [
+                TraitConstraint.model_validate(
+                    {"trait": trait, "cold_start_relationships": "forbidden"}
+                )
+                for trait in ("patron", "dependents", "obligations")
+            ]
+            sheet = _character_sheet(
+                "patron",
+                "dependents",
+                "obligations",
+                inputs=inputs,
+                constraints=constraints,
+            )
+
+            dry_result = compile_character_traits(
+                cur,
+                character=sheet,
+                character_id=character_id,
+                character_entity_id=character_entity_id,
+                dry_run=True,
+            )
+            apply_result = apply_character_trait_compilation(
+                cur,
+                character=sheet,
+                character_id=character_id,
+                character_entity_id=character_entity_id,
+            )
+
+            for result in (dry_result, apply_result):
+                assert result.created_entities == []
+                assert result.created_relationships == []
+                assert result.applied_pair_tags == []
+                assert {item.reason_code for item in result.prose_only_remainders} == {
+                    TraitCompileReasonCode.COLD_START_RELATIONSHIPS_FORBIDDEN
+                }
+            cur.execute(
+                "SELECT count(*) FROM characters WHERE name = ANY(%s)",
+                ([PATRON_NAME, DEPENDENT_NAME, OBLIGATION_CHARACTER_NAME],),
+            )
+            assert cur.fetchone() == (0,)
+            cur.execute(
+                "SELECT count(*) FROM character_relationships "
+                "WHERE character1_id = %s",
+                (character_id,),
+            )
+            assert cur.fetchone() == (0,)
     finally:
         conn.rollback()
         conn.close()

--- a/tests/test_trait_input_derivation.py
+++ b/tests/test_trait_input_derivation.py
@@ -11,7 +11,12 @@ from typing import List
 
 import pytest
 
-from nexus.api.new_story_schemas import CharacterSheet, CharacterTrait, SettingCard
+from nexus.api.new_story_schemas import (
+    CharacterSheet,
+    CharacterTrait,
+    SettingCard,
+    TraitConstraint,
+)
 from nexus.api.trait_compiler_schemas import (
     DependentsTraitInput,
     DependentTargetInput,
@@ -31,10 +36,15 @@ from nexus.api.trait_input_derivation import (
     render_trait_input_prompt,
     selected_canonical_traits,
     selected_trait_compile_inputs_model,
+    traits_requiring_derived_inputs,
 )
 
 
-def _character(trait_names: List[str]) -> CharacterSheet:
+def _character(
+    trait_names: List[str],
+    *,
+    constraints: List[TraitConstraint] | None = None,
+) -> CharacterSheet:
     traits = [
         CharacterTrait(name=name, description=f"{name} description for testing")
         for name in trait_names
@@ -53,6 +63,7 @@ def _character(trait_names: List[str]) -> CharacterSheet:
         trait_1=traits[0],
         trait_2=traits[1],
         trait_3=traits[2],
+        trait_constraints=constraints or [],
     )
 
 
@@ -236,6 +247,29 @@ def test_prompt_renders_selected_traits_and_vocabulary() -> None:
     assert '"magnate"' in prompt  # resource vocabulary present
     assert '"sovereign"' in prompt  # status vocabulary present
     assert "Hard Rules" in prompt
+
+
+def test_forbidden_relationship_trait_is_removed_before_derivation() -> None:
+    """The structured schema cannot emit a mintable target for a forbidden trait."""
+
+    character = _character(
+        ["status", "enemies", "obligations"],
+        constraints=[
+            TraitConstraint(
+                trait="enemies",
+                cold_start_relationships="forbidden",
+            )
+        ],
+    )
+
+    assert traits_requiring_derived_inputs(character) == ["status", "obligations"]
+    schema = selected_trait_compile_inputs_model(
+        traits_requiring_derived_inputs(character)
+    ).model_json_schema()
+    assert "enemies" not in schema["properties"]
+    prompt = render_trait_input_prompt(character=character, setting=_setting())
+    assert '"forbidden_cold_start_relationship_traits": [' in prompt
+    assert '"enemies"' in prompt
 
 
 def test_prompt_requires_existing_prompt_file() -> None:


### PR DESCRIPTION
Fixes #601 (midnight adversarial QA finding 4), implementing the owner's recorded Option 0 ruling on the issue.

## Design
1. **Typed at the source** — `TraitConstraint` (`cold_start_relationships: allowed | forbidden`) populated by the wizard model in the same `submit_trait_selection` structured call (zero extra API calls, zero added friction); validated unique + selection-scoped; persisted beside rationales in `assets.traits` (migration 097, collision-checked against all remote branches and open PRs).
2. **Threaded through every call** — R4 generation packet, R5 selection payload + rubric line, R6 expansion. The selection judge can now see and act on constraints it was previously blind to.
3. **Enforced at materialization** — a relationship plan whose type matches a forbidden trait and involves the protagonist yields the named violation `cold_start_relationships_forbidden` into the existing `ModelRetry` budget; exhaustion raises loudly with the final violation named.

The taste line (owner-ruled): backstory events are never rejected — the `e_voss_practice_dispute` pattern persists; only mechanical relationship rows breach the contract. Encoded in the R5 rubric, the R6 validator, and the wizard prompt (`prompts/storyteller_new.md`).

## Proof
- **Live**: gated real-model test on disposable slot 3 (`NEXUS_ISSUE_601_LIVE=1` + disposable-DB double confirmation) — model populates the constraint from a "no preexisting nemesis" rationale; persistence, hydration, and packet threading verified. Passed in 8.9s.
- **Real Postgres**: disposable-clone regression (CREATE DATABASE … TEMPLATE NEXUS_template, dropped after) asserts the dispute event persists while zero enemy relationship rows exist for the PC.
- 988 orrery tests + 138 targeted wizard/schema/cache tests green; mypy and black clean across all 12 touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fs3R2bgfcWPiU4QgToRxo