### PR TITLE
Repair stale tests tracked by #604

### DIFF
--- a/tests/test_api/test_mock_wizard_responses.py
+++ b/tests/test_api/test_mock_wizard_responses.py
@@ -287,37 +287,6 @@ def test_responses_wizard_transition_returns_phase_specific_intro(
     assert expected_copy in wizard_response.message.lower()
 
 
-def test_responses_non_wizard_skald_turn_route_is_unchanged(
-    mock_rows,
-) -> None:
-    """Wizard precedence must not disturb semantic-update storyteller routing."""
-
-    response = TestClient(mock_openai.app).post(
-        "/v1/responses",
-        json={
-            "model": "TEST",
-            "tools": [
-                {
-                    "type": "function",
-                    "name": "final_result",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {"updates": {"type": "array"}},
-                    },
-                    "strict": True,
-                }
-            ],
-            "input": [{"role": "user", "content": "Continue the story."}],
-        },
-    )
-
-    assert response.status_code == 200
-    tool_call = response.json()["output"][0]
-    assert tool_call["type"] == "function_call"
-    assert tool_call["name"] == "final_result"
-    assert json.loads(tool_call["arguments"])["narrative"].startswith("[TEST MODE]")
-
-
 @pytest.mark.parametrize(
     "builder",
     [

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -331,38 +331,41 @@ def test_sync_generation_rejects_mid_turn_route_drift(
 
 @pytest.mark.requires_postgres
 def test_lore_keeps_logon_lazy(patched_provider: Dict[str, int]) -> None:
-    """LORE should not initialize LOGON on construction when lazy mode is enabled."""
+    """LORE should construct LOGON without eagerly constructing its provider."""
 
     lore = LORE(debug=True, enable_logon=True)
     assert patched_provider["count"] == 0
     assert lore.logon is None
-
-
-@pytest.mark.requires_postgres
-def test_logon_initializes_on_first_use(
-    patched_provider: Dict[str, int], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """LOGON provider should initialize only when requested."""
-
-    lore = LORE(debug=True, enable_logon=True)
     lore.ensure_logon()
     assert lore.logon is not None
+    assert lore.logon.provider is None
     assert patched_provider["count"] == 0
 
-    # This DB-backed utility legitimately demands a parent id for the
-    # presence baseline; the test's subject is provider laziness, so the
-    # reader is stubbed at its consumption seam.
-    monkeypatch.setattr(
-        "nexus.agents.lore.logon_utility.read_presence_baseline",
-        lambda _dbname, _parent_chunk_id: None,
+
+def test_logon_initializes_provider_on_first_generation(
+    patched_provider: Dict[str, int],
+) -> None:
+    """The first narrative generation should initialize the provider exactly once."""
+
+    # Provider laziness is independent of the production two-pass default.
+    # Pin the simplest generation route so this regression test does not absorb
+    # database, contextual-tag-library, or writer/Gaia fixture contracts.
+    logon = LogonUtility(
+        {"API Settings": {"apex": {"turn_pipeline": "single_pass"}}},
+        model_override="dummy-model",
     )
-    payload = _minimal_payload()
-    payload["metadata"] = {"target_chunk_id": 1}
-    response = lore.logon.generate_narrative(payload)
+    assert logon.provider is None
+    assert patched_provider["count"] == 0
+
+    response = logon.generate_narrative(
+        _minimal_payload(),
+        effective_context_window=75_000,
+    )
+
     assert patched_provider["count"] == 1
-    assert isinstance(lore.logon.provider, _DummyProvider)
-    assert lore.logon.provider.calls == 1
-    assert lore.logon.provider.schema_models == [SkaldTurnWire]
+    assert isinstance(logon.provider, _DummyProvider)
+    assert logon.provider.calls == 1
+    assert logon.provider.schema_models == [SkaldTurnWire]
     assert response.narrative.startswith("dummy:")
     assert response.generation_model == "dummy-model"
 

--- a/tests/test_lore/test_retrieval_coverage_live.py
+++ b/tests/test_lore/test_retrieval_coverage_live.py
@@ -100,6 +100,7 @@ def test_handle_user_input_writes_exact_coverage_and_empty_detection() -> None:
                 },
                 memnon=LiveReferenceMemnon(connection, int(covered.chunk_id)),
                 provider_wire_type="openai",
+                provider_name="openai",
             )
             manager.handle_storyteller_response(
                 narrative="The prior scene closes.",


### PR DESCRIPTION
## Summary

- preserve the provider-laziness regression as a fast, DB-less first-generation test pinned to the single-pass fixture it actually exercises
- retain the live retrieval-coverage proof and supply the provider-name half of its current budget contract
- remove the redundant wizard-route test whose updates-only schema now correctly identifies the Gaia projection

## Root cause

The tests lagged three intentional runtime changes: contextual per-turn tag libraries, provider-name-keyed resource profiles, and schema-signature routing for the writer/Gaia split. The production contracts are unchanged by this PR.

## Validation

- `poetry run black --check tests/test_lore/test_logon_lazy_init.py tests/test_lore/test_retrieval_coverage_live.py tests/test_api/test_mock_wizard_responses.py`
- focused surrounding suite: 66 passed, 3 skipped
- PostgreSQL-gated regressions: 2 passed; the retrieval-coverage transaction rolled back
- full default suite: 1,947 passed, 449 skipped, with four deterministic pre-existing failures in untouched areas (`test_shipped_gaia_model_resolves_to_openai_registry_id`, two narrative-generation LORE doubles missing `settings_path`, and the corresponding tag-validation LORE double)

No configuration, schema, or persistent data changes.

Closes #604

Codex (GPT-5)