### PR TITLE
Repair four stale test contracts

### DIFF
--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -149,12 +149,12 @@ def test_shipped_turn_pipeline_is_two_pass() -> None:
     assert settings.apex.turn_pipeline == "two_pass"
 
 
-def test_shipped_gaia_model_resolves_to_openai_registry_id() -> None:
-    """Committed gaia seat = @openai.default, resolved concrete at load (#578)."""
+def test_shipped_gaia_model_resolves_to_openai_gaia_registry_id() -> None:
+    """Committed Gaia seat resolves through its dedicated OpenAI role (#592)."""
     settings = Settings(**_nexus_toml_dict())
 
-    openai_default = settings.global_.model.api_models["openai"].roles["default"]
-    assert settings.apex.gaia_model == openai_default
+    openai_gaia = settings.global_.model.api_models["openai"].roles["gaia"]
+    assert settings.apex.gaia_model == openai_gaia
     assert not settings.apex.gaia_model.startswith("@")
 
 

--- a/tests/test_api/test_narrative_generation.py
+++ b/tests/test_api/test_narrative_generation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -56,6 +57,7 @@ async def test_lore_phase_failure_is_reported_before_adapter_coercion(
 
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             self.kwargs = kwargs
+            self.settings_path = Path("test-settings.toml")
             self.turn_context = SimpleNamespace(
                 error_log=[
                     "TurnPhase.WARM_ANALYSIS: FATAL: No warm slice chunks retrieved."
@@ -126,6 +128,7 @@ async def test_continuation_threads_logon_model_into_incubator(
         calls: list[tuple[str, int, str | None]] = []
 
         def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.settings_path = Path("test-settings.toml")
             self.turn_context = SimpleNamespace(error_log=[], orrery_proposal=None)
 
         async def process_turn(

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast, List, Literal, Optional, Tuple
 
@@ -1157,6 +1158,7 @@ async def test_exhausted_declaration_validation_never_reaches_incubator(
 
     class InvalidDeclarationLore:
         def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            self.settings_path = Path("test-settings.toml")
             self.turn_context = SimpleNamespace(error_log=[])
 
         async def process_turn(


### PR DESCRIPTION
## Summary

- keep the shipped Gaia model-resolution test, but update it to the dedicated `openai.gaia` role introduced by #592
- keep the three narrative/orchestration tests and complete their LORE doubles with the observable `settings_path` contract introduced by #603
- leave production behavior and `nexus.toml` unchanged

## Disposition

All four tests still protect useful contracts. One assertion was stale; three test doubles were incomplete.

## Verification

- `poetry run black --check tests/config/test_settings_models.py tests/test_api/test_narrative_generation.py tests/test_orrery_tag_validation.py`
- containing modules: 112 passed
- full suite: 1,951 passed, 449 skipped

Codex (GPT-5)