### PR TITLE
CLI: Surface Seed-Completion Transition Failures Loudly

### DIFF
--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -1139,6 +1139,34 @@ def _generation_timeout_seconds() -> int:
     return load_settings().apex.generation_timeout_seconds
 
 
+def _seed_transition_failure(
+    *,
+    result: Dict[str, Any],
+    slot: int,
+    detail: str,
+    status_code: Optional[int],
+    status: str,
+) -> Dict[str, Any]:
+    """Report a persisted seed whose narrative transition did not complete."""
+    retry_command = f"nexus continue --slot {slot}"
+    result.update(
+        {
+            "success": False,
+            "error": (
+                "Seed artifact was saved, but the narrative transition failed. "
+                f"Retry with: {retry_command}"
+            ),
+            "transition_error": {
+                "status": status,
+                "status_code": status_code,
+                "detail": detail,
+            },
+            "retry_command": retry_command,
+        }
+    )
+    return result
+
+
 def _apply_traits_to_wildcard_transition(
     *,
     url: str,
@@ -1450,32 +1478,52 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                     elif next_phase == "ready":
                         # Seed phase complete → transition to narrative mode
                         transition_url = f"{get_api_url()}/api/story/new/transition"
-                        transition_response = _api_post(
-                            transition_url,
-                            json={"slot": args.slot},
-                            timeout=_transition_timeout_seconds(),
+                        try:
+                            transition_response = _api_post(
+                                transition_url,
+                                json={"slot": args.slot},
+                                timeout=_transition_timeout_seconds(),
+                            )
+                        except requests.exceptions.Timeout as exc:
+                            return _seed_transition_failure(
+                                result=result,
+                                slot=args.slot,
+                                detail=str(exc) or "Transition request timed out.",
+                                status_code=None,
+                                status="timeout",
+                            )
+                        if not transition_response.ok:
+                            detail = transition_response.text.strip() or (
+                                "Transition request failed with HTTP "
+                                f"{transition_response.status_code}."
+                            )
+                            return _seed_transition_failure(
+                                result=result,
+                                slot=args.slot,
+                                detail=detail,
+                                status_code=transition_response.status_code,
+                                status="http_error",
+                            )
+                        result["retrograde"] = transition_response.json().get(
+                            "retrograde"
                         )
-                        if transition_response.ok:
-                            result["retrograde"] = transition_response.json().get(
-                                "retrograde"
+                        # Bootstrap narrative by calling continue endpoint
+                        continue_url = f"{get_api_url()}/api/narrative/continue"
+                        continue_payload = {"slot": args.slot, "user_text": ""}
+                        if model_to_use:
+                            continue_payload["model"] = model_to_use
+                        narrative_response = _api_post(
+                            continue_url, json=continue_payload, timeout=120
+                        )
+                        if narrative_response.ok:
+                            narrative_data = narrative_response.json()
+                            result["narrative_bootstrap"] = True
+                            result["next_phase_intro"] = narrative_data.get(
+                                "storyteller_text"
                             )
-                            # Bootstrap narrative by calling continue endpoint
-                            continue_url = f"{get_api_url()}/api/narrative/continue"
-                            continue_payload = {"slot": args.slot, "user_text": ""}
-                            if model_to_use:
-                                continue_payload["model"] = model_to_use
-                            narrative_response = _api_post(
-                                continue_url, json=continue_payload, timeout=120
-                            )
-                            if narrative_response.ok:
-                                narrative_data = narrative_response.json()
-                                result["narrative_bootstrap"] = True
-                                result["next_phase_intro"] = narrative_data.get(
-                                    "storyteller_text"
-                                )
-                                result["choices"] = narrative_data.get("choices", [])
-                                result["chunk_id"] = narrative_data.get("chunk_id")
-                                result["phase"] = None  # Clear wizard phase
+                            result["choices"] = narrative_data.get("choices", [])
+                            result["chunk_id"] = narrative_data.get("chunk_id")
+                            result["phase"] = None  # Clear wizard phase
 
                 return result
 
@@ -3707,7 +3755,10 @@ def main() -> int:
 
     # Check for errors (consistent format: success=False with error message)
     if not result.get("success", True) or result.get("error"):
-        emit_error(result.get("error", "Unknown error"), args.json)
+        if args.json and result.get("transition_error"):
+            print(json.dumps(result, indent=2, sort_keys=True), file=sys.stderr)
+        else:
+            emit_error(result.get("error", "Unknown error"), args.json)
         return 1
 
     emit_output(result, args.json, truncate=args.truncate)

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -1492,7 +1492,7 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                                 status_code=None,
                                 status="timeout",
                             )
-                        if not transition_response.ok:
+                        if not 200 <= transition_response.status_code < 300:
                             detail = transition_response.text.strip() or (
                                 "Transition request failed with HTTP "
                                 f"{transition_response.status_code}."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from argparse import Namespace
 from typing import Any
 
 import pytest
+import requests
 
 from nexus import cli
 from nexus.cli import _is_terminal_generation_status
@@ -301,6 +302,143 @@ def test_trait_confirmation_intro_failure_exposes_recovery(monkeypatch) -> None:
     assert "Traits were saved" in result["message"]
     assert recovery_command in result["message"]
     assert len(posts) == 2
+
+
+def _stub_seed_completion_requests(
+    monkeypatch,
+    transition_response: DummyResponse | requests.exceptions.Timeout,
+) -> None:
+    """Stub the gateway boundary for a public seed-completion CLI command."""
+
+    def fake_get(url: str, **kwargs: Any) -> DummyResponse:
+        assert url.endswith("/api/slot/5/state")
+        return DummyResponse(
+            {
+                "is_empty": False,
+                "is_wizard_mode": True,
+                "phase": "seed",
+                "choices": ["Commit the final seed."],
+            }
+        )
+
+    def fake_post(url: str, json: dict[str, Any], **kwargs: Any) -> DummyResponse:
+        if url.endswith("/api/story/new/chat"):
+            assert json["message"] == "Commit the final seed."
+            return DummyResponse(
+                {
+                    "message": "The seed is saved.",
+                    "phase": "seed",
+                    "artifact_type": "story_seed",
+                    "data": {"title": "The Glass Orchard"},
+                    "phase_complete": True,
+                }
+            )
+        if url.endswith("/api/story/new/transition"):
+            if isinstance(transition_response, requests.exceptions.Timeout):
+                raise transition_response
+            return transition_response
+        if url.endswith("/api/narrative/continue"):
+            return DummyResponse(
+                {
+                    "storyteller_text": "Rain needles the orchard glass.",
+                    "choices": ["Enter the gate."],
+                    "chunk_id": 1,
+                }
+            )
+        raise AssertionError(f"Unexpected POST {url}")
+
+    monkeypatch.setattr(cli.requests, "get", fake_get)
+    monkeypatch.setattr(cli.requests, "post", fake_post)
+
+
+@pytest.mark.parametrize("status_code", [400, 422, 500])
+def test_seed_completion_transition_http_failure_exits_nonzero_with_retry(
+    monkeypatch, capsys, status_code: int
+) -> None:
+    """A persisted seed cannot make a failed atomic transition look successful."""
+    detail = f'{{"detail":"Atomic transition failed with {status_code}"}}'
+    _stub_seed_completion_requests(
+        monkeypatch,
+        DummyResponse({}, ok=False, text=detail, status_code=status_code),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["nexus", "--json", "continue", "--slot", "5", "--choice", "1"],
+    )
+
+    assert cli.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["success"] is False
+    assert payload["phase_complete"] is True
+    assert payload["artifact_type"] == "story_seed"
+    assert payload["artifact_data"] == {"title": "The Glass Orchard"}
+    assert payload["transition_error"] == {
+        "status": "http_error",
+        "status_code": status_code,
+        "detail": detail,
+    }
+    assert payload["retry_command"] == "nexus continue --slot 5"
+    assert payload["retry_command"] in payload["error"]
+
+
+def test_seed_completion_transition_timeout_exits_nonzero_with_retry(
+    monkeypatch, capsys
+) -> None:
+    """A transition timeout reports the saved seed and an explicit retry."""
+    _stub_seed_completion_requests(
+        monkeypatch,
+        requests.exceptions.Timeout("Transition timed out after 900 seconds."),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["nexus", "--json", "continue", "--slot", "5", "--choice", "1"],
+    )
+
+    assert cli.main() == 1
+
+    payload = json.loads(capsys.readouterr().err)
+    assert payload["success"] is False
+    assert payload["phase_complete"] is True
+    assert payload["artifact_data"] == {"title": "The Glass Orchard"}
+    assert payload["transition_error"] == {
+        "status": "timeout",
+        "status_code": None,
+        "detail": "Transition timed out after 900 seconds.",
+    }
+    assert payload["retry_command"] == "nexus continue --slot 5"
+
+
+def test_seed_completion_success_transitions_and_bootstraps_narrative(
+    monkeypatch, capsys
+) -> None:
+    """A successful transition retains the seed and reports narrative success."""
+    _stub_seed_completion_requests(
+        monkeypatch,
+        DummyResponse({"retrograde": {"status": "complete"}}),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["nexus", "--json", "continue", "--slot", "5", "--choice", "1"],
+    )
+
+    assert cli.main() == 0
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["success"] is True
+    assert payload["phase_complete"] is True
+    assert payload["artifact_data"] == {"title": "The Glass Orchard"}
+    assert payload["retrograde"] == {"status": "complete"}
+    assert payload["narrative_bootstrap"] is True
+    assert payload["next_phase_intro"] == "Rain needles the orchard glass."
+    assert payload["phase"] is None
 
 
 @pytest.mark.parametrize("confirmation_path", ["free-text", "deterministic"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -351,15 +351,21 @@ def _stub_seed_completion_requests(
     monkeypatch.setattr(cli.requests, "post", fake_post)
 
 
-@pytest.mark.parametrize("status_code", [400, 422, 500])
+@pytest.mark.parametrize(
+    "status_code,requests_ok", [(300, True), (400, False), (422, False), (500, False)]
+)
 def test_seed_completion_transition_http_failure_exits_nonzero_with_retry(
-    monkeypatch, capsys, status_code: int
+    monkeypatch, capsys, status_code: int, requests_ok: bool
 ) -> None:
-    """A persisted seed cannot make a failed atomic transition look successful."""
+    """A persisted seed cannot make a failed atomic transition look successful.
+
+    requests.Response.ok is True for any status < 400, so a 3xx must fail
+    the strict 2xx contract even while ok=True.
+    """
     detail = f'{{"detail":"Atomic transition failed with {status_code}"}}'
     _stub_seed_completion_requests(
         monkeypatch,
-        DummyResponse({}, ok=False, text=detail, status_code=status_code),
+        DummyResponse({}, ok=requests_ok, text=detail, status_code=status_code),
     )
     monkeypatch.setattr(
         sys,


### PR DESCRIPTION
## Summary

Fixes #611 (night-QA round 2). The seed-completion branch in `run_continue` checked `if transition_response.ok:` with no `else`, so a failed atomic transition fell through to `return result` — reporting `success: true` and exiting 0 while the slot remained in wizard mode.

## Changes

- `_seed_transition_failure` helper: marks the result `success=false`, attaches `transition_error` (status, status_code, detail) and `retry_command`, and preserves the separately-persisted seed artifact fields.
- Timeout and non-2xx transition responses both route through it; the success path is de-nested.
- JSON mode emits the full structured failure to stderr (upgrade from the bare `{"error": ...}` shape); exit code is 1.

## Testing

Tests drive `cli.main()` via argv — the genuine public entry — with the gateway stubbed only at the `requests` boundary, matching the existing `test_trait_confirmation_intro_failure_exposes_recovery` idiom. Coverage: 400/422/500 (parametrized), timeout, and successful transition+bootstrap.

- Focused: `26 passed`
- Full suite: `1955 passed, 450 skipped`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fs3R2bgfcWPiU4QgToRxo