### PR TITLE
Narrative Continue: Validate Before Mutating, Require Choice Resolution

### DIFF
--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -382,11 +382,16 @@ def _record_player_response_for_chunk(
                         )
                 return existing_choice_text
 
-            if not has_new_input and not require_response:
+            has_unresolved_choices = bool(choice_object and choice_object["presented"])
+            if (
+                not has_new_input
+                and not require_response
+                and not has_unresolved_choices
+            ):
                 return user_text
 
             if not has_new_input:
-                if choice_object and choice_object["presented"]:
+                if has_unresolved_choices:
                     raise HTTPException(
                         status_code=400,
                         detail=(
@@ -641,7 +646,10 @@ async def continue_narrative(
             logger.info(
                 f"Resolved chunk_id={request.chunk_id} from slot {request.slot}"
             )
-    elif request.chunk_id and _has_player_response_input(request):
+    elif request.chunk_id:
+        # Runs even without player input: the resolver owns the
+        # unresolved-choice guard, so an explicitly addressed chunk cannot
+        # bypass it the way slot-resolved continues cannot.
         resolved_user_text = _record_player_response_for_chunk(
             slot=request.slot,
             chunk_id=request.chunk_id,

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -386,6 +386,14 @@ def _record_player_response_for_chunk(
                 return user_text
 
             if not has_new_input:
+                if choice_object and choice_object["presented"]:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            "Current chunk has unresolved choices; provide choice, "
+                            "non-empty user_text, or accept_fate."
+                        ),
+                    )
                 raise HTTPException(status_code=400, detail="No input provided")
 
             try:
@@ -554,20 +562,21 @@ async def continue_narrative(
 
     Initiates async generation and returns session_id for tracking.
     """
-    if request.model:
-        if request.slot is None:
-            raise HTTPException(
-                status_code=400,
-                detail="Model override requires a slot to persist the selection.",
-            )
-        from nexus.api.save_slots import upsert_slot
-
-        upsert_slot(request.slot, model=request.model, dbname=slot_dbname(request.slot))
-        logger.info("Persisted model %s to slot %s", request.model, request.slot)
+    if request.choice is not None and request.accept_fate:
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot provide both choice and accept_fate",
+        )
+    if request.model and request.slot is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Model override requires a slot to persist the selection.",
+        )
 
     # Resolve chunk_id from slot state if not provided
     resolved_user_text = request.user_text
-    if request.chunk_id is None and request.slot is not None:
+    state = None
+    if request.slot is not None:
         from nexus.api.slot_state import get_slot_state
 
         state = get_slot_state(request.slot)
@@ -576,6 +585,8 @@ async def continue_narrative(
                 status_code=400,
                 detail="Slot is in wizard mode. Use /api/story/new/chat for wizard.",
             )
+
+    if request.chunk_id is None and state is not None:
         if state.narrative_state is not None:
             narrative_state = state.narrative_state
             if narrative_state.has_pending:
@@ -614,7 +625,7 @@ async def continue_narrative(
                 request.chunk_id = approved_chunk_id
             else:
                 request.chunk_id = narrative_state.current_chunk_id
-                if _has_player_response_input(request) and (
+                if (
                     request.choice is not None
                     or request.accept_fate
                     or narrative_state.choices
@@ -625,7 +636,7 @@ async def continue_narrative(
                         user_text=request.user_text,
                         choice=request.choice,
                         accept_fate=request.accept_fate,
-                        require_response=False,
+                        require_response=bool(narrative_state.choices),
                     )
             logger.info(
                 f"Resolved chunk_id={request.chunk_id} from slot {request.slot}"
@@ -639,6 +650,15 @@ async def continue_narrative(
             accept_fate=request.accept_fate,
             require_response=False,
         )
+
+    # A request-level override is intentionally persistent, but only after every
+    # synchronous continue validation above has succeeded. Rejected requests
+    # must not alter the model used by later turns.
+    if request.model:
+        from nexus.api.save_slots import upsert_slot
+
+        upsert_slot(request.slot, model=request.model, dbname=slot_dbname(request.slot))
+        logger.info("Persisted model %s to slot %s", request.model, request.slot)
 
     session_id = str(uuid.uuid4())
 

--- a/tests/test_api/test_narrative_continue_validation.py
+++ b/tests/test_api/test_narrative_continue_validation.py
@@ -1,0 +1,458 @@
+"""Route-level regression coverage for narrative continue validation."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+import psycopg2
+import pytest
+from fastapi.testclient import TestClient
+from psycopg2 import sql
+from psycopg2.extras import Json, RealDictCursor
+
+from nexus.api import chunk_workflow, narrative, save_slots, slot_endpoints, slot_state
+from nexus.api.slot_state import NarrativeState, SlotState, WizardState
+from nexus.config import get_available_api_models
+
+
+class ChoiceCursor:
+    """Serve one committed chunk through the production response resolver."""
+
+    def __init__(self, connection: "ChoiceConnection") -> None:
+        self.connection = connection
+        self.result: dict[str, Any] | None = None
+        self.rowcount = 0
+
+    def __enter__(self) -> "ChoiceCursor":
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def execute(self, query: str, params: Any = None) -> None:
+        normalized = " ".join(query.split())
+        if "FROM incubator" in normalized:
+            self.result = None
+            return
+        if "FROM narrative_chunks" in normalized and normalized.startswith("SELECT"):
+            self.result = self.connection.chunk.copy()
+            return
+        if normalized.startswith("UPDATE"):
+            self.connection.updates.append((normalized, params))
+            self.rowcount = 1
+            return
+        raise AssertionError(f"Unexpected choice query: {normalized}")
+
+    def fetchone(self) -> dict[str, Any] | None:
+        return self.result
+
+
+class ChoiceConnection:
+    """Minimal transaction double for committed-choice route tests."""
+
+    def __init__(self, chunk: dict[str, Any]) -> None:
+        self.chunk = chunk
+        self.updates: list[tuple[str, Any]] = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+
+    def cursor(self, **_kwargs: Any) -> ChoiceCursor:
+        return ChoiceCursor(self)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _committed_state(*, choices: list[str]) -> SlotState:
+    """Build the slot-state result returned by the production resolver."""
+    return SlotState(
+        slot=3,
+        is_empty=False,
+        is_wizard_mode=False,
+        wizard_state=None,
+        narrative_state=NarrativeState(
+            current_chunk_id=17,
+            has_pending=False,
+            storyteller_text="The door waits.",
+            choices=choices,
+            session_id=None,
+        ),
+        model="existing-model",
+    )
+
+
+def _wizard_state() -> SlotState:
+    """Build a wizard-mode slot state for route rejection coverage."""
+    return SlotState(
+        slot=3,
+        is_empty=False,
+        is_wizard_mode=True,
+        wizard_state=WizardState(
+            phase="setting",
+            thread_id="wizard-thread",
+            choices=[],
+        ),
+        narrative_state=None,
+        model="existing-model",
+    )
+
+
+def _valid_override() -> str:
+    """Return a configured concrete model accepted by the request schema."""
+    return get_available_api_models()[0]
+
+
+def _capture_model_writes(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Capture persistent model writes made by the route."""
+    writes: list[dict[str, Any]] = []
+
+    def capture(slot: int, **kwargs: Any) -> None:
+        writes.append({"slot": slot, **kwargs})
+
+    monkeypatch.setattr(save_slots, "upsert_slot", capture)
+    return writes
+
+
+def test_invalid_choice_does_not_persist_model_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Choice-range rejection precedes every canonical write."""
+    choices = ["Open the door.", "Wait in silence."]
+    connection = ChoiceConnection(
+        {
+            "id": 17,
+            "storyteller_text": "The door waits.",
+            "choice_object": {"presented": choices, "selected": None},
+            "choice_text": None,
+        }
+    )
+    monkeypatch.setattr(
+        slot_state, "get_slot_state", lambda _slot: _committed_state(choices=choices)
+    )
+    monkeypatch.setattr(narrative, "get_db_connection", lambda _slot: connection)
+    model_writes = _capture_model_writes(monkeypatch)
+
+    response = TestClient(narrative.app).post(
+        "/api/narrative/continue",
+        json={"slot": 3, "choice": 99, "model": _valid_override()},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Choice 99 out of range (1-2)"
+    assert model_writes == []
+    assert connection.updates == []
+    assert connection.commits == 0
+    assert connection.rollbacks == 1
+
+
+def test_conflicting_choice_and_accept_fate_does_not_persist_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mutually exclusive player inputs fail before slot mutation."""
+    model_writes = _capture_model_writes(monkeypatch)
+
+    response = TestClient(narrative.app).post(
+        "/api/narrative/continue",
+        json={
+            "slot": 3,
+            "choice": 1,
+            "accept_fate": True,
+            "model": _valid_override(),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Cannot provide both choice and accept_fate"
+    assert model_writes == []
+
+
+def test_unresolved_committed_choices_require_player_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plain continue cannot skip an unresolved committed choice."""
+    choices = ["Open the door.", "Wait in silence."]
+    connection = ChoiceConnection(
+        {
+            "id": 17,
+            "storyteller_text": "The door waits.",
+            "choice_object": {"presented": choices, "selected": None},
+            "choice_text": None,
+        }
+    )
+    monkeypatch.setattr(
+        slot_state, "get_slot_state", lambda _slot: _committed_state(choices=choices)
+    )
+    monkeypatch.setattr(narrative, "get_db_connection", lambda _slot: connection)
+    model_writes = _capture_model_writes(monkeypatch)
+
+    response = TestClient(narrative.app).post(
+        "/api/narrative/continue",
+        json={"slot": 3, "model": _valid_override()},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "Current chunk has unresolved choices; provide choice, non-empty "
+        "user_text, or accept_fate."
+    )
+    assert model_writes == []
+    assert connection.updates == []
+
+
+def test_wizard_mode_rejection_precedes_model_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even an explicit chunk cannot bypass slot-mode validation."""
+    monkeypatch.setattr(slot_state, "get_slot_state", lambda _slot: _wizard_state())
+    model_writes = _capture_model_writes(monkeypatch)
+
+    response = TestClient(narrative.app).post(
+        "/api/narrative/continue",
+        json={"slot": 3, "chunk_id": 17, "model": _valid_override()},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "Slot is in wizard mode. Use /api/story/new/chat for wizard."
+    )
+    assert model_writes == []
+
+
+def test_choice_free_empty_continue_persists_override_and_starts_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Choice-free chunks retain deliberate empty-input continuation."""
+    monkeypatch.setattr(
+        slot_state, "get_slot_state", lambda _slot: _committed_state(choices=[])
+    )
+    model_writes = _capture_model_writes(monkeypatch)
+    generation_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def capture_generation(*args: Any, **kwargs: Any) -> None:
+        generation_calls.append((args, kwargs))
+
+    monkeypatch.setattr(narrative, "generate_narrative_async", capture_generation)
+    monkeypatch.setattr(
+        narrative,
+        "_trigger_locked_chunk_embedding",
+        lambda **_kwargs: None,
+    )
+
+    response = TestClient(narrative.app).post(
+        "/api/narrative/continue",
+        json={"slot": 3, "model": _valid_override()},
+    )
+
+    assert response.status_code == 200
+    assert model_writes == [
+        {
+            "slot": 3,
+            "model": _valid_override(),
+            "dbname": "save_03",
+        }
+    ]
+    assert len(generation_calls) == 1
+    generation_args, _generation_kwargs = generation_calls[0]
+    assert generation_args[1:4] == (17, "", 3)
+
+
+def _connect(dbname: str, *, dict_cursor: bool = False) -> Any:
+    """Open a direct PostgreSQL connection for a disposable clone."""
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+        cursor_factory=RealDictCursor if dict_cursor else None,
+    )
+
+
+@pytest.fixture()
+def disposable_narrative_db() -> Iterator[str]:
+    """Yield an isolated NEXUS_template clone and drop it afterward."""
+    dbname = f"nexus_test_continue_{uuid.uuid4().hex[:12]}"
+    admin = None
+    try:
+        try:
+            admin = _connect("postgres")
+        except psycopg2.Error as exc:
+            pytest.skip(f"PostgreSQL admin connection unavailable: {exc}")
+        admin.autocommit = True
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier("NEXUS_template"),
+                )
+            )
+        yield dbname
+    finally:
+        if admin is not None:
+            with admin.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = %s AND pid <> pg_backend_pid()",
+                    (dbname,),
+                )
+                cur.execute(
+                    sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+                )
+            admin.close()
+
+
+@contextmanager
+def _clone_connection(dbname: str, *, dict_cursor: bool = False) -> Iterator[Any]:
+    """Match the production pooled-connection transaction contract."""
+    conn = _connect(dbname, dict_cursor=dict_cursor)
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+@pytest.mark.requires_postgres
+def test_undo_restores_unresolved_parent_and_plain_continue_rejects(
+    monkeypatch: pytest.MonkeyPatch,
+    disposable_narrative_db: str,
+) -> None:
+    """The real undo→continue path cannot advance without a player decision."""
+    dbname = disposable_narrative_db
+    choices = ["Open the door.", "Wait in silence."]
+    storyteller_text = "The door waits."
+    selected_text = choices[0]
+    session_id = str(uuid.uuid4())
+
+    with _clone_connection(dbname) as conn:
+        with conn.cursor() as cur:
+            cur.execute("TRUNCATE incubator, narrative_chunks RESTART IDENTITY CASCADE")
+            cur.execute("DELETE FROM assets.new_story_creator")
+            cur.execute(
+                """
+                INSERT INTO narrative_chunks (
+                    raw_text, storyteller_text, choice_object, choice_text, state
+                ) VALUES (%s, %s, %s, %s, 'finalized')
+                RETURNING id
+                """,
+                (
+                    f"{storyteller_text}\n\n{selected_text}",
+                    storyteller_text,
+                    Json({"presented": choices, "selected": 1}),
+                    selected_text,
+                ),
+            )
+            parent_chunk_id = cur.fetchone()[0]
+            cur.execute(
+                """
+                INSERT INTO incubator (
+                    id, chunk_id, parent_chunk_id, user_text, storyteller_text,
+                    generation_model, choice_object, choice_text,
+                    metadata_updates, entity_updates, reference_updates,
+                    orrery_proposal, orrery_adjudications, new_entities,
+                    session_id, llm_response_id, status
+                ) VALUES (
+                    TRUE, %s, %s, %s, %s, %s, %s, %s,
+                    %s, %s, %s, %s, %s, %s, %s, %s, %s
+                )
+                """,
+                (
+                    parent_chunk_id + 1,
+                    parent_chunk_id,
+                    selected_text,
+                    "The hinges sigh open.",
+                    _valid_override(),
+                    Json({"presented": ["Enter."], "selected": None}),
+                    None,
+                    Json({}),
+                    Json({}),
+                    Json({}),
+                    None,
+                    Json([]),
+                    Json([]),
+                    session_id,
+                    "test-response",
+                    "complete",
+                ),
+            )
+
+    monkeypatch.setattr(slot_state, "slot_dbname", lambda _slot: dbname)
+    monkeypatch.setattr(
+        slot_state,
+        "get_connection",
+        lambda _dbname, dict_cursor=False: _clone_connection(
+            dbname, dict_cursor=dict_cursor
+        ),
+    )
+    monkeypatch.setattr(slot_endpoints, "slot_dbname", lambda _slot: dbname)
+    monkeypatch.setattr(
+        slot_endpoints,
+        "get_connection",
+        lambda _dbname, dict_cursor=False: _clone_connection(
+            dbname, dict_cursor=dict_cursor
+        ),
+    )
+    monkeypatch.setattr(chunk_workflow, "VALID_DATABASES", {dbname})
+    monkeypatch.setattr(
+        chunk_workflow,
+        "get_connection",
+        lambda _dbname, dict_cursor=False: _clone_connection(
+            dbname, dict_cursor=dict_cursor
+        ),
+    )
+    monkeypatch.setattr(narrative, "get_db_connection", lambda _slot: _connect(dbname))
+    generation_calls: list[tuple[Any, ...]] = []
+
+    async def capture_generation(*args: Any, **_kwargs: Any) -> None:
+        generation_calls.append(args)
+
+    monkeypatch.setattr(narrative, "generate_narrative_async", capture_generation)
+
+    with TestClient(narrative.app) as client:
+        undo_response = client.post("/api/slot/3/undo")
+        continue_response = client.post(
+            "/api/narrative/continue",
+            json={"slot": 3},
+        )
+
+    assert undo_response.status_code == 200
+    assert undo_response.json()["success"] is True
+    assert continue_response.status_code == 400
+    assert continue_response.json()["detail"] == (
+        "Current chunk has unresolved choices; provide choice, non-empty "
+        "user_text, or accept_fate."
+    )
+    assert generation_calls == []
+
+    with _clone_connection(dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) AS count FROM incubator")
+            assert cur.fetchone()["count"] == 0
+            cur.execute(
+                """
+                SELECT raw_text, storyteller_text, choice_text, choice_object
+                FROM narrative_chunks
+                WHERE id = %s
+                """,
+                (parent_chunk_id,),
+            )
+            parent = cur.fetchone()
+            assert parent["raw_text"] == storyteller_text
+            assert parent["storyteller_text"] == storyteller_text
+            assert parent["choice_text"] is None
+            assert parent["choice_object"] == {
+                "presented": choices,
+                "selected": None,
+            }

--- a/tests/test_api/test_narrative_continue_validation.py
+++ b/tests/test_api/test_narrative_continue_validation.py
@@ -266,6 +266,74 @@ def test_choice_free_empty_continue_persists_override_and_starts_generation(
     assert generation_args[1:4] == (17, "", 3)
 
 
+def test_explicit_slotless_chunk_with_unresolved_choices_requires_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicitly addressed chunk cannot bypass the unresolved-choice guard."""
+    choices = ["Open the door.", "Wait in silence."]
+    connection = ChoiceConnection(
+        {
+            "id": 17,
+            "storyteller_text": "The door waits.",
+            "choice_object": {"presented": choices, "selected": None},
+            "choice_text": None,
+        }
+    )
+    monkeypatch.setattr(narrative, "get_db_connection", lambda _slot: connection)
+    model_writes = _capture_model_writes(monkeypatch)
+
+    response = TestClient(narrative.app).post(
+        "/api/narrative/continue",
+        json={"chunk_id": 17},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "Current chunk has unresolved choices; provide choice, non-empty "
+        "user_text, or accept_fate."
+    )
+    assert model_writes == []
+    assert connection.updates == []
+
+
+def test_explicit_slotless_choice_free_chunk_keeps_empty_continue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A choice-free explicitly addressed chunk retains empty-input continuation."""
+    connection = ChoiceConnection(
+        {
+            "id": 17,
+            "storyteller_text": "The road runs on.",
+            "choice_object": None,
+            "choice_text": None,
+        }
+    )
+    monkeypatch.setattr(narrative, "get_db_connection", lambda _slot: connection)
+    model_writes = _capture_model_writes(monkeypatch)
+    generation_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def capture_generation(*args: Any, **kwargs: Any) -> None:
+        generation_calls.append((args, kwargs))
+
+    monkeypatch.setattr(narrative, "generate_narrative_async", capture_generation)
+    monkeypatch.setattr(
+        narrative,
+        "_trigger_locked_chunk_embedding",
+        lambda **_kwargs: None,
+    )
+
+    response = TestClient(narrative.app).post(
+        "/api/narrative/continue",
+        json={"chunk_id": 17},
+    )
+
+    assert response.status_code == 200
+    assert model_writes == []
+    assert len(generation_calls) == 1
+    generation_args, _generation_kwargs = generation_calls[0]
+    assert generation_args[1:3] == (17, "")
+
+
 def _connect(dbname: str, *, dict_cursor: bool = False) -> Any:
     """Open a direct PostgreSQL connection for a disposable clone."""
     return psycopg2.connect(

--- a/tests/test_api/test_narrative_generation.py
+++ b/tests/test_api/test_narrative_generation.py
@@ -283,8 +283,40 @@ async def test_bootstrap_threads_logon_model_into_incubator_payload(
 
 
 @pytest.mark.asyncio
-async def test_continue_route_threads_parent_into_generation_task() -> None:
+async def test_continue_route_threads_parent_into_generation_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The continue API schedules generation with its canonical parent id."""
+
+    class ChoiceFreeCursor:
+        def __enter__(self) -> "ChoiceFreeCursor":
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            return None
+
+        def execute(self, sql: str, _params: Any = None) -> None:
+            self._from_incubator = "FROM incubator" in sql
+
+        def fetchone(self) -> dict[str, Any] | None:
+            if self._from_incubator:
+                return None
+            return {
+                "id": 17,
+                "storyteller_text": "The road runs on.",
+                "choice_object": None,
+                "choice_text": None,
+            }
+
+    class ChoiceFreeConnection(DummyConnection):
+        def cursor(self, **_kwargs: Any) -> ChoiceFreeCursor:
+            return ChoiceFreeCursor()
+
+    monkeypatch.setattr(
+        narrative,
+        "get_db_connection",
+        lambda _slot=None: ChoiceFreeConnection(),
+    )
 
     background_tasks = BackgroundTasks()
     await narrative.continue_narrative(


### PR DESCRIPTION
## Summary

Fixes #614 and #615 together (night-QA round 2) — both are pre-generation validation-ordering defects in the same `continue_narrative` path.

## Changes

- **#614**: `upsert_slot(model=...)` moved from before any validation to after all synchronous validation (slot state, input combination, choice resolution). A rejected continue now leaves all canonical state unchanged, including model selection. The model-without-slot and choice+accept_fate conflicts are rejected up front.
- **#615**: for a committed parent, choice resolution now runs whenever the chunk presents choices (`require_response=bool(narrative_state.choices)`), not only when input happens to be present. A plain continue against unresolved choices returns an actionable 400; choice-free chunks retain deliberate empty-input continuation.

## Deliberately out of scope

The per-slot generation lease / concurrent-continue race is #616, sequenced after this lands (same entry path).

## Testing

Real FastAPI route via TestClient; `upsert_slot` is spied (never emulated) to assert zero model writes on every rejection path. The undo → committed-parent regression reproduces #615's exact repro against a disposable `NEXUS_template` clone (`NEXUS_RUN_POSTGRES=1`).

- Focused + pg-gated: `6 passed` (includes the disposable-clone regression)
- Full suite: `1955 passed, 451 skipped`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fs3R2bgfcWPiU4QgToRxo