### PR TITLE
Wizard: Represent Story-Start Seconds End to End

### DIFF
--- a/nexus/api/mock_openai.py
+++ b/nexus/api/mock_openai.py
@@ -266,6 +266,7 @@ def build_story_seed_arguments(cache: Dict[str, Any]) -> Dict[str, Any]:
         "day": base_timestamp.day,
         "hour": base_timestamp.hour,
         "minute": base_timestamp.minute,
+        "second": base_timestamp.second,
     }
 
     location_name = location.get("name", "unknown location")

--- a/nexus/api/new_story_cache.py
+++ b/nexus/api/new_story_cache.py
@@ -370,6 +370,7 @@ class WizardCache:
             "day": ts.day,
             "hour": ts.hour,
             "minute": ts.minute,
+            "second": ts.second,
         }
         return {
             "seed_type": self.seed.seed_type,

--- a/nexus/api/new_story_schemas.py
+++ b/nexus/api/new_story_schemas.py
@@ -55,7 +55,7 @@ _MONTH_DAY_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _ISO_DATETIME_PATTERN = re.compile(
-    r"(?<!\d)(?P<year>[1-9]\d{0,3})-"
+    r"(?<!\d)(?P<year>[1-9]\d{2,3})-"
     r"(?P<month>0[1-9]|1[0-2])-"
     r"(?P<day>0[1-9]|[12]\d|3[01])"
     r"(?:T|\s+)(?P<hour>[01]\d|2[0-3]):"

--- a/nexus/api/new_story_schemas.py
+++ b/nexus/api/new_story_schemas.py
@@ -54,6 +54,15 @@ _MONTH_DAY_PATTERN = re.compile(
     r"(?P<day>[1-9]|[12]\d|3[01])(?:st|nd|rd|th)?\b",
     re.IGNORECASE,
 )
+_ISO_DATETIME_PATTERN = re.compile(
+    r"(?<!\d)(?P<year>[1-9]\d{0,3})-"
+    r"(?P<month>0[1-9]|1[0-2])-"
+    r"(?P<day>0[1-9]|[12]\d|3[01])"
+    r"(?:T|\s+)(?P<hour>[01]\d|2[0-3]):"
+    r"(?P<minute>[0-5]\d):(?P<second>[0-5]\d)"
+    r"(?:\s*(?:Z|UTC))?\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -63,6 +72,7 @@ class SettingDateConstraint:
     year: int
     month: int
     day: Optional[int] = None
+    second: Optional[int] = None
 
     def conflicts_with(self, timestamp: "StoryTimestamp") -> bool:
         """Return whether a seed timestamp contradicts an explicit setting field."""
@@ -70,13 +80,17 @@ class SettingDateConstraint:
             timestamp.year != self.year
             or timestamp.month != self.month
             or (self.day is not None and timestamp.day != self.day)
+            or (self.second is not None and timestamp.second != self.second)
         )
 
     def describe(self) -> str:
         """Render the constraint for a model-facing repair error."""
         month_name = calendar.month_name[self.month]
         if self.day is not None:
-            return f"{month_name} {self.day}, {self.year}"
+            description = f"{month_name} {self.day}, {self.year}"
+            if self.second is not None:
+                return f"{description} with second {self.second}"
+            return description
         return f"{month_name} {self.year}"
 
 
@@ -93,6 +107,9 @@ def _year_month_candidates(text: str) -> set[tuple[int, int]]:
                     _MONTH_NUMBERS[match.group("month").lower()],
                 )
             )
+    for match in _ISO_DATETIME_PATTERN.finditer(text):
+        date_spans.append(match.span())
+        candidates.add((int(match.group("year")), int(match.group("month"))))
     for pattern in (_MONTH_YEAR_PATTERN, _YEAR_MONTH_PATTERN):
         for match in pattern.finditer(text):
             start, end = match.span()
@@ -113,6 +130,9 @@ def _year_month_candidates(text: str) -> set[tuple[int, int]]:
 def _day_candidates(text: str, *, year: int, month: int) -> set[int]:
     """Extract days tied to the selected explicit year and month."""
     days: set[int] = set()
+    for match in _ISO_DATETIME_PATTERN.finditer(text):
+        if int(match.group("year")) == year and int(match.group("month")) == month:
+            days.add(int(match.group("day")))
     for pattern in (_DAY_MONTH_YEAR_PATTERN, _MONTH_DAY_YEAR_PATTERN):
         for match in pattern.finditer(text):
             if (
@@ -130,6 +150,9 @@ def _day_candidates(text: str, *, year: int, month: int) -> set[int]:
 def _matching_full_date_days(text: str, *, year: int, month: int) -> set[int]:
     """Extract days only from full dates matching an established year/month."""
     days: set[int] = set()
+    for match in _ISO_DATETIME_PATTERN.finditer(text):
+        if int(match.group("year")) == year and int(match.group("month")) == month:
+            days.add(int(match.group("day")))
     for pattern in (_DAY_MONTH_YEAR_PATTERN, _MONTH_DAY_YEAR_PATTERN):
         for match in pattern.finditer(text):
             if (
@@ -138,6 +161,25 @@ def _matching_full_date_days(text: str, *, year: int, month: int) -> set[int]:
             ):
                 days.add(int(match.group("day")))
     return days
+
+
+def _matching_full_date_seconds(
+    text: str,
+    *,
+    year: int,
+    month: int,
+    day: int,
+) -> set[int]:
+    """Extract seconds only from full datetimes matching the accepted date."""
+    seconds: set[int] = set()
+    for match in _ISO_DATETIME_PATTERN.finditer(text):
+        if (
+            int(match.group("year")) == year
+            and int(match.group("month")) == month
+            and int(match.group("day")) == day
+        ):
+            seconds.add(int(match.group("second")))
+    return seconds
 
 
 def extract_setting_date_constraint(
@@ -170,7 +212,25 @@ def extract_setting_date_constraint(
 
     if day is not None and day > calendar.monthrange(year, month)[1]:
         day = None
-    return SettingDateConstraint(year=year, month=month, day=day)
+    second: Optional[int] = None
+    if day is not None:
+        second_candidates = _matching_full_date_seconds(
+            setting.time_period,
+            year=year,
+            month=month,
+            day=day,
+        )
+        second_candidates.update(
+            _matching_full_date_seconds(
+                setting.diegetic_artifact,
+                year=year,
+                month=month,
+                day=day,
+            )
+        )
+        if len(second_candidates) == 1:
+            second = next(iter(second_candidates))
+    return SettingDateConstraint(year=year, month=month, day=day, second=second)
 
 
 def _strip_legacy_orrery_proposals(value: Any) -> Any:
@@ -867,9 +927,11 @@ class StoryTimestamp(BaseModel):
     we use constrained integer fields that are validated individually.
 
     Example:
-        >>> ts = StoryTimestamp(year=1347, month=9, day=15, hour=16, minute=30)
+        >>> ts = StoryTimestamp(
+        ...     year=1347, month=9, day=15, hour=16, minute=30, second=45
+        ... )
         >>> ts.to_datetime()
-        datetime(1347, 9, 15, 16, 30, 0, tzinfo=timezone.utc)
+        datetime(1347, 9, 15, 16, 30, 45, tzinfo=timezone.utc)
     """
 
     model_config = ConfigDict(str_strip_whitespace=True)
@@ -881,6 +943,12 @@ class StoryTimestamp(BaseModel):
     day: int = Field(..., ge=1, le=31, description="Day of month (1-31)")
     hour: int = Field(..., ge=0, le=23, description="Hour in 24h format (0-23)")
     minute: int = Field(..., ge=0, le=59, description="Minute (0-59)")
+    second: int = Field(
+        0,
+        ge=0,
+        le=59,
+        description="Second (0-59); use 0 when the setting specifies only minutes",
+    )
 
     @model_validator(mode="after")
     def validate_date(self) -> "StoryTimestamp":
@@ -895,14 +963,14 @@ class StoryTimestamp(BaseModel):
         return self
 
     def to_datetime(self, tz: timezone = timezone.utc) -> datetime:
-        """Convert to datetime object with seconds=0."""
+        """Convert all represented fields to a timezone-aware datetime."""
         return datetime(
             year=self.year,
             month=self.month,
             day=self.day,
             hour=self.hour,
             minute=self.minute,
-            second=0,
+            second=self.second,
             tzinfo=tz,
         )
 
@@ -954,6 +1022,7 @@ class StorySeed(BaseModel):
             "default to the current real-world date. For Earth-based historical, "
             "contemporary, or near-future settings, choose a date that fits the "
             "setting card. Choose the hour and minute to serve the opening scene."
+            " Preserve explicit seconds from the accepted setting; otherwise use 0."
         ),
     )
     weather: Optional[str] = Field(None, description="Weather conditions if relevant")

--- a/tests/test_api/test_mock_wizard_responses.py
+++ b/tests/test_api/test_mock_wizard_responses.py
@@ -1,23 +1,32 @@
 """Schema and routing coverage for TEST-mode Responses API wizard calls."""
 
 import json
-from datetime import datetime
+import os
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Iterator, List, Tuple
 
+import psycopg2
 import pytest
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
+from psycopg2 import sql
 
 from nexus.api import mock_openai
+from nexus.api import new_story_cache as cache_module
+from nexus.api import new_story_flow
+from nexus.api.db_pool import close_all_pools
 from nexus.api.new_story_schemas import (
     CharacterConceptSubmission,
     SettingCard,
+    StorySeed,
     StorySeedSubmission,
     TraitSelection,
     WildcardTrait,
     WizardResponse,
 )
+from nexus.api.slot_utils import VALID_DBNAMES
 from nexus.api.wizard_agent import WizardContext, get_wizard_agent
 
 FIXTURE_PATH = Path(__file__).parents[1] / "fixtures" / "test_cache_wizard.json"
@@ -100,6 +109,97 @@ def _responses_tool(name: str, schema: type[BaseModel]) -> Dict[str, Any]:
         "parameters": schema.model_json_schema(),
         "strict": True,
     }
+
+
+def _connect(dbname: str) -> Any:
+    """Open a direct connection for disposable-database administration."""
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+@pytest.fixture()
+def disposable_timestamp_dbname() -> Iterator[str]:
+    """Yield a current-template clone and remove it after the regression."""
+    dbname = f"nexus_test_issue_613_{uuid.uuid4().hex[:12]}"
+    admin: Any = None
+    try:
+        try:
+            admin = _connect("postgres")
+        except psycopg2.Error as exc:
+            pytest.skip(f"PostgreSQL admin connection unavailable: {exc}")
+        admin.autocommit = True
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier("NEXUS_template"),
+                )
+            )
+        VALID_DBNAMES.add(dbname)
+        yield dbname
+    finally:
+        close_all_pools()
+        VALID_DBNAMES.discard(dbname)
+        if admin is not None:
+            with admin.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = %s AND pid <> pg_backend_pid()",
+                    (dbname,),
+                )
+                cur.execute(
+                    sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+                )
+            admin.close()
+
+
+@pytest.mark.requires_postgres
+def test_seconds_round_trip_through_cache_resume_and_transition(
+    disposable_timestamp_dbname: str,
+    monkeypatch,
+) -> None:
+    """Real PostgreSQL preserves an explicit second through transition."""
+    raw = json.loads(FIXTURE_PATH.read_text())
+    seed_payload = json.loads(raw["selected_seed"])
+    seed_payload["base_timestamp"]["second"] = 30
+    accepted_seed = StorySeed.model_validate(seed_payload)
+    expected_timestamp = accepted_seed.get_base_datetime()
+    cache_module.write_cache(
+        thread_id=raw["thread_id"],
+        setting_draft=json.loads(raw["setting_draft"]),
+        character_draft=json.loads(raw["character_draft"]),
+        selected_seed=accepted_seed.model_dump(),
+        layer_draft=json.loads(raw["layer_draft"]),
+        zone_draft=json.loads(raw["zone_draft"]),
+        initial_location=json.loads(raw["initial_location"]),
+        base_timestamp=expected_timestamp.isoformat(),
+        target_slot=4,
+        dbname=disposable_timestamp_dbname,
+    )
+    monkeypatch.setattr(
+        new_story_flow,
+        "slot_dbname",
+        lambda _slot: disposable_timestamp_dbname,
+    )
+
+    resumed = new_story_flow.resume_setup(4)
+    assert resumed is not None
+    resumed_seed = resumed.get_seed_dict()
+    assert resumed_seed is not None
+    assert resumed_seed["base_timestamp"]["second"] == 30
+
+    transition = new_story_flow.build_transition_data_from_cache(resumed)
+    assert transition.seed.base_timestamp.second == 30
+    assert transition.seed.get_base_datetime() == expected_timestamp
+    assert transition.base_timestamp == expected_timestamp
+    assert (
+        transition.base_timestamp.astimezone(timezone.utc).isoformat()
+        == "2087-11-03T22:47:30+00:00"
+    )
 
 
 def test_canned_artifact_arguments_validate_against_current_schemas() -> None:

--- a/tests/test_api/test_mock_wizard_timestamp.py
+++ b/tests/test_api/test_mock_wizard_timestamp.py
@@ -44,6 +44,7 @@ def test_mock_seed_declares_fixed_diegetic_timestamp(monkeypatch) -> None:
         "day": 3,
         "hour": 22,
         "minute": 47,
+        "second": 0,
     }
 
 

--- a/tests/test_new_story_schemas.py
+++ b/tests/test_new_story_schemas.py
@@ -172,6 +172,39 @@ class TestNewStorySchemas:
         assert constraint is not None
         assert (constraint.year, constraint.month, constraint.day) == (887, 10, None)
 
+    def test_setting_date_constraint_preserves_explicit_seconds(self) -> None:
+        """A full setting datetime constrains the seed's seconds field."""
+        constraint = extract_setting_date_constraint(
+            _dated_setting(time_period="2032-02-29 23:58:30 UTC"),
+        )
+
+        assert constraint is not None
+        assert (
+            constraint.year,
+            constraint.month,
+            constraint.day,
+            constraint.second,
+        ) == (2032, 2, 29, 30)
+        assert (
+            constraint.conflicts_with(
+                StoryTimestamp(
+                    year=2032,
+                    month=2,
+                    day=29,
+                    hour=23,
+                    minute=58,
+                    second=30,
+                )
+            )
+            is False
+        )
+        assert (
+            constraint.conflicts_with(
+                StoryTimestamp(year=2032, month=2, day=29, hour=23, minute=58)
+            )
+            is True
+        )
+
     def test_character_sheet_creation(self):
         """Test creating a valid CharacterSheet with Mind's Eye Theatre traits."""
         character = CharacterSheet(
@@ -400,6 +433,45 @@ class TestNewStorySchemas:
         """February 29 on a non-leap year should fail."""
         with pytest.raises(ValidationError):
             StoryTimestamp(year=2023, month=2, day=29, hour=12, minute=0)
+
+    def test_story_timestamp_seconds_default_validate_and_convert(self):
+        """Seconds are bounded, preserved, and optional for legacy payloads."""
+        minute_only = StoryTimestamp(
+            year=2032,
+            month=2,
+            day=29,
+            hour=23,
+            minute=58,
+        )
+        explicit = StoryTimestamp(
+            year=2032,
+            month=2,
+            day=29,
+            hour=23,
+            minute=58,
+            second=30,
+        )
+
+        assert minute_only.second == 0
+        assert minute_only.to_datetime().second == 0
+        assert explicit.to_datetime() == datetime(
+            2032,
+            2,
+            29,
+            23,
+            58,
+            30,
+            tzinfo=timezone.utc,
+        )
+        with pytest.raises(ValidationError):
+            StoryTimestamp(
+                year=2032,
+                month=2,
+                day=29,
+                hour=23,
+                minute=58,
+                second=60,
+            )
 
     def test_place_profile_creation(self):
         """Test creating a valid PlaceProfile."""

--- a/tests/test_new_story_schemas.py
+++ b/tests/test_new_story_schemas.py
@@ -172,6 +172,15 @@ class TestNewStorySchemas:
         assert constraint is not None
         assert (constraint.year, constraint.month, constraint.day) == (887, 10, None)
 
+    def test_setting_date_constraint_ignores_version_like_datetimes(self) -> None:
+        """A 1-2 digit leading number is a version string, never a story year."""
+        assert (
+            extract_setting_date_constraint(
+                _dated_setting(time_period="Protocol v5-12-01 10:00:30"),
+            )
+            is None
+        )
+
     def test_setting_date_constraint_preserves_explicit_seconds(self) -> None:
         """A full setting datetime constrains the seed's seconds field."""
         constraint = extract_setting_date_constraint(

--- a/tests/test_wizard_agent.py
+++ b/tests/test_wizard_agent.py
@@ -424,6 +424,7 @@ def test_seed_timestamp_round_trips_through_record_drafts(monkeypatch) -> None:
     monkeypatch.setattr(new_story_flow, "write_cache", persist_cache)
 
     submission = sample_seed_submission()
+    submission.seed.base_timestamp.second = 30
     new_story_flow.record_drafts(
         1,
         seed=submission.seed.model_dump(),
@@ -437,6 +438,7 @@ def test_seed_timestamp_round_trips_through_record_drafts(monkeypatch) -> None:
     stored_seed = stored_cache.get_seed_dict()
     assert stored_seed is not None
     assert stored_seed["base_timestamp"]["year"] == 1347
+    assert stored_seed["base_timestamp"]["second"] == 30
 
 
 def test_get_seed_dict_rejects_missing_diegetic_timestamp() -> None:
@@ -486,6 +488,7 @@ def test_get_seed_dict_normalizes_timestamp_display_offset() -> None:
         "day": 14,
         "hour": 10,
         "minute": 48,
+        "second": 0,
     }
 
 


### PR DESCRIPTION
## Summary

Fixes #613 (night-QA round 2). An explicit story-start second ("2032-02-29 23:58:30 UTC") was unrepresentable: `StoryTimestamp` had no seconds field and `to_datetime()` hard-pinned `second=0`, so the canonical world clock started up to 59 seconds early and every downstream chronology inherited the shift.

## Changes

- `StoryTimestamp.second` (0–59, default 0 — existing minute-only fixtures stay valid) with `to_datetime()` honoring it.
- Cache dict serialization (`get_seed_dict`) and TEST-mode reconstruction include seconds; the datetime-typed cache column (`timestamptz`) already preserved them natively, so the two fixed sites were the only truncation points.
- The #606 `SettingDateConstraint` gains a conservative seconds rule: only a full ISO datetime matching the accepted year/month/day contributes seconds, and only when unambiguous. The seed prompt instructs preserving explicit seconds.

## Testing

The round-trip regression drives production `write_cache` → `resume_setup` → `build_transition_data_from_cache` against a real disposable `NEXUS_template` clone (`NEXUS_RUN_POSTGRES=1`) — an earlier SQL-emulating fake cursor was rejected in review and replaced. Pure-schema coverage: defaults, bounds, conversion, explicit `:30` constraint extraction.

- Focused (pg-gated): `29 passed`
- Full suite: `1952 passed, 451 skipped`
- Pre-existing, unrelated: `test_resolve_four_template_states_are_distinguishable` fails identically on clean `main` against live save_05 (will be filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fs3R2bgfcWPiU4QgToRxo