### PR TITLE
Retrograde: Validate seek_redemption Prerequisite at R6, Not Persistence

### DIFF
--- a/nexus/agents/orrery/retrograde_expansion.py
+++ b/nexus/agents/orrery/retrograde_expansion.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Annotated, Any, Literal, Mapping, Optional, cast
+from typing import Annotated, Any, Literal, Mapping, Optional, Sequence, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -13,6 +13,11 @@ from nexus.agents.orrery.retrograde_junctions import resolve_junctions
 from nexus.agents.orrery.retrograde_packet import (
     CORE_ENTITIES_HEADING,
     NAMED_SEED_NPCS_HEADING,
+)
+from nexus.agents.orrery.retrograde_project_dependencies import (
+    coerce_project_start_relationships,
+    planned_project_start_relationships,
+    seek_redemption_dependency_issue,
 )
 from nexus.agents.orrery.retrograde_seed_candidates import (
     RetrogradeProjectType,
@@ -642,6 +647,9 @@ def render_expansion_prompt(
         "selected_candidates": selected_candidates,
         "selected_junctions": selected_junctions,
         "trait_constraints": seed_generation_request.get("trait_constraints", []),
+        "project_start_relationships": coerce_project_start_relationships(
+            packet.get("project_start_relationships")
+        ),
         "protagonist_identity": seed_generation_request.get("protagonist_identity", {}),
         "core_prompt_sections": (
             seed_generation_request.get("prompt_sections", [])[:4]
@@ -731,6 +739,9 @@ def validate_expansion_plan(
         candidates_by_id={
             candidate.seed_id: candidate for candidate in candidates.candidates
         },
+        project_start_relationships=coerce_project_start_relationships(
+            packet.get("project_start_relationships")
+        ),
         forbidden_relationship_traits=forbidden_relationship_traits,
         forbidden_pair_tag_traits=forbidden_pair_tag_traits,
         protagonist_identity=_packet_protagonist_identity(packet),
@@ -835,6 +846,7 @@ def _expansion_contract_issues(
     selected_junctions: list[dict[str, Any]],
     vocabulary: SeedEligibleVocabulary,
     candidates_by_id: Mapping[str, Any],
+    project_start_relationships: Sequence[Mapping[str, Any]],
     forbidden_relationship_traits: Mapping[str, set[str]],
     forbidden_pair_tag_traits: Mapping[str, set[str]],
     protagonist_identity: Mapping[str, Any],
@@ -949,6 +961,7 @@ def _expansion_contract_issues(
         _project_plan_issues(
             response=response,
             candidates_by_id=candidates_by_id,
+            project_start_relationships=project_start_relationships,
         )
     )
 
@@ -984,10 +997,15 @@ def _project_plan_issues(
     *,
     response: RetrogradeExpansionPlanResponse,
     candidates_by_id: Mapping[str, Any],
+    project_start_relationships: Sequence[Mapping[str, Any]],
 ) -> list[str]:
     """Keep R6 project rows faithful to the selected seed intent."""
 
     issues: list[str] = []
+    available_relationships = [
+        *project_start_relationships,
+        *planned_project_start_relationships(response.relationship_plan),
+    ]
     threads_by_seed = {thread.seed_id: thread for thread in response.thread_plan}
     projects_by_seed = {project.seed_id: project for project in response.project_plan}
     dead_character_refs = {
@@ -1043,6 +1061,15 @@ def _project_plan_issues(
                 f"project plan seed {project.seed_id!r} character target_ref "
                 f"{project.target_ref!r} appears in death_plan"
             )
+        dependency_issue = seek_redemption_dependency_issue(
+            seed_id=project.seed_id,
+            project_type=project.project_type,
+            actor_ref=project.actor_ref,
+            target_ref=project.target_ref,
+            relationships=available_relationships,
+        )
+        if dependency_issue is not None:
+            issues.append(dependency_issue)
         thread = threads_by_seed.get(project.seed_id)
         if thread is not None and thread.status != "woven":
             issues.append(
@@ -1791,6 +1818,11 @@ def _hard_validation_rules() -> list[str]:
         (
             "project_plan may carry only a woven selected seed's exact "
             "project_intent; explain any dropped woven intent in thread_plan.note."
+        ),
+        (
+            "Every seek_redemption project requires a TARGET->ACTOR relationship "
+            "at wary-or-worse valence in project_start_relationships or this "
+            "response's relationship mechanics."
         ),
         (
             "Entity refs (subject_ref, object_ref, location_ref) "

--- a/nexus/agents/orrery/retrograde_expansion.py
+++ b/nexus/agents/orrery/retrograde_expansion.py
@@ -962,6 +962,7 @@ def _expansion_contract_issues(
             response=response,
             candidates_by_id=candidates_by_id,
             project_start_relationships=project_start_relationships,
+            relationship_types=relationship_types,
         )
     )
 
@@ -998,13 +999,21 @@ def _project_plan_issues(
     response: RetrogradeExpansionPlanResponse,
     candidates_by_id: Mapping[str, Any],
     project_start_relationships: Sequence[Mapping[str, Any]],
+    relationship_types: set[str],
 ) -> list[str]:
     """Keep R6 project rows faithful to the selected seed intent."""
 
     issues: list[str] = []
+    planned_relationships, relationship_dependency_issues = (
+        _planned_project_dependency_relationships(
+            response=response,
+            relationship_types=relationship_types,
+        )
+    )
+    issues.extend(relationship_dependency_issues)
     available_relationships = [
         *project_start_relationships,
-        *planned_project_start_relationships(response.relationship_plan),
+        *planned_relationships,
     ]
     threads_by_seed = {thread.seed_id: thread for thread in response.thread_plan}
     projects_by_seed = {project.seed_id: project for project in response.project_plan}
@@ -1088,6 +1097,38 @@ def _project_plan_issues(
                 f"woven seed {seed_id!r} drops project_intent without a thread note"
             )
     return issues
+
+
+def _planned_project_dependency_relationships(
+    *,
+    response: RetrogradeExpansionPlanResponse,
+    relationship_types: set[str],
+) -> tuple[list[Mapping[str, Any]], list[str]]:
+    """Convert model relationship rows without escaping the repair boundary."""
+
+    redemption_seed_ids = [
+        project.seed_id
+        for project in response.project_plan
+        if project.project_type == "seek_redemption"
+    ]
+    if not redemption_seed_ids:
+        return [], []
+
+    relationships: list[Mapping[str, Any]] = []
+    issues: list[str] = []
+    for index, relationship in enumerate(response.relationship_plan):
+        try:
+            relationships.extend(planned_project_start_relationships([relationship]))
+        except ValueError as exc:
+            issues.append(
+                "seek_redemption project seed(s) "
+                f"{redemption_seed_ids!r} cannot classify "
+                f"relationship_plan[{index}].relationship_type "
+                f"{relationship.relationship_type!r}: {exc}. Use one of "
+                "seed_eligible_vocabulary.relationship_types "
+                f"{sorted(relationship_types)!r}"
+            )
+    return relationships, issues
 
 
 STUB_CREATABLE_ENTITY_KINDS = frozenset({"character", "place", "faction"})

--- a/nexus/agents/orrery/retrograde_maturation.py
+++ b/nexus/agents/orrery/retrograde_maturation.py
@@ -44,6 +44,10 @@ from nexus.agents.orrery.declaration_validation import (
     collect_new_entity_declaration_vocabulary_issues,
 )
 from nexus.agents.orrery.geo import resolve_zone_for_point, story_active_zone
+from nexus.agents.orrery.retrograde_project_dependencies import (
+    ProjectStartRelationship,
+    load_project_start_relationships,
+)
 from nexus.agents.orrery.retrograde_vocabulary import SeedEligibleVocabulary
 from nexus.agents.orrery.status_family import STATUS_TAGS, level_from_status_tag
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
@@ -1036,6 +1040,9 @@ def build_runtime_maturation_packet(
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "maturation_target": target_card,
         "geo_authoring": geo_context,
+        "project_start_relationships": list(
+            context.get("project_start_relationships", [])
+        ),
         "declaration": declaration,
         "requesting_chunk_id": int(row["requesting_chunk_id"]),
         "weird": weird,
@@ -1327,7 +1334,24 @@ def _load_job_context(
         "chunk_excerpt": excerpt,
         "scene_entities": scene_entities,
         "geo_authoring": geo_authoring,
+        "project_start_relationships": _load_project_start_relationships(
+            cur,
+            actor_entity_id=int(row["entity_id"]),
+        ),
     }
+
+
+def _load_project_start_relationships(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+) -> list[ProjectStartRelationship]:
+    """Load inbound relationship facts for runtime project validation."""
+
+    return load_project_start_relationships(
+        cur,
+        object_entity_id=actor_entity_id,
+    )
 
 
 def _apply_maturation_coordinates(

--- a/nexus/agents/orrery/retrograde_packet.py
+++ b/nexus/agents/orrery/retrograde_packet.py
@@ -152,6 +152,7 @@ def build_retrograde_dry_run_packet(
             cache.current_phase() if hasattr(cache, "current_phase") else "unknown"
         ),
         "generated_at": datetime.now(timezone.utc).isoformat(),
+        "project_start_relationships": [],
         "inputs": {
             "setting": setting,
             "character": character,

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -30,7 +30,7 @@ from nexus.agents.orrery.retrograde_markers import (
     RETROGRADE_PROLOGUE_MARKER,
 )
 from nexus.agents.orrery.retrograde_project_dependencies import (
-    planned_project_start_relationships,
+    dry_run_project_start_relationships,
     seek_redemption_dependency_issue,
 )
 from nexus.agents.orrery.retrograde_vocabulary import (
@@ -438,6 +438,7 @@ def _build_plan(
         event_origin=project_event_origin,
         event_ref_prefix=project_event_ref_prefix,
         log_context=project_log_context,
+        relationship_rows=relationship_rows,
     )
     for project_row in project_rows:
         counters[f"projects_{project_row['status']}"] += 1
@@ -1089,6 +1090,7 @@ def _plan_project_rows(
     event_origin: str,
     event_ref_prefix: Optional[str],
     log_context: Optional[str],
+    relationship_rows: Sequence[Mapping[str, Any]],
 ) -> list[dict[str, Any]]:
     """Plan or insert typed stage-one projects after relationship persistence."""
 
@@ -1238,6 +1240,8 @@ def _plan_project_rows(
             project=project,
             actor=actor,
             target=target,
+            dry_run=dry_run,
+            relationship_rows=relationship_rows,
         )
         started_event_type = PROJECT_STARTED_EVENT_TYPES[project.project_type]
         if started_event_type not in event_types:
@@ -1416,6 +1420,8 @@ def _validate_project_start_dependencies(
     project: RetrogradeProjectPlan,
     actor: Mapping[str, Any],
     target: Optional[Mapping[str, Any]],
+    dry_run: bool = False,
+    relationship_rows: Sequence[Mapping[str, Any]] = (),
 ) -> None:
     dead_character_refs = {
         normalize_entity_ref(death.entity_ref)
@@ -1455,9 +1461,7 @@ def _validate_project_start_dependencies(
         return
     if target is None:
         raise AssertionError("seek_redemption target shape was not validated")
-    available_relationships = planned_project_start_relationships(
-        expansion.relationship_plan
-    )
+    available_relationships: list[Mapping[str, Any]] = []
     if actor["resolution"] == "resolved" and target["resolution"] == "resolved":
         cur.execute(
             """
@@ -1478,6 +1482,10 @@ def _validate_project_start_dependencies(
                     "emotional_valence": str(_row_value(row, "emotional_valence", 0)),
                 }
             )
+    if dry_run:
+        available_relationships.extend(
+            dry_run_project_start_relationships(relationship_rows)
+        )
     dependency_issue = seek_redemption_dependency_issue(
         seed_id=project.seed_id,
         project_type=project.project_type,

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -29,6 +29,10 @@ from nexus.agents.orrery.retrograde_expansion import (
 from nexus.agents.orrery.retrograde_markers import (
     RETROGRADE_PROLOGUE_MARKER,
 )
+from nexus.agents.orrery.retrograde_project_dependencies import (
+    planned_project_start_relationships,
+    seek_redemption_dependency_issue,
+)
 from nexus.agents.orrery.retrograde_vocabulary import (
     fold_entity_ref_for_identity,
     normalize_entity_ref,
@@ -1451,16 +1455,38 @@ def _validate_project_start_dependencies(
         return
     if target is None:
         raise AssertionError("seek_redemption target shape was not validated")
-    if not _has_redemption_wrong(
-        cur,
-        expansion=expansion,
-        actor=actor,
-        target=target,
-    ):
-        raise ValueError(
-            f"Retrograde project seed {project.seed_id!r} seek_redemption "
-            "requires a TARGET->ACTOR wary-or-worse relationship"
+    available_relationships = planned_project_start_relationships(
+        expansion.relationship_plan
+    )
+    if actor["resolution"] == "resolved" and target["resolution"] == "resolved":
+        cur.execute(
+            """
+            /* orrery:retrograde:redemption_relationship */
+            SELECT cr.emotional_valence::text
+            FROM character_relationships cr
+            JOIN characters target_c ON target_c.id = cr.character1_id
+            JOIN characters actor_c ON actor_c.id = cr.character2_id
+            WHERE target_c.entity_id = %s AND actor_c.entity_id = %s
+            """,
+            (target["entity_id"], actor["entity_id"]),
         )
+        for row in cur.fetchall():
+            available_relationships.append(
+                {
+                    "subject_ref": str(target["entity_ref"]),
+                    "object_ref": str(actor["entity_ref"]),
+                    "emotional_valence": str(_row_value(row, "emotional_valence", 0)),
+                }
+            )
+    dependency_issue = seek_redemption_dependency_issue(
+        seed_id=project.seed_id,
+        project_type=project.project_type,
+        actor_ref=project.actor_ref,
+        target_ref=project.target_ref,
+        relationships=available_relationships,
+    )
+    if dependency_issue is not None:
+        raise ValueError(dependency_issue)
 
 
 def _existing_open_project_id(cur: Any, actor_entity_id: int) -> Optional[int]:
@@ -1476,51 +1502,6 @@ def _existing_open_project_id(cur: Any, actor_entity_id: int) -> Optional[int]:
     )
     row = cur.fetchone()
     return int(_row_value(row, "id", 0)) if row is not None else None
-
-
-def _has_redemption_wrong(
-    cur: Any,
-    *,
-    expansion: RetrogradeExpansionPlanResponse,
-    actor: Mapping[str, Any],
-    target: Mapping[str, Any],
-) -> bool:
-    if actor["resolution"] == "resolved" and target["resolution"] == "resolved":
-        cur.execute(
-            """
-            /* orrery:retrograde:redemption_relationship */
-            SELECT cr.emotional_valence::text
-            FROM character_relationships cr
-            JOIN characters target_c ON target_c.id = cr.character1_id
-            JOIN characters actor_c ON actor_c.id = cr.character2_id
-            WHERE target_c.entity_id = %s AND actor_c.entity_id = %s
-            LIMIT 1
-            """,
-            (target["entity_id"], actor["entity_id"]),
-        )
-        row = cur.fetchone()
-        if row is not None:
-            return _is_wary_or_worse(str(_row_value(row, "emotional_valence", 0)))
-
-    actor_ref = normalize_entity_ref(str(actor["entity_ref"]))
-    target_ref = normalize_entity_ref(str(target["entity_ref"]))
-    for relationship in expansion.relationship_plan:
-        if (
-            relationship.subject_kind == "character"
-            and relationship.object_kind == "character"
-            and normalize_entity_ref(relationship.subject_ref) == target_ref
-            and normalize_entity_ref(relationship.object_ref) == actor_ref
-            and _is_wary_or_worse(
-                _default_emotional_valence(relationship.relationship_type)
-            )
-        ):
-            return True
-    return False
-
-
-def _is_wary_or_worse(value: str) -> bool:
-    match = re.match(r"^([+-]?\d+)\|", value)
-    return match is not None and int(match.group(1)) <= -1
 
 
 def _insert_seeded_project(

--- a/nexus/agents/orrery/retrograde_project_dependencies.py
+++ b/nexus/agents/orrery/retrograde_project_dependencies.py
@@ -1,0 +1,183 @@
+"""Shared Retrograde project-start dependency validation."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Optional, TypedDict
+
+from nexus.agents.logon.apex_enums import EmotionalValence
+from nexus.agents.orrery.retrograde_vocabulary import (
+    normalize_entity_ref,
+    relationship_type_default_emotional_valence,
+)
+
+
+class ProjectStartRelationship(TypedDict):
+    """One directed relationship fact available to an R6 project start."""
+
+    subject_ref: str
+    object_ref: str
+    emotional_valence: str
+
+
+_VALENCE_RUNG_BY_LITERAL = {
+    valence.value: int(valence.value.split("|", maxsplit=1)[0])
+    for valence in EmotionalValence
+}
+_WARY_RUNG = _VALENCE_RUNG_BY_LITERAL[EmotionalValence.WARY.value]
+
+
+def is_wary_or_worse(value: str) -> bool:
+    """Return whether a canonical authored valence is wary or worse."""
+
+    try:
+        rung = _VALENCE_RUNG_BY_LITERAL[str(value)]
+    except KeyError as exc:
+        raise ValueError(
+            "Unrecognized emotional valence "
+            f"{value!r}; expected a canonical EmotionalValence ladder literal"
+        ) from exc
+    return rung <= _WARY_RUNG
+
+
+def coerce_project_start_relationships(
+    value: Any,
+) -> list[ProjectStartRelationship]:
+    """Validate packet relationship facts used by project-start checks."""
+
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("packet.project_start_relationships must be a list")
+
+    facts: list[ProjectStartRelationship] = []
+    for index, raw in enumerate(value):
+        if not isinstance(raw, Mapping):
+            raise ValueError(
+                "packet.project_start_relationships" f"[{index}] must be a mapping"
+            )
+        expected = {"subject_ref", "object_ref", "emotional_valence"}
+        if set(raw) != expected:
+            raise ValueError(
+                "packet.project_start_relationships"
+                f"[{index}] must contain exactly {sorted(expected)!r}"
+            )
+        subject_ref = str(raw["subject_ref"]).strip()
+        object_ref = str(raw["object_ref"]).strip()
+        emotional_valence = str(raw["emotional_valence"]).strip()
+        if not subject_ref or not object_ref:
+            raise ValueError(
+                "packet.project_start_relationships"
+                f"[{index}] requires non-empty endpoint refs"
+            )
+        is_wary_or_worse(emotional_valence)
+        facts.append(
+            {
+                "subject_ref": subject_ref,
+                "object_ref": object_ref,
+                "emotional_valence": emotional_valence,
+            }
+        )
+    return facts
+
+
+def planned_project_start_relationships(
+    relationship_plans: Iterable[Any],
+) -> list[ProjectStartRelationship]:
+    """Project R6 relationship rows into directed dependency facts."""
+
+    facts: list[ProjectStartRelationship] = []
+    for plan in relationship_plans:
+        relationship_type = str(_field(plan, "relationship_type"))
+        facts.append(
+            {
+                "subject_ref": str(_field(plan, "subject_ref")),
+                "object_ref": str(_field(plan, "object_ref")),
+                "emotional_valence": relationship_type_default_emotional_valence(
+                    relationship_type
+                ),
+            }
+        )
+    return facts
+
+
+def seek_redemption_dependency_issue(
+    *,
+    seed_id: str,
+    project_type: str,
+    actor_ref: str,
+    target_ref: Optional[str],
+    relationships: Iterable[Mapping[str, Any]],
+) -> Optional[str]:
+    """Return the shared seek-redemption prerequisite issue, if any."""
+
+    if project_type != "seek_redemption":
+        return None
+    if target_ref is None:
+        raise AssertionError("seek_redemption target shape was not validated")
+
+    actor_key = normalize_entity_ref(actor_ref)
+    target_key = normalize_entity_ref(target_ref)
+    for relationship in relationships:
+        if (
+            normalize_entity_ref(str(relationship["subject_ref"])) == target_key
+            and normalize_entity_ref(str(relationship["object_ref"])) == actor_key
+            and is_wary_or_worse(str(relationship["emotional_valence"]))
+        ):
+            return None
+    return (
+        f"Retrograde project seed {seed_id!r} seek_redemption requires a "
+        "TARGET->ACTOR wary-or-worse relationship"
+    )
+
+
+def load_project_start_relationships(
+    cur: Any,
+    *,
+    object_entity_id: Optional[int] = None,
+) -> list[ProjectStartRelationship]:
+    """Load qualifying directed character relationships for R6 validation."""
+
+    where = ""
+    params: tuple[Any, ...] = ()
+    if object_entity_id is not None:
+        where = "WHERE object_character.entity_id = %s"
+        params = (object_entity_id,)
+    cur.execute(
+        f"""
+        /* orrery:retrograde:project_start_relationships */
+        SELECT subject_character.name AS subject_ref,
+               object_character.name AS object_ref,
+               relationship.emotional_valence::text AS emotional_valence
+        FROM character_relationships relationship
+        JOIN characters subject_character
+          ON subject_character.id = relationship.character1_id
+        JOIN characters object_character
+          ON object_character.id = relationship.character2_id
+        {where}
+        ORDER BY subject_character.id, object_character.id
+        """,
+        params,
+    )
+    facts = coerce_project_start_relationships(
+        [
+            {
+                "subject_ref": _row_value(row, "subject_ref", 0),
+                "object_ref": _row_value(row, "object_ref", 1),
+                "emotional_valence": _row_value(row, "emotional_valence", 2),
+            }
+            for row in cur.fetchall()
+        ]
+    )
+    return [fact for fact in facts if is_wary_or_worse(fact["emotional_valence"])]
+
+
+def _field(value: Any, field: str) -> Any:
+    if isinstance(value, Mapping):
+        return value[field]
+    return getattr(value, field)
+
+
+def _row_value(row: Any, key: str, index: int) -> Any:
+    if isinstance(row, Mapping):
+        return row[key]
+    return row[index]

--- a/nexus/agents/orrery/retrograde_project_dependencies.py
+++ b/nexus/agents/orrery/retrograde_project_dependencies.py
@@ -100,6 +100,37 @@ def planned_project_start_relationships(
     return facts
 
 
+def dry_run_project_start_relationships(
+    relationship_rows: Iterable[Mapping[str, Any]],
+) -> list[ProjectStartRelationship]:
+    """Project only relationship rows that persistence would materialize."""
+
+    facts: list[ProjectStartRelationship] = []
+    for row in relationship_rows:
+        status = str(row.get("status"))
+        if status == "already_present":
+            existing = row.get("existing")
+            if not isinstance(existing, Mapping):
+                raise AssertionError(
+                    "already_present relationship row is missing stored state"
+                )
+            emotional_valence = str(existing["emotional_valence"])
+        elif status == "would_insert":
+            emotional_valence = relationship_type_default_emotional_valence(
+                str(row["relationship_type"])
+            )
+        else:
+            continue
+        facts.append(
+            {
+                "subject_ref": str(row["subject_ref"]),
+                "object_ref": str(row["object_ref"]),
+                "emotional_valence": emotional_valence,
+            }
+        )
+    return facts
+
+
 def seek_redemption_dependency_issue(
     *,
     seed_id: str,

--- a/tests/test_orrery/test_retrograde_constraints_pg.py
+++ b/tests/test_orrery/test_retrograde_constraints_pg.py
@@ -23,6 +23,9 @@ from nexus.agents.orrery.retrograde_packet import build_retrograde_dry_run_packe
 from nexus.agents.orrery.retrograde_persistence import (
     build_retrograde_persistence_plan,
 )
+from nexus.agents.orrery.retrograde_project_dependencies import (
+    load_project_start_relationships,
+)
 from nexus.agents.orrery.retrograde_seed_candidates import (
     SEED_CANDIDATE_RESPONSE_SCHEMA_VERSION,
 )
@@ -641,3 +644,232 @@ def test_persistence_refuses_database_alias_stub_even_without_packet_alias(
         with conn.cursor() as cur:
             cur.execute("SELECT count(*) AS count FROM characters WHERE name = 'J.M.'")
             assert cur.fetchone()["count"] == 0
+
+
+def test_seek_redemption_dependency_is_repaired_before_mapper_transaction(
+    disposable_dbname: str,
+) -> None:
+    """A real cache path enforces direction/threshold, then persists atomically."""
+
+    cache = _hydrate_fixture(disposable_dbname)
+    transition, packet, vocabulary = _build_transition_and_packet(
+        disposable_dbname,
+        cache,
+        trait_inputs=TraitCompileInputs.model_validate({}),
+    )
+
+    with _connect(disposable_dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO characters (name, summary)
+                VALUES
+                    ('Existing Actor', 'A preexisting runtime character.'),
+                    ('Existing Target', 'A preexisting wronged character.')
+                RETURNING entity_id, id, name
+                """
+            )
+            actor, target = cur.fetchall()
+            cur.execute(
+                """
+                DELETE FROM character_relationships
+                WHERE character1_id IN (%s, %s)
+                  AND character2_id IN (%s, %s)
+                """,
+                (actor["id"], target["id"], actor["id"], target["id"]),
+            )
+            cur.execute(
+                """
+                INSERT INTO character_relationships (
+                    character1_id, character2_id, relationship_type,
+                    emotional_valence, dynamic, recent_events, history
+                ) VALUES (%s, %s, 'rival', '-1|wary', '', '', '')
+                """,
+                (target["id"], actor["id"]),
+            )
+            packet["project_start_relationships"] = load_project_start_relationships(
+                cur,
+                object_entity_id=int(actor["entity_id"]),
+            )
+
+    seed_response, expansion = _redemption_contract(
+        packet,
+        vocabulary,
+        actor_ref=str(actor["name"]),
+        target_ref=str(target["name"]),
+    )
+    validated = validate_expansion_plan(
+        payload=expansion,
+        packet=packet,
+        seed_candidate_response=seed_response,
+    )
+    assert validated.project_plan[0].project_type == "seek_redemption"
+
+    with _connect(disposable_dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE character_relationships
+                SET emotional_valence = '0|neutral'
+                WHERE character1_id = %s AND character2_id = %s
+                """,
+                (target["id"], actor["id"]),
+            )
+            packet["project_start_relationships"] = load_project_start_relationships(
+                cur,
+                object_entity_id=int(actor["entity_id"]),
+            )
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="seed 'seed_01' seek_redemption.*TARGET->ACTOR wary-or-worse",
+    ):
+        validate_expansion_plan(
+            payload=expansion,
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+
+    packet["project_start_relationships"] = [
+        {
+            "subject_ref": str(actor["name"]),
+            "object_ref": str(target["name"]),
+            "emotional_valence": "-1|wary",
+        }
+    ]
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="seed 'seed_01' seek_redemption.*TARGET->ACTOR wary-or-worse",
+    ):
+        validate_expansion_plan(
+            payload=expansion,
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+
+    unchanged_cache = read_cache(disposable_dbname)
+    assert unchanged_cache is not None
+    assert unchanged_cache.current_phase() == "ready"
+
+    packet["project_start_relationships"] = []
+    seed_response, expansion = _redemption_contract(
+        packet,
+        vocabulary,
+        actor_ref="Redemption Actor",
+        target_ref="Wronged Target",
+        planned_wrong=True,
+    )
+    validate_expansion_plan(
+        payload=expansion,
+        packet=packet,
+        seed_candidate_response=seed_response,
+    )
+
+    manifest_holder: dict[str, Any] = {}
+
+    def persist(cur: Any) -> None:
+        manifest_holder["manifest"] = build_retrograde_persistence_plan(
+            cur,
+            packet=packet,
+            seed_candidate_response=seed_response,
+            expansion_plan_payload=expansion,
+            slot=3,
+            dbname=disposable_dbname,
+            dry_run=False,
+            create_missing_entities=True,
+            summaries_enabled=False,
+            project_seeding_enabled=True,
+            project_settings=load_settings().orrery.projects,
+        )
+
+    NewStoryDatabaseMapper(dbname=disposable_dbname).perform_transition(
+        transition,
+        in_transaction=persist,
+    )
+
+    with _connect(disposable_dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT source.name AS subject_ref,
+                       target.name AS object_ref,
+                       relationship.emotional_valence::text AS emotional_valence
+                FROM character_relationships relationship
+                JOIN characters source ON source.id = relationship.character1_id
+                JOIN characters target ON target.id = relationship.character2_id
+                WHERE source.name = 'Wronged Target'
+                  AND target.name = 'Redemption Actor'
+                """
+            )
+            assert cur.fetchone() == {
+                "subject_ref": "Wronged Target",
+                "object_ref": "Redemption Actor",
+                "emotional_valence": "-3|resentful",
+            }
+            cur.execute(
+                """
+                SELECT project_type, status, stage
+                FROM character_project_states project
+                JOIN characters actor ON actor.entity_id = project.character_entity_id
+                WHERE actor.name = 'Redemption Actor'
+                """
+            )
+            assert cur.fetchone() == {
+                "project_type": "seek_redemption",
+                "status": "active",
+                "stage": "owning_the_wrong",
+            }
+
+    manifest = manifest_holder["manifest"]
+    assert manifest["counters"]["relationships_inserted"] == 1
+    assert manifest["counters"]["projects_inserted"] == 1
+
+
+def _redemption_contract(
+    packet: Mapping[str, Any],
+    vocabulary: SeedEligibleVocabulary,
+    *,
+    actor_ref: str,
+    target_ref: str,
+    planned_wrong: bool = False,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build model outputs around the production-generated packet."""
+
+    seed_response = _seed_response(packet, vocabulary)
+    old_seed_id = seed_response["candidates"][0]["seed_id"]
+    candidate = seed_response["candidates"][0]
+    candidate["seed_id"] = "seed_01"
+    candidate["coverage_functions"] = ["unresolved_ledger"]
+    candidate["project_intent"] = {
+        "project_type": "seek_redemption",
+        "target_ref": target_ref,
+        "rationale": "The actor must answer for an old wrong.",
+    }
+    seed_response["selected_seed_ids"] = ["seed_01"]
+
+    expansion = _expansion(vocabulary)
+    expansion["selected_seed_ids"] = ["seed_01"]
+    expansion["event_plan"][0]["seed_ids"] = ["seed_01"]
+    expansion["thread_plan"][0]["seed_id"] = "seed_01"
+    expansion["project_plan"] = [
+        {
+            "seed_id": "seed_01",
+            "project_type": "seek_redemption",
+            "actor_ref": actor_ref,
+            "target_ref": target_ref,
+            "rationale": "Begin by owning the wrong.",
+        }
+    ]
+    if planned_wrong:
+        expansion["relationship_plan"] = [
+            {
+                "subject_ref": target_ref,
+                "subject_kind": "character",
+                "relationship_type": "enemy",
+                "object_ref": actor_ref,
+                "object_kind": "character",
+                "source_event_ref": "e_voss_practice_dispute",
+                "rationale": "The target remains resentful over the old wrong.",
+            }
+        ]
+    assert old_seed_id != candidate["seed_id"]
+    return seed_response, expansion

--- a/tests/test_orrery/test_retrograde_expansion.py
+++ b/tests/test_orrery/test_retrograde_expansion.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
+import asyncio
 import copy
 from typing import Any
 
 import pytest
+from pydantic_ai import ModelRetry
 from pydantic import ValidationError
 
 from nexus.agents.orrery.retrograde_expansion import (
     RETROGRADE_EXPANSION_RESPONSE_SCHEMA_VERSION,
+    RetrogradeExpansionPlanResponse,
     RetrogradeExpansionWireResponse,
     RetrogradeExpansionValidationError,
     RetrogradeProjectPlan,
     coerce_expansion_response_payload,
+    generate_expansion_with_skald,
     render_expansion_prompt,
     validate_expansion_plan,
 )
@@ -359,6 +363,155 @@ def test_project_plan_carries_exact_woven_seed_intent() -> None:
     )
 
     assert response.project_plan[0].seed_id == "seed_001"
+
+
+def test_seek_redemption_requires_target_to_actor_wrong_at_r6() -> None:
+    """An impossible redemption project enters the structured repair boundary."""
+
+    _vocabulary, packet, seed_response, payload = _redemption_contract()
+
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match=(
+            "Retrograde project seed 'seed_001' seek_redemption requires a "
+            "TARGET->ACTOR wary-or-worse relationship"
+        ),
+    ):
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+
+
+def test_seek_redemption_accepts_same_expansion_target_to_actor_wrong() -> None:
+    """The exact TARGET->ACTOR direction satisfies the R6 dependency."""
+
+    _vocabulary, packet, seed_response, payload = _redemption_contract()
+    payload["relationship_plan"] = [
+        {
+            "subject_ref": "Vale",
+            "subject_kind": "character",
+            "relationship_type": "enemy",
+            "object_ref": "Mara",
+            "object_kind": "character",
+            "source_event_ref": "retro_event_001",
+        }
+    ]
+
+    response = validate_expansion_plan(
+        payload=payload,
+        packet=packet,
+        seed_candidate_response=seed_response,
+    )
+
+    assert response.project_plan[0].project_type == "seek_redemption"
+
+
+def test_seek_redemption_rejects_reverse_expansion_relationship() -> None:
+    """ACTOR->TARGET hostility is not evidence that TARGET was wronged."""
+
+    _vocabulary, packet, seed_response, payload = _redemption_contract()
+    payload["relationship_plan"] = [
+        {
+            "subject_ref": "Mara",
+            "subject_kind": "character",
+            "relationship_type": "enemy",
+            "object_ref": "Vale",
+            "object_kind": "character",
+            "source_event_ref": "retro_event_001",
+        }
+    ]
+
+    with pytest.raises(
+        RetrogradeExpansionValidationError,
+        match="TARGET->ACTOR wary-or-worse",
+    ):
+        validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+
+
+@pytest.mark.parametrize(
+    ("emotional_valence", "accepted"),
+    [
+        ("-2|disapproving", True),
+        ("-1|wary", True),
+        ("0|neutral", False),
+    ],
+)
+def test_seek_redemption_uses_canonical_wary_threshold(
+    emotional_valence: str,
+    accepted: bool,
+) -> None:
+    """R6 uses the canonical ladder's inclusive wary boundary."""
+
+    _vocabulary, packet, seed_response, payload = _redemption_contract()
+    packet["project_start_relationships"] = [
+        {
+            "subject_ref": "Vale",
+            "object_ref": "Mara",
+            "emotional_valence": emotional_valence,
+        }
+    ]
+
+    if accepted:
+        response = validate_expansion_plan(
+            payload=payload,
+            packet=packet,
+            seed_candidate_response=seed_response,
+        )
+        assert response.project_plan[0].project_type == "seek_redemption"
+    else:
+        with pytest.raises(
+            RetrogradeExpansionValidationError,
+            match="TARGET->ACTOR wary-or-worse",
+        ):
+            validate_expansion_plan(
+                payload=payload,
+                packet=packet,
+                seed_candidate_response=seed_response,
+            )
+
+
+def test_seek_redemption_retry_exhaustion_names_seed_and_project(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated invalid R6 output stays loud and never reaches persistence."""
+
+    _vocabulary, packet, seed_response, payload = _redemption_contract()
+    invalid_output = RetrogradeExpansionPlanResponse.model_validate(payload)
+
+    class ExhaustingProvider:
+        output_validator: Any = None
+
+        def get_structured_completion(self, _prompt: str, _schema: Any) -> Any:
+            assert self.output_validator is not None
+            try:
+                asyncio.run(self.output_validator(None, invalid_output))
+            except ModelRetry as exc:
+                raise RuntimeError("structured retries exhausted") from exc
+            raise AssertionError("Invalid redemption output unexpectedly validated")
+
+    monkeypatch.setattr(
+        "nexus.api.native_structured_output.build_native_structured_provider",
+        lambda **_kwargs: ExhaustingProvider(),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "(?s)exhausted validation retries.*seed 'seed_001' "
+            "seek_redemption.*TARGET->ACTOR"
+        ),
+    ):
+        generate_expansion_with_skald(
+            packet=packet,
+            seed_candidate_response=seed_response,
+            model_name="@provider.unused_test",
+        )
 
 
 @pytest.mark.parametrize(
@@ -1486,3 +1639,34 @@ def _valid_expansion(vocabulary: SeedEligibleVocabulary) -> dict[str, Any]:
             "explanation": "Dry-run plan only.",
         },
     }
+
+
+def _redemption_contract() -> tuple[
+    SeedEligibleVocabulary,
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+]:
+    """Return one valid project-intent contract missing only its dependency."""
+
+    vocabulary = _expansion_test_vocabulary()
+    packet = _packet(vocabulary)
+    seed_response = _seed_response(vocabulary)
+    seed_response["candidates"][0]["coverage_functions"] = ["unresolved_ledger"]
+    seed_response["candidates"][0]["project_intent"] = {
+        "project_type": "seek_redemption",
+        "target_ref": "Vale",
+        "rationale": "Mara must answer for an old wrong.",
+    }
+    payload = _valid_expansion(vocabulary)
+    payload["relationship_plan"] = []
+    payload["project_plan"] = [
+        {
+            "seed_id": "seed_001",
+            "project_type": "seek_redemption",
+            "actor_ref": "Mara",
+            "target_ref": "Vale",
+            "rationale": "Begin by owning the wrong.",
+        }
+    ]
+    return vocabulary, packet, seed_response, payload

--- a/tests/test_orrery/test_retrograde_expansion.py
+++ b/tests/test_orrery/test_retrograde_expansion.py
@@ -514,6 +514,55 @@ def test_seek_redemption_retry_exhaustion_names_seed_and_project(
         )
 
 
+def test_unclassified_redemption_relationship_uses_structured_repair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A schema-free invented type becomes a named ModelRetry issue."""
+
+    _vocabulary, packet, seed_response, payload = _redemption_contract()
+    payload["relationship_plan"] = [
+        {
+            "subject_ref": "Vale",
+            "subject_kind": "character",
+            "relationship_type": "invented_hostility",
+            "object_ref": "Mara",
+            "object_kind": "character",
+            "source_event_ref": "retro_event_001",
+        }
+    ]
+    invalid_output = RetrogradeExpansionPlanResponse.model_validate(payload)
+
+    class ExhaustingProvider:
+        output_validator: Any = None
+
+        def get_structured_completion(self, _prompt: str, _schema: Any) -> Any:
+            assert self.output_validator is not None
+            try:
+                asyncio.run(self.output_validator(None, invalid_output))
+            except ModelRetry as exc:
+                raise RuntimeError("structured retries exhausted") from exc
+            raise AssertionError("Invented relationship type unexpectedly validated")
+
+    monkeypatch.setattr(
+        "nexus.api.native_structured_output.build_native_structured_provider",
+        lambda **_kwargs: ExhaustingProvider(),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        generate_expansion_with_skald(
+            packet=packet,
+            seed_candidate_response=seed_response,
+            model_name="@provider.unused_test",
+        )
+
+    issue = str(exc_info.value)
+    assert "exhausted validation retries" in issue
+    assert "seed_001" in issue
+    assert "relationship_plan[0].relationship_type" in issue
+    assert "invented_hostility" in issue
+    assert "seed_eligible_vocabulary.relationship_types" in issue
+
+
 @pytest.mark.parametrize(
     ("death_ref", "issue"),
     [

--- a/tests/test_orrery/test_retrograde_projects_live.py
+++ b/tests/test_orrery/test_retrograde_projects_live.py
@@ -404,6 +404,66 @@ def test_seek_redemption_requires_target_to_actor_negative_valence(
             )
 
 
+def test_seek_redemption_rejects_non_materializing_planned_enemy(
+    project_db: dict[str, Any],
+) -> None:
+    """An already-present friendly row defeats a planned enemy prerequisite."""
+
+    db = project_db
+    actor_id, actor = db["characters"][0]
+    target_id, target = db["characters"][8]
+    with db["conn"].cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO character_relationships (
+                character1_id, character2_id, relationship_type,
+                emotional_valence, dynamic, recent_events, history
+            )
+            SELECT target_c.id, actor_c.id, 'friend',
+                   '+2|friendly', '', '', ''
+            FROM characters target_c, characters actor_c
+            WHERE target_c.entity_id = %s
+              AND actor_c.entity_id = %s
+            """,
+            (target_id, actor_id),
+        )
+        packet, seeds, expansion = _contracts(
+            db["vocabulary"],
+            [("seed_redemption", "seek_redemption", actor, target)],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                "seed 'seed_redemption_.*' seek_redemption requires a "
+                "TARGET->ACTOR wary-or-worse relationship"
+            ),
+        ):
+            build_retrograde_persistence_plan(
+                cur,
+                packet=packet,
+                seed_candidate_response=seeds,
+                expansion_plan_payload=expansion,
+                slot=2,
+                dbname="save_02",
+                dry_run=False,
+                create_missing_entities=True,
+                project_seeding_enabled=True,
+                project_settings=load_settings().orrery.projects,
+            )
+
+        cur.execute(
+            """
+            SELECT count(*)
+            FROM character_project_states
+            WHERE character_entity_id = %s
+              AND project_type = 'seek_redemption'
+            """,
+            (actor_id,),
+        )
+        assert cur.fetchone()[0] == 0
+
+
 def test_writer_rejects_project_participants_in_death_plan(
     project_db: dict[str, Any],
 ) -> None:

--- a/tests/test_orrery/test_retrograde_projects_live.py
+++ b/tests/test_orrery/test_retrograde_projects_live.py
@@ -383,6 +383,13 @@ def test_seek_redemption_requires_target_to_actor_negative_valence(
             specs,
             include_redemption_wrong=False,
         )
+        packet["project_start_relationships"] = [
+            {
+                "subject_ref": target,
+                "object_ref": actor,
+                "emotional_valence": "-1|wary",
+            }
+        ]
         with pytest.raises(ValueError, match="wary-or-worse"):
             build_retrograde_persistence_plan(
                 cur,


### PR DESCRIPTION
## Summary

Fixes #612 (night-QA round 2). The `seek_redemption` TARGET→ACTOR wary-or-worse precondition was first checked in `retrograde_persistence._validate_project_start_dependencies()` — after the repairable R6 structured-output boundary — so impossible projects survived every model retry, burned the full multi-call latency, and rolled back only inside the mapper transaction.

## Changes

- New `retrograde_project_dependencies` module: the single shared rule (`seek_redemption_dependency_issue`), the canonical-ladder valence threshold (`is_wary_or_worse`, derived from `EmotionalValence` — no literal rungs), and the DB loader for qualifying relationships.
- R6 expansion validation enforces the rule against packet-carried existing relationships plus the same expansion's planned relationship rows; failures return through the bounded structured repair path before any transaction.
- The hard-validation doctrine tells the model the rule up front (prevention before repair).
- Maturation threads existing inbound wary-or-worse relationships into runtime packets; wizard packets declare a clean slate.
- Persistence's transactional recheck now calls the same shared rule (race-proofing retained, drift impossible).

## Testing

Structured-boundary tests: missing, reversed-direction, boundary-valence, same-expansion-satisfied, and retry-exhaustion. PostgreSQL regression drives the checked-in fixture cache → production build → expansion validation → atomic persistence (`NEXUS_RUN_POSTGRES=1`).

- Orrery pg-gated: `1321 passed, 5 skipped`
- Full suite: `1957 passed, 451 skipped`
- Targeted mypy: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fs3R2bgfcWPiU4QgToRxo