### PR TITLE
Narrative: Durable Per-Slot Generation Lease and Truthful Sessions

### DIFF
--- a/migrations/098_narrative_generation_lease.sql
+++ b/migrations/098_narrative_generation_lease.sql
@@ -1,0 +1,41 @@
+-- Serialize narrative generation per slot database and retain durable session truth.
+
+CREATE TABLE IF NOT EXISTS narrative_generation_sessions (
+    session_id UUID PRIMARY KEY,
+    operation TEXT NOT NULL
+        CHECK (operation IN ('continue', 'regenerate')),
+    parent_chunk_id BIGINT,
+    status TEXT NOT NULL
+        CHECK (status IN ('initiated', 'complete', 'error')),
+    chunk_id BIGINT,
+    error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS narrative_generation_lease (
+    id BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id),
+    session_id UUID NOT NULL UNIQUE
+        REFERENCES narrative_generation_sessions(session_id) ON DELETE CASCADE,
+    parent_chunk_id BIGINT,
+    operation TEXT NOT NULL
+        CHECK (operation IN ('continue', 'regenerate')),
+    acquired_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS narrative_parent_embedding_claims (
+    parent_chunk_id BIGINT PRIMARY KEY,
+    session_id UUID NOT NULL
+        REFERENCES narrative_generation_sessions(session_id) ON DELETE RESTRICT,
+    claimed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE narrative_generation_lease IS
+    'Per-slot singleton lease preventing concurrent narrative turn pipelines';
+
+COMMENT ON TABLE narrative_generation_sessions IS
+    'Durable generation status whose complete rows must remain bound to incubator';
+
+COMMENT ON TABLE narrative_parent_embedding_claims IS
+    'Single-fire guard for the locked-chunk embedding trigger per accepted parent';

--- a/nexus.toml
+++ b/nexus.toml
@@ -214,6 +214,11 @@ max_tokens = 4096
 # import-time code must never connect at all (issue #369).
 connect_timeout_seconds = 5
 
+[api.narrative_generation]
+# A crashed gateway must not brick a slot. This exceeds the longest configured
+# storyteller request budget while still allowing eventual lease reclamation.
+stale_lease_timeout_seconds = 3600
+
 [api.uploads]
 # Per-file size cap (MB) for character portrait / place image uploads and
 # the maximum number of files accepted in a single upload request.

--- a/nexus/api/config_utils.py
+++ b/nexus/api/config_utils.py
@@ -48,3 +48,11 @@ def get_max_choice_text_length() -> int:
         .get("constraints", {})
         .get("max_choice_text_length", 1000)
     )
+
+
+def get_generation_lease_timeout_seconds() -> int:
+    """Return the configured stale narrative-generation lease timeout."""
+    settings = load_settings()
+    if settings.api is None:
+        raise RuntimeError("nexus.toml is missing the required [api] section")
+    return settings.api.narrative_generation.stale_lease_timeout_seconds

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -64,7 +64,16 @@ from nexus.api.narrative_generation import (
     write_to_incubator,
     generate_bootstrap_narrative,
 )
-from nexus.api.config_utils import get_max_choice_text_length
+from nexus.api.narrative_lease import (
+    abandon_generation,
+    acquire_generation_lease,
+    bind_generation_parent,
+    claim_parent_embedding,
+)
+from nexus.api.config_utils import (
+    get_generation_lease_timeout_seconds,
+    get_max_choice_text_length,
+)
 from nexus.api.asset_endpoints import router as asset_router
 from nexus.api.reader_endpoints import router as reader_router
 from nexus.api.local_models_endpoints import router as local_models_router
@@ -219,6 +228,7 @@ def load_settings():
 from nexus.api.narrative_schemas import (
     ContinueNarrativeRequest,
     ContinueNarrativeResponse,
+    GenerationLeaseConflictResponse,
     RegenerateNarrativeRequest,
     ApproveNarrativeRequest,
     NarrativeStatus,
@@ -316,6 +326,8 @@ def _record_player_response_for_chunk(
     choice: Optional[int],
     accept_fate: bool,
     require_response: bool,
+    connection: Any = None,
+    incubator_session_id: Optional[str] = None,
 ) -> str:
     """
     Resolve and persist the player's response for an incubator/committed chunk.
@@ -323,21 +335,35 @@ def _record_player_response_for_chunk(
     Returns:
         The response text that should be sent into the next generation.
     """
-    try:
-        conn = get_db_connection(slot)
-    except Exception as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    owns_connection = connection is None
+    if owns_connection:
+        try:
+            conn = get_db_connection(slot)
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+    else:
+        conn = connection
 
     try:
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
-            cur.execute(
-                """
-                SELECT chunk_id AS id, storyteller_text, choice_object, choice_text
-                FROM incubator
-                WHERE chunk_id = %s
-                """,
-                (chunk_id,),
-            )
+            if incubator_session_id is None:
+                cur.execute(
+                    """
+                    SELECT chunk_id AS id, storyteller_text, choice_object, choice_text
+                    FROM incubator
+                    WHERE chunk_id = %s
+                    """,
+                    (chunk_id,),
+                )
+            else:
+                cur.execute(
+                    """
+                    SELECT chunk_id AS id, storyteller_text, choice_object, choice_text
+                    FROM incubator
+                    WHERE chunk_id = %s AND session_id = %s
+                    """,
+                    (chunk_id, incubator_session_id),
+                )
             chunk = cur.fetchone()
             is_incubator = chunk is not None
 
@@ -430,18 +456,22 @@ def _record_player_response_for_chunk(
                 choice_text=resolved.choice_text,
             )
 
-        conn.commit()
+        if owns_connection:
+            conn.commit()
         return resolved.choice_text
 
     except HTTPException:
-        conn.rollback()
+        if owns_connection:
+            conn.rollback()
         raise
     except Exception as exc:
-        conn.rollback()
+        if owns_connection:
+            conn.rollback()
         logger.error("Error recording player response for chunk %s: %s", chunk_id, exc)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     finally:
-        conn.close()
+        if owns_connection:
+            conn.close()
 
 
 def _trigger_locked_chunk_embedding(
@@ -530,6 +560,109 @@ def _trigger_locked_chunk_embedding(
         )
 
 
+def _acquire_generation_owner(
+    *, slot: Optional[int], session_id: str, operation: str
+) -> None:
+    """Acquire the durable slot lease or raise the documented 409."""
+    conn = get_db_connection(slot)
+    try:
+        conflict = acquire_generation_lease(
+            conn,
+            session_id=session_id,
+            operation=operation,
+            stale_timeout_seconds=get_generation_lease_timeout_seconds(),
+        )
+    finally:
+        conn.close()
+    if conflict is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": "Another narrative generation owns this slot.",
+                "active_session_id": conflict.active_session_id,
+            },
+        )
+
+
+def _bind_generation_owner(
+    *,
+    slot: Optional[int],
+    session_id: str,
+    parent_chunk_id: int,
+    claim_embedding: bool,
+) -> bool:
+    """Bind the resolved parent and optionally claim its embedding trigger."""
+    conn = get_db_connection(slot)
+    try:
+        bind_generation_parent(
+            conn,
+            session_id=session_id,
+            parent_chunk_id=parent_chunk_id,
+        )
+        if claim_embedding:
+            return claim_parent_embedding(
+                conn,
+                session_id=session_id,
+                parent_chunk_id=parent_chunk_id,
+            )
+        return False
+    finally:
+        conn.close()
+
+
+def _abandon_generation_owner(
+    *, slot: Optional[int], session_id: str, error: str
+) -> None:
+    """Release a route-owned lease after a pre-scheduling failure."""
+    conn = get_db_connection(slot)
+    try:
+        abandon_generation(conn, session_id=session_id, error=error)
+    finally:
+        conn.close()
+
+
+def _resolve_and_approve_pending(
+    *,
+    slot: Optional[int],
+    session_id: str,
+    chunk_id: int,
+    user_text: str,
+    choice: Optional[int],
+    accept_fate: bool,
+    background_tasks: BackgroundTasks,
+) -> tuple[str, int]:
+    """Resolve the pending choice and approve it in one transaction."""
+    from nexus.api.commit_handler_sync import commit_incubator_to_database_sync
+
+    conn = get_db_connection(slot)
+    try:
+        resolved_user_text = _record_player_response_for_chunk(
+            slot=slot,
+            chunk_id=chunk_id,
+            user_text=user_text,
+            choice=choice,
+            accept_fate=accept_fate,
+            require_response=True,
+            connection=conn,
+            incubator_session_id=session_id,
+        )
+        approved_chunk_id = commit_incubator_to_database_sync(conn, session_id, slot)
+        background_tasks.add_task(_run_post_commit_orrery_work, slot)
+        return resolved_user_text, approved_chunk_id
+    except HTTPException:
+        conn.rollback()
+        raise
+    except Exception as exc:
+        conn.rollback()
+        logger.error("Failed to commit narrative: %s", exc)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to commit narrative: {str(exc)}",
+        ) from exc
+    finally:
+        conn.close()
+
+
 # API Endpoints
 @app.get("/health")
 async def health_check():
@@ -553,7 +686,16 @@ async def get_config_models():
     }
 
 
-@app.post("/api/narrative/continue", response_model=ContinueNarrativeResponse)
+@app.post(
+    "/api/narrative/continue",
+    response_model=ContinueNarrativeResponse,
+    responses={
+        409: {
+            "model": GenerationLeaseConflictResponse,
+            "description": "Another generation currently owns the slot",
+        }
+    },
+)
 async def continue_narrative(
     request: ContinueNarrativeRequest, background_tasks: BackgroundTasks
 ):
@@ -578,7 +720,6 @@ async def continue_narrative(
             detail="Model override requires a slot to persist the selection.",
         )
 
-    # Resolve chunk_id from slot state if not provided
     resolved_user_text = request.user_text
     state = None
     if request.slot is not None:
@@ -591,158 +732,195 @@ async def continue_narrative(
                 detail="Slot is in wizard mode. Use /api/story/new/chat for wizard.",
             )
 
-    if request.chunk_id is None and state is not None:
-        if state.narrative_state is not None:
-            narrative_state = state.narrative_state
-            if narrative_state.has_pending:
-                if narrative_state.session_id is None:
-                    raise HTTPException(
-                        status_code=409,
-                        detail="Slot has pending incubator content that must be approved before continuing.",
+    session_id = str(uuid.uuid4())
+    _acquire_generation_owner(
+        slot=request.slot,
+        session_id=session_id,
+        operation="continue",
+    )
+    scheduled = False
+    try:
+        if request.chunk_id is None and state is not None:
+            if state.narrative_state is not None:
+                narrative_state = state.narrative_state
+                if narrative_state.has_pending:
+                    if narrative_state.session_id is None:
+                        raise HTTPException(
+                            status_code=409,
+                            detail=(
+                                "Slot has pending incubator content that must be "
+                                "approved before continuing."
+                            ),
+                        )
+                    logger.info(
+                        "Auto-approving pending incubator session %s for slot %s",
+                        narrative_state.session_id,
+                        request.slot,
                     )
+                    resolved_user_text, approved_chunk_id = (
+                        _resolve_and_approve_pending(
+                            slot=request.slot,
+                            session_id=narrative_state.session_id,
+                            chunk_id=narrative_state.current_chunk_id,
+                            user_text=request.user_text,
+                            choice=request.choice,
+                            accept_fate=request.accept_fate,
+                            background_tasks=background_tasks,
+                        )
+                    )
+                    request.chunk_id = approved_chunk_id
+                else:
+                    request.chunk_id = narrative_state.current_chunk_id
+                    if (
+                        request.choice is not None
+                        or request.accept_fate
+                        or narrative_state.choices
+                    ):
+                        resolved_user_text = _record_player_response_for_chunk(
+                            slot=request.slot,
+                            chunk_id=narrative_state.current_chunk_id,
+                            user_text=request.user_text,
+                            choice=request.choice,
+                            accept_fate=request.accept_fate,
+                            require_response=bool(narrative_state.choices),
+                        )
                 logger.info(
-                    "Auto-approving pending incubator session %s for slot %s",
-                    narrative_state.session_id,
+                    "Resolved chunk_id=%s from slot %s",
+                    request.chunk_id,
                     request.slot,
                 )
-                resolved_user_text = _record_player_response_for_chunk(
-                    slot=request.slot,
-                    chunk_id=narrative_state.current_chunk_id,
-                    user_text=request.user_text,
-                    choice=request.choice,
-                    accept_fate=request.accept_fate,
-                    require_response=True,
-                )
-                approval = await approve_narrative(
-                    session_id=narrative_state.session_id,
-                    background_tasks=background_tasks,
-                    request=ApproveNarrativeRequest(
-                        session_id=narrative_state.session_id, commit=True
-                    ),
-                    slot=request.slot,
-                )
-                approved_chunk_id = approval.get("chunk_id") if approval else None
-                if not approved_chunk_id:
-                    raise HTTPException(
-                        status_code=409,
-                        detail="Pending incubator content must be approved before continuing.",
-                    )
-                request.chunk_id = approved_chunk_id
-            else:
-                request.chunk_id = narrative_state.current_chunk_id
-                if (
-                    request.choice is not None
-                    or request.accept_fate
-                    or narrative_state.choices
-                ):
-                    resolved_user_text = _record_player_response_for_chunk(
-                        slot=request.slot,
-                        chunk_id=narrative_state.current_chunk_id,
-                        user_text=request.user_text,
-                        choice=request.choice,
-                        accept_fate=request.accept_fate,
-                        require_response=bool(narrative_state.choices),
-                    )
-            logger.info(
-                f"Resolved chunk_id={request.chunk_id} from slot {request.slot}"
+        elif request.chunk_id:
+            resolved_user_text = _record_player_response_for_chunk(
+                slot=request.slot,
+                chunk_id=request.chunk_id,
+                user_text=request.user_text,
+                choice=request.choice,
+                accept_fate=request.accept_fate,
+                require_response=False,
             )
-    elif request.chunk_id:
-        # Runs even without player input: the resolver owns the
-        # unresolved-choice guard, so an explicitly addressed chunk cannot
-        # bypass it the way slot-resolved continues cannot.
-        resolved_user_text = _record_player_response_for_chunk(
+
+        if request.model:
+            from nexus.api.save_slots import upsert_slot
+
+            upsert_slot(
+                request.slot,
+                model=request.model,
+                dbname=slot_dbname(request.slot),
+            )
+            logger.info("Persisted model %s to slot %s", request.model, request.slot)
+
+        parent_chunk_id = request.chunk_id if request.chunk_id else 0
+        is_bootstrap = parent_chunk_id == 0
+        embedding_claimed = _bind_generation_owner(
             slot=request.slot,
-            chunk_id=request.chunk_id,
-            user_text=request.user_text,
-            choice=request.choice,
-            accept_fate=request.accept_fate,
-            require_response=False,
-        )
-
-    # A request-level override is intentionally persistent, but only after every
-    # synchronous continue validation above has succeeded. Rejected requests
-    # must not alter the model used by later turns.
-    if request.model:
-        from nexus.api.save_slots import upsert_slot
-
-        upsert_slot(request.slot, model=request.model, dbname=slot_dbname(request.slot))
-        logger.info("Persisted model %s to slot %s", request.model, request.slot)
-
-    session_id = str(uuid.uuid4())
-
-    # Normalize chunk_id: None and 0 both mean bootstrap
-    parent_chunk_id = request.chunk_id if request.chunk_id else 0
-    is_bootstrap = parent_chunk_id == 0
-
-    if is_bootstrap:
-        logger.info("Starting narrative bootstrap (first chunk)")
-    else:
-        logger.info(f"Starting narrative continuation for chunk {parent_chunk_id}")
-    logger.info(f"Session ID: {session_id}")
-    logger.info(f"User text: {resolved_user_text[:100]}...")
-
-    # Send initial progress
-    await manager.send_progress(
-        session_id,
-        "initiated",
-        {
-            "chunk_id": parent_chunk_id,
-            "parent_chunk_id": parent_chunk_id,
-            "is_bootstrap": is_bootstrap,
-        },
-    )
-
-    # Start async generation in background
-    background_tasks.add_task(
-        generate_narrative_async,
-        session_id,
-        parent_chunk_id,
-        resolved_user_text,
-        request.slot,
-        get_db_connection=get_db_connection,
-        load_settings=load_settings,
-        manager=manager,
-    )
-    if not is_bootstrap and request.slot is not None:
-        background_tasks.add_task(
-            _trigger_locked_chunk_embedding,
-            slot=request.slot,
+            session_id=session_id,
             parent_chunk_id=parent_chunk_id,
+            claim_embedding=not is_bootstrap and request.slot is not None,
         )
 
-    message = (
-        "Narrative bootstrap started"
-        if is_bootstrap
-        else f"Narrative generation started for chunk {parent_chunk_id}"
-    )
-    return ContinueNarrativeResponse(
-        session_id=session_id,
-        status="processing",
-        message=message,
-    )
+        if is_bootstrap:
+            logger.info("Starting narrative bootstrap (first chunk)")
+        else:
+            logger.info("Starting narrative continuation for chunk %s", parent_chunk_id)
+        logger.info("Session ID: %s", session_id)
+        logger.info("User text: %s...", resolved_user_text[:100])
+
+        await manager.send_progress(
+            session_id,
+            "initiated",
+            {
+                "chunk_id": parent_chunk_id,
+                "parent_chunk_id": parent_chunk_id,
+                "is_bootstrap": is_bootstrap,
+                "slot": request.slot,
+            },
+        )
+
+        background_tasks.add_task(
+            generate_narrative_async,
+            session_id,
+            parent_chunk_id,
+            resolved_user_text,
+            request.slot,
+            get_db_connection=get_db_connection,
+            load_settings=load_settings,
+            manager=manager,
+            manage_generation_lease=True,
+        )
+        if embedding_claimed:
+            background_tasks.add_task(
+                _trigger_locked_chunk_embedding,
+                slot=request.slot,
+                parent_chunk_id=parent_chunk_id,
+            )
+        scheduled = True
+
+        message = (
+            "Narrative bootstrap started"
+            if is_bootstrap
+            else f"Narrative generation started for chunk {parent_chunk_id}"
+        )
+        return ContinueNarrativeResponse(
+            session_id=session_id,
+            status="processing",
+            message=message,
+        )
+    except Exception as exc:
+        if not scheduled:
+            try:
+                _abandon_generation_owner(
+                    slot=request.slot,
+                    session_id=session_id,
+                    error=str(exc),
+                )
+            except Exception as release_exc:
+                logger.error(
+                    "Failed to abandon generation lease %s: %s",
+                    session_id,
+                    release_exc,
+                )
+        raise
 
 
 @app.get("/api/narrative/status/{session_id}", response_model=NarrativeStatus)
 async def get_narrative_status(session_id: str, slot: Optional[int] = None):
-    """Get status of a narrative generation session"""
-
-    # Check WebSocket manager for active sessions
-    if session_id in manager.session_progress:
-        progress = manager.session_progress[session_id]
-        return NarrativeStatus(
-            session_id=session_id,
-            status=progress["status"],
-            chunk_id=progress.get("data", {}).get("chunk_id"),
-            parent_chunk_id=progress.get("data", {}).get("parent_chunk_id"),
-            created_at=datetime.fromisoformat(progress["timestamp"]),
-            error=progress.get("data", {}).get("error"),
-        )
-
-    # Check incubator for completed sessions
+    """Get durable status, validating every completed result binding."""
     conn = get_db_connection(slot)
     try:
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
-            cur.execute("SELECT * FROM incubator WHERE session_id = %s", (session_id,))
+            cur.execute(
+                """
+                SELECT
+                    gs.session_id,
+                    CASE
+                        WHEN gs.status = 'complete' AND i.session_id IS NULL
+                            THEN 'error'
+                        ELSE gs.status
+                    END AS status,
+                    CASE
+                        WHEN gs.status = 'complete' AND i.session_id IS NULL
+                            THEN NULL
+                        ELSE gs.chunk_id
+                    END AS chunk_id,
+                    gs.parent_chunk_id,
+                    gs.created_at,
+                    CASE
+                        WHEN gs.status = 'complete' AND i.session_id IS NULL
+                            THEN (
+                                'Completed result is no longer loadable for '
+                                'this session.'
+                            )
+                        ELSE gs.error
+                    END AS error
+                FROM narrative_generation_sessions gs
+                LEFT JOIN incubator i
+                  ON i.session_id = gs.session_id
+                 AND i.chunk_id = gs.chunk_id
+                 AND i.parent_chunk_id = gs.parent_chunk_id
+                WHERE gs.session_id = %s
+                """,
+                (session_id,),
+            )
             result = cur.fetchone()
 
         if result:
@@ -752,7 +930,7 @@ async def get_narrative_status(session_id: str, slot: Optional[int] = None):
                 chunk_id=result["chunk_id"],
                 parent_chunk_id=result["parent_chunk_id"],
                 created_at=result["created_at"],
-                error=None,
+                error=result["error"],
             )
 
         raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
@@ -761,7 +939,16 @@ async def get_narrative_status(session_id: str, slot: Optional[int] = None):
         conn.close()
 
 
-@app.post("/api/narrative/regenerate", response_model=ContinueNarrativeResponse)
+@app.post(
+    "/api/narrative/regenerate",
+    response_model=ContinueNarrativeResponse,
+    responses={
+        409: {
+            "model": GenerationLeaseConflictResponse,
+            "description": "Another generation currently owns the slot",
+        }
+    },
+)
 async def regenerate_narrative(
     request: RegenerateNarrativeRequest,
     background_tasks: BackgroundTasks,
@@ -770,8 +957,8 @@ async def regenerate_narrative(
     Regenerate the storyteller turn currently in the incubator.
 
     Replaces the incubator's pending content with a fresh generation,
-    reusing the same parent_chunk_id, user_text, and session_id for
-    "replace in place" semantics. The CLI/UI polls
+    reusing the same parent_chunk_id and user_text while assigning a new
+    generation session. The CLI/UI polls
     /api/narrative/status/{session_id} for completion.
     """
     conn = get_db_connection(request.slot)
@@ -794,52 +981,86 @@ async def regenerate_narrative(
                     ),
                 )
 
-            session_id = str(row["session_id"])
+            incumbent_session_id = str(row["session_id"])
             chunk_id = row["chunk_id"]
             parent_chunk_id = row["parent_chunk_id"]
             user_text = row["user_text"] or ""
-            # Intentionally NOT deleting the incubator row here. write_to_incubator
-            # (called inside generate_narrative_async on success) does DELETE+INSERT
-            # atomically. If we deleted eagerly and generation later failed (LLM error,
-            # timeout, etc.), the slot would be left with no pending turn — irrecoverable
-            # data loss of the draft the user was trying to re-roll.
+            # Keep the incumbent until generation succeeds. The writer replaces
+            # it only when this exact session/parent pair is still present, so a
+            # failed re-roll preserves the draft without enabling last-writer-wins.
     finally:
         conn.close()
 
-    note = request.note.strip() if request.note else None
-    logger.info(
-        f"Regenerating chunk {chunk_id} (parent={parent_chunk_id}) for session {session_id}"
-        f"{' [with note]' if note else ''}"
-    )
-
-    await manager.send_progress(
-        session_id,
-        "initiated",
-        {
-            "chunk_id": chunk_id,
-            "parent_chunk_id": parent_chunk_id,
-            "is_bootstrap": parent_chunk_id == 0,
-            "regenerate": True,
-        },
-    )
-
-    background_tasks.add_task(
-        generate_narrative_async,
-        session_id,
-        parent_chunk_id,
-        user_text,
-        request.slot,
-        get_db_connection=get_db_connection,
-        load_settings=load_settings,
-        manager=manager,
-        note=note,
-    )
-
-    return ContinueNarrativeResponse(
+    session_id = str(uuid.uuid4())
+    _acquire_generation_owner(
+        slot=request.slot,
         session_id=session_id,
-        status="processing",
-        message=f"Regenerating chunk {chunk_id}",
+        operation="regenerate",
     )
+    scheduled = False
+    try:
+        _bind_generation_owner(
+            slot=request.slot,
+            session_id=session_id,
+            parent_chunk_id=parent_chunk_id,
+            claim_embedding=False,
+        )
+        note = request.note.strip() if request.note else None
+        logger.info(
+            "Regenerating chunk %s (parent=%s) for session %s%s",
+            chunk_id,
+            parent_chunk_id,
+            session_id,
+            " [with note]" if note else "",
+        )
+
+        await manager.send_progress(
+            session_id,
+            "initiated",
+            {
+                "chunk_id": chunk_id,
+                "parent_chunk_id": parent_chunk_id,
+                "is_bootstrap": parent_chunk_id == 0,
+                "regenerate": True,
+                "slot": request.slot,
+            },
+        )
+
+        background_tasks.add_task(
+            generate_narrative_async,
+            session_id,
+            parent_chunk_id,
+            user_text,
+            request.slot,
+            get_db_connection=get_db_connection,
+            load_settings=load_settings,
+            manager=manager,
+            note=note,
+            expected_incubator_session=incumbent_session_id,
+            manage_generation_lease=True,
+        )
+        scheduled = True
+
+        return ContinueNarrativeResponse(
+            session_id=session_id,
+            status="processing",
+            message=f"Regenerating chunk {chunk_id}",
+        )
+    except Exception as exc:
+        if not scheduled:
+            try:
+                _abandon_generation_owner(
+                    slot=request.slot,
+                    session_id=session_id,
+                    error=str(exc),
+                )
+            except Exception as release_exc:
+                logger.error(
+                    "Failed to abandon regeneration lease %s: %s",
+                    session_id,
+                    release_exc,
+                )
+        raise
 
 
 @app.post("/api/narrative/approve")

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -346,25 +346,29 @@ def _record_player_response_for_chunk(
 
     try:
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
-            if incubator_session_id is None:
-                cur.execute(
-                    """
-                    SELECT chunk_id AS id, storyteller_text, choice_object, choice_text
-                    FROM incubator
-                    WHERE chunk_id = %s
-                    """,
-                    (chunk_id,),
-                )
-            else:
-                cur.execute(
-                    """
-                    SELECT chunk_id AS id, storyteller_text, choice_object, choice_text
-                    FROM incubator
-                    WHERE chunk_id = %s AND session_id = %s
-                    """,
-                    (chunk_id, incubator_session_id),
-                )
+            cur.execute(
+                """
+                SELECT chunk_id AS id, storyteller_text, choice_object,
+                       choice_text, session_id
+                FROM incubator
+                WHERE chunk_id = %s
+                """,
+                (chunk_id,),
+            )
             chunk = cur.fetchone()
+            if (
+                chunk is not None
+                and incubator_session_id is not None
+                and str(chunk["session_id"]) != incubator_session_id
+            ):
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "message": f"Incubator session mismatch for chunk {chunk_id}.",
+                        "expected_session_id": incubator_session_id,
+                        "actual_session_id": str(chunk["session_id"]),
+                    },
+                )
             is_incubator = chunk is not None
 
             if not chunk:

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -243,15 +243,24 @@ async def generate_narrative_async(
                 chunk_id=incubator_data["chunk_id"],
             )
 
-        # Send progress: complete
-        await manager.send_progress(
-            session_id,
-            "complete",
-            {
-                "chunk_id": parent_chunk_id + 1,
-                "preview": incubator_data["storyteller_text"][:200] + "...",
-            },
-        )
+        # The result and terminal status are already committed. A stale
+        # WebSocket must not turn successful durable work into an error.
+        try:
+            await manager.send_progress(
+                session_id,
+                "complete",
+                {
+                    "chunk_id": parent_chunk_id + 1,
+                    "preview": incubator_data["storyteller_text"][:200] + "...",
+                },
+            )
+        except Exception as notification_exc:
+            logger.error(
+                "Failed to broadcast completed generation session %s; "
+                "durable status remains complete: %s",
+                session_id,
+                notification_exc,
+            )
 
         logger.info(f"Narrative generation complete for session {session_id}")
 
@@ -273,7 +282,14 @@ async def generate_narrative_async(
                     session_id,
                     status_exc,
                 )
-        await manager.send_progress(session_id, "error", {"error": error_detail})
+        try:
+            await manager.send_progress(session_id, "error", {"error": error_detail})
+        except Exception as notification_exc:
+            logger.error(
+                "Failed to broadcast terminal error for generation session %s: %s",
+                session_id,
+                notification_exc,
+            )
     finally:
         if conn:
             conn.close()

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -21,6 +21,7 @@ from nexus.api.lore_adapter import (
     response_to_incubator,
     validate_incubator_data,
 )
+from nexus.api.narrative_lease import finish_generation
 
 logger = logging.getLogger("nexus.api.narrative_generation")
 
@@ -75,6 +76,8 @@ async def generate_narrative_async(
     load_settings: Callable[[], Dict[str, Any]],
     manager: ProgressManager,
     note: Optional[str] = None,
+    expected_incubator_session: Optional[str] = None,
+    manage_generation_lease: bool = True,
 ) -> None:
     """
     Async function to generate narrative.
@@ -96,6 +99,10 @@ async def generate_narrative_async(
         manager: Progress notification manager
         note: Optional soft author's note for the storyteller (used by regenerate
             for meta-hints; ignored by bootstrap path).
+        expected_incubator_session: Existing incubator owner that this generation
+            may replace. ``None`` requires the singleton to be empty.
+        manage_generation_lease: Persist terminal durable status and release the
+            lease. Production route tasks enable this after acquisition.
     """
     conn = None
     is_bootstrap = parent_chunk_id == 0
@@ -220,7 +227,21 @@ async def generate_narrative_async(
             validate_incubator_data(incubator_data)
 
         # Write to incubator
-        await write_to_incubator(conn, incubator_data)
+        if expected_incubator_session is None:
+            await write_to_incubator(conn, incubator_data)
+        else:
+            await write_to_incubator(
+                conn,
+                incubator_data,
+                expected_incubator_session=expected_incubator_session,
+            )
+        if manage_generation_lease:
+            finish_generation(
+                conn,
+                session_id=session_id,
+                status="complete",
+                chunk_id=incubator_data["chunk_id"],
+            )
 
         # Send progress: complete
         await manager.send_progress(
@@ -237,6 +258,21 @@ async def generate_narrative_async(
     except Exception as e:
         error_detail = _exception_detail(e)
         logger.error(f"Error generating narrative: {error_detail}")
+        if conn is not None and manage_generation_lease:
+            conn.rollback()
+            try:
+                finish_generation(
+                    conn,
+                    session_id=session_id,
+                    status="error",
+                    error=error_detail,
+                )
+            except Exception as status_exc:
+                logger.error(
+                    "Failed to persist terminal error for session %s: %s",
+                    session_id,
+                    status_exc,
+                )
         await manager.send_progress(session_id, "error", {"error": error_detail})
     finally:
         if conn:
@@ -272,61 +308,136 @@ async def get_chunk_info(conn, chunk_id: int) -> Dict[str, Any]:
     return dict(result)
 
 
-async def write_to_incubator(conn, data: Dict[str, Any]):
-    """Write data to the incubator table."""
+async def write_to_incubator(
+    conn,
+    data: Dict[str, Any],
+    *,
+    expected_incubator_session: Optional[str] = None,
+) -> None:
+    """Persist only while the expected parent/session still owns the slot."""
     generation_model = data["generation_model"]
     if not isinstance(generation_model, str) or not generation_model.strip():
         raise ValueError("Generated incubator payload is missing its model id")
 
-    with conn.cursor() as cur:
-        # Clear any existing incubator entry (singleton table)
-        cur.execute("DELETE FROM incubator WHERE id = TRUE")
+    values = (
+        data["chunk_id"],
+        data["parent_chunk_id"],
+        data["user_text"],
+        data["storyteller_text"],
+        generation_model,
+        json.dumps(data.get("choice_object")) if data.get("choice_object") else None,
+        data.get("choice_text"),
+        json.dumps(data["metadata_updates"]),
+        json.dumps(data["entity_updates"]),
+        json.dumps(data["reference_updates"]),
+        (
+            json.dumps(data.get("orrery_proposal"))
+            if data.get("orrery_proposal")
+            else None
+        ),
+        json.dumps(data.get("orrery_adjudications", [])),
+        json.dumps(data.get("new_entities", [])),
+        data["session_id"],
+        data["llm_response_id"],
+        data["status"],
+    )
 
-        # Insert new incubator entry
-        query = """
-        INSERT INTO incubator (
-            id, chunk_id, parent_chunk_id, user_text, storyteller_text,
-            generation_model,
-            choice_object, choice_text,
-            metadata_updates, entity_updates, reference_updates,
-            orrery_proposal, orrery_adjudications,
-            new_entities, session_id, llm_response_id, status
-        ) VALUES (
-            TRUE, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
-        )
-        """
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT session_id, parent_chunk_id
+                FROM narrative_generation_lease
+                WHERE id = TRUE
+                  AND session_id = %s
+                  AND parent_chunk_id = %s
+                  AND expires_at > NOW()
+                FOR UPDATE
+                """,
+                (data["session_id"], data["parent_chunk_id"]),
+            )
+            if cur.fetchone() is None:
+                raise RuntimeError(
+                    "Refusing incubator write: generation lease does not match "
+                    f"session {data['session_id']} and parent "
+                    f"{data['parent_chunk_id']}."
+                )
 
-        cur.execute(
-            query,
-            (
-                data["chunk_id"],
-                data["parent_chunk_id"],
-                data["user_text"],
-                data["storyteller_text"],
-                generation_model,
-                (
-                    json.dumps(data.get("choice_object"))
-                    if data.get("choice_object")
-                    else None
-                ),
-                data.get("choice_text"),
-                json.dumps(data["metadata_updates"]),
-                json.dumps(data["entity_updates"]),
-                json.dumps(data["reference_updates"]),
-                (
-                    json.dumps(data.get("orrery_proposal"))
-                    if data.get("orrery_proposal")
-                    else None
-                ),
-                json.dumps(data.get("orrery_adjudications", [])),
-                json.dumps(data.get("new_entities", [])),
-                data["session_id"],
-                data["llm_response_id"],
-                data["status"],
-            ),
-        )
-
-    conn.commit()
+            cur.execute(
+                """
+                SELECT session_id, parent_chunk_id
+                FROM incubator
+                WHERE id = TRUE
+                FOR UPDATE
+                """
+            )
+            incumbent = cur.fetchone()
+            if expected_incubator_session is None:
+                if incumbent is not None:
+                    raise RuntimeError(
+                        "Refusing incubator write: the singleton is owned by "
+                        f"session {incumbent['session_id']}."
+                    )
+                cur.execute(
+                    """
+                    INSERT INTO incubator (
+                        id, chunk_id, parent_chunk_id, user_text, storyteller_text,
+                        generation_model, choice_object, choice_text,
+                        metadata_updates, entity_updates, reference_updates,
+                        orrery_proposal, orrery_adjudications,
+                        new_entities, session_id, llm_response_id, status
+                    ) VALUES (
+                        TRUE, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s
+                    )
+                    """,
+                    values,
+                )
+            else:
+                if (
+                    incumbent is None
+                    or str(incumbent["session_id"]) != expected_incubator_session
+                    or incumbent["parent_chunk_id"] != data["parent_chunk_id"]
+                ):
+                    raise RuntimeError(
+                        "Refusing incubator replacement: expected session "
+                        f"{expected_incubator_session} with parent "
+                        f"{data['parent_chunk_id']}."
+                    )
+                cur.execute(
+                    """
+                    UPDATE incubator
+                    SET chunk_id = %s,
+                        parent_chunk_id = %s,
+                        user_text = %s,
+                        storyteller_text = %s,
+                        generation_model = %s,
+                        choice_object = %s,
+                        choice_text = %s,
+                        metadata_updates = %s,
+                        entity_updates = %s,
+                        reference_updates = %s,
+                        orrery_proposal = %s,
+                        orrery_adjudications = %s,
+                        new_entities = %s,
+                        session_id = %s,
+                        llm_response_id = %s,
+                        status = %s,
+                        created_at = NOW()
+                    WHERE id = TRUE
+                      AND session_id = %s
+                      AND parent_chunk_id = %s
+                    """,
+                    (*values, expected_incubator_session, data["parent_chunk_id"]),
+                )
+                if cur.rowcount != 1:
+                    raise RuntimeError(
+                        "Incubator ownership changed during conditional replacement."
+                    )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
 
 
 async def generate_bootstrap_narrative(

--- a/nexus/api/narrative_lease.py
+++ b/nexus/api/narrative_lease.py
@@ -1,0 +1,210 @@
+"""Durable per-slot ownership for narrative generation pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from psycopg2.extras import RealDictCursor
+
+
+@dataclass(frozen=True)
+class GenerationLeaseConflict:
+    """Describe the active owner that prevented lease acquisition."""
+
+    active_session_id: str
+
+
+def acquire_generation_lease(
+    conn: Any,
+    *,
+    session_id: str,
+    operation: str,
+    stale_timeout_seconds: int,
+) -> Optional[GenerationLeaseConflict]:
+    """Acquire the slot singleton, replacing only an expired owner."""
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            # Row locking cannot serialize the empty-table case. This table is
+            # a one-row mutex, so a short transaction-level table lock closes
+            # the first-acquisition race without blocking generation itself.
+            cur.execute(
+                """
+                LOCK TABLE narrative_generation_lease
+                IN SHARE ROW EXCLUSIVE MODE
+                """
+            )
+            cur.execute(
+                """
+                SELECT session_id, expires_at <= NOW() AS is_stale
+                FROM narrative_generation_lease
+                WHERE id = TRUE
+                FOR UPDATE
+                """
+            )
+            incumbent = cur.fetchone()
+            if incumbent and not incumbent["is_stale"]:
+                conn.rollback()
+                return GenerationLeaseConflict(
+                    active_session_id=str(incumbent["session_id"])
+                )
+
+            if incumbent:
+                stale_session_id = str(incumbent["session_id"])
+                cur.execute(
+                    """
+                    UPDATE narrative_generation_sessions
+                    SET status = 'error',
+                        error = 'Generation lease expired before completion.',
+                        updated_at = NOW()
+                    WHERE session_id = %s
+                    """,
+                    (stale_session_id,),
+                )
+                cur.execute("DELETE FROM narrative_generation_lease WHERE id = TRUE")
+
+            cur.execute(
+                """
+                INSERT INTO narrative_generation_sessions (
+                    session_id, operation, status
+                ) VALUES (%s, %s, 'initiated')
+                ON CONFLICT (session_id) DO UPDATE
+                SET operation = EXCLUDED.operation,
+                    parent_chunk_id = NULL,
+                    status = 'initiated',
+                    chunk_id = NULL,
+                    error = NULL,
+                    updated_at = NOW()
+                """,
+                (session_id, operation),
+            )
+            cur.execute(
+                """
+                INSERT INTO narrative_generation_lease (
+                    id, session_id, operation, expires_at
+                ) VALUES (
+                    TRUE, %s, %s,
+                    NOW() + make_interval(secs => %s)
+                )
+                """,
+                (session_id, operation, stale_timeout_seconds),
+            )
+        conn.commit()
+        return None
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def bind_generation_parent(conn: Any, *, session_id: str, parent_chunk_id: int) -> None:
+    """Bind the active owner and its durable status to the resolved parent."""
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE narrative_generation_lease
+                SET parent_chunk_id = %s
+                WHERE id = TRUE
+                  AND session_id = %s
+                  AND expires_at > NOW()
+                """,
+                (parent_chunk_id, session_id),
+            )
+            if cur.rowcount != 1:
+                raise RuntimeError(
+                    f"Generation session {session_id} no longer owns the slot lease."
+                )
+            cur.execute(
+                """
+                UPDATE narrative_generation_sessions
+                SET parent_chunk_id = %s, updated_at = NOW()
+                WHERE session_id = %s
+                """,
+                (parent_chunk_id, session_id),
+            )
+            if cur.rowcount != 1:
+                raise RuntimeError(
+                    f"Generation session record {session_id} is missing."
+                )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def claim_parent_embedding(conn: Any, *, session_id: str, parent_chunk_id: int) -> bool:
+    """Claim the locked-chunk embedding trigger once for a parent."""
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO narrative_parent_embedding_claims (
+                    parent_chunk_id, session_id
+                )
+                SELECT %s, %s
+                FROM narrative_generation_lease
+                WHERE id = TRUE
+                  AND session_id = %s
+                  AND parent_chunk_id = %s
+                  AND expires_at > NOW()
+                ON CONFLICT (parent_chunk_id) DO NOTHING
+                """,
+                (parent_chunk_id, session_id, session_id, parent_chunk_id),
+            )
+            claimed = cur.rowcount == 1
+        conn.commit()
+        return claimed
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def finish_generation(
+    conn: Any,
+    *,
+    session_id: str,
+    status: str,
+    chunk_id: Optional[int] = None,
+    error: Optional[str] = None,
+) -> None:
+    """Persist terminal status and release only this session's lease."""
+    if status not in {"complete", "error"}:
+        raise ValueError(f"Unsupported terminal generation status: {status}")
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE narrative_generation_sessions
+                SET status = %s,
+                    chunk_id = %s,
+                    error = %s,
+                    updated_at = NOW()
+                WHERE session_id = %s
+                """,
+                (status, chunk_id, error, session_id),
+            )
+            if cur.rowcount != 1:
+                raise RuntimeError(
+                    f"Generation session record {session_id} is missing."
+                )
+            cur.execute(
+                """
+                DELETE FROM narrative_generation_lease
+                WHERE id = TRUE AND session_id = %s
+                """,
+                (session_id,),
+            )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def abandon_generation(conn: Any, *, session_id: str, error: str) -> None:
+    """Fail and release a lease when the route aborts before scheduling."""
+    finish_generation(
+        conn,
+        session_id=session_id,
+        status="error",
+        error=error,
+    )

--- a/nexus/api/narrative_lease.py
+++ b/nexus/api/narrative_lease.py
@@ -1,11 +1,26 @@
-"""Durable per-slot ownership for narrative generation pipelines."""
+"""Durable per-slot ownership for narrative generation pipelines.
+
+Lock-order invariant
+--------------------
+Every transaction in this module locks or mutates
+``narrative_generation_lease`` before touching
+``narrative_generation_sessions``. Transactions that also touch embedding
+claims use the order lease -> claims -> sessions. Acquisition takes an
+explicit lease-table lock first because there may not yet be a singleton row;
+that lock remains held while the new session and its foreign-keyed lease row
+are inserted. Keeping this order uniform prevents stale takeover and terminal
+completion from forming an ABBA deadlock.
+"""
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any, Optional
 
 from psycopg2.extras import RealDictCursor
+
+logger = logging.getLogger("nexus.api.narrative_lease")
 
 
 @dataclass(frozen=True)
@@ -51,6 +66,7 @@ def acquire_generation_lease(
 
             if incumbent:
                 stale_session_id = str(incumbent["session_id"])
+                cur.execute("DELETE FROM narrative_generation_lease WHERE id = TRUE")
                 cur.execute(
                     """
                     UPDATE narrative_generation_sessions
@@ -61,7 +77,6 @@ def acquire_generation_lease(
                     """,
                     (stale_session_id,),
                 )
-                cur.execute("DELETE FROM narrative_generation_lease WHERE id = TRUE")
 
             cur.execute(
                 """
@@ -133,23 +148,43 @@ def bind_generation_parent(conn: Any, *, session_id: str, parent_chunk_id: int) 
 
 
 def claim_parent_embedding(conn: Any, *, session_id: str, parent_chunk_id: int) -> bool:
-    """Claim the locked-chunk embedding trigger once for a parent."""
+    """Claim a parent, replacing only a terminal-error session's orphan."""
     try:
-        with conn.cursor() as cur:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
             cur.execute(
                 """
-                INSERT INTO narrative_parent_embedding_claims (
-                    parent_chunk_id, session_id
-                )
-                SELECT %s, %s
+                SELECT session_id
                 FROM narrative_generation_lease
                 WHERE id = TRUE
                   AND session_id = %s
                   AND parent_chunk_id = %s
                   AND expires_at > NOW()
-                ON CONFLICT (parent_chunk_id) DO NOTHING
+                FOR UPDATE
                 """,
-                (parent_chunk_id, session_id, session_id, parent_chunk_id),
+                (session_id, parent_chunk_id),
+            )
+            if cur.fetchone() is None:
+                raise RuntimeError(
+                    f"Generation session {session_id} no longer owns parent "
+                    f"{parent_chunk_id}."
+                )
+            cur.execute(
+                """
+                INSERT INTO narrative_parent_embedding_claims (
+                    parent_chunk_id, session_id
+                ) VALUES (%s, %s)
+                ON CONFLICT (parent_chunk_id) DO UPDATE
+                SET session_id = EXCLUDED.session_id,
+                    claimed_at = NOW()
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM narrative_generation_sessions incumbent
+                    WHERE incumbent.session_id =
+                        narrative_parent_embedding_claims.session_id
+                      AND incumbent.status = 'error'
+                )
+                """,
+                (parent_chunk_id, session_id),
             )
             claimed = cur.rowcount == 1
         conn.commit()
@@ -167,11 +202,84 @@ def finish_generation(
     chunk_id: Optional[int] = None,
     error: Optional[str] = None,
 ) -> None:
-    """Persist terminal status and release only this session's lease."""
+    """Persist monotonic terminal status and release only this session's lease."""
+    _finish_generation(
+        conn,
+        session_id=session_id,
+        status=status,
+        chunk_id=chunk_id,
+        error=error,
+        release_embedding_claim=False,
+    )
+
+
+def _finish_generation(
+    conn: Any,
+    *,
+    session_id: str,
+    status: str,
+    chunk_id: Optional[int],
+    error: Optional[str],
+    release_embedding_claim: bool,
+) -> None:
+    """Apply one terminal transition using lease -> claims -> session order."""
     if status not in {"complete", "error"}:
         raise ValueError(f"Unsupported terminal generation status: {status}")
     try:
-        with conn.cursor() as cur:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                DELETE FROM narrative_generation_lease
+                WHERE id = TRUE AND session_id = %s
+                RETURNING session_id
+                """,
+                (session_id,),
+            )
+            released_lease = cur.fetchone() is not None
+            if release_embedding_claim:
+                cur.execute(
+                    """
+                    DELETE FROM narrative_parent_embedding_claims
+                    WHERE session_id = %s
+                    """,
+                    (session_id,),
+                )
+
+            cur.execute(
+                """
+                SELECT status, chunk_id
+                FROM narrative_generation_sessions
+                WHERE session_id = %s
+                FOR UPDATE
+                """,
+                (session_id,),
+            )
+            session = cur.fetchone()
+            if session is None:
+                raise RuntimeError(
+                    f"Generation session record {session_id} is missing."
+                )
+
+            current_status = str(session["status"])
+            if current_status == "complete" and status == "error":
+                logger.error(
+                    "Refusing to downgrade completed generation session %s to error: %s",
+                    session_id,
+                    error,
+                )
+                raise RuntimeError(
+                    f"Generation session {session_id} is already complete; "
+                    "refusing error downgrade."
+                )
+            if not released_lease and current_status == "initiated":
+                raise RuntimeError(
+                    f"Generation session {session_id} does not own the slot lease."
+                )
+            if not released_lease and status == "complete":
+                raise RuntimeError(
+                    f"Generation session {session_id} lost its lease before completion."
+                )
+
             cur.execute(
                 """
                 UPDATE narrative_generation_sessions
@@ -183,17 +291,6 @@ def finish_generation(
                 """,
                 (status, chunk_id, error, session_id),
             )
-            if cur.rowcount != 1:
-                raise RuntimeError(
-                    f"Generation session record {session_id} is missing."
-                )
-            cur.execute(
-                """
-                DELETE FROM narrative_generation_lease
-                WHERE id = TRUE AND session_id = %s
-                """,
-                (session_id,),
-            )
         conn.commit()
     except Exception:
         conn.rollback()
@@ -201,10 +298,12 @@ def finish_generation(
 
 
 def abandon_generation(conn: Any, *, session_id: str, error: str) -> None:
-    """Fail and release a lease when the route aborts before scheduling."""
-    finish_generation(
+    """Fail a pre-scheduling route and release both its lease and parent claim."""
+    _finish_generation(
         conn,
         session_id=session_id,
         status="error",
+        chunk_id=None,
         error=error,
+        release_embedding_claim=True,
     )

--- a/nexus/api/narrative_schemas.py
+++ b/nexus/api/narrative_schemas.py
@@ -60,6 +60,21 @@ class ContinueNarrativeResponse(BaseModel):
     message: str = Field(description="Status message")
 
 
+class GenerationLeaseConflictDetail(BaseModel):
+    """Ownership details returned for a competing generation request."""
+
+    message: str = Field(description="Why the request could not start")
+    active_session_id: str = Field(
+        description="Session ID of the generation that currently owns the slot"
+    )
+
+
+class GenerationLeaseConflictResponse(BaseModel):
+    """HTTP 409 body when another generation owns the slot."""
+
+    detail: GenerationLeaseConflictDetail
+
+
 class RegenerateNarrativeRequest(BaseModel):
     """Request to regenerate the storyteller turn currently in the incubator."""
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -2832,6 +2832,21 @@ class APIDatabaseSettings(BaseModel):
     )
 
 
+class APINarrativeGenerationSettings(BaseModel):
+    """Ownership settings for durable narrative generation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    stale_lease_timeout_seconds: int = Field(
+        ...,
+        ge=1,
+        description=(
+            "Maximum seconds a generation may own a slot before the lease "
+            "may be reclaimed after a gateway crash"
+        ),
+    )
+
+
 class APIUploadsSettings(BaseModel):
     """Limits for image upload endpoints (character portraits, place images)."""
 
@@ -2859,6 +2874,9 @@ class APISettings(BaseModel):
     )
     database: APIDatabaseSettings = Field(
         ..., description="Slot database connection behavior"
+    )
+    narrative_generation: APINarrativeGenerationSettings = Field(
+        ..., description="Durable narrative generation ownership"
     )
     uploads: Optional[APIUploadsSettings] = Field(
         default=None, description="Image upload limits"

--- a/tests/test_api/test_narrative_continue_validation.py
+++ b/tests/test_api/test_narrative_continue_validation.py
@@ -23,6 +23,7 @@ from nexus.api import (
     chunk_workflow,
     narrative,
     narrative_generation,
+    narrative_lease,
     save_slots,
     slot_endpoints,
     slot_state,
@@ -449,13 +450,8 @@ def _route_clone_to_slot(monkeypatch: pytest.MonkeyPatch, dbname: str) -> None:
     monkeypatch.setattr(narrative, "get_db_connection", lambda _slot: _connect(dbname))
 
 
-@pytest.mark.requires_postgres
-def test_concurrent_continues_have_one_owner_and_truthful_result(
-    monkeypatch: pytest.MonkeyPatch,
-    disposable_narrative_db: str,
-) -> None:
-    """Two genuine route calls serialize on one durable slot generation lease."""
-    dbname = disposable_narrative_db
+def _reset_to_committed_parent(dbname: str) -> int:
+    """Reset a clone to one playable committed parent and return its id."""
     with _clone_connection(dbname) as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -486,6 +482,40 @@ def test_concurrent_continues_have_one_owner_and_truthful_result(
                 """,
                 (parent_chunk_id,),
             )
+    return int(parent_chunk_id)
+
+
+class ImmediateLore:
+    """Frontier-only success double for genuine route/DB pipeline tests."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.settings_path = Path("test-settings.toml")
+        self.turn_context = SimpleNamespace(error_log=[], orrery_proposal=None)
+
+    async def process_turn(
+        self,
+        user_text: str,
+        parent_chunk_id: int,
+        note: str | None = None,
+    ) -> StorytellerResponseMinimal:
+        return StorytellerResponseMinimal(
+            generation_model="route-lease-fixture",
+            narrative="A single train enters the station.",
+            choices=["Board it.", "Let it pass."],
+        )
+
+    def close(self) -> None:
+        return None
+
+
+@pytest.mark.requires_postgres
+def test_concurrent_continues_have_one_owner_and_truthful_result(
+    monkeypatch: pytest.MonkeyPatch,
+    disposable_narrative_db: str,
+) -> None:
+    """Concurrent calls serialize and notification failure cannot corrupt success."""
+    dbname = disposable_narrative_db
+    parent_chunk_id = _reset_to_committed_parent(dbname)
 
     _route_clone_to_slot(monkeypatch, dbname)
     entered_generation = threading.Event()
@@ -526,6 +556,22 @@ def test_concurrent_continues_have_one_owner_and_truthful_result(
         narrative,
         "_trigger_locked_chunk_embedding",
         lambda *, slot, parent_chunk_id: embedding_calls.append(parent_chunk_id),
+    )
+    original_send_progress = narrative.manager.send_progress
+
+    async def fail_completed_broadcast(
+        session_id: str,
+        status: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        if status == "complete":
+            raise RuntimeError("stale WebSocket fixture")
+        await original_send_progress(session_id, status, data)
+
+    monkeypatch.setattr(
+        narrative.manager,
+        "send_progress",
+        fail_completed_broadcast,
     )
 
     def post_continue() -> Any:
@@ -596,6 +642,15 @@ def test_concurrent_continues_have_one_owner_and_truthful_result(
                 }
             ]
 
+    with _connect(dbname) as conn:
+        with pytest.raises(RuntimeError, match="refusing error downgrade"):
+            narrative_lease.finish_generation(
+                conn,
+                session_id=owner_session_id,
+                status="error",
+                error="late notification failure",
+            )
+
     with TestClient(narrative.app) as client:
         status = client.get(
             f"/api/narrative/status/{owner_session_id}",
@@ -619,6 +674,256 @@ def test_concurrent_continues_have_one_owner_and_truthful_result(
     assert unloaded_status.json()["error"] == (
         "Completed result is no longer loadable for this session."
     )
+
+
+@pytest.mark.requires_postgres
+def test_errored_embedding_claim_is_reclaimed_and_scheduled(
+    monkeypatch: pytest.MonkeyPatch,
+    disposable_narrative_db: str,
+) -> None:
+    """A retry replaces an errored owner's orphan claim and schedules work."""
+    dbname = disposable_narrative_db
+    parent_chunk_id = _reset_to_committed_parent(dbname)
+    crashed_session_id = str(uuid.uuid4())
+    with _connect(dbname) as conn:
+        assert (
+            narrative_lease.acquire_generation_lease(
+                conn,
+                session_id=crashed_session_id,
+                operation="continue",
+                stale_timeout_seconds=60,
+            )
+            is None
+        )
+        narrative_lease.bind_generation_parent(
+            conn,
+            session_id=crashed_session_id,
+            parent_chunk_id=parent_chunk_id,
+        )
+        assert narrative_lease.claim_parent_embedding(
+            conn,
+            session_id=crashed_session_id,
+            parent_chunk_id=parent_chunk_id,
+        )
+        narrative_lease.finish_generation(
+            conn,
+            session_id=crashed_session_id,
+            status="error",
+            error="Simulated crash after durable claim.",
+        )
+
+    _route_clone_to_slot(monkeypatch, dbname)
+    monkeypatch.setattr(narrative_generation, "LORE", ImmediateLore)
+    embedding_calls: list[int] = []
+    monkeypatch.setattr(
+        narrative,
+        "_trigger_locked_chunk_embedding",
+        lambda *, slot, parent_chunk_id: embedding_calls.append(parent_chunk_id),
+    )
+
+    with TestClient(narrative.app) as client:
+        response = client.post("/api/narrative/continue", json={"slot": 3})
+
+    assert response.status_code == 200
+    retry_session_id = response.json()["session_id"]
+    assert embedding_calls == [parent_chunk_id]
+    with _clone_connection(dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT session_id
+                FROM narrative_parent_embedding_claims
+                WHERE parent_chunk_id = %s
+                """,
+                (parent_chunk_id,),
+            )
+            assert str(cur.fetchone()["session_id"]) == retry_session_id
+
+
+@pytest.mark.requires_postgres
+def test_live_embedding_claim_cannot_be_stolen(
+    monkeypatch: pytest.MonkeyPatch,
+    disposable_narrative_db: str,
+) -> None:
+    """A retry pipeline cannot replace a claim whose owner remains live."""
+    dbname = disposable_narrative_db
+    parent_chunk_id = _reset_to_committed_parent(dbname)
+    live_session_id = str(uuid.uuid4())
+    with _connect(dbname) as conn:
+        assert (
+            narrative_lease.acquire_generation_lease(
+                conn,
+                session_id=live_session_id,
+                operation="continue",
+                stale_timeout_seconds=60,
+            )
+            is None
+        )
+        narrative_lease.bind_generation_parent(
+            conn,
+            session_id=live_session_id,
+            parent_chunk_id=parent_chunk_id,
+        )
+        assert narrative_lease.claim_parent_embedding(
+            conn,
+            session_id=live_session_id,
+            parent_chunk_id=parent_chunk_id,
+        )
+        with conn.cursor() as cur:
+            # Simulate loss of the mutex without falsely terminalizing the
+            # session: its durable status remains live/initiated.
+            cur.execute(
+                """
+                DELETE FROM narrative_generation_lease
+                WHERE session_id = %s
+                """,
+                (live_session_id,),
+            )
+        conn.commit()
+
+    _route_clone_to_slot(monkeypatch, dbname)
+    monkeypatch.setattr(narrative_generation, "LORE", ImmediateLore)
+    embedding_calls: list[int] = []
+    monkeypatch.setattr(
+        narrative,
+        "_trigger_locked_chunk_embedding",
+        lambda *, slot, parent_chunk_id: embedding_calls.append(parent_chunk_id),
+    )
+
+    with TestClient(narrative.app) as client:
+        response = client.post("/api/narrative/continue", json={"slot": 3})
+
+    assert response.status_code == 200
+    assert embedding_calls == []
+    with _clone_connection(dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT session_id
+                FROM narrative_parent_embedding_claims
+                WHERE parent_chunk_id = %s
+                """,
+                (parent_chunk_id,),
+            )
+            assert str(cur.fetchone()["session_id"]) == live_session_id
+
+
+@pytest.mark.requires_postgres
+def test_pre_scheduling_failure_releases_embedding_claim(
+    monkeypatch: pytest.MonkeyPatch,
+    disposable_narrative_db: str,
+) -> None:
+    """Abandoning after claim but before task scheduling leaves no orphan."""
+    dbname = disposable_narrative_db
+    _reset_to_committed_parent(dbname)
+    _route_clone_to_slot(monkeypatch, dbname)
+
+    async def fail_initiated_broadcast(
+        session_id: str,
+        status: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        raise RuntimeError("pre-scheduling notification fixture")
+
+    monkeypatch.setattr(
+        narrative.manager,
+        "send_progress",
+        fail_initiated_broadcast,
+    )
+
+    with TestClient(narrative.app, raise_server_exceptions=False) as client:
+        response = client.post("/api/narrative/continue", json={"slot": 3})
+
+    assert response.status_code == 500
+    with _clone_connection(dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) AS count FROM narrative_generation_lease")
+            assert cur.fetchone()["count"] == 0
+            cur.execute(
+                "SELECT COUNT(*) AS count FROM narrative_parent_embedding_claims"
+            )
+            assert cur.fetchone()["count"] == 0
+            cur.execute("SELECT status FROM narrative_generation_sessions")
+            assert cur.fetchall() == [{"status": "error"}]
+
+
+@pytest.mark.requires_postgres
+def test_pending_incubator_session_mismatch_is_409(
+    monkeypatch: pytest.MonkeyPatch,
+    disposable_narrative_db: str,
+) -> None:
+    """A stale state read cannot fall through past another incubator owner."""
+    dbname = disposable_narrative_db
+    parent_chunk_id = _reset_to_committed_parent(dbname)
+    expected_session_id = str(uuid.uuid4())
+    actual_session_id = str(uuid.uuid4())
+    choices = ["Open the door.", "Wait in silence."]
+    with _clone_connection(dbname) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO incubator (
+                    id, chunk_id, parent_chunk_id, user_text, storyteller_text,
+                    generation_model, choice_object, choice_text,
+                    metadata_updates, entity_updates, reference_updates,
+                    orrery_proposal, orrery_adjudications, new_entities,
+                    session_id, llm_response_id, status
+                ) VALUES (
+                    TRUE, %s, %s, %s, %s, %s, %s, NULL,
+                    %s, %s, %s, NULL, %s, %s, %s, %s, 'provisional'
+                )
+                """,
+                (
+                    parent_chunk_id + 1,
+                    parent_chunk_id,
+                    "Approach the door.",
+                    "The hinges begin to move.",
+                    _valid_override(),
+                    Json({"presented": choices, "selected": None}),
+                    Json({}),
+                    Json({}),
+                    Json({"characters": [], "places": [], "factions": []}),
+                    Json([]),
+                    Json([]),
+                    expected_session_id,
+                    "session-mismatch-fixture",
+                ),
+            )
+
+    _route_clone_to_slot(monkeypatch, dbname)
+    production_get_slot_state = slot_state.get_slot_state
+    changed_owner = False
+
+    def stale_slot_state(slot: int) -> SlotState:
+        nonlocal changed_owner
+        state = production_get_slot_state(slot)
+        if not changed_owner:
+            with _clone_connection(dbname) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        UPDATE incubator
+                        SET session_id = %s
+                        WHERE session_id = %s
+                        """,
+                        (actual_session_id, expected_session_id),
+                    )
+            changed_owner = True
+        return state
+
+    monkeypatch.setattr(slot_state, "get_slot_state", stale_slot_state)
+    with TestClient(narrative.app) as client:
+        response = client.post(
+            "/api/narrative/continue",
+            json={"slot": 3, "choice": 1},
+        )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "message": f"Incubator session mismatch for chunk {parent_chunk_id + 1}.",
+        "expected_session_id": expected_session_id,
+        "actual_session_id": actual_session_id,
+    }
 
 
 @pytest.mark.requires_postgres

--- a/tests/test_api/test_narrative_continue_validation.py
+++ b/tests/test_api/test_narrative_continue_validation.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
+import threading
 import uuid
 from contextlib import contextmanager
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Iterator
 
 import psycopg2
@@ -13,9 +18,42 @@ from fastapi.testclient import TestClient
 from psycopg2 import sql
 from psycopg2.extras import Json, RealDictCursor
 
-from nexus.api import chunk_workflow, narrative, save_slots, slot_endpoints, slot_state
+from nexus.agents.logon.apex_schema import StorytellerResponseMinimal
+from nexus.api import (
+    chunk_workflow,
+    narrative,
+    narrative_generation,
+    save_slots,
+    slot_endpoints,
+    slot_state,
+)
 from nexus.api.slot_state import NarrativeState, SlotState, WizardState
 from nexus.config import get_available_api_models
+
+
+@pytest.fixture(autouse=True)
+def _unit_route_generation_lease(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep legacy transaction doubles focused outside PostgreSQL coverage."""
+    if request.node.get_closest_marker("requires_postgres") is not None:
+        return
+    monkeypatch.setattr(
+        narrative,
+        "_acquire_generation_owner",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        narrative,
+        "_bind_generation_owner",
+        lambda **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        narrative,
+        "_abandon_generation_owner",
+        lambda **_kwargs: None,
+    )
 
 
 class ChoiceCursor:
@@ -363,6 +401,12 @@ def disposable_narrative_db() -> Iterator[str]:
                     sql.Identifier("NEXUS_template"),
                 )
             )
+        migration_sql = Path(
+            "migrations/098_narrative_generation_lease.sql"
+        ).read_text()
+        with _connect(dbname) as migration_conn:
+            with migration_conn.cursor() as cur:
+                cur.execute(migration_sql)
         yield dbname
     finally:
         if admin is not None:
@@ -390,6 +434,365 @@ def _clone_connection(dbname: str, *, dict_cursor: bool = False) -> Iterator[Any
         raise
     finally:
         conn.close()
+
+
+def _route_clone_to_slot(monkeypatch: pytest.MonkeyPatch, dbname: str) -> None:
+    """Route production slot/database helpers to one disposable clone."""
+    monkeypatch.setattr(slot_state, "slot_dbname", lambda _slot: dbname)
+    monkeypatch.setattr(
+        slot_state,
+        "get_connection",
+        lambda _dbname, dict_cursor=False: _clone_connection(
+            dbname, dict_cursor=dict_cursor
+        ),
+    )
+    monkeypatch.setattr(narrative, "get_db_connection", lambda _slot: _connect(dbname))
+
+
+@pytest.mark.requires_postgres
+def test_concurrent_continues_have_one_owner_and_truthful_result(
+    monkeypatch: pytest.MonkeyPatch,
+    disposable_narrative_db: str,
+) -> None:
+    """Two genuine route calls serialize on one durable slot generation lease."""
+    dbname = disposable_narrative_db
+    with _clone_connection(dbname) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                TRUNCATE incubator, narrative_chunks,
+                    narrative_generation_lease,
+                    narrative_parent_embedding_claims,
+                    narrative_generation_sessions
+                RESTART IDENTITY CASCADE
+                """
+            )
+            cur.execute("DELETE FROM assets.new_story_creator")
+            cur.execute(
+                """
+                INSERT INTO narrative_chunks (
+                    raw_text, storyteller_text, state
+                ) VALUES (%s, %s, 'finalized')
+                RETURNING id
+                """,
+                ("The platform waits.", "The platform waits."),
+            )
+            parent_chunk_id = cur.fetchone()[0]
+            cur.execute(
+                """
+                INSERT INTO chunk_metadata (
+                    chunk_id, season, episode, scene, world_layer, slug
+                ) VALUES (%s, 1, 1, 1, 'primary', 'S01E01_001')
+                """,
+                (parent_chunk_id,),
+            )
+
+    _route_clone_to_slot(monkeypatch, dbname)
+    entered_generation = threading.Event()
+    release_generation = threading.Event()
+    embedding_calls: list[int] = []
+
+    class BlockingLore:
+        """Frontier-only double; route, DB reads, adapter, and writer stay real."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.settings_path = Path("test-settings.toml")
+            self.turn_context = SimpleNamespace(
+                error_log=[],
+                orrery_proposal=None,
+            )
+
+        async def process_turn(
+            self,
+            user_text: str,
+            parent_chunk_id: int,
+            note: str | None = None,
+        ) -> StorytellerResponseMinimal:
+            entered_generation.set()
+            released = await asyncio.to_thread(release_generation.wait, 10)
+            if not released:
+                raise RuntimeError("Timed out waiting to release generation fixture")
+            return StorytellerResponseMinimal(
+                generation_model="route-concurrency-fixture",
+                narrative="A single train enters the station.",
+                choices=["Board it.", "Let it pass."],
+            )
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(narrative_generation, "LORE", BlockingLore)
+    monkeypatch.setattr(
+        narrative,
+        "_trigger_locked_chunk_embedding",
+        lambda *, slot, parent_chunk_id: embedding_calls.append(parent_chunk_id),
+    )
+
+    def post_continue() -> Any:
+        with TestClient(narrative.app) as client:
+            return client.post(
+                "/api/narrative/continue",
+                json={"slot": 3},
+            )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        owner_future = executor.submit(post_continue)
+        assert entered_generation.wait(10), "owner never reached storyteller generation"
+        competitor = post_continue()
+        release_generation.set()
+        owner = owner_future.result(timeout=15)
+
+    assert owner.status_code == 200
+    owner_session_id = owner.json()["session_id"]
+    assert competitor.status_code == 409
+    assert competitor.json()["detail"] == {
+        "message": "Another narrative generation owns this slot.",
+        "active_session_id": owner_session_id,
+    }
+    assert embedding_calls == [parent_chunk_id]
+
+    with _clone_connection(dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT session_id, parent_chunk_id, chunk_id
+                FROM incubator
+                """
+            )
+            incubator = cur.fetchone()
+            assert incubator == {
+                "session_id": owner_session_id,
+                "parent_chunk_id": parent_chunk_id,
+                "chunk_id": parent_chunk_id + 1,
+            }
+            cur.execute("SELECT COUNT(*) AS count FROM narrative_generation_lease")
+            assert cur.fetchone()["count"] == 0
+
+            cur.execute(
+                """
+                SELECT session_id, status, parent_chunk_id, chunk_id
+                FROM narrative_generation_sessions
+                """
+            )
+            sessions = cur.fetchall()
+            assert sessions == [
+                {
+                    "session_id": owner_session_id,
+                    "status": "complete",
+                    "parent_chunk_id": parent_chunk_id,
+                    "chunk_id": parent_chunk_id + 1,
+                }
+            ]
+            cur.execute(
+                """
+                SELECT parent_chunk_id, session_id
+                FROM narrative_parent_embedding_claims
+                """
+            )
+            assert cur.fetchall() == [
+                {
+                    "parent_chunk_id": parent_chunk_id,
+                    "session_id": owner_session_id,
+                }
+            ]
+
+    with TestClient(narrative.app) as client:
+        status = client.get(
+            f"/api/narrative/status/{owner_session_id}",
+            params={"slot": 3},
+        )
+        cleared = client.delete(
+            "/api/narrative/incubator",
+            params={"slot": 3},
+        )
+        unloaded_status = client.get(
+            f"/api/narrative/status/{owner_session_id}",
+            params={"slot": 3},
+        )
+    assert status.status_code == 200
+    assert status.json()["status"] == "complete"
+    assert status.json()["chunk_id"] == parent_chunk_id + 1
+    assert cleared.status_code == 200
+    assert unloaded_status.status_code == 200
+    assert unloaded_status.json()["status"] == "error"
+    assert unloaded_status.json()["chunk_id"] is None
+    assert unloaded_status.json()["error"] == (
+        "Completed result is no longer loadable for this session."
+    )
+
+
+@pytest.mark.requires_postgres
+def test_pending_choice_rolls_back_when_auto_approval_validation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    disposable_narrative_db: str,
+) -> None:
+    """The real pending continue route makes choice resolution and approval atomic."""
+    dbname = disposable_narrative_db
+    choices = ["Open the door.", "Wait in silence."]
+    pending_session_id = str(uuid.uuid4())
+    with _clone_connection(dbname) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                TRUNCATE incubator, narrative_chunks,
+                    narrative_generation_lease,
+                    narrative_parent_embedding_claims,
+                    narrative_generation_sessions
+                RESTART IDENTITY CASCADE
+                """
+            )
+            cur.execute("DELETE FROM assets.new_story_creator")
+            cur.execute(
+                """
+                INSERT INTO narrative_chunks (
+                    raw_text, storyteller_text, state
+                ) VALUES (%s, %s, 'finalized')
+                RETURNING id
+                """,
+                ("The door waits.", "The door waits."),
+            )
+            parent_chunk_id = cur.fetchone()[0]
+            cur.execute(
+                """
+                INSERT INTO chunk_metadata (
+                    chunk_id, season, episode, scene, world_layer, slug
+                ) VALUES (%s, 1, 1, 1, 'primary', 'S01E01_001')
+                """,
+                (parent_chunk_id,),
+            )
+            cur.execute(
+                """
+                INSERT INTO incubator (
+                    id, chunk_id, parent_chunk_id, user_text, storyteller_text,
+                    generation_model, choice_object, choice_text,
+                    metadata_updates, entity_updates, reference_updates,
+                    orrery_proposal, orrery_adjudications, new_entities,
+                    session_id, llm_response_id, status
+                ) VALUES (
+                    TRUE, %s, %s, %s, %s, %s, %s, NULL,
+                    %s, %s, %s, NULL, %s, %s, %s, %s, 'provisional'
+                )
+                """,
+                (
+                    parent_chunk_id + 1,
+                    parent_chunk_id,
+                    "Approach the door.",
+                    "The hinges begin to move.",
+                    _valid_override(),
+                    Json({"presented": choices, "selected": None}),
+                    Json(
+                        {
+                            "chronology": {"episode_transition": "invalid-transition"},
+                            "world_layer": "primary",
+                        }
+                    ),
+                    Json({}),
+                    Json({"characters": [], "places": [], "factions": []}),
+                    Json([]),
+                    Json([]),
+                    pending_session_id,
+                    "invalid-approval-fixture",
+                ),
+            )
+
+    _route_clone_to_slot(monkeypatch, dbname)
+    with TestClient(narrative.app, raise_server_exceptions=False) as client:
+        response = client.post(
+            "/api/narrative/continue",
+            json={"slot": 3, "choice": 1},
+        )
+
+    assert response.status_code == 500
+    with _clone_connection(dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT choice_text, choice_object
+                FROM incubator
+                WHERE session_id = %s
+                """,
+                (pending_session_id,),
+            )
+            pending = cur.fetchone()
+            assert pending == {
+                "choice_text": None,
+                "choice_object": {"presented": choices, "selected": None},
+            }
+            cur.execute("SELECT COUNT(*) AS count FROM narrative_chunks")
+            assert cur.fetchone()["count"] == 1
+            cur.execute("SELECT COUNT(*) AS count FROM narrative_generation_lease")
+            assert cur.fetchone()["count"] == 0
+
+    # Simulate the carried finding's already-in-the-wild recovery state: an
+    # earlier request committed the choice before approval failed. The same
+    # choice must be reusable without a conflict, and real approval must commit.
+    with _clone_connection(dbname) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE incubator
+                SET choice_text = %s,
+                    choice_object = %s,
+                    metadata_updates = %s
+                WHERE session_id = %s
+                """,
+                (
+                    choices[0],
+                    Json({"presented": choices, "selected": 1}),
+                    Json(
+                        {
+                            "chronology": {
+                                "episode_transition": "continue",
+                                "time_delta_minutes": 1,
+                            },
+                            "world_layer": "primary",
+                        }
+                    ),
+                    pending_session_id,
+                ),
+            )
+
+    async def stop_after_approval(
+        session_id: str,
+        _parent_chunk_id: int,
+        _user_text: str,
+        slot: int,
+        **_kwargs: Any,
+    ) -> None:
+        narrative._abandon_generation_owner(
+            slot=slot,
+            session_id=session_id,
+            error="Fixture stops after proving approval recovery.",
+        )
+
+    monkeypatch.setattr(narrative, "generate_narrative_async", stop_after_approval)
+    monkeypatch.setattr(
+        narrative,
+        "_run_post_commit_orrery_work",
+        lambda _slot: None,
+    )
+    with TestClient(narrative.app) as client:
+        recovered = client.post(
+            "/api/narrative/continue",
+            json={"slot": 3, "choice": 1},
+        )
+
+    assert recovered.status_code == 200
+    with _clone_connection(dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT choice_text, choice_object
+                FROM narrative_chunks
+                ORDER BY id DESC
+                LIMIT 1
+                """
+            )
+            committed = cur.fetchone()
+            assert committed == {
+                "choice_text": choices[0],
+                "choice_object": {"presented": choices, "selected": 1},
+            }
 
 
 @pytest.mark.requires_postgres

--- a/tests/test_api/test_narrative_generation.py
+++ b/tests/test_api/test_narrative_generation.py
@@ -20,6 +20,28 @@ from nexus.api.narrative_schemas import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _unit_route_generation_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep orchestration doubles focused on task argument threading."""
+    monkeypatch.setattr(
+        narrative,
+        "_acquire_generation_owner",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        narrative,
+        "_bind_generation_owner",
+        lambda **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        narrative,
+        "_abandon_generation_owner",
+        lambda **_kwargs: None,
+    )
+
+
 class DummyProgressManager:
     """Capture progress events sent by narrative generation."""
 
@@ -102,6 +124,7 @@ async def test_lore_phase_failure_is_reported_before_adapter_coercion(
         get_db_connection=lambda slot: conn,
         load_settings=lambda: {},
         manager=manager,
+        manage_generation_lease=False,
     )
 
     error_events = [event for event in manager.events if event[1] == "error"]
@@ -171,6 +194,7 @@ async def test_continuation_threads_logon_model_into_incubator(
         get_db_connection=lambda slot: conn,
         load_settings=lambda: {},
         manager=manager,
+        manage_generation_lease=False,
     )
 
     assert written[0]["generation_model"] == "resolved-provider-model"
@@ -373,4 +397,6 @@ async def test_regenerate_route_threads_incubator_parent_into_generation_task(
     assert len(background_tasks.tasks) == 1
     task = background_tasks.tasks[0]
     assert task.func is narrative_generation.generate_narrative_async
+    assert task.args[0] != "pending-session"
     assert task.args[1] == 17
+    assert task.kwargs["expected_incubator_session"] == "pending-session"

--- a/tests/test_orrery/test_generation_model_provenance_live.py
+++ b/tests/test_orrery/test_generation_model_provenance_live.py
@@ -12,6 +12,10 @@ from sqlalchemy import create_engine, text
 
 from nexus.api.commit_handler_sync import commit_incubator_to_database_sync
 from nexus.api.narrative_generation import write_to_incubator
+from nexus.api.narrative_lease import (
+    acquire_generation_lease,
+    bind_generation_parent,
+)
 from nexus.api.slot_utils import get_slot_db_url
 from tests.test_orrery.claim_accounts_test_support import (
     install_claim_accounts_shadow_sync,
@@ -56,9 +60,13 @@ def provenance_db() -> Iterator[dict[str, Any]]:
     reveal_migration_sql = (
         Path(__file__).parents[2] / "migrations" / "091_backstory_secrets.sql"
     ).read_text()
+    lease_migration_sql = (
+        Path(__file__).parents[2] / "migrations" / "098_narrative_generation_lease.sql"
+    ).read_text()
     try:
         with raw_connection.cursor() as cur:
             cur.execute(migration_sql)
+            cur.execute(lease_migration_sql)
             schema = f"provenance_reveal_{uuid4().hex[:12]}"
             cur.execute(f'CREATE SCHEMA "{schema}"')
             cur.execute(f'SET LOCAL search_path = "{schema}", public')
@@ -90,6 +98,7 @@ def provenance_db() -> Iterator[dict[str, Any]]:
                 """
             )
             parent_chunk_id = cur.fetchone()[0]
+            cur.execute("DELETE FROM incubator WHERE id = TRUE")
         if parent_chunk_id is None:
             pytest.skip("save_05 needs an accepted narrative chunk")
 
@@ -138,6 +147,23 @@ def _incubator_payload(
     }
 
 
+def _own_parent(db: dict[str, Any], session_id: str) -> None:
+    """Establish the production writer precondition inside the rollback fixture."""
+    conn = db["production_connection"]
+    conflict = acquire_generation_lease(
+        conn,
+        session_id=session_id,
+        operation="continue",
+        stale_timeout_seconds=60,
+    )
+    assert conflict is None
+    bind_generation_parent(
+        conn,
+        session_id=session_id,
+        parent_chunk_id=int(db["parent_chunk_id"]),
+    )
+
+
 @pytest.mark.asyncio
 async def test_sync_accept_copies_incubator_generation_model(
     provenance_db: dict[str, Any],
@@ -145,6 +171,7 @@ async def test_sync_accept_copies_incubator_generation_model(
     """The synchronous accept path preserves the successful model id."""
 
     session_id = str(uuid4())
+    _own_parent(provenance_db, session_id)
     await write_to_incubator(
         provenance_db["production_connection"],
         _incubator_payload(
@@ -189,8 +216,13 @@ async def test_regenerate_singleton_write_replaces_generation_model(
         generation_model="regenerating-model",
     )
 
+    _own_parent(provenance_db, session_id)
     await write_to_incubator(provenance_db["production_connection"], first)
-    await write_to_incubator(provenance_db["production_connection"], second)
+    await write_to_incubator(
+        provenance_db["production_connection"],
+        second,
+        expected_incubator_session=session_id,
+    )
 
     row = (
         provenance_db["connection"]

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -1216,6 +1216,7 @@ async def test_exhausted_declaration_validation_never_reaches_incubator(
         get_db_connection=lambda _slot: conn,
         load_settings=lambda: {},
         manager=manager,
+        manage_generation_lease=False,
     )
 
     errors = [data for _session, status, data in manager.events if status == "error"]


### PR DESCRIPTION
## Summary

Fixes #616 (night-QA round 2, the last of the crop) plus the atomicity finding carried from #619's independent review.

## Changes

- **Migration 098**: `narrative_generation_sessions` (durable status), `narrative_generation_lease` (one-row boolean-PK singleton per slot DB), `narrative_parent_embedding_claims` (single-fire guard).
- **`narrative_lease.py`**: acquisition under a short table lock (closes the empty-table race), stale-owner replacement with error-marking, ownership-checked parent binding, owner-scoped release — all loud on lost ownership.
- **Route integration**: continue/regenerate/bootstrap acquire the lease after validation, 409 with `active_session_id` on conflict (documented response model), abandonment on pre-scheduling failure.
- **`write_to_incubator`**: locks the lease row `FOR UPDATE`, verifies session+parent+expiry before replacing the singleton — a stale pipeline can no longer delete the current owner's result.
- **Carried #619 [P2]**: pending-choice resolution + auto-approval share one transaction; approval failure rolls back the choice write.
- Stale-lease timeout configurable in `nexus.toml`.

## Testing

Concurrency regression on a real disposable clone with two genuine route calls — only the frontier call is doubled (blocking stub holds pipeline A mid-generation while B arrives): one owner, one 409 with the active session id, one incubator row bound to the winner, embedding claimed once. Status-truthfulness, rollback, and retry coverage alongside.

- API pg-gated: `219 passed` (1 pre-existing failure = #622)
- Full suite: `1966 passed, 454 skipped`
- flake8 on touched files: 53 violations vs 57 on `main` (net −4, none introduced)

Migration 098 will be applied fleet-wide + template after merge, per the standing workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fs3R2bgfcWPiU4QgToRxo