### PR TITLE
Usage: Record Exact Per-Attempt API Tokens at the Provider Boundary

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,6 +51,28 @@ the Access headers are omitted if its origin differs from
 
 ## Commands
 
+### `usage` — View Exact API Token Usage
+
+Reads the append-only provider telemetry for a UTC quota day. This command is
+slotless and does not require a running gateway. Its totals are API-reported
+usage, not NEXUS prompt-budget estimates.
+
+```bash
+# Current UTC day
+poetry run nexus usage
+
+# Specific UTC day, as machine-readable JSON
+poetry run nexus usage --json --day 2026-07-29
+
+# Restrict the event list and totals to one correlated run
+poetry run nexus usage --json --run ab12cd34ef56
+```
+
+Human output lists totals by provider and logical seat, unknown-usage response
+counts, the OpenAI-only UTC-day total, and configured readout-only allowances.
+The JSON payload places `day`, `events`, `providers`, `seats`,
+`openai_day_total`, and `allowance` under the `usage` key.
+
 ### `load` — View Current State
 
 Shows the current state of a slot: wizard phase, narrative text, or empty status.

--- a/nexus.toml
+++ b/nexus.toml
@@ -1138,6 +1138,19 @@ reasoning_effort = "high"     # Reasoning effort level (low/medium/high)
 max_choice_text_length = 1000  # Maximum length of choice text
 
 # =============================================================================
+# Provider-reported API token usage (issue #626)
+# =============================================================================
+
+[usage]
+enabled = true
+usage_dir = ".nexus/runtime/usage"  # relative paths resolve against the repo root; shared by gateway/CLI/worker processes
+
+[usage.daily_allowance]
+# Per-provider daily API-token allowances (UTC day), used for readout only —
+# measurement, never enforcement. Providers without an entry show no allowance.
+openai = 2500000
+
+# =============================================================================
 # Managed Runtime (issue #396) — nexus up / down / restart / status / logs
 # =============================================================================
 

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -681,6 +681,8 @@ class LogonUtility:
                 structured_transport=anthropic_transport,
                 structured_output_retries=structured_output_retries,
                 output_validator=output_validator,
+                usage_provider_name=provider_type,
+                usage_seat="skald_single_pass",
             )
         else:
             # Native OpenAI, or any OpenAI-compatible server registered with a
@@ -698,6 +700,8 @@ class LogonUtility:
                 structured_output_retries=structured_output_retries,
                 output_validator=output_validator,
                 request_params=endpoint.get("request_params") if endpoint else None,
+                usage_provider_name=provider_type,
+                usage_seat="skald_single_pass",
             )
 
         logger.info(
@@ -976,6 +980,7 @@ class LogonUtility:
             raise RuntimeError("Correspondence compaction requires a provider")
         compaction_provider = copy.copy(self.provider)
         compaction_provider.system_prompt = system_prompt
+        compaction_provider.usage_seat = "correspondence_compaction"
         compaction_provider.output_validator = build_digest_length_validator(
             max_digest_tokens=max_digest_tokens
         )
@@ -1005,6 +1010,7 @@ class LogonUtility:
         *,
         system_prompt: Optional[str],
         output_validator: Any,
+        usage_seat: str,
         anthropic_transport: Optional[
             Literal["native", "prompted", "tool_envelope"]
         ] = None,
@@ -1016,6 +1022,7 @@ class LogonUtility:
         pass_provider = copy.copy(self.provider)
         pass_provider.system_prompt = system_prompt
         pass_provider.output_validator = output_validator
+        pass_provider.usage_seat = usage_seat
         if self._provider_wire_type == "anthropic":
             if anthropic_transport is None:
                 raise ValueError(
@@ -1107,7 +1114,7 @@ class LogonUtility:
         inherits the same apex generation settings as the writer, differing
         only in model, endpoint, and transport.
         """
-        gaia_model, _provider_type, endpoint, gaia_wire = gaia_route
+        gaia_model, provider_type, endpoint, gaia_wire = gaia_route
         apex_settings = self.settings.get("API Settings", {}).get("apex", {})
         structured_output_retries = apex_settings.get("structured_output_retries", 3)
         if gaia_wire == "anthropic":
@@ -1123,6 +1130,8 @@ class LogonUtility:
                 structured_transport=anthropic_transport,
                 structured_output_retries=structured_output_retries,
                 output_validator=output_validator,
+                usage_provider_name=provider_type,
+                usage_seat="gaia",
             )
         base_url = endpoint["base_url"] if endpoint else None
         api_key = endpoint["api_key"] if endpoint else None
@@ -1144,6 +1153,8 @@ class LogonUtility:
             structured_output_retries=structured_output_retries,
             output_validator=output_validator,
             request_params=endpoint.get("request_params") if endpoint else None,
+            usage_provider_name=provider_type,
+            usage_seat="gaia",
         )
 
     def _gaia_effective_window(self, gaia_route: StorytellerRoute) -> int:
@@ -1288,6 +1299,7 @@ class LogonUtility:
         writer_provider = self._clone_provider_for_two_pass(
             system_prompt=self._writer_system_prompt(),
             output_validator=self._build_letter_output_validator(),
+            usage_seat="skald_writer",
             anthropic_transport=(
                 "native" if self._provider_wire_type == "anthropic" else None
             ),
@@ -1326,6 +1338,7 @@ class LogonUtility:
             gaia_provider = self._clone_provider_for_two_pass(
                 system_prompt=gaia_system_prompt,
                 output_validator=gaia_validator,
+                usage_seat="gaia",
                 anthropic_transport=anthropic_gaia_transport,
             )
         gaia, _gaia_response = gaia_provider.get_structured_completion(
@@ -1369,6 +1382,7 @@ class LogonUtility:
         writer_provider = self._clone_provider_for_two_pass(
             system_prompt=self._writer_system_prompt(),
             output_validator=self._build_letter_output_validator(),
+            usage_seat="skald_writer",
             anthropic_transport=(
                 "native" if self._provider_wire_type == "anthropic" else None
             ),
@@ -1409,6 +1423,7 @@ class LogonUtility:
             gaia_provider = self._clone_provider_for_two_pass(
                 system_prompt=gaia_system_prompt,
                 output_validator=gaia_validator,
+                usage_seat="gaia",
                 anthropic_transport=anthropic_gaia_transport,
             )
         gaia, _gaia_response = await gaia_provider.get_structured_completion_async(

--- a/nexus/agents/orrery/geo_authoring.py
+++ b/nexus/agents/orrery/geo_authoring.py
@@ -90,6 +90,7 @@ def author_place_coordinates(
         max_tokens=max_tokens,
         system_prompt=prompt,
         structured_output_retries=get_wizard_retry_budget(),
+        seat="geo_authoring",
     )
     response, _llm_response = provider.get_structured_completion(
         prompt,

--- a/nexus/agents/orrery/retrograde_expansion.py
+++ b/nexus/agents/orrery/retrograde_expansion.py
@@ -793,6 +793,7 @@ def generate_expansion_with_skald(
             "Return a non-mutating expansion plan only."
         ),
         structured_output_retries=get_wizard_retry_budget(),
+        seat="retrograde_expansion",
     )
 
     async def _validate_output(

--- a/nexus/agents/orrery/retrograde_maturation.py
+++ b/nexus/agents/orrery/retrograde_maturation.py
@@ -62,6 +62,7 @@ from nexus.config.settings_models import (
     OrreryRetrogradeRetrievalSettings,
     Settings,
 )
+from nexus.telemetry.usage import usage_context
 
 logger = logging.getLogger("nexus.orrery.retrograde_maturation")
 
@@ -559,14 +560,18 @@ def drain_maturation_jobs_sync(
         failed = 0
         for row in rows:
             try:
-                _mature_one(
-                    conn,
-                    row=row,
-                    cfg=cfg,
-                    settings_dict=settings_dict,
-                    settings=typed_settings,
-                    slot=slot,
-                )
+                with usage_context(
+                    slot=(int(row["slot"]) if row.get("slot") is not None else None),
+                    run_id=str(row["job_id"]),
+                ):
+                    _mature_one(
+                        conn,
+                        row=row,
+                        cfg=cfg,
+                        settings_dict=settings_dict,
+                        settings=typed_settings,
+                        slot=slot,
+                    )
                 matured += 1
             except Exception as exc:
                 failed += 1

--- a/nexus/agents/orrery/retrograde_seed_candidates.py
+++ b/nexus/agents/orrery/retrograde_seed_candidates.py
@@ -652,6 +652,7 @@ def generate_seed_candidates_with_skald(
             "occurred."
         ),
         structured_output_retries=get_wizard_retry_budget(),
+        seat="retrograde_seed_candidates",
     )
 
     async def _validate_output(
@@ -1612,6 +1613,7 @@ def select_seed_candidates_with_skald(
             "them. No canonical writes occur at this stage."
         ),
         structured_output_retries=get_wizard_retry_budget(),
+        seat="retrograde_seed_selection",
     )
 
     async def _validate_output(

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -18,6 +18,7 @@ from nexus.agents.orrery.retrograde_maturation import (
 )
 from nexus.config import load_settings_as_dict
 from nexus.config.settings_models import OrreryNarrationSettings, OrreryPromoteSettings
+from nexus.telemetry.usage import usage_context
 
 logger = logging.getLogger("nexus.orrery.worker")
 
@@ -259,7 +260,12 @@ def drain_narration_outbox_sync(
         failed = 0
         for row in rows:
             try:
-                narration_text = _generate_narration(provider, row)
+                with usage_context(
+                    seat="orrery_narration",
+                    slot=(int(row["slot"]) if row.get("slot") is not None else None),
+                    run_id=str(row["job_id"]),
+                ):
+                    narration_text = _generate_narration(provider, row)
                 descriptor = _perceptual_descriptor(row)
                 with conn:
                     with conn.cursor(cursor_factory=RealDictCursor) as cur:
@@ -657,6 +663,8 @@ def _narration_provider(settings: Mapping[str, Any]) -> Any:
             temperature=narration.temperature,
             max_tokens=narration.max_output_tokens,
             system_prompt=NARRATION_SYSTEM_PROMPT,
+            usage_provider_name=provider_name,
+            usage_seat="orrery_narration",
         )
     if provider_name == "openai":
         return OpenAIProvider(
@@ -664,6 +672,8 @@ def _narration_provider(settings: Mapping[str, Any]) -> Any:
             temperature=narration.temperature,
             max_output_tokens=narration.max_output_tokens,
             system_prompt=NARRATION_SYSTEM_PROMPT,
+            usage_provider_name=provider_name,
+            usage_seat="orrery_narration",
         )
     # Any other provider must be the model's own registry provider with an
     # OpenAI-compatible base_url (mock TEST server, Ollama, vLLM, ...).
@@ -679,6 +689,8 @@ def _narration_provider(settings: Mapping[str, Any]) -> Any:
             structured_transport=endpoint["structured_transport"],
             request_timeout=endpoint["request_timeout_seconds"],
             request_params=endpoint.get("request_params"),
+            usage_provider_name=provider_name,
+            usage_seat="orrery_narration",
         )
     raise ValueError(f"Unsupported Orrery narration provider: {provider_name}")
 

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -11,7 +11,8 @@ This module handles async narrative generation including:
 import json
 import logging
 import uuid
-from typing import Any, Callable, Dict, Optional, Protocol
+from functools import wraps
+from typing import Any, Awaitable, Callable, Dict, Optional, Protocol
 
 from fastapi import HTTPException
 from psycopg2.extras import RealDictCursor
@@ -22,6 +23,7 @@ from nexus.api.lore_adapter import (
     validate_incubator_data,
 )
 from nexus.api.narrative_lease import finish_generation
+from nexus.telemetry.usage import usage_context
 
 logger = logging.getLogger("nexus.api.narrative_generation")
 
@@ -66,6 +68,32 @@ class ProgressManager(Protocol):
         ...
 
 
+def _correlate_generation_usage(
+    function: Callable[..., Awaitable[None]],
+) -> Callable[..., Awaitable[None]]:
+    """Decorate the canonical background task with its usage correlation."""
+
+    @wraps(function)
+    async def wrapped(
+        session_id: str,
+        parent_chunk_id: int,
+        user_text: str,
+        slot: Optional[int] = None,
+        **kwargs: Any,
+    ) -> None:
+        with usage_context(run_id=session_id, slot=slot):
+            await function(
+                session_id,
+                parent_chunk_id,
+                user_text,
+                slot,
+                **kwargs,
+            )
+
+    return wrapped
+
+
+@_correlate_generation_usage
 async def generate_narrative_async(
     session_id: str,
     parent_chunk_id: int,

--- a/nexus/api/native_structured_output.py
+++ b/nexus/api/native_structured_output.py
@@ -206,6 +206,7 @@ def build_native_structured_provider(
     output_validator: Optional[Callable[..., Any]] = None,
     temperature: Optional[float] = None,
     reasoning_effort: Optional[str] = None,
+    seat: Optional[str] = None,
 ) -> Any:
     """Build the repo's native strict structured-output provider wrapper.
 
@@ -233,6 +234,8 @@ def build_native_structured_provider(
             system_prompt=system_prompt,
             structured_output_retries=structured_output_retries,
             output_validator=output_validator,
+            usage_provider_name=provider_type,
+            usage_seat=seat,
             **anthropic_kwargs,
         )
     if provider_type == "openai" or endpoint is not None:
@@ -254,6 +257,8 @@ def build_native_structured_provider(
             structured_output_retries=structured_output_retries,
             output_validator=output_validator,
             request_params=endpoint.get("request_params") if endpoint else None,
+            usage_provider_name=provider_type,
+            usage_seat=seat,
             **openai_kwargs,
         )
     raise ValueError(f"Unsupported provider type for model {model!r}: {provider_type}")

--- a/nexus/api/new_story_generator.py
+++ b/nexus/api/new_story_generator.py
@@ -84,6 +84,7 @@ class StoryComponentGenerator:
             max_tokens=self._max_tokens,
             system_prompt=system_prompt,
             structured_output_retries=self._retry_budget,
+            seat="new_story",
         )
         result, _llm_response = provider.get_structured_completion(
             self._prompt_with_history(user_prompt, message_history),
@@ -608,6 +609,7 @@ cold climates, coastal coordinates for harbors, etc.)."""
         max_tokens=get_wizard_max_tokens(),
         system_prompt=system_prompt,
         structured_output_retries=get_wizard_retry_budget(),
+        seat="set_designer",
     )
 
     output, _llm_response = await provider.get_structured_completion_async(

--- a/nexus/api/pydantic_ai_utils.py
+++ b/nexus/api/pydantic_ai_utils.py
@@ -39,29 +39,48 @@ def get_base_url_for_model(model: str) -> Optional[str]:
     return endpoint["base_url"] if endpoint else None
 
 
-def build_pydantic_ai_model(model: str) -> Model:
-    """Create a Pydantic AI model with the correct provider and credentials."""
+def build_pydantic_ai_model_with_provider(model: str) -> tuple[Model, str]:
+    """Create a Pydantic AI model and return its registry provider name."""
+
     provider = get_provider_for_model(model)
     if provider is None:
         raise ValueError(f"Unknown provider for model {model!r}")
     if provider == "openai":
-        legacy_provider = LegacyOpenAIProvider(model=model)
-        pyd_provider = PydanticOpenAIProvider(api_key=legacy_provider.api_key)
-        return OpenAIResponsesModel(model_name=model, provider=pyd_provider)
+        legacy_openai_provider = LegacyOpenAIProvider(model=model)
+        openai_provider = PydanticOpenAIProvider(api_key=legacy_openai_provider.api_key)
+        return (
+            OpenAIResponsesModel(model_name=model, provider=openai_provider),
+            provider,
+        )
     if provider == "anthropic":
-        legacy_provider = LegacyAnthropicProvider(model=model)
-        pyd_provider = PydanticAnthropicProvider(api_key=legacy_provider.api_key)
+        legacy_anthropic_provider = LegacyAnthropicProvider(model=model)
+        anthropic_provider = PydanticAnthropicProvider(
+            api_key=legacy_anthropic_provider.api_key
+        )
         override = get_native_structured_output_override(model)
         if override is not None:
+            base_profile = anthropic_model_profile(model)
+            if base_profile is None:
+                raise ValueError(
+                    f"Pydantic AI has no Anthropic profile for model {model!r}"
+                )
             profile = replace(
-                anthropic_model_profile(model),
+                base_profile,
                 json_schema_transformer=AnthropicJsonSchemaTransformer,
                 supports_json_schema_output=override,
             )
-            return AnthropicModel(
-                model_name=model, provider=pyd_provider, profile=profile
+            return (
+                AnthropicModel(
+                    model_name=model,
+                    provider=anthropic_provider,
+                    profile=profile,
+                ),
+                provider,
             )
-        return AnthropicModel(model_name=model, provider=pyd_provider)
+        return (
+            AnthropicModel(model_name=model, provider=anthropic_provider),
+            provider,
+        )
     # Any other provider is an OpenAI-compatible server registered via
     # base_url in [global.model.api_models] (mock TEST server, Ollama, vLLM).
     endpoint = get_openai_compatible_endpoint(model)
@@ -72,7 +91,7 @@ def build_pydantic_ai_model(model: str) -> Model:
         # Slow local servers (for example, grammar compilation) blow past the OpenAI
         # SDK's 600s default. Mirror the legacy provider call sites: hand the
         # pydantic-ai provider a client that carries the registry timeout.
-        pyd_provider = PydanticOpenAIProvider(
+        compatible_provider = PydanticOpenAIProvider(
             openai_client=AsyncOpenAI(
                 api_key=endpoint["api_key"],
                 base_url=endpoint["base_url"],
@@ -80,12 +99,25 @@ def build_pydantic_ai_model(model: str) -> Model:
             )
         )
     else:
-        pyd_provider = PydanticOpenAIProvider(
+        compatible_provider = PydanticOpenAIProvider(
             api_key=endpoint["api_key"], base_url=endpoint["base_url"]
         )
     if endpoint["structured_transport"] == "chat_completions":
-        return OpenAIChatModel(model_name=model, provider=pyd_provider)
-    return OpenAIResponsesModel(model_name=model, provider=pyd_provider)
+        return (
+            OpenAIChatModel(model_name=model, provider=compatible_provider),
+            provider,
+        )
+    return (
+        OpenAIResponsesModel(model_name=model, provider=compatible_provider),
+        provider,
+    )
+
+
+def build_pydantic_ai_model(model: str) -> Model:
+    """Create a Pydantic AI model with the correct provider and credentials."""
+
+    resolved_model, _provider = build_pydantic_ai_model_with_provider(model)
+    return resolved_model
 
 
 def build_message_history(

--- a/nexus/api/trait_input_derivation.py
+++ b/nexus/api/trait_input_derivation.py
@@ -308,6 +308,7 @@ def derive_trait_compile_inputs(
             "trait compiler inputs. Follow the hard rules exactly."
         ),
         structured_output_retries=retries,
+        seat="trait_input_derivation",
     )
 
     async def _validate_output(_ctx: Any, output: BaseModel) -> TraitCompileInputs:

--- a/nexus/api/wizard_chat.py
+++ b/nexus/api/wizard_chat.py
@@ -52,7 +52,10 @@ from nexus.api.new_story_schemas import (
     TraitRationales,
     WizardResponse,
 )
-from nexus.api.pydantic_ai_utils import build_message_history, build_pydantic_ai_model
+from nexus.api.pydantic_ai_utils import (
+    build_message_history,
+    build_pydantic_ai_model_with_provider,
+)
 from nexus.api.slot_utils import slot_dbname
 from nexus.api.wizard_agent import (
     WizardContext,
@@ -61,6 +64,7 @@ from nexus.api.wizard_agent import (
     apply_trait_selection_to_state,
     _character_subphase,
 )
+from nexus.telemetry.usage import record_pydantic_ai_result
 
 logger = logging.getLogger("nexus.api.wizard_chat")
 
@@ -167,6 +171,8 @@ async def _handle_accept_fate_traits(
     slot: int,
     message_history: list,
     model: Any,
+    model_name: str,
+    provider_name: str,
     model_settings: ModelSettings,
     client: ConversationsClient,
     thread_id: str,
@@ -219,6 +225,14 @@ async def _handle_accept_fate_traits(
         message_history=message_history,
         model=model,
         model_settings=model_settings,
+    )
+    record_pydantic_ai_result(
+        result,
+        provider=provider_name,
+        model=model_name,
+        seat="wizard_wildcard",
+        slot=slot,
+        run_id=thread_id,
     )
 
     if context.last_tool_result:
@@ -452,7 +466,7 @@ async def new_story_chat_endpoint(request: ChatRequest):
         )
 
         message_history = build_message_history(history)
-        model = build_pydantic_ai_model(selected_model)
+        model, provider_name = build_pydantic_ai_model_with_provider(selected_model)
         model_settings = ModelSettings(max_tokens=get_wizard_max_tokens())
 
         if dev_mode:
@@ -462,6 +476,14 @@ async def new_story_chat_endpoint(request: ChatRequest):
                 message_history=message_history,
                 model=model,
                 model_settings=model_settings,
+            )
+            record_pydantic_ai_result(
+                result,
+                provider=provider_name,
+                model=selected_model,
+                seat="wizard_debug",
+                slot=request.slot,
+                run_id=request.thread_id,
             )
             content = result.output
             client.add_message(request.thread_id, "assistant", content)
@@ -486,6 +508,8 @@ async def new_story_chat_endpoint(request: ChatRequest):
             slot=request.slot,
             message_history=message_history,
             model=model,
+            model_name=selected_model,
+            provider_name=provider_name,
             model_settings=model_settings,
             client=client,
             thread_id=request.thread_id,
@@ -506,6 +530,14 @@ async def new_story_chat_endpoint(request: ChatRequest):
             message_history=message_history,
             model=model,
             model_settings=model_settings,
+        )
+        record_pydantic_ai_result(
+            result,
+            provider=provider_name,
+            model=selected_model,
+            seat="wizard",
+            slot=request.slot,
+            run_id=request.thread_id,
         )
 
         if context.last_tool_result:
@@ -753,7 +785,7 @@ async def new_story_chat_stream_endpoint(request: ChatRequest):
     )
 
     message_history = build_message_history(history)
-    model = build_pydantic_ai_model(selected_model)
+    model, provider_name = build_pydantic_ai_model_with_provider(selected_model)
     model_settings = ModelSettings(max_tokens=get_wizard_max_tokens())
 
     async def event_stream():
@@ -764,6 +796,14 @@ async def new_story_chat_stream_endpoint(request: ChatRequest):
                 message_history=message_history,
                 model=model,
                 model_settings=model_settings,
+            )
+            record_pydantic_ai_result(
+                result,
+                provider=provider_name,
+                model=selected_model,
+                seat="wizard_debug",
+                slot=request.slot,
+                run_id=request.thread_id,
             )
             payload = {"type": "message", "message": result.output, "choices": []}
             yield json.dumps(payload) + "\n"
@@ -778,6 +818,8 @@ async def new_story_chat_stream_endpoint(request: ChatRequest):
             slot=request.slot,
             message_history=message_history,
             model=model,
+            model_name=selected_model,
+            provider_name=provider_name,
             model_settings=model_settings,
             client=client,
             thread_id=request.thread_id,

--- a/nexus/api/wizard_chat.py
+++ b/nexus/api/wizard_chat.py
@@ -852,6 +852,14 @@ async def new_story_chat_stream_endpoint(request: ChatRequest):
                     ) + "\n"
 
             final_output = await streamed_result.get_output()
+            record_pydantic_ai_result(
+                streamed_result,
+                provider=provider_name,
+                model=selected_model,
+                seat="wizard",
+                slot=request.slot,
+                run_id=request.thread_id,
+            )
             if isinstance(final_output, DeferredToolRequests):
                 payload = context.last_tool_result or {
                     "message": "Wizard tool call completed without a response payload.",

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -38,7 +38,8 @@ import os
 from pathlib import Path
 import sys
 import time
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Callable, Dict, List, Mapping, Optional
+import uuid
 
 import requests
 
@@ -908,6 +909,10 @@ def emit_output(payload: Dict[str, Any], as_json: bool, truncate: bool = False) 
     # Human-readable output
     if payload.get("error"):
         print(f"Error: {payload['error']}")
+        return
+
+    if payload.get("usage"):
+        _print_usage(payload)
         return
 
     # Display message/storyteller text
@@ -3015,6 +3020,85 @@ def run_logs(args: argparse.Namespace) -> Dict[str, Any]:
         return {"success": False, "error": str(exc)}
 
 
+def run_usage(args: argparse.Namespace) -> Dict[str, Any]:
+    """Return exact provider-reported usage for one UTC day or run."""
+
+    from nexus.telemetry.usage import summarize_usage
+
+    return {
+        "success": True,
+        "usage": summarize_usage(day=args.day, run_id=args.run),
+    }
+
+
+def _run_with_cli_usage(
+    args: argparse.Namespace,
+    command: Callable[[argparse.Namespace], Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Correlate all provider calls made by one in-process CLI invocation."""
+
+    from nexus.telemetry.usage import usage_context
+
+    with usage_context(
+        slot=getattr(args, "slot", None),
+        run_id=uuid.uuid4().hex[:12],
+    ):
+        return command(args)
+
+
+def _print_usage(payload: Dict[str, Any]) -> None:
+    """Render provider-reported usage without conflating prompt estimates."""
+
+    usage = payload["usage"]
+    day = usage["day"]
+    openai = usage["openai_day_total"]
+    print(f"OpenAI API-reported tokens (UTC day {day}): " f"{openai['total_tokens']:,}")
+    if openai["unknown_usage_events"]:
+        print(
+            "OpenAI responses with unknown API usage: "
+            f"{openai['unknown_usage_events']:,}"
+        )
+
+    allowance = usage.get("allowance") or {}
+    for provider, values in sorted(allowance.items()):
+        print(
+            f"{provider} allowance: {values['used']:,} / "
+            f"{values['allowance']:,} (remaining {values['remaining']:,}; "
+            f"unknown events {values['unknown_usage_events']:,})"
+        )
+
+    for title, key in (("Providers", "providers"), ("Seats", "seats")):
+        print()
+        print(f"{title}:")
+        rows = usage.get(key) or {}
+        if not rows:
+            print("  (none)")
+            continue
+        header = ("NAME", "INPUT", "OUTPUT", "TOTAL", "EVENTS", "UNKNOWN")
+        values = [
+            (
+                name,
+                totals["input"],
+                totals["output"],
+                totals["total"],
+                totals["events"],
+                totals["unknown_usage_events"],
+            )
+            for name, totals in sorted(rows.items())
+        ]
+        widths = [
+            max(len(str(row[index])) for row in [header] + values)
+            for index in range(len(header))
+        ]
+        for row in [header] + values:
+            print(
+                "  "
+                + "  ".join(
+                    str(cell).ljust(widths[index]) for index, cell in enumerate(row)
+                )
+            )
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build CLI argument parser with subcommands."""
     parser = argparse.ArgumentParser(
@@ -3025,6 +3109,7 @@ Examples:
   nexus up                      Start the runtime (gateway + enabled services)
   nexus up --foreground         Stay attached; Ctrl+C tears down
   nexus status                  Runtime health, processes, slot, version
+  nexus usage --day 2026-07-29 Show exact API-reported UTC-day token usage
   nexus logs gateway -f         Follow the gateway log
   nexus down                    Stop the runtime
   nexus load --slot 5           Show current state of slot 5
@@ -3120,6 +3205,28 @@ Examples:
         "-f", "--follow", action="store_true", help="Follow the log"
     )
     _add_config_arg(logs_parser)
+
+    usage_parser = subparsers.add_parser(
+        "usage",
+        help="Show exact provider-reported API token usage",
+    )
+    usage_parser.add_argument(
+        "--json",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Emit JSON output",
+    )
+    usage_parser.add_argument(
+        "--truncate",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Truncate long text fields (accepted for global CLI consistency)",
+    )
+    usage_parser.add_argument(
+        "--day",
+        help="UTC quota day in YYYY-MM-DD format (default: current UTC day)",
+    )
+    usage_parser.add_argument("--run", help="Filter events by correlation run id")
 
     # load command
     load_parser = subparsers.add_parser("load", help="Display current slot state")
@@ -3703,6 +3810,8 @@ def main() -> int:
         result = run_status(args)
     elif args.command == "logs":
         result = run_logs(args)
+    elif args.command == "usage":
+        result = run_usage(args)
     elif args.command == "load":
         result = run_load(args)
     elif args.command == "continue":
@@ -3716,13 +3825,13 @@ def main() -> int:
     elif args.command == "clear":
         result = run_clear(args)
     elif args.command == "trait-audit":
-        result = run_trait_audit(args)
+        result = _run_with_cli_usage(args, run_trait_audit)
     elif args.command == "retrograde-packet":
         result = run_retrograde_packet(args)
     elif args.command == "retrograde-seed-candidates":
-        result = run_retrograde_seed_candidates(args)
+        result = _run_with_cli_usage(args, run_retrograde_seed_candidates)
     elif args.command == "retrograde-expand-seeds":
-        result = run_retrograde_expand_seeds(args)
+        result = _run_with_cli_usage(args, run_retrograde_expand_seeds)
     elif args.command == "retrograde-apply-expansion":
         result = run_retrograde_apply_expansion(args)
     elif args.command == "retrograde-embed-history":

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -590,6 +590,48 @@ class RuntimeGatewaySettings(BaseModel):
         return self
 
 
+class UsageSettings(BaseModel):
+    """Provider-reported API token telemetry configuration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(
+        default=True,
+        description="Whether completed provider responses are recorded",
+    )
+    usage_dir: str = Field(
+        default=".nexus/runtime/usage",
+        description=(
+            "Shared usage JSONL directory; relative paths resolve against the "
+            "repository root"
+        ),
+    )
+    daily_allowance: Dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Optional per-provider UTC-day API-token allowances used for "
+            "measurement readout only"
+        ),
+    )
+
+    @field_validator("daily_allowance")
+    @classmethod
+    def _validate_daily_allowances(cls, value: Dict[str, int]) -> Dict[str, int]:
+        """Require positive provider allowances."""
+
+        invalid = {
+            provider: allowance
+            for provider, allowance in value.items()
+            if allowance < 1
+        }
+        if invalid:
+            raise ValueError(
+                "daily_allowance values must be at least 1: "
+                f"{sorted(invalid.items())}"
+            )
+        return value
+
+
 class RuntimeSettings(BaseModel):
     """Managed runtime configuration (nexus up / down / status / logs)."""
 
@@ -3203,6 +3245,10 @@ class Settings(BaseModel):
     runtime: Optional[RuntimeSettings] = Field(
         default=None,
         description="Managed runtime settings (nexus up/down/status/logs)",
+    )
+    usage: UsageSettings = Field(
+        default_factory=UsageSettings,
+        description="Provider-reported API token telemetry settings",
     )
 
     @model_validator(mode="before")

--- a/nexus/telemetry/__init__.py
+++ b/nexus/telemetry/__init__.py
@@ -1,0 +1,10 @@
+"""NEXUS telemetry surfaces."""
+
+from .usage import UsageEvent, record_usage_event, summarize_usage, usage_context
+
+__all__ = [
+    "UsageEvent",
+    "record_usage_event",
+    "summarize_usage",
+    "usage_context",
+]

--- a/nexus/telemetry/usage.py
+++ b/nexus/telemetry/usage.py
@@ -1,0 +1,567 @@
+"""Exact provider-reported token usage recording and summaries."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from datetime import datetime, timezone
+import json
+import logging
+import os
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, Iterator, Literal, Optional
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from nexus.config import load_settings
+
+
+logger = logging.getLogger("nexus.usage")
+
+UsageOutcome = Literal["accepted", "rejected_validation", "error", "aggregate"]
+UsageTransport = Literal[
+    "responses", "chat_completions", "anthropic_messages", "pydantic_ai"
+]
+
+_UNSET = object()
+_seat_context: ContextVar[Optional[str]] = ContextVar("nexus_usage_seat", default=None)
+_slot_context: ContextVar[Optional[int]] = ContextVar("nexus_usage_slot", default=None)
+_run_id_context: ContextVar[Optional[str]] = ContextVar(
+    "nexus_usage_run_id", default=None
+)
+
+
+class UsageWriteError(RuntimeError):
+    """Raised when a usage event cannot be appended durably."""
+
+
+class UsageReadError(RuntimeError):
+    """Raised when a usage day file cannot be parsed exactly."""
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_utc_timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"ts must be an ISO-8601 timestamp: {value!r}") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("ts must include a UTC offset")
+    return parsed.astimezone(timezone.utc)
+
+
+class UsageEvent(BaseModel):
+    """One completed provider response without prompt or response content."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ts: str = Field(default_factory=_utc_timestamp)
+    quota_day: str = Field(default="")
+    provider: str
+    model: str
+    seat: str
+    slot: Optional[int] = None
+    run_id: Optional[str] = None
+    attempt: int = Field(ge=1)
+    outcome: UsageOutcome
+    transport: UsageTransport
+    request_id: Optional[str] = None
+    input_tokens: Optional[int] = Field(default=None, ge=0)
+    output_tokens: Optional[int] = Field(default=None, ge=0)
+    total_tokens: Optional[int] = Field(default=None, ge=0)
+    cached_input_tokens: Optional[int] = Field(default=None, ge=0)
+    cache_creation_tokens: Optional[int] = Field(default=None, ge=0)
+    reasoning_tokens: Optional[int] = Field(default=None, ge=0)
+    service_tier: Optional[str] = None
+    aggregate: bool = False
+    requests: Optional[int] = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def _derive_quota_day(self) -> "UsageEvent":
+        """Derive the quota day from the timestamp after normalizing to UTC."""
+
+        utc_ts = _parse_utc_timestamp(self.ts)
+        self.quota_day = utc_ts.date().isoformat()
+        return self
+
+
+class _RecorderConfig(BaseModel):
+    enabled: bool
+    usage_dir: Path
+    daily_allowance: Dict[str, int]
+
+
+_config: Optional[_RecorderConfig] = None
+_config_lock = Lock()
+
+
+def _repo_root() -> Path:
+    """The repository root, derived from the nexus package location.
+
+    Mirrors nexus.runtime.supervisor.repo_root without importing the
+    supervisor from this leaf module. Relative usage_dir values must anchor
+    here — never to the NEXUS_RUNTIME_CONFIG file's directory — so alternate
+    runtime configs (QA lanes) share one account-level usage ledger.
+    """
+
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_recorder_config() -> _RecorderConfig:
+    settings = load_settings()
+    usage_dir = Path(settings.usage.usage_dir)
+    if not usage_dir.is_absolute():
+        usage_dir = _repo_root() / usage_dir
+    return _RecorderConfig(
+        enabled=settings.usage.enabled,
+        usage_dir=usage_dir,
+        daily_allowance=dict(settings.usage.daily_allowance),
+    )
+
+
+def _get_recorder_config() -> _RecorderConfig:
+    global _config
+    if _config is None:
+        with _config_lock:
+            if _config is None:
+                _config = _load_recorder_config()
+    return _config
+
+
+def _reset_usage_config_cache() -> None:
+    """Reset the lazy config singleton for isolated tests."""
+
+    global _config
+    with _config_lock:
+        _config = None
+
+
+@contextmanager
+def usage_context(
+    *,
+    seat: object = _UNSET,
+    slot: object = _UNSET,
+    run_id: object = _UNSET,
+) -> Iterator[None]:
+    """Temporarily supply usage correlation, overriding only provided fields."""
+
+    tokens: list[tuple[ContextVar[Any], Any]] = []
+    if seat is not _UNSET:
+        tokens.append((_seat_context, _seat_context.set(_optional_str(seat, "seat"))))
+    if slot is not _UNSET:
+        tokens.append((_slot_context, _slot_context.set(_optional_int(slot, "slot"))))
+    if run_id is not _UNSET:
+        tokens.append(
+            (_run_id_context, _run_id_context.set(_optional_str(run_id, "run_id")))
+        )
+    try:
+        yield
+    finally:
+        for variable, token in reversed(tokens):
+            variable.reset(token)
+
+
+def _optional_str(value: object, field: str) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be str or None")
+    return value
+
+
+def _optional_int(value: object, field: str) -> Optional[int]:
+    if value is None:
+        return None
+    if not isinstance(value, int):
+        raise TypeError(f"{field} must be int or None")
+    return value
+
+
+def current_usage_context() -> tuple[Optional[str], Optional[int], Optional[str]]:
+    """Return the effective ambient seat, slot, and run id."""
+
+    slot = _slot_context.get()
+    if slot is None:
+        raw_slot = os.environ.get("NEXUS_SLOT")
+        if raw_slot is not None:
+            try:
+                slot = int(raw_slot)
+            except ValueError as exc:
+                raise ValueError(
+                    f"NEXUS_SLOT must be an integer for usage telemetry: {raw_slot!r}"
+                ) from exc
+    return _seat_context.get(), slot, _run_id_context.get()
+
+
+def provider_name_from_base_url(
+    *,
+    native_name: str,
+    base_url: Optional[str],
+) -> str:
+    """Resolve native or explicit OpenAI-compatible provider identity."""
+
+    if base_url is None:
+        return native_name
+    host = urlparse(base_url).hostname
+    if not host:
+        raise ValueError(
+            f"Cannot derive usage provider from base_url without a host: {base_url!r}"
+        )
+    return f"openai_compatible:{host}"
+
+
+def record_usage_event(event: UsageEvent) -> None:
+    """Atomically append one event and emit its grep-stable gateway log line."""
+
+    config = _get_recorder_config()
+    if not config.enabled:
+        return
+
+    path = config.usage_dir / f"usage-{event.quota_day}.jsonl"
+    line = (
+        json.dumps(event.model_dump(mode="json"), separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+    try:
+        config.usage_dir.mkdir(parents=True, exist_ok=True)
+        fd = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+        try:
+            written = os.write(fd, line)
+            if written != len(line):
+                raise UsageWriteError(
+                    f"Short usage append to {path}: wrote {written} of "
+                    f"{len(line)} bytes"
+                )
+        finally:
+            os.close(fd)
+    except UsageWriteError:
+        raise
+    except OSError as exc:
+        raise UsageWriteError(f"Failed to append usage event to {path}: {exc}") from exc
+
+    logger.info(
+        "USAGE provider=%s model=%s seat=%s slot=%s run=%s attempt=%s "
+        "outcome=%s in=%s out=%s total=%s cached=%s reasoning=%s tier=%s",
+        event.provider,
+        event.model,
+        event.seat or "unknown",
+        event.slot if event.slot is not None else "-",
+        event.run_id if event.run_id is not None else "-",
+        event.attempt,
+        event.outcome,
+        _display_unknown(event.input_tokens),
+        _display_unknown(event.output_tokens),
+        _display_unknown(event.total_tokens),
+        _display_unknown(event.cached_input_tokens),
+        _display_unknown(event.reasoning_tokens),
+        _display_unknown(event.service_tier),
+    )
+
+
+def _display_unknown(value: object) -> object:
+    return "?" if value is None else value
+
+
+def _empty_totals() -> Dict[str, int]:
+    return {
+        "input": 0,
+        "output": 0,
+        "total": 0,
+        "cached_input": 0,
+        "reasoning": 0,
+        "events": 0,
+        "unknown_usage_events": 0,
+    }
+
+
+def _add_event(totals: Dict[str, int], event: UsageEvent) -> None:
+    totals["events"] += 1
+    if (
+        event.input_tokens is None
+        and event.output_tokens is None
+        and event.total_tokens is None
+    ):
+        totals["unknown_usage_events"] += 1
+    for output_key, field_name in (
+        ("input", "input_tokens"),
+        ("output", "output_tokens"),
+        ("total", "total_tokens"),
+        ("cached_input", "cached_input_tokens"),
+        ("reasoning", "reasoning_tokens"),
+    ):
+        value = getattr(event, field_name)
+        if value is not None:
+            totals[output_key] += value
+
+
+def summarize_usage(
+    day: Optional[str] = None,
+    run_id: Optional[str] = None,
+    usage_dir: Optional[Path] = None,
+) -> dict:
+    """Read one UTC day exactly and aggregate provider and seat totals."""
+
+    selected_day = day or datetime.now(timezone.utc).date().isoformat()
+    try:
+        datetime.strptime(selected_day, "%Y-%m-%d")
+    except ValueError as exc:
+        raise ValueError(f"Usage day must be YYYY-MM-DD, got {selected_day!r}") from exc
+
+    config = _get_recorder_config()
+    directory = Path(usage_dir) if usage_dir is not None else config.usage_dir
+    path = directory / f"usage-{selected_day}.jsonl"
+    events: list[UsageEvent] = []
+    if path.exists():
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                for line_number, raw_line in enumerate(handle, start=1):
+                    try:
+                        payload = json.loads(raw_line)
+                        event = UsageEvent.model_validate(payload)
+                    except Exception as exc:
+                        raise UsageReadError(
+                            f"Malformed usage event in {path} at line "
+                            f"{line_number}: {exc}"
+                        ) from exc
+                    if event.quota_day != selected_day:
+                        raise UsageReadError(
+                            f"Usage event day mismatch in {path} at line "
+                            f"{line_number}: event quota_day={event.quota_day}"
+                        )
+                    if run_id is None or event.run_id == run_id:
+                        events.append(event)
+        except UsageReadError:
+            raise
+        except OSError as exc:
+            raise UsageReadError(f"Failed to read usage file {path}: {exc}") from exc
+
+    providers: Dict[str, Dict[str, int]] = {}
+    seats: Dict[str, Dict[str, int]] = {}
+    for event in events:
+        provider_totals = providers.setdefault(event.provider, _empty_totals())
+        seat_totals = seats.setdefault(event.seat or "unknown", _empty_totals())
+        _add_event(provider_totals, event)
+        _add_event(seat_totals, event)
+
+    openai_totals = providers.get("openai", _empty_totals())
+    allowance = {}
+    for provider, limit in config.daily_allowance.items():
+        totals = providers.get(provider, _empty_totals())
+        used = totals["total"]
+        allowance[provider] = {
+            "allowance": limit,
+            "used": used,
+            "remaining": max(0, limit - used),
+            "unknown_usage_events": totals["unknown_usage_events"],
+        }
+
+    return {
+        "day": selected_day,
+        "events": [event.model_dump(mode="json") for event in events],
+        "providers": providers,
+        "seats": seats,
+        "openai_day_total": {
+            "total_tokens": openai_totals["total"],
+            "unknown_usage_events": openai_totals["unknown_usage_events"],
+        },
+        "allowance": allowance,
+    }
+
+
+def make_usage_event(
+    *,
+    provider: str,
+    model: str,
+    seat: Optional[str],
+    attempt: int,
+    outcome: UsageOutcome,
+    transport: UsageTransport,
+    request_id: Optional[str],
+    input_tokens: Optional[int],
+    output_tokens: Optional[int],
+    total_tokens: Optional[int],
+    cached_input_tokens: Optional[int] = None,
+    cache_creation_tokens: Optional[int] = None,
+    reasoning_tokens: Optional[int] = None,
+    service_tier: Optional[str] = None,
+    aggregate: bool = False,
+    requests: Optional[int] = None,
+    slot: Optional[int] = None,
+    run_id: Optional[str] = None,
+) -> UsageEvent:
+    """Build an event using ambient correlation only when explicit values are absent."""
+
+    ambient_seat, ambient_slot, ambient_run_id = current_usage_context()
+    return UsageEvent(
+        provider=provider,
+        model=model,
+        seat=seat if seat is not None else (ambient_seat or "unknown"),
+        slot=slot if slot is not None else ambient_slot,
+        run_id=run_id if run_id is not None else ambient_run_id,
+        attempt=attempt,
+        outcome=outcome,
+        transport=transport,
+        request_id=request_id,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        cached_input_tokens=cached_input_tokens,
+        cache_creation_tokens=cache_creation_tokens,
+        reasoning_tokens=reasoning_tokens,
+        service_tier=service_tier,
+        aggregate=aggregate,
+        requests=requests,
+    )
+
+
+def _nested_attr(value: Any, *names: str) -> Any:
+    current = value
+    for name in names:
+        if current is None:
+            return None
+        current = getattr(current, name, None)
+    return current
+
+
+def record_openai_response(
+    response: Any,
+    *,
+    provider: str,
+    model: str,
+    seat: Optional[str],
+    attempt: int,
+    outcome: UsageOutcome,
+    transport: Literal["responses", "chat_completions"],
+) -> None:
+    """Extract truthful usage from one raw OpenAI-compatible response."""
+
+    usage = getattr(response, "usage", None)
+    if transport == "responses":
+        input_tokens = getattr(usage, "input_tokens", None)
+        output_tokens = getattr(usage, "output_tokens", None)
+        cached_input_tokens = _nested_attr(
+            usage, "input_tokens_details", "cached_tokens"
+        )
+        reasoning_tokens = _nested_attr(
+            usage, "output_tokens_details", "reasoning_tokens"
+        )
+    else:
+        input_tokens = getattr(usage, "prompt_tokens", None)
+        if input_tokens is None:
+            input_tokens = getattr(usage, "input_tokens", None)
+        output_tokens = getattr(usage, "completion_tokens", None)
+        if output_tokens is None:
+            output_tokens = getattr(usage, "output_tokens", None)
+        cached_input_tokens = _nested_attr(
+            usage, "prompt_tokens_details", "cached_tokens"
+        )
+        reasoning_tokens = None
+    total_tokens = getattr(usage, "total_tokens", None)
+    if total_tokens is None and input_tokens is not None and output_tokens is not None:
+        total_tokens = input_tokens + output_tokens
+    event = make_usage_event(
+        provider=provider,
+        model=model,
+        seat=seat,
+        attempt=attempt,
+        outcome=outcome,
+        transport=transport,
+        request_id=getattr(response, "id", None),
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        cached_input_tokens=cached_input_tokens,
+        reasoning_tokens=reasoning_tokens,
+        service_tier=getattr(response, "service_tier", None),
+    )
+    record_usage_event(event)
+
+
+def record_anthropic_response(
+    response: Any,
+    *,
+    provider: str,
+    model: str,
+    seat: Optional[str],
+    attempt: int,
+    outcome: UsageOutcome,
+) -> None:
+    """Extract truthful usage from one raw Anthropic Messages response."""
+
+    usage = getattr(response, "usage", None)
+    input_tokens = getattr(usage, "input_tokens", None)
+    output_tokens = getattr(usage, "output_tokens", None)
+    total_tokens = (
+        input_tokens + output_tokens
+        if input_tokens is not None and output_tokens is not None
+        else None
+    )
+    event = make_usage_event(
+        provider=provider,
+        model=model,
+        seat=seat,
+        attempt=attempt,
+        outcome=outcome,
+        transport="anthropic_messages",
+        request_id=getattr(response, "id", None),
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        cached_input_tokens=getattr(usage, "cache_read_input_tokens", None),
+        cache_creation_tokens=getattr(usage, "cache_creation_input_tokens", None),
+    )
+    record_usage_event(event)
+
+
+def record_pydantic_ai_result(
+    result: Any,
+    *,
+    provider: str,
+    model: str,
+    seat: str,
+    slot: Optional[int] = None,
+    run_id: Optional[str] = None,
+) -> None:
+    """Record one Pydantic AI run-level aggregate including internal requests."""
+
+    usage = result.usage()
+    input_tokens = getattr(usage, "input_tokens", None)
+    if input_tokens is None:
+        input_tokens = getattr(usage, "request_tokens", None)
+    output_tokens = getattr(usage, "output_tokens", None)
+    if output_tokens is None:
+        output_tokens = getattr(usage, "response_tokens", None)
+    total_tokens = getattr(usage, "total_tokens", None)
+    if total_tokens is None and input_tokens is not None and output_tokens is not None:
+        total_tokens = input_tokens + output_tokens
+    details = getattr(usage, "details", None) or {}
+    cached_input_tokens = getattr(usage, "cache_read_tokens", None)
+    if cached_input_tokens is None:
+        cached_input_tokens = details.get("cached_input_tokens")
+    cache_creation_tokens = getattr(usage, "cache_write_tokens", None)
+    if cache_creation_tokens is None:
+        cache_creation_tokens = details.get("cache_creation_tokens")
+    event = make_usage_event(
+        provider=provider,
+        model=model,
+        seat=seat,
+        slot=slot,
+        run_id=run_id,
+        attempt=1,
+        outcome="aggregate",
+        transport="pydantic_ai",
+        request_id=None,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        cached_input_tokens=cached_input_tokens,
+        cache_creation_tokens=cache_creation_tokens,
+        reasoning_tokens=details.get("reasoning_tokens"),
+        aggregate=True,
+        requests=getattr(usage, "requests", None),
+    )
+    record_usage_event(event)

--- a/nexus/telemetry/usage.py
+++ b/nexus/telemetry/usage.py
@@ -538,6 +538,10 @@ def record_pydantic_ai_result(
     total_tokens = getattr(usage, "total_tokens", None)
     if total_tokens is None and input_tokens is not None and output_tokens is not None:
         total_tokens = input_tokens + output_tokens
+    if not input_tokens and not output_tokens and not total_tokens:
+        # pydantic-ai RunUsage zero-fills unreported counts; a completed
+        # request cannot cost zero input tokens, so all-zero means unreported.
+        input_tokens = output_tokens = total_tokens = None
     details = getattr(usage, "details", None) or {}
     cached_input_tokens = getattr(usage, "cache_read_tokens", None)
     if cached_input_tokens is None:

--- a/scripts/api_anthropic.py
+++ b/scripts/api_anthropic.py
@@ -695,15 +695,15 @@ class AnthropicProvider(LLMProvider):
                 return parsed_output, llm_response
             except ModelRetry as exc:
                 last_error = exc
+                usage_outcome = "rejected_validation"
                 if attempt >= self.structured_output_retries:
                     raise
-                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
+                usage_outcome = "rejected_validation"
                 if attempt >= self.structured_output_retries:
                     raise
-                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, str(exc))
             finally:
                 if response is not None:
@@ -761,15 +761,15 @@ class AnthropicProvider(LLMProvider):
                 return parsed_output, llm_response
             except ModelRetry as exc:
                 last_error = exc
+                usage_outcome = "rejected_validation"
                 if attempt >= self.structured_output_retries:
                     raise
-                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
+                usage_outcome = "rejected_validation"
                 if attempt >= self.structured_output_retries:
                     raise
-                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, str(exc))
             finally:
                 if response is not None:
@@ -821,15 +821,15 @@ class AnthropicProvider(LLMProvider):
                 return parsed_output, llm_response
             except ModelRetry as exc:
                 last_error = exc
+                usage_outcome = "rejected_validation"
                 if attempt >= self.structured_output_retries:
                     raise
-                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
+                usage_outcome = "rejected_validation"
                 if attempt >= self.structured_output_retries:
                     raise
-                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, str(exc))
             finally:
                 if response is not None:

--- a/scripts/api_anthropic.py
+++ b/scripts/api_anthropic.py
@@ -82,6 +82,7 @@ from nexus.api.native_structured_output import (
     retry_prompt,
     run_output_validator,
 )
+from nexus.telemetry.usage import record_anthropic_response
 
 # Configure logging
 logging.basicConfig(
@@ -296,6 +297,8 @@ class AnthropicProvider(LLMProvider):
         structured_transport: Literal["native", "prompted", "tool_envelope"] = "native",
         structured_output_retries: Optional[int] = None,
         output_validator: Optional[Any] = None,
+        usage_provider_name: Optional[str] = None,
+        usage_seat: Optional[str] = None,
     ):
         """
         Initialize Anthropic provider.
@@ -317,6 +320,8 @@ class AnthropicProvider(LLMProvider):
                 output agents (apex.structured_output_retries in nexus.toml)
             output_validator: Optional async pydantic_ai output validator
                 registered on structured agents (may raise ModelRetry)
+            usage_provider_name: Registry provider name for billing identity
+            usage_seat: Optional logical operation recorded for each response
         """
         self.top_p = top_p
         self.top_k = top_k
@@ -336,6 +341,8 @@ class AnthropicProvider(LLMProvider):
             else self.STRUCTURED_OUTPUT_RETRIES
         )
         self.output_validator = output_validator
+        self.usage_provider_name = usage_provider_name or "anthropic"
+        self.usage_seat = usage_seat
 
         # Validate thinking configuration
         if thinking_enabled and thinking_budget_tokens is None:
@@ -452,6 +459,8 @@ class AnthropicProvider(LLMProvider):
                 "budget_tokens": self.thinking_budget_tokens,
             }
 
+        response: Any = None
+        usage_outcome: Literal["accepted", "error"] = "error"
         try:
             # Call the API
             if extra_body:
@@ -478,7 +487,7 @@ class AnthropicProvider(LLMProvider):
             )
 
             # Create and return a standardized response
-            return LLMResponse(
+            result = LLMResponse(
                 content=content,
                 input_tokens=response.usage.input_tokens,
                 output_tokens=response.usage.output_tokens,
@@ -487,6 +496,8 @@ class AnthropicProvider(LLMProvider):
                 cache_creation_tokens=cache_creation_tokens,
                 cache_read_tokens=cache_read_tokens,
             )
+            usage_outcome = "accepted"
+            return result
         except Exception as e:
             # Handle API errors
             logger.error(f"Error calling Anthropic API: {str(e)}")
@@ -516,6 +527,16 @@ class AnthropicProvider(LLMProvider):
 
             # Re-raise other exceptions
             raise
+        finally:
+            if response is not None:
+                record_anthropic_response(
+                    response,
+                    provider=self.usage_provider_name,
+                    model=cast(str, self.model),
+                    seat=self.usage_seat,
+                    attempt=1,
+                    outcome=usage_outcome,
+                )
 
     def get_structured_completion(
         self,
@@ -648,6 +669,8 @@ class AnthropicProvider(LLMProvider):
         active_prompt = prompt
         last_error: Optional[BaseException] = None
         for attempt in range(self.structured_output_retries + 1):
+            response: Any = None
+            usage_outcome: Literal["accepted", "rejected_validation", "error"] = "error"
             try:
                 response = self.client.beta.messages.create(
                     **self._build_native_structured_request_params(
@@ -665,19 +688,33 @@ class AnthropicProvider(LLMProvider):
                         self.output_validator, parsed_output, retry=attempt
                     )
                 )
-                return parsed_output, self._native_response_to_llm_response(
+                llm_response = self._native_response_to_llm_response(
                     parsed_output, response
                 )
+                usage_outcome = "accepted"
+                return parsed_output, llm_response
             except ModelRetry as exc:
                 last_error = exc
                 if attempt >= self.structured_output_retries:
                     raise
+                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
                 if attempt >= self.structured_output_retries:
                     raise
+                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, str(exc))
+            finally:
+                if response is not None:
+                    record_anthropic_response(
+                        response,
+                        provider=self.usage_provider_name,
+                        model=cast(str, self.model),
+                        seat=self.usage_seat,
+                        attempt=attempt + 1,
+                        outcome=usage_outcome,
+                    )
 
         raise RuntimeError("Structured completion failed") from last_error
 
@@ -695,6 +732,8 @@ class AnthropicProvider(LLMProvider):
         active_prompt = prompt
         last_error: Optional[BaseException] = None
         for attempt in range(self.structured_output_retries + 1):
+            response: Any = None
+            usage_outcome: Literal["accepted", "rejected_validation", "error"] = "error"
             try:
                 response = self.client.beta.messages.create(
                     **self._build_tool_envelope_structured_request_params(
@@ -714,20 +753,34 @@ class AnthropicProvider(LLMProvider):
                         retry=attempt,
                     )
                 )
-                return parsed_output, self._native_response_to_llm_response(
+                llm_response = self._native_response_to_llm_response(
                     parsed_output,
                     response,
                 )
+                usage_outcome = "accepted"
+                return parsed_output, llm_response
             except ModelRetry as exc:
                 last_error = exc
                 if attempt >= self.structured_output_retries:
                     raise
+                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
                 if attempt >= self.structured_output_retries:
                     raise
+                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, str(exc))
+            finally:
+                if response is not None:
+                    record_anthropic_response(
+                        response,
+                        provider=self.usage_provider_name,
+                        model=cast(str, self.model),
+                        seat=self.usage_seat,
+                        attempt=attempt + 1,
+                        outcome=usage_outcome,
+                    )
 
         raise RuntimeError("Structured completion failed") from last_error
 
@@ -743,6 +796,8 @@ class AnthropicProvider(LLMProvider):
         active_prompt = prompt
         last_error: Optional[BaseException] = None
         for attempt in range(self.structured_output_retries + 1):
+            response: Any = None
+            usage_outcome: Literal["accepted", "rejected_validation", "error"] = "error"
             try:
                 response = self.client.beta.messages.create(
                     **self._build_prompted_structured_request_params(active_prompt)
@@ -758,20 +813,34 @@ class AnthropicProvider(LLMProvider):
                         retry=attempt,
                     )
                 )
-                return parsed_output, self._native_response_to_llm_response(
+                llm_response = self._native_response_to_llm_response(
                     parsed_output,
                     response,
                 )
+                usage_outcome = "accepted"
+                return parsed_output, llm_response
             except ModelRetry as exc:
                 last_error = exc
                 if attempt >= self.structured_output_retries:
                     raise
+                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
                 if attempt >= self.structured_output_retries:
                     raise
+                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, str(exc))
+            finally:
+                if response is not None:
+                    record_anthropic_response(
+                        response,
+                        provider=self.usage_provider_name,
+                        model=cast(str, self.model),
+                        seat=self.usage_seat,
+                        attempt=attempt + 1,
+                        outcome=usage_outcome,
+                    )
 
         raise RuntimeError("Structured completion failed") from last_error
 

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -552,15 +552,15 @@ class OpenAIProvider(LLMProvider):
                 return parsed_output, llm_response
             except ModelRetry as exc:
                 last_error = exc
+                usage_outcome = "rejected_validation"
                 if attempt >= self.structured_output_retries:
                     raise
-                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
+                usage_outcome = "rejected_validation"
                 if attempt >= self.structured_output_retries:
                     raise
-                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, str(exc))
             finally:
                 if response is not None:
@@ -653,15 +653,15 @@ class OpenAIProvider(LLMProvider):
                 return parsed_output, llm_response
             except ModelRetry as exc:
                 last_error = exc
+                usage_outcome = "rejected_validation"
                 if attempt >= self.structured_output_retries:
                     raise
-                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
+                usage_outcome = "rejected_validation"
                 if attempt >= self.structured_output_retries:
                     raise
-                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, str(exc))
             finally:
                 if response is not None:

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -54,6 +54,7 @@ from typing import (
     Type,
     TypeVar,
     Literal,
+    cast,
 )
 from datetime import datetime, timedelta
 
@@ -86,6 +87,10 @@ from nexus.api.native_structured_output import (
     openai_response_text_format,
     retry_prompt,
     run_output_validator,
+)
+from nexus.telemetry.usage import (
+    provider_name_from_base_url,
+    record_openai_response,
 )
 
 # Configure logging
@@ -297,6 +302,8 @@ class OpenAIProvider(LLMProvider):
         structured_output_retries: Optional[int] = None,
         output_validator: Optional[Any] = None,
         request_params: Optional[Dict[str, Any]] = None,
+        usage_provider_name: Optional[str] = None,
+        usage_seat: Optional[str] = None,
     ):
         """
         Initialize OpenAI provider with additional reasoning parameter.
@@ -323,6 +330,8 @@ class OpenAIProvider(LLMProvider):
             request_params: Per-model provider-specific request-body params
                 from the registry (issue #580), merged into chat-completions
                 calls via the SDK's extra_body
+            usage_provider_name: Registry provider name for billing identity
+            usage_seat: Optional logical operation recorded for each response
         """
         self.reasoning_effort = reasoning_effort
         # Deep copy: nested param objects (e.g. {"reasoning": {"effort": ...}})
@@ -330,6 +339,11 @@ class OpenAIProvider(LLMProvider):
         self.request_params = copy.deepcopy(request_params) if request_params else {}
         self.max_output_tokens = max_output_tokens or max_tokens
         self.base_url = base_url
+        self.usage_provider_name = usage_provider_name or provider_name_from_base_url(
+            native_name="openai",
+            base_url=base_url,
+        )
+        self.usage_seat = usage_seat
         self.request_timeout = request_timeout
         if structured_transport not in {"responses", "chat_completions"}:
             raise ValueError(
@@ -503,6 +517,8 @@ class OpenAIProvider(LLMProvider):
         active_prompt = prompt
         last_error: Optional[BaseException] = None
         for attempt in range(self.structured_output_retries + 1):
+            response: Any = None
+            usage_outcome: Literal["accepted", "rejected_validation", "error"] = "error"
             try:
                 try:
                     response = self.client.responses.parse(
@@ -529,19 +545,34 @@ class OpenAIProvider(LLMProvider):
                         self.output_validator, parsed_output, retry=attempt
                     )
                 )
-                return parsed_output, self._native_response_to_llm_response(
+                llm_response = self._native_response_to_llm_response(
                     parsed_output, response
                 )
+                usage_outcome = "accepted"
+                return parsed_output, llm_response
             except ModelRetry as exc:
                 last_error = exc
                 if attempt >= self.structured_output_retries:
                     raise
+                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
                 if attempt >= self.structured_output_retries:
                     raise
+                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, str(exc))
+            finally:
+                if response is not None:
+                    record_openai_response(
+                        response,
+                        provider=self.usage_provider_name,
+                        model=cast(str, self.model),
+                        seat=self.usage_seat,
+                        attempt=attempt + 1,
+                        outcome=usage_outcome,
+                        transport="responses",
+                    )
 
         raise RuntimeError("Structured completion failed") from last_error
 
@@ -601,6 +632,8 @@ class OpenAIProvider(LLMProvider):
         active_prompt = prompt
         last_error: Optional[BaseException] = None
         for attempt in range(self.structured_output_retries + 1):
+            response: Any = None
+            usage_outcome: Literal["accepted", "rejected_validation", "error"] = "error"
             try:
                 response = self.client.chat.completions.create(
                     **self._build_chat_structured_request_params(
@@ -613,19 +646,34 @@ class OpenAIProvider(LLMProvider):
                         self.output_validator, parsed_output, retry=attempt
                     )
                 )
-                return parsed_output, self._chat_response_to_llm_response(
+                llm_response = self._chat_response_to_llm_response(
                     parsed_output, response
                 )
+                usage_outcome = "accepted"
+                return parsed_output, llm_response
             except ModelRetry as exc:
                 last_error = exc
                 if attempt >= self.structured_output_retries:
                     raise
+                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
                 if attempt >= self.structured_output_retries:
                     raise
+                usage_outcome = "rejected_validation"
                 active_prompt = retry_prompt(prompt, str(exc))
+            finally:
+                if response is not None:
+                    record_openai_response(
+                        response,
+                        provider=self.usage_provider_name,
+                        model=cast(str, self.model),
+                        seat=self.usage_seat,
+                        attempt=attempt + 1,
+                        outcome=usage_outcome,
+                        transport="chat_completions",
+                    )
 
         raise RuntimeError("Structured chat completion failed") from last_error
 
@@ -863,14 +911,28 @@ class OpenAIProvider(LLMProvider):
             )
             return self._get_completion_chat_completions(prompt)
 
-        # Format response to match our standard format
-        return LLMResponse(
-            content=response.output_text,
-            input_tokens=response.usage.input_tokens,
-            output_tokens=response.usage.output_tokens,
-            model=self.model,
-            raw_response=response,
-        )
+        usage_outcome: Literal["accepted", "error"] = "error"
+        try:
+            # Format response to match our standard format
+            result = LLMResponse(
+                content=response.output_text,
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+                model=cast(str, self.model),
+                raw_response=response,
+            )
+            usage_outcome = "accepted"
+            return result
+        finally:
+            record_openai_response(
+                response,
+                provider=self.usage_provider_name,
+                model=cast(str, self.model),
+                seat=self.usage_seat,
+                attempt=1,
+                outcome=usage_outcome,
+                transport="responses",
+            )
 
     def _get_completion_chat_completions(self, prompt: str) -> LLMResponse:
         """Get an unstructured completion through Chat Completions."""
@@ -892,17 +954,31 @@ class OpenAIProvider(LLMProvider):
             request_params["extra_body"] = copy.deepcopy(self.request_params)
 
         response = self.client.chat.completions.create(**request_params)
-        choices = getattr(response, "choices", None) or []
-        message = getattr(choices[0], "message", None) if choices else None
-        content = getattr(message, "content", "") if message else ""
-        usage = getattr(response, "usage", None)
-        return LLMResponse(
-            content=content,
-            input_tokens=getattr(usage, "prompt_tokens", 0) if usage else 0,
-            output_tokens=getattr(usage, "completion_tokens", 0) if usage else 0,
-            model=self.model,
-            raw_response=response,
-        )
+        usage_outcome: Literal["accepted", "error"] = "error"
+        try:
+            choices = getattr(response, "choices", None) or []
+            message = getattr(choices[0], "message", None) if choices else None
+            content = getattr(message, "content", "") if message else ""
+            usage = getattr(response, "usage", None)
+            result = LLMResponse(
+                content=content,
+                input_tokens=getattr(usage, "prompt_tokens", 0) if usage else 0,
+                output_tokens=(getattr(usage, "completion_tokens", 0) if usage else 0),
+                model=cast(str, self.model),
+                raw_response=response,
+            )
+            usage_outcome = "accepted"
+            return result
+        finally:
+            record_openai_response(
+                response,
+                provider=self.usage_provider_name,
+                model=cast(str, self.model),
+                seat=self.usage_seat,
+                attempt=1,
+                outcome=usage_outcome,
+                transport="chat_completions",
+            )
 
     def _get_api_key(self) -> str:
         """Get OpenAI API key via the central secret manager (Keychain)."""

--- a/scripts/summarize_narrative.py
+++ b/scripts/summarize_narrative.py
@@ -1477,6 +1477,7 @@ class SummaryGenerator:
                 structured_output_retries=self._structured_output_retries,
                 temperature=(None if self.is_reasoning_model else self.temperature),
                 reasoning_effort=(self.effort if self.is_reasoning_model else None),
+                seat="summaries",
             )
             logger.info(
                 "Initialized %s summary provider for %s using %s",

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -84,6 +84,25 @@ def test_summaries_follow_the_storyteller_by_default():
     assert settings.summaries.model == settings.apex.model
 
 
+def test_usage_settings_validate_and_round_trip() -> None:
+    raw = _nexus_toml_dict()
+    raw["usage"] = {
+        "enabled": True,
+        "usage_dir": ".nexus/runtime/test-usage",
+        "daily_allowance": {"openai": 1234},
+    }
+
+    settings = Settings(**raw)
+
+    assert settings.usage.enabled is True
+    assert settings.usage.usage_dir == ".nexus/runtime/test-usage"
+    assert settings.usage.daily_allowance == {"openai": 1234}
+
+    raw["usage"]["daily_allowance"]["openai"] = 0
+    with pytest.raises(ValidationError, match="daily_allowance values"):
+        Settings(**raw)
+
+
 def test_apex_tag_library_settings_round_trip() -> None:
     """Context selection and repair limits survive validated serialization."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Iterable
 
 import psycopg2
 import pytest
+
+from nexus.telemetry import usage as usage_telemetry
 
 
 def _flag_enabled(name: str) -> bool:
@@ -37,6 +40,21 @@ def _forbid_unopted_postgres_connections(monkeypatch: pytest.MonkeyPatch) -> Non
         )
 
     monkeypatch.setattr(psycopg2, "connect", fail_connect)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_provider_usage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep every fabricated provider response out of runtime telemetry."""
+
+    config = usage_telemetry._RecorderConfig(
+        enabled=True,
+        usage_dir=tmp_path / "usage",
+        daily_allowance={"openai": 2_500_000},
+    )
+    monkeypatch.setattr(usage_telemetry, "_config", config)
 
 
 def pytest_collection_modifyitems(

--- a/tests/test_logon_mock_integration.py
+++ b/tests/test_logon_mock_integration.py
@@ -1,8 +1,13 @@
 """Integration test for LogonUtility → mock server routing."""
 
+from pathlib import Path
+from types import SimpleNamespace
+
 import psycopg2
 import pytest
 
+from nexus.agents.lore.logon_utility import LogonUtility
+from nexus.telemetry.usage import summarize_usage
 from scripts.api_openai import OpenAIProvider
 from nexus.agents.logon.skald_wire import SkaldTurnWire
 
@@ -80,3 +85,68 @@ def test_provider_routes_to_mock_server():
     assert response.updates is None
     assert response.orrery_adjudications == []
     assert "deterministic mock control" in response.narrative
+
+
+def test_logon_real_entrypoint_records_registry_provider_and_single_pass_seat(
+    tmp_path: Path,
+) -> None:
+    """The genuine LOGON path preserves registry billing identity at the SDK seam."""
+
+    utility = LogonUtility(
+        {
+            "API Settings": {"apex": {"turn_pipeline": "single_pass"}},
+            "storyteller": {
+                "correspondence": {
+                    "max_letter_tokens": 300,
+                }
+            },
+        },
+        model_override="registry-test-model",
+    )
+    endpoint = {
+        "base_url": "http://127.0.0.1:5102/v1",
+        "api_key": "test-dummy-key",
+        "structured_transport": "responses",
+        "request_timeout_seconds": None,
+        "request_params": {},
+    }
+    utility._initialize_provider(
+        False,
+        resolved_route=("registry-test-model", "test", endpoint, "local"),
+    )
+    assert isinstance(utility.provider, OpenAIProvider)
+
+    wire = SkaldTurnWire(
+        narrative="The mocked boundary returns a complete turn.",
+        choices=["Continue.", "Wait."],
+        letter="Keep the next consequence private.",
+    )
+    raw_response = SimpleNamespace(
+        id="resp_logon_integration",
+        output_parsed=wire,
+        output_text=wire.model_dump_json(),
+        usage=SimpleNamespace(
+            input_tokens=101,
+            output_tokens=23,
+            total_tokens=124,
+        ),
+    )
+    utility.provider.client = SimpleNamespace(
+        responses=SimpleNamespace(parse=lambda **_kwargs: raw_response)
+    )
+
+    response = utility.generate_narrative(
+        {
+            "user_input": "Continue.",
+            "warm_slice": {"chunks": []},
+            "entity_data": {},
+            "retrieved_passages": {"results": []},
+        },
+        effective_context_window=75_000,
+    )
+
+    assert response.generation_model == "registry-test-model"
+    event = summarize_usage(usage_dir=tmp_path / "usage")["events"][0]
+    assert event["provider"] == "test"
+    assert event["seat"] == "skald_single_pass"
+    assert event["total_tokens"] == 124

--- a/tests/test_lore/test_two_pass_pipeline.py
+++ b/tests/test_lore/test_two_pass_pipeline.py
@@ -174,6 +174,7 @@ class _RecordingProvider:
                 "output_validator": self.output_validator,
                 "structured_transport": self.structured_transport,
                 "structured_output_retries": self.structured_output_retries,
+                "usage_seat": getattr(self, "usage_seat", None),
             }
         )
 
@@ -408,6 +409,8 @@ def _assert_two_pass_calls(
     assert writer_call["output_validator"] is not gaia_call["output_validator"]
     assert writer_call["structured_output_retries"] == 3
     assert gaia_call["structured_output_retries"] == 3
+    assert writer_call["usage_seat"] == "skald_writer"
+    assert gaia_call["usage_seat"] == "gaia"
     # Writer pass = core doctrine + explicit scope note (gaia work excluded);
     # schema-free writers obey the core prompt over the repair loop without it.
     assert writer_call["system_prompt"].startswith("Core storyteller prompt")
@@ -927,6 +930,7 @@ def _install_gaia_capture(
         captured["anthropic_transport"] = anthropic_transport
         gaia_recorder.system_prompt = system_prompt
         gaia_recorder.output_validator = output_validator
+        gaia_recorder.usage_seat = "gaia"
         return gaia_recorder
 
     monkeypatch.setattr(utility, "_build_gaia_provider", fake_build)
@@ -983,6 +987,8 @@ def test_sync_pinned_gaia_runs_fresh_openai_seat(
     assert len(gaia_recorder.calls) == 1
     gaia_call = gaia_recorder.calls[0]
     assert gaia_call["schema_model"] is SkaldGaiaWire
+    assert provider.calls[0]["usage_seat"] == "skald_writer"
+    assert gaia_call["usage_seat"] == "gaia"
     # Heterogeneous kwargs: strict OpenAI gaia schema under this writer wire.
     assert gaia_call["kwargs"] == {"text_format": skald_gaia_strict_text_format()}
     assert captured["route"][0] == "pinned-gaia-model"

--- a/tests/test_usage_recorder.py
+++ b/tests/test_usage_recorder.py
@@ -1,0 +1,418 @@
+"""Provider-boundary usage recorder regression tests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import logging
+import multiprocessing
+from pathlib import Path
+from types import SimpleNamespace
+
+from pydantic import BaseModel
+import pytest
+
+from nexus import cli
+from nexus.telemetry import usage as usage_telemetry
+from nexus.telemetry.usage import (
+    UsageEvent,
+    UsageReadError,
+    record_pydantic_ai_result,
+    record_usage_event,
+    summarize_usage,
+)
+from scripts.api_openai import OpenAIProvider
+
+
+class _StructuredAnswer(BaseModel):
+    value: str
+
+
+def _usage(
+    input_tokens: int,
+    output_tokens: int,
+    *,
+    cached_tokens: int = 0,
+    reasoning_tokens: int = 0,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+        input_tokens_details=SimpleNamespace(cached_tokens=cached_tokens),
+        output_tokens_details=SimpleNamespace(reasoning_tokens=reasoning_tokens),
+    )
+
+
+def _response(
+    value: str,
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    response_id: str,
+) -> SimpleNamespace:
+    parsed = _StructuredAnswer(value=value)
+    return SimpleNamespace(
+        id=response_id,
+        output_parsed=parsed,
+        output_text=parsed.model_dump_json(),
+        usage=_usage(input_tokens, output_tokens),
+        service_tier="default",
+    )
+
+
+def _event(
+    *,
+    ts: str,
+    provider: str = "openai",
+    seat: str = "skald_single_pass",
+    total: int | None = 3,
+    run_id: str | None = None,
+) -> UsageEvent:
+    return UsageEvent(
+        ts=ts,
+        provider=provider,
+        model=f"{provider}-model",
+        seat=seat,
+        run_id=run_id,
+        attempt=1,
+        outcome="accepted",
+        transport="responses",
+        input_tokens=None if total is None else 1,
+        output_tokens=None if total is None else total - 1,
+        total_tokens=total,
+        cached_input_tokens=None,
+        cache_creation_tokens=None,
+        reasoning_tokens=None,
+        aggregate=False,
+        requests=None,
+    )
+
+
+def _concurrent_writer(path: str, process_index: int, events: int) -> None:
+    usage_telemetry._config = usage_telemetry._RecorderConfig(
+        enabled=True,
+        usage_dir=Path(path),
+        daily_allowance={},
+    )
+    for event_index in range(events):
+        record_usage_event(
+            _event(
+                ts="2026-07-29T12:00:00Z",
+                run_id=f"{process_index}-{event_index}",
+            )
+        )
+
+
+def test_single_responses_call_records_jsonl_log_and_cli_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    response = _response(
+        "done",
+        input_tokens=123,
+        output_tokens=45,
+        response_id="resp_single",
+    )
+
+    class FakeResponses:
+        def parse(self, **_kwargs: object) -> SimpleNamespace:
+            return response
+
+    provider = OpenAIProvider(
+        model="gpt-test",
+        api_key="test-key",
+        usage_provider_name="openai",
+        usage_seat="skald_single_pass",
+    )
+    provider.client = SimpleNamespace(responses=FakeResponses())
+
+    with caplog.at_level(logging.INFO, logger="nexus.usage"):
+        parsed, _llm_response = provider.get_structured_completion(
+            "prompt", _StructuredAnswer
+        )
+
+    assert parsed.value == "done"
+    day = datetime.now(timezone.utc).date().isoformat()
+    path = tmp_path / "usage" / f"usage-{day}.jsonl"
+    events = [json.loads(line) for line in path.read_text().splitlines()]
+    assert len(events) == 1
+    assert events[0]["input_tokens"] == 123
+    assert events[0]["output_tokens"] == 45
+    assert events[0]["total_tokens"] == 168
+    assert "USAGE provider=openai model=gpt-test" in caplog.text
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["nexus", "usage", "--json", "--day", day],
+    )
+    assert cli.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["usage"]["events"][0]["request_id"] == "resp_single"
+    assert payload["usage"]["openai_day_total"]["total_tokens"] == 168
+
+
+def test_two_provider_passes_keep_seats_models_and_sum(tmp_path: Path) -> None:
+    responses = iter(
+        [
+            _response(
+                "writer",
+                input_tokens=10,
+                output_tokens=4,
+                response_id="resp_writer",
+            ),
+            _response(
+                "gaia",
+                input_tokens=8,
+                output_tokens=3,
+                response_id="resp_gaia",
+            ),
+        ]
+    )
+
+    class FakeResponses:
+        def parse(self, **_kwargs: object) -> SimpleNamespace:
+            return next(responses)
+
+    writer = OpenAIProvider(
+        model="writer-model",
+        api_key="test-key",
+        usage_provider_name="openai",
+        usage_seat="skald_writer",
+    )
+    writer.client = SimpleNamespace(responses=FakeResponses())
+    gaia = OpenAIProvider(
+        model="gaia-model",
+        api_key="test-key",
+        usage_provider_name="openai",
+        usage_seat="gaia",
+    )
+    gaia.client = SimpleNamespace(responses=FakeResponses())
+
+    writer.get_structured_completion("writer", _StructuredAnswer)
+    gaia.get_structured_completion("gaia", _StructuredAnswer)
+
+    summary = summarize_usage(usage_dir=tmp_path / "usage")
+    assert [event["seat"] for event in summary["events"]] == [
+        "skald_writer",
+        "gaia",
+    ]
+    assert [event["model"] for event in summary["events"]] == [
+        "writer-model",
+        "gaia-model",
+    ]
+    assert summary["providers"]["openai"]["total"] == 25
+
+
+def test_repair_loop_records_rejected_then_accepted(tmp_path: Path) -> None:
+    responses = iter(
+        [
+            SimpleNamespace(
+                id="resp_rejected",
+                output_parsed=None,
+                output_text='{"wrong":"shape"}',
+                usage=_usage(20, 5),
+            ),
+            _response(
+                "repaired",
+                input_tokens=24,
+                output_tokens=6,
+                response_id="resp_accepted",
+            ),
+        ]
+    )
+
+    class FakeResponses:
+        def parse(self, **_kwargs: object) -> SimpleNamespace:
+            return next(responses)
+
+    provider = OpenAIProvider(
+        model="repair-model",
+        api_key="test-key",
+        structured_output_retries=1,
+        usage_provider_name="openai",
+        usage_seat="geo_authoring",
+    )
+    provider.client = SimpleNamespace(responses=FakeResponses())
+
+    parsed, _response_value = provider.get_structured_completion(
+        "prompt", _StructuredAnswer
+    )
+
+    assert parsed.value == "repaired"
+    summary = summarize_usage(usage_dir=tmp_path / "usage")
+    assert [event["outcome"] for event in summary["events"]] == [
+        "rejected_validation",
+        "accepted",
+    ]
+    assert [event["attempt"] for event in summary["events"]] == [1, 2]
+    assert summary["providers"]["openai"]["total"] == 55
+
+
+def test_pydantic_ai_aggregate_records_internal_request_count(
+    tmp_path: Path,
+) -> None:
+    result = SimpleNamespace(
+        usage=lambda: SimpleNamespace(
+            requests=3,
+            input_tokens=30,
+            output_tokens=12,
+            total_tokens=42,
+            details={"cached_input_tokens": 7, "reasoning_tokens": 4},
+        )
+    )
+
+    record_pydantic_ai_result(
+        result,
+        provider="openai",
+        model="wizard-model",
+        seat="wizard",
+        slot=2,
+        run_id="thread-1",
+    )
+
+    event = summarize_usage(usage_dir=tmp_path / "usage")["events"][0]
+    assert event["aggregate"] is True
+    assert event["outcome"] == "aggregate"
+    assert event["requests"] == 3
+    assert event["total_tokens"] == 42
+
+
+def test_missing_usage_stays_null_and_counts_unknown(tmp_path: Path) -> None:
+    response = _response(
+        "done",
+        input_tokens=1,
+        output_tokens=1,
+        response_id="resp_unknown",
+    )
+    response.usage = None
+
+    class FakeResponses:
+        def parse(self, **_kwargs: object) -> SimpleNamespace:
+            return response
+
+    provider = OpenAIProvider(
+        model="unknown-model",
+        api_key="test-key",
+        usage_provider_name="openai",
+        usage_seat="skald_single_pass",
+    )
+    provider.client = SimpleNamespace(responses=FakeResponses())
+    provider.get_structured_completion("prompt", _StructuredAnswer)
+
+    summary = summarize_usage(usage_dir=tmp_path / "usage")
+    event = summary["events"][0]
+    assert event["input_tokens"] is None
+    assert event["output_tokens"] is None
+    assert event["total_tokens"] is None
+    assert summary["providers"]["openai"]["total"] == 0
+    assert summary["providers"]["openai"]["unknown_usage_events"] == 1
+
+
+def test_concurrent_process_appends_are_complete_and_exact(tmp_path: Path) -> None:
+    process_count = 4
+    events_per_process = 40
+    usage_dir = tmp_path / "concurrent"
+    context = multiprocessing.get_context("spawn")
+    processes = [
+        context.Process(
+            target=_concurrent_writer,
+            args=(str(usage_dir), process_index, events_per_process),
+        )
+        for process_index in range(process_count)
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=30)
+        assert process.exitcode == 0
+
+    summary = summarize_usage(
+        day="2026-07-29",
+        usage_dir=usage_dir,
+    )
+    expected_events = process_count * events_per_process
+    assert len(summary["events"]) == expected_events
+    assert summary["providers"]["openai"]["total"] == expected_events * 3
+    assert len({event["run_id"] for event in summary["events"]}) == expected_events
+
+
+def test_openai_day_total_excludes_other_providers(tmp_path: Path) -> None:
+    for provider in ("openai", "test", "local", "anthropic"):
+        record_usage_event(
+            _event(
+                ts="2026-07-29T12:00:00Z",
+                provider=provider,
+                total=10,
+            )
+        )
+
+    summary = summarize_usage(day="2026-07-29", usage_dir=tmp_path / "usage")
+    assert summary["openai_day_total"]["total_tokens"] == 10
+    assert summary["providers"]["test"]["total"] == 10
+    assert summary["providers"]["local"]["total"] == 10
+    assert summary["providers"]["anthropic"]["total"] == 10
+
+
+def test_utc_midnight_routes_events_to_distinct_day_files(tmp_path: Path) -> None:
+    record_usage_event(_event(ts="2026-07-29T23:59:59.999999Z", total=5))
+    record_usage_event(_event(ts="2026-07-30T00:00:00Z", total=7))
+
+    before = summarize_usage(day="2026-07-29", usage_dir=tmp_path / "usage")
+    after = summarize_usage(day="2026-07-30", usage_dir=tmp_path / "usage")
+    assert before["openai_day_total"]["total_tokens"] == 5
+    assert after["openai_day_total"]["total_tokens"] == 7
+
+
+def test_malformed_line_raises_with_path_and_line(tmp_path: Path) -> None:
+    path = tmp_path / "usage" / "usage-2026-07-29.jsonl"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(_event(ts="2026-07-29T12:00:00Z").model_dump(mode="json"))
+        + "\n"
+        + "{not-json}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        UsageReadError,
+        match=r"usage-2026-07-29\.jsonl at line 2",
+    ):
+        summarize_usage(day="2026-07-29", usage_dir=tmp_path / "usage")
+
+
+def test_relative_usage_dir_anchors_to_repo_root_not_config_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """QA lanes with NEXUS_RUNTIME_CONFIG elsewhere share one usage ledger."""
+
+    repo_root = Path(usage_telemetry.__file__).resolve().parents[2]
+    config_copy = tmp_path / "lane" / "nexus.toml"
+    config_copy.parent.mkdir(parents=True)
+    config_copy.write_text(
+        (repo_root / "nexus.toml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("NEXUS_RUNTIME_CONFIG", str(config_copy))
+
+    config = usage_telemetry._load_recorder_config()
+
+    assert not config.usage_dir.is_relative_to(tmp_path)
+    assert config.usage_dir == repo_root / ".nexus" / "runtime" / "usage"
+
+
+def test_missing_day_file_is_valid_empty_summary(tmp_path: Path) -> None:
+    summary = summarize_usage(
+        day="2026-07-29",
+        usage_dir=tmp_path / "missing",
+    )
+    assert summary["events"] == []
+    assert summary["providers"] == {}
+    assert summary["openai_day_total"] == {
+        "total_tokens": 0,
+        "unknown_usage_events": 0,
+    }

--- a/tests/test_usage_recorder.py
+++ b/tests/test_usage_recorder.py
@@ -251,6 +251,71 @@ def test_repair_loop_records_rejected_then_accepted(tmp_path: Path) -> None:
     assert summary["providers"]["openai"]["total"] == 55
 
 
+def test_exhausted_repair_labels_final_attempt_rejected_validation(
+    tmp_path: Path,
+) -> None:
+    """An exhausted repair attempt records what happened to IT, not the loop."""
+
+    bad = SimpleNamespace(
+        id="resp_bad",
+        output_parsed=None,
+        output_text='{"wrong":"shape"}',
+        usage=_usage(9, 2),
+    )
+
+    class FakeResponses:
+        def parse(self, **_kwargs: object) -> SimpleNamespace:
+            return bad
+
+    provider = OpenAIProvider(
+        model="exhaust-model",
+        api_key="test-key",
+        structured_output_retries=1,
+        usage_provider_name="openai",
+        usage_seat="trait_input_derivation",
+    )
+    provider.client = SimpleNamespace(responses=FakeResponses())
+
+    with pytest.raises(Exception):
+        provider.get_structured_completion("prompt", _StructuredAnswer)
+
+    summary = summarize_usage(usage_dir=tmp_path / "usage")
+    assert [event["outcome"] for event in summary["events"]] == [
+        "rejected_validation",
+        "rejected_validation",
+    ]
+    assert summary["providers"]["openai"]["total"] == 22
+
+
+def test_pydantic_ai_all_zero_usage_is_unknown_not_zero(tmp_path: Path) -> None:
+    """pydantic-ai RunUsage zero-fills unreported counts; record them as unknown."""
+
+    result = SimpleNamespace(
+        usage=lambda: SimpleNamespace(
+            requests=1,
+            input_tokens=0,
+            output_tokens=0,
+            total_tokens=0,
+            details={},
+        )
+    )
+
+    record_pydantic_ai_result(
+        result,
+        provider="openai",
+        model="wizard-model",
+        seat="wizard",
+    )
+
+    summary = summarize_usage(usage_dir=tmp_path / "usage")
+    event = summary["events"][0]
+    assert event["input_tokens"] is None
+    assert event["output_tokens"] is None
+    assert event["total_tokens"] is None
+    assert summary["providers"]["openai"]["total"] == 0
+    assert summary["providers"]["openai"]["unknown_usage_events"] == 1
+
+
 def test_pydantic_ai_aggregate_records_internal_request_count(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes #626.

## What This Does

One central recorder at the provider boundary observes **every completed remote model response** — including structured-output repair-loop attempts that are billed but discarded today — and surfaces exact API-reported usage three ways:

1. **Gateway log line** per response via the `nexus.usage` logger (`USAGE provider=… seat=… attempt=… outcome=… in=… out=… total=…`), with unknown fields rendered `?`, never `0`.
2. **Machine-readable events**: atomic O_APPEND JSONL day-files (`.nexus/runtime/usage/usage-YYYY-MM-DD.jsonl`), one single-syscall append per event — lock-free multi-process safety across the gateway, CLI, and worker processes; the UTC-day total is derived on read, so it cannot be lost or double-counted.
3. **`nexus usage [--json] [--day YYYY-MM-DD] [--run ID]`**: slotless CLI readout with per-provider/per-seat totals, an OpenAI-only UTC-day total (never mixed with test/local/openrouter/anthropic), and readout-only `[usage.daily_allowance]` remaining-headroom math. This is what a scheduled QA shift parses to stop before exhausting the complimentary-token quota.

## Design Notes

- **Hook placement**: immediately after each of the four OpenAI SDK call sites (and the Anthropic mirror's four), *before* parse/validation can raise — exactly-once per completed HTTP response via record-in-finally with an outcome local. A rejected repair attempt records `rejected_validation`; a final-attempt rejection that propagates records `error`.
- **Provider identity is the registry name**, threaded through `build_native_structured_provider(seat=…)`, LOGON, gaia, and narration construction — `OpenAIProvider` also fronts OpenRouter/local/test via `base_url`, so class identity is never conflated with billing identity. Unthreaded constructions resolve to `openai_compatible:<host>`, never silently `openai`.
- **Wizard (Pydantic AI)** records one `aggregate=True` event per run from `result.usage()`, including retry/tool-call turns (`requests=N`).
- **Correlation**: gateway turns reuse the narrative `session_id`; the worker uses `job_id`; wizard uses `thread_id`; in-process CLI generation commands mint a run id in `main()`.
- **Unknown usage stays `null`** and is counted separately (`unknown_usage_events`) — the existing `LLMResponse` zero-coercion is deliberately untouched (callers depend on ints; the recorder is the truthful record).
- **Repo-root anchoring** (coordinator fix on top of the delegated build): relative `usage_dir` anchors to the repo root, not the `NEXUS_RUNTIME_CONFIG` file's directory, so QA lanes running alternate configs append to the same account-level ledger. Regression test included.
- **Total synthesis** (coordinator fix): when a compatible server reports input/output but omits `total_tokens`, the total derives from the reported components — truthful arithmetic, distinct from zero-filling unknowns.

## Config

New validated `[usage]` section in nexus.toml (`enabled`, `usage_dir`, `[usage.daily_allowance]` per-provider table, values ≥ 1). No migrations; the store is file-based because the quota is account-level and cross-slot (slotless LOGON usage exists), and per-slot Postgres is the wrong scope.

## Validation

- `poetry run pytest -q` → **2004 passed, 461 skipped** (pipefail-honest exit 0)
- `tests/test_usage_recorder.py` (11): single-pass exact tokens in JSONL+log+CLI JSON; two-pass seat/model separation and summing; repair loop records rejected+accepted attempts (both billable); Pydantic AI aggregate with `requests=3`; missing usage → `null` + unknown count, never a false zero; 4-process×40-event concurrency with exact line count; OpenAI day total excludes other providers; UTC midnight file split; malformed line raises with path+line; empty day = valid empty state; repo-root anchoring regression.
- `tests/test_logon_mock_integration.py`: drives the genuine `LogonUtility.generate_narrative` entry point (mock only at the SDK client seam) and asserts registry provider + seat on the recorded event.
- black/mypy/flake8 clean on new surfaces; pre-existing repo-wide baselines unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwQAcSeuSfJAcjUvxVzadv