### PR TITLE
Retrograde: Audit Pair Stacks by Template-Required Slots, Not Target Only

### DIFF
--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -24,8 +24,8 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
-from nexus.agents.orrery.needs import NEED_SEVERITY_PREFIX
 from nexus.agents.orrery.audit import NOT_APPLICABLE_REASON
+from nexus.agents.orrery.needs import NEED_SEVERITY_PREFIX
 from nexus.agents.orrery.reconstruction import playable_narrative_predicate
 from nexus.agents.orrery.resolver import (
     OrreryTickProposal,
@@ -254,16 +254,19 @@ def test_resolve_four_template_states_are_distinguishable(
         for stack in group["two_party_stacks"] + group["scene_pressure_stacks"]:
             stack_ids = {t["template_id"] for t in stack["templates"]}
             assert stack_ids <= MULTI_PARTY_TEMPLATE_IDS
+            # Routes pair one binding set with templates of exactly one slot
+            # signature — target for (actor, target) pairs, faction for
+            # court-patron (actor, faction) pairs — so a stack never mixes
+            # shapes, and its non-null bindings are exactly that signature.
+            signatures = {
+                frozenset(REQUIRED_SLOTS_BY_TEMPLATE[template_id])
+                for template_id in stack_ids
+            }
+            assert len(signatures) == 1
             bound = {
                 slot for slot, entity in stack["bindings"].items() if entity is not None
             }
-            assert "actor" in bound
-            # The counterparty is whatever the routed templates require:
-            # target for (actor, target) pairs, faction for court-patron
-            # (actor, faction) pairs — a pair stack never lacks both.
-            assert bound & COUNTERPARTY_SLOTS
-            for template_id in stack_ids:
-                assert REQUIRED_SLOTS_BY_TEMPLATE[template_id] <= bound
+            assert bound == set(next(iter(signatures)))
 
         # Not-applicable is exactly "no two-party binding composed", and is
         # never conflated with an evaluated-and-refused gate.

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -25,6 +25,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
 from nexus.agents.orrery.needs import NEED_SEVERITY_PREFIX
+from nexus.agents.orrery.audit import NOT_APPLICABLE_REASON
 from nexus.agents.orrery.reconstruction import playable_narrative_predicate
 from nexus.agents.orrery.resolver import (
     OrreryTickProposal,
@@ -39,10 +40,16 @@ from nexus.config import load_settings, load_settings_as_dict
 LIVE_SLOT = 5
 AUDIT_SLOTS = (LIVE_SLOT,)
 
-TWO_PARTY_TEMPLATE_IDS = {t.id for t in BUILTIN_TEMPLATES if len(t.required_slots) == 2}
+MULTI_PARTY_TEMPLATE_IDS = {
+    t.id for t in BUILTIN_TEMPLATES if len(t.required_slots) >= 2
+}
 ACTOR_ONLY_TEMPLATE_IDS = {
     t.id for t in BUILTIN_TEMPLATES if len(t.required_slots) == 1
 }
+REQUIRED_SLOTS_BY_TEMPLATE = {
+    t.id: {slot.value for slot in t.required_slots} for t in BUILTIN_TEMPLATES
+}
+COUNTERPARTY_SLOTS = {"target", "faction"}
 
 
 @pytest.fixture(scope="module")
@@ -243,11 +250,20 @@ def test_resolve_four_template_states_are_distinguishable(
         # Stack composition respects arity — the stack-split trap guard.
         actor_stack_ids = {t["template_id"] for t in group["actor_stack"]["templates"]}
         assert actor_stack_ids == ACTOR_ONLY_TEMPLATE_IDS
-        assert "target" not in group["actor_stack"]["bindings"]
+        assert not COUNTERPARTY_SLOTS & set(group["actor_stack"]["bindings"])
         for stack in group["two_party_stacks"] + group["scene_pressure_stacks"]:
             stack_ids = {t["template_id"] for t in stack["templates"]}
-            assert stack_ids <= TWO_PARTY_TEMPLATE_IDS
-            assert stack["bindings"].get("target") is not None
+            assert stack_ids <= MULTI_PARTY_TEMPLATE_IDS
+            bound = {
+                slot for slot, entity in stack["bindings"].items() if entity is not None
+            }
+            assert "actor" in bound
+            # The counterparty is whatever the routed templates require:
+            # target for (actor, target) pairs, faction for court-patron
+            # (actor, faction) pairs — a pair stack never lacks both.
+            assert bound & COUNTERPARTY_SLOTS
+            for template_id in stack_ids:
+                assert REQUIRED_SLOTS_BY_TEMPLATE[template_id] <= bound
 
         # Not-applicable is exactly "no two-party binding composed", and is
         # never conflated with an evaluated-and-refused gate.
@@ -255,9 +271,10 @@ def test_resolve_four_template_states_are_distinguishable(
             assert group["not_applicable"] == []
         else:
             marked = {item["template_id"] for item in group["not_applicable"]}
-            assert marked == TWO_PARTY_TEMPLATE_IDS
+            assert marked == MULTI_PARTY_TEMPLATE_IDS
             assert all(
-                item["reason"] == "no_target_bound" for item in group["not_applicable"]
+                item["reason"] == NOT_APPLICABLE_REASON
+                for item in group["not_applicable"]
             )
 
     for _, stack in _all_stacks(payload):


### PR DESCRIPTION
Closes #622.

## Diagnosis (issue hypothesis a)

The four-state distinguishability test asserted every two-party/scene-pressure stack binds a `target`. That invariant went stale in PR #546: the court-patron templates (`START_COURT_PATRON_FACTION`, `ADVANCE_COURT_PATRON_FACTION`) legally declare `required_slots=(ACTOR, FACTION)` and never bind a target. The resolver treats faction counterparties as first-class throughout — dedicated composition (`compose_actor_faction_bindings`), routing (`compose_actor_faction_routes` → `two_party_stacks`), the fanout pair predicate (`"target" in bindings or "faction" in bindings`), and the not-applicable markers all include faction templates. Slot 5 recently grew an institutional actor→faction pair (24→25) that routes these templates, turning the stale assertion red on clean `main`. **The resolver is correct; the test encoded a vocabulary snapshot ("second party = target") instead of the contract ("second party = whatever the template's required slots say").**

## Fix (test-only)

- Each pair stack's non-null bindings must cover every routed template's `required_slots`, always include `actor`, and always include a counterparty (`target` or `faction`).
- `MULTI_PARTY_TEMPLATE_IDS` = `len(required_slots) >= 2`, which also defuses the sibling landmine: the audit already routes `(ACTOR, TARGET, FACTION)` triple templates into these stacks, and the old `== 2` set would have broken the day the first triple ships.
- The not-applicable branch asserts the audit module's `NOT_APPLICABLE_REASON` constant instead of a hardcoded string, and the actor-only stack now also asserts no `faction` binding.

## De-Flake Rationale (issue acceptance item 2)

The corrected invariant is shape-universal — any legal resolver output passes and any missing-required-slot output fails — so the pass/fail boundary no longer depends on mutable live-slot data. save_05 remains what this audit file's charter makes it: coverage breadth, guarded by the existing non-vacuity test. A pinned disposable clone was considered and rejected: the strict target-only invariant it would have preserved was simply false.

## Validation

- `NEXUS_RUN_POSTGRES=1 poetry run pytest tests/test_api/test_orrery_dev_endpoints.py -q` → **19 passed** against live save_05 (previously 1 failed), pipefail-honest exit 0.
- black/flake8 clean on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwQAcSeuSfJAcjUvxVzadv