### PR TITLE
Track native Codex adversarial QA shift utility

### DIFF
--- a/scripts/qa_shift/README.md
+++ b/scripts/qa_shift/README.md
@@ -83,7 +83,9 @@ Exit code `0` means generation may continue. Exit code `2` means stop
 generating and report. Exit code `1` means the guard itself could not establish
 a trustworthy reading, which is also a stop. Checks are appended to
 `usage_checks.jsonl`; `shift_state.json`, `usage_start.json`, and
-`usage_end.json` provide the end-to-end tally.
+`usage_end.json` provide the end-to-end tally. If UTC midnight interrupts a
+shift, `finish` explicitly re-reads the archived quota day rather than mixing
+the new day’s cumulative total with the old baseline.
 
 ## Safety boundary
 

--- a/scripts/qa_shift/README.md
+++ b/scripts/qa_shift/README.md
@@ -1,0 +1,94 @@
+# NEXUS adversarial QA shift
+
+This tracked utility turns the previous one-off `temp/qa_shift` experiment into
+a repeatable native Codex Scheduled task. The operator remains Codex itself;
+there is no nested `codex exec`, launchd plist, systemd unit, or six-hour shell
+wrapper.
+
+Run evidence still belongs in ignored `temp/qa_night_*` archives. The durable
+policy, usage guard, configuration, and templates live here in version control.
+
+## Schedule it in Codex
+
+Create a recurring standalone task that uses the local project at
+`/Users/pythagor/nexus`. A nightly 11:30 PM `America/Chicago` start leaves the
+normal workday alone and avoids the OpenAI UTC-day boundary during the
+configured one-hour shift.
+
+Use this task prompt:
+
+```text
+Open /Users/pythagor/nexus/scripts/qa_shift/mission_prompt.md and execute the
+NEXUS Night QA Shift exactly as written. Issue publication is explicitly
+authorized.
+```
+
+The machine must be awake, the Codex app must be running, and the scheduled
+task must have the shell, local-filesystem, network, PostgreSQL, Keychain, and
+GitHub access needed by the mission. Run the prompt once manually before
+enabling recurrence.
+
+## Completion policy
+
+Defaults in `qa_shift.toml` deliberately combine independent bounds:
+
+- at most five verified, published issues;
+- three consecutive dry probe families, after at least five total families;
+- a 60-minute wall clock; and
+- a 10,000,000-token daily allowance with a 1,000,000-token reserve.
+
+The issue count is a cap, not a quota. The dry-well rule lets a healthy build
+finish without manufacturing bugs, while the token and time fences remain
+backstops.
+
+The 10M figure is operational configuration, not a billing entitlement
+discovery mechanism. Reconfirm the organization’s current complimentary-token
+enrollment and eligible model group before raising it or changing
+`target_model`.
+
+## Usage guard
+
+Run the helper through Poetry:
+
+```text
+poetry run python scripts/qa_shift/qa_shift.py config
+poetry run python scripts/qa_shift/qa_shift.py begin
+poetry run python scripts/qa_shift/qa_shift.py check temp/qa_night_...
+poetry run python scripts/qa_shift/qa_shift.py check temp/qa_night_... --expect-call
+poetry run python scripts/qa_shift/qa_shift.py finish temp/qa_night_... --exit-condition dry_well
+```
+
+`begin` creates the archive, captures the UTC-day baseline, copies the report
+and ledger templates, and generates an isolated runtime config. That config
+pins both the default and Gaia OpenAI roles to the configured target model and
+sets the slot default to the same model. It never edits `nexus.toml`.
+
+The ledger is exact for API responses recorded by this NEXUS checkout; it is
+not the OpenAI organization-wide usage meter. Concurrent NEXUS traffic is
+conservatively included in the shift delta, while API calls made outside NEXUS
+are invisible. Run the shift when no other API client is drawing on the same
+allowance, or reduce the configured limit to leave room for that traffic.
+
+Each `check` calls `nexus usage --json` and records:
+
+- the OpenAI delta since the previous check;
+- the provider-reported token fields for each new QA-slot API response;
+- cumulative shift and UTC-day totals;
+- the largest check-to-check delta;
+- events and effective model routes for the QA slot;
+- remaining room before the token fence; and
+- elapsed wall time.
+
+Exit code `0` means generation may continue. Exit code `2` means stop
+generating and report. Exit code `1` means the guard itself could not establish
+a trustworthy reading, which is also a stop. Checks are appended to
+`usage_checks.jsonl`; `shift_state.json`, `usage_start.json`, and
+`usage_end.json` provide the end-to-end tally.
+
+## Safety boundary
+
+The configured lane is disposable slot 3 on port 8012. The mission prompt
+forbids touching the normal port-8002 runtime, changing tracked source, or
+filing anything weaker than a reproduced and deduplicated issue. A pre-shift
+database dump is retained because the final QA state is intentionally left
+available for diagnosis.

--- a/scripts/qa_shift/__init__.py
+++ b/scripts/qa_shift/__init__.py
@@ -1,0 +1,1 @@
+"""Tracked tooling for unattended NEXUS adversarial QA shifts."""

--- a/scripts/qa_shift/mission_prompt.md
+++ b/scripts/qa_shift/mission_prompt.md
@@ -1,0 +1,145 @@
+# NEXUS Night QA Shift — Adversarial Goal Loop
+
+You are the night-shift QA operator for NEXUS. Work directly in
+`/Users/pythagor/nexus`. This is the prompt for a native Codex Scheduled task:
+do not run `codex exec`, launch another Codex task, or delegate the mission.
+
+Issue publication is explicitly authorized. Source changes, commits, pushes,
+and pull requests are not authorized during this QA mission.
+
+## Objective and exit policy
+
+Publish up to the configured verified-issue budget, stopping at the first of:
+
+1. the issue budget is reached;
+2. the dry well is reached;
+3. the usage guard says `stop` or cannot produce a trustworthy reading;
+4. the wall-clock guard fires; or
+5. an environmental blocker prevents safe testing.
+
+The issue budget is a ceiling, not pressure to invent findings. The dry well is
+the co-primary completion rule: it requires the configured number of
+consecutive, distinct probe families with no promotable finding, and it cannot
+fire until the configured minimum number of families has been completed. A
+published issue resets the dry-well streak. An unresolved anomaly is neither a
+finding nor a dry family; resolve it or report it as a blocker.
+
+Read `scripts/qa_shift/qa_shift.toml` for the authoritative slot, lane, model,
+issue, dry-well, wall-clock, and token settings.
+
+## Hard boundaries
+
+- Use only the configured disposable slot and gateway port. Never stop, query,
+  or mutate another slot or the normal port-8002 runtime.
+- Use the generated isolated runtime config and configured `target_model` for
+  every remote-model call. Verify effective routing from usage events and
+  generation metadata/logs, not configuration alone.
+- Do not edit tracked source, install dependencies, commit, push, or open PRs.
+- Run public NEXUS CLI/API behavior as a human player. SQL and source reads are
+  verification tools, not substitutes for public reproduction.
+- Preserve evidence under the run archive in ignored `temp/`.
+- Do not weaken, bypass, estimate around, or continue past the usage guard.
+
+## Preflight and run initialization
+
+1. Confirm `git status --short --branch` is clean and on `main`.
+2. Run `git fetch origin`. If clean `main` is merely behind, fast-forward it
+   with `git merge --ff-only origin/main`. Stop on divergence or local changes.
+3. Confirm `gh auth status` and read all open and closed issues plus recent
+   merged PRs before promoting any finding.
+4. Run:
+
+   ```text
+   poetry run python scripts/qa_shift/qa_shift.py config
+   poetry run python scripts/qa_shift/qa_shift.py begin
+   ```
+
+   Record the exact archive path returned by `begin`. It contains
+   `runtime_env.sh`, the isolated `nexus.qa.toml`, a probe ledger, report
+   template, usage baseline, and shift state. Source `runtime_env.sh` in every
+   later runtime/QA shell.
+5. Run the default pytest suite against the checked-in config (explicitly
+   without `NEXUS_RUNTIME_CONFIG`) and save its complete output in the archive.
+   A baseline failure is a candidate, not permission to patch it.
+6. Stop only the isolated QA lane if it is stale. Back up `save_03` with
+   `pg_dump -Fc`, checksum the dump, reset only the configured slot through
+   `scripts/new_story_setup.py --force`, start the isolated gateway, and verify
+   its health and effective model. Save the commands and outputs.
+
+If any preflight step fails, write the blocker into the mission report, perform
+the applicable teardown, and stop.
+
+## Exact usage protocol
+
+The guard reads the provider-reported ledger added in PR #627. Around every
+command that can call a remote model:
+
+1. Run
+   `poetry run python scripts/qa_shift/qa_shift.py check ARCHIVE` immediately
+   before the command.
+2. If its status is not `continue`, make no remote request.
+3. Run one public CLI/API command, explicitly selecting the configured model
+   wherever the surface accepts a model override.
+4. Run
+   `poetry run python scripts/qa_shift/qa_shift.py check ARCHIVE --expect-call`
+   immediately afterward.
+5. Record the returned per-command delta in the probe ledger.
+
+The post-call check fails closed when no matching slot/model event appears,
+when routing leaves the configured provider/model, when any OpenAI response has
+unknown usage, at UTC-day rollover, at the token fence, or at the wall-clock
+limit. One NEXUS command may make several provider attempts; their sum is the
+command delta. The ledger is exact for NEXUS calls recorded by this checkout,
+not an organization-wide Platform meter. Count any known non-NEXUS API usage
+against the configured limit before starting. Read-only commands that cannot
+call a model do not need an `--expect-call` check.
+
+## Probe-family standard
+
+Behave like an unhinged, unpredictable, but honest user. Vary malformed,
+contradictory, free-text, adversarial, concurrency, undo/regenerate, and
+continuity-sensitive inputs. A probe family is distinct only when it tests a
+different public contract or state transition, not a cosmetic prompt variant.
+
+For every family:
+
+- exercise the public CLI/API and at least one adversarial variant;
+- inspect PostgreSQL and the isolated gateway log for the resulting state;
+- record negative results as well as anomalies in `probe_ledger.md`;
+- compare against all existing issues, open or closed, and relevant recent PRs;
+- do not promote model taste, expected nondeterminism, or an unreproduced
+  oddity.
+
+A publishable issue requires:
+
+- a repeatable public reproduction;
+- expected versus actual behavior and user impact;
+- PostgreSQL and gateway-log evidence;
+- likely-cause source locations;
+- explicit acceptance criteria;
+- deduplication notes; and
+- a final line identifying Codex and the model actually running the scheduled
+  task (for example, `Codex — GPT-5.6-Sol`; do not copy that model name if it
+  is no longer true).
+
+Create it with `gh issue create`, then re-read the published issue and verify
+its URL, body, labels/state if used, and signature. Update the ledger only
+after publication succeeds.
+
+## Teardown and report
+
+Always complete teardown, including early exits:
+
+1. Copy the isolated gateway log into the archive before stopping that lane.
+2. Stop only the configured QA gateway. Do not restore the disposable slot
+   automatically; preserve its final state for follow-up and retain the
+   checksummed pre-shift dump.
+3. Run
+   `poetry run python scripts/qa_shift/qa_shift.py finish ARCHIVE
+   --exit-condition CONDITION`, selecting the truthful configured condition.
+4. Complete `mission_report.md` with checkout and suite baseline, issue links,
+   probe-family negative results, evidence inventory, start/end/delta/max
+   usage, exit condition, and final lane/slot disposition.
+5. Return a concise scheduled-task result with the report path and issue links.
+
+The report is mandatory even if zero issues are published.

--- a/scripts/qa_shift/mission_report_template.md
+++ b/scripts/qa_shift/mission_report_template.md
@@ -1,0 +1,43 @@
+# NEXUS Night QA — mission report
+
+Status: in progress.
+
+## Baseline
+
+- Checkout:
+- Default suite:
+- GitHub issue/PR preflight:
+- Isolated lane:
+- Pre-shift backup and checksum:
+- Usage at start:
+
+## Published issues
+
+None yet.
+
+## Probe families
+
+Summarize both failures and negative results from `probe_ledger.md`.
+
+## Preserved evidence
+
+- `gateway-8012.log`:
+- `save_03_before.dump`:
+- Additional payloads/traces:
+
+## Usage
+
+- UTC quota day:
+- Start daily total:
+- End daily total:
+- Shift delta:
+- Largest model-generating command delta:
+- Unknown-usage events:
+
+## Exit
+
+- Exit condition:
+- Issue count:
+- Completed probe families:
+- Final dry-well streak:
+- Slot/gateway disposition:

--- a/scripts/qa_shift/probe_ledger_template.md
+++ b/scripts/qa_shift/probe_ledger_template.md
@@ -1,0 +1,7 @@
+# Probe ledger
+
+The dry-well streak counts only completed, distinct probe families. An
+unresolved anomaly is not a dry family.
+
+| # | Probe family | Public surface and adversarial variants | DB/log verification | Outcome | Issue |
+|---|---|---|---|---|---|

--- a/scripts/qa_shift/qa_shift.py
+++ b/scripts/qa_shift/qa_shift.py
@@ -1,0 +1,655 @@
+#!/usr/bin/env python3
+"""Prepare and enforce the mechanical boundaries of a NEXUS QA shift.
+
+The native Codex Scheduled task is the operator. This utility does not launch
+another Codex process. It creates a per-run archive and isolated runtime
+configuration, then wraps ``nexus usage --json`` with a fail-closed guard.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tomllib
+from typing import Any, Callable, Mapping, Sequence, cast
+
+import tomlkit
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG_PATH = Path(__file__).with_name("qa_shift.toml")
+STATE_FILE = "shift_state.json"
+CHECKS_FILE = "usage_checks.jsonl"
+STOP_EXIT_CODE = 2
+
+
+class ShiftError(RuntimeError):
+    """Raised when the QA shift cannot continue safely."""
+
+
+@dataclass(frozen=True)
+class ShiftConfig:
+    """Validated, durable QA shift settings."""
+
+    slot: int
+    gateway_port: int
+    target_model: str
+    issue_budget: int
+    minimum_probe_families: int
+    dry_well_families: int
+    wall_clock_minutes: int
+    archive_root: Path
+    daily_token_limit: int
+    reserve_tokens: int
+
+    @property
+    def token_fence(self) -> int:
+        """Return the daily total at which generation must stop."""
+
+        return self.daily_token_limit - self.reserve_tokens
+
+
+UsageReader = Callable[[Path], dict[str, Any]]
+
+
+def _required_int(table: Mapping[str, Any], key: str) -> int:
+    value = table.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ShiftError(f"{key} must be an integer")
+    return value
+
+
+def _required_str(table: Mapping[str, Any], key: str) -> str:
+    value = table.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ShiftError(f"{key} must be a non-empty string")
+    return value
+
+
+def load_shift_config(path: Path = DEFAULT_CONFIG_PATH) -> ShiftConfig:
+    """Load and validate the tracked QA shift configuration."""
+
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ShiftError(f"Cannot read QA shift config {path}: {exc}") from exc
+
+    shift = raw.get("shift")
+    usage = raw.get("usage")
+    if not isinstance(shift, dict) or not isinstance(usage, dict):
+        raise ShiftError("qa_shift.toml requires [shift] and [usage] tables")
+
+    config = ShiftConfig(
+        slot=_required_int(shift, "slot"),
+        gateway_port=_required_int(shift, "gateway_port"),
+        target_model=_required_str(shift, "target_model"),
+        issue_budget=_required_int(shift, "issue_budget"),
+        minimum_probe_families=_required_int(shift, "minimum_probe_families"),
+        dry_well_families=_required_int(shift, "dry_well_families"),
+        wall_clock_minutes=_required_int(shift, "wall_clock_minutes"),
+        archive_root=Path(_required_str(shift, "archive_root")),
+        daily_token_limit=_required_int(usage, "daily_token_limit"),
+        reserve_tokens=_required_int(usage, "reserve_tokens"),
+    )
+
+    if config.slot not in range(2, 6):
+        raise ShiftError("slot must be one of the disposable slots 2-5")
+    if not 1024 <= config.gateway_port <= 65535:
+        raise ShiftError("gateway_port must be between 1024 and 65535")
+    if config.gateway_port == 8002:
+        raise ShiftError("gateway_port 8002 is the normal runtime, not a QA lane")
+    for field_name in (
+        "issue_budget",
+        "minimum_probe_families",
+        "dry_well_families",
+        "wall_clock_minutes",
+        "daily_token_limit",
+        "reserve_tokens",
+    ):
+        if getattr(config, field_name) <= 0:
+            raise ShiftError(f"{field_name} must be positive")
+    if config.reserve_tokens >= config.daily_token_limit:
+        raise ShiftError("reserve_tokens must be smaller than daily_token_limit")
+    return config
+
+
+def _config_payload(config: ShiftConfig) -> dict[str, Any]:
+    payload = asdict(config)
+    payload["archive_root"] = str(config.archive_root)
+    payload["token_fence"] = config.token_fence
+    return payload
+
+
+def _read_usage(repo_root: Path) -> dict[str, Any]:
+    """Read exact provider-reported usage through the public NEXUS CLI."""
+
+    try:
+        completed = subprocess.run(
+            ["nexus", "usage", "--json"],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise ShiftError(
+            "The nexus executable is unavailable; run this utility with "
+            "`poetry run python`."
+        ) from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise ShiftError(f"`nexus usage --json` failed: {detail}")
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise ShiftError("`nexus usage --json` returned invalid JSON") from exc
+    if payload.get("success") is not True:
+        raise ShiftError(f"`nexus usage --json` reported failure: {payload}")
+    return payload
+
+
+def _usage_snapshot(payload: Mapping[str, Any]) -> dict[str, Any]:
+    usage = payload.get("usage")
+    if not isinstance(usage, dict):
+        raise ShiftError("Usage payload has no object at .usage")
+    openai = usage.get("openai_day_total")
+    events = usage.get("events")
+    day = usage.get("day")
+    if not isinstance(openai, dict):
+        raise ShiftError("Usage payload has no .usage.openai_day_total object")
+    if not isinstance(events, list):
+        raise ShiftError("Usage payload has no .usage.events list")
+    if not isinstance(day, str):
+        raise ShiftError("Usage payload has no string at .usage.day")
+
+    total = openai.get("total_tokens")
+    unknown = openai.get("unknown_usage_events")
+    if isinstance(total, bool) or not isinstance(total, int):
+        raise ShiftError("OpenAI total_tokens is not an integer")
+    if isinstance(unknown, bool) or not isinstance(unknown, int):
+        raise ShiftError("OpenAI unknown_usage_events is not an integer")
+    return {
+        "day": day,
+        "total": total,
+        "unknown": unknown,
+        "events": events,
+    }
+
+
+def _utc_text(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_utc(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ShiftError(f"Invalid shift timestamp {value!r}") from exc
+    if parsed.tzinfo is None:
+        raise ShiftError(f"Shift timestamp lacks an offset: {value!r}")
+    return parsed.astimezone(timezone.utc)
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def _append_jsonl(path: Path, payload: Mapping[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+        handle.write("\n")
+
+
+def _new_archive(root: Path, now: datetime) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    stem = f"qa_night_{now.astimezone(timezone.utc):%Y-%m-%d_%H%M%SZ}"
+    for suffix in ("", *[f"_{index}" for index in range(2, 100)]):
+        candidate = root / f"{stem}{suffix}"
+        try:
+            candidate.mkdir()
+        except FileExistsError:
+            continue
+        return candidate
+    raise ShiftError(f"Could not allocate a unique archive under {root}")
+
+
+def _write_runtime_config(
+    *,
+    repo_root: Path,
+    archive: Path,
+    config: ShiftConfig,
+) -> Path:
+    source = repo_root / "nexus.toml"
+    try:
+        document = tomlkit.parse(source.read_text(encoding="utf-8"))
+        dynamic_document = cast(Any, document)
+        model = dynamic_document["global"]["model"]
+        openai = model["api_models"]["openai"]
+        registered = {
+            entry["id"]
+            for entry in openai["models"]
+            if isinstance(entry, dict) and isinstance(entry.get("id"), str)
+        }
+    except (KeyError, OSError, TypeError, tomlkit.exceptions.ParseError) as exc:
+        raise ShiftError(f"Cannot derive isolated config from {source}: {exc}") from exc
+    if config.target_model not in registered:
+        raise ShiftError(
+            f"Target model {config.target_model!r} is not registered in {source}"
+        )
+
+    model["default_slot_model"] = config.target_model
+    openai["roles"]["default"] = config.target_model
+    openai["roles"]["gaia"] = config.target_model
+    dynamic_document["usage"]["daily_allowance"]["openai"] = config.daily_token_limit
+
+    destination = archive / "nexus.qa.toml"
+    destination.write_text(tomlkit.dumps(document), encoding="utf-8")
+    return destination
+
+
+def _write_environment(
+    *,
+    archive: Path,
+    runtime_config: Path,
+    config: ShiftConfig,
+) -> Path:
+    environment = archive / "runtime_env.sh"
+    values = {
+        "NEXUS_RUNTIME_CONFIG": str(runtime_config.resolve()),
+        "NEXUS_GATEWAY_PORT": str(config.gateway_port),
+        "NEXUS_API_URL": f"http://127.0.0.1:{config.gateway_port}",
+        "NEXUS_SLOT": str(config.slot),
+    }
+    lines = ["# Generated by scripts/qa_shift/qa_shift.py; source per shell."]
+    lines.extend(
+        f"export {name}={shlex.quote(value)}" for name, value in values.items()
+    )
+    environment.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    environment.chmod(0o700)
+    return environment
+
+
+def begin_shift(
+    *,
+    config: ShiftConfig,
+    repo_root: Path = REPO_ROOT,
+    usage_reader: UsageReader = _read_usage,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Create a shift archive, isolated config, and usage baseline."""
+
+    current_time = now or datetime.now(timezone.utc)
+    usage_payload = usage_reader(repo_root)
+    usage = _usage_snapshot(usage_payload)
+    if usage["unknown"]:
+        raise ShiftError(
+            "OpenAI usage already contains unknown events for this UTC day; "
+            "the complimentary-token fence cannot be trusted."
+        )
+    if usage["total"] >= config.token_fence:
+        raise ShiftError(
+            "OpenAI daily usage has reached the configured token fence "
+            f"({usage['total']:,} >= {config.token_fence:,})."
+        )
+
+    archive_root = config.archive_root
+    if not archive_root.is_absolute():
+        archive_root = repo_root / archive_root
+    archive = _new_archive(archive_root.resolve(), current_time)
+    runtime_config = _write_runtime_config(
+        repo_root=repo_root,
+        archive=archive,
+        config=config,
+    )
+    environment = _write_environment(
+        archive=archive,
+        runtime_config=runtime_config,
+        config=config,
+    )
+    utility_root = Path(__file__).resolve().parent
+    shutil.copyfile(
+        utility_root / "probe_ledger_template.md",
+        archive / "probe_ledger.md",
+    )
+    shutil.copyfile(
+        utility_root / "mission_report_template.md",
+        archive / "mission_report.md",
+    )
+    _atomic_write_json(archive / "usage_start.json", usage_payload)
+
+    state = {
+        "schema_version": 1,
+        "status": "active",
+        "started_at": _utc_text(current_time),
+        "quota_day": usage["day"],
+        "baseline_total": usage["total"],
+        "last_total": usage["total"],
+        "baseline_event_count": len(usage["events"]),
+        "last_event_count": len(usage["events"]),
+        "last_unknown_usage_events": usage["unknown"],
+        "checks": 0,
+        "max_command_delta": 0,
+        "config": _config_payload(config),
+    }
+    _atomic_write_json(archive / STATE_FILE, state)
+    result = {
+        "status": "ready",
+        "archive": str(archive),
+        "runtime_environment": str(environment),
+        "quota_day": usage["day"],
+        "daily_total": usage["total"],
+        "daily_limit": config.daily_token_limit,
+        "token_fence": config.token_fence,
+        "tokens_before_fence": config.token_fence - usage["total"],
+    }
+    _append_jsonl(
+        archive / CHECKS_FILE,
+        {"kind": "begin", "at": _utc_text(current_time), **result},
+    )
+    return result
+
+
+def _load_state(archive: Path) -> dict[str, Any]:
+    path = archive / STATE_FILE
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ShiftError(f"Cannot read shift state {path}: {exc}") from exc
+    if state.get("schema_version") != 1:
+        raise ShiftError(f"Unsupported shift state schema in {path}")
+    if state.get("status") != "active":
+        raise ShiftError(f"Shift state is not active: {state.get('status')!r}")
+    return state
+
+
+def evaluate_check(
+    *,
+    state: Mapping[str, Any],
+    usage_payload: Mapping[str, Any],
+    expect_call: bool,
+    now: datetime,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Evaluate one pre/post-call usage check without filesystem access."""
+
+    usage = _usage_snapshot(usage_payload)
+    config = state["config"]
+    reasons: list[str] = []
+    previous_total = int(state["last_total"])
+    previous_events = int(state["last_event_count"])
+    raw_delta = usage["total"] - previous_total
+    delta = max(0, raw_delta)
+
+    if usage["day"] != state["quota_day"]:
+        reasons.append("quota_day_changed")
+    if raw_delta < 0:
+        reasons.append("daily_total_decreased")
+    if len(usage["events"]) < previous_events:
+        reasons.append("event_count_decreased")
+        new_events: list[Any] = []
+    else:
+        new_events = usage["events"][previous_events:]
+
+    slot = int(config["slot"])
+    target_model = str(config["target_model"])
+    qa_events = [
+        event
+        for event in new_events
+        if isinstance(event, dict) and event.get("slot") == slot
+    ]
+    qa_api_calls = [
+        {
+            key: event.get(key)
+            for key in (
+                "request_id",
+                "run_id",
+                "seat",
+                "provider",
+                "model",
+                "attempt",
+                "outcome",
+                "input_tokens",
+                "output_tokens",
+                "total_tokens",
+            )
+        }
+        for event in qa_events
+    ]
+    expected_events = [
+        event
+        for event in qa_events
+        if event.get("provider") == "openai" and event.get("model") == target_model
+    ]
+    unexpected_routes = sorted(
+        {
+            f"{event.get('provider', 'unknown')}:{event.get('model', 'unknown')}"
+            for event in qa_events
+            if event.get("provider") != "openai" or event.get("model") != target_model
+        }
+    )
+    if unexpected_routes:
+        reasons.append("unexpected_qa_model_route")
+    if expect_call and not expected_events:
+        reasons.append("expected_usage_event_missing")
+    if usage["unknown"] > 0:
+        reasons.append("unknown_openai_usage")
+
+    token_fence = int(config["token_fence"])
+    if usage["total"] >= token_fence:
+        reasons.append("token_fence_reached")
+
+    started_at = _parse_utc(str(state["started_at"]))
+    elapsed_minutes = (now.astimezone(timezone.utc) - started_at).total_seconds() / 60
+    if elapsed_minutes >= int(config["wall_clock_minutes"]):
+        reasons.append("wall_clock_reached")
+
+    updated = dict(state)
+    updated.update(
+        {
+            "last_total": usage["total"],
+            "last_event_count": len(usage["events"]),
+            "last_unknown_usage_events": usage["unknown"],
+            "last_checked_at": _utc_text(now),
+            "checks": int(state["checks"]) + 1,
+            "max_command_delta": max(int(state["max_command_delta"]), delta),
+        }
+    )
+    result = {
+        "status": "stop" if reasons else "continue",
+        "reasons": reasons,
+        "quota_day": usage["day"],
+        "daily_total": usage["total"],
+        "daily_limit": int(config["daily_token_limit"]),
+        "daily_headroom": max(0, int(config["daily_token_limit"]) - usage["total"]),
+        "token_fence": token_fence,
+        "tokens_before_fence": max(0, token_fence - usage["total"]),
+        "openai_delta_since_last_check": delta,
+        "shift_openai_total": max(0, usage["total"] - int(state["baseline_total"])),
+        "max_command_delta": updated["max_command_delta"],
+        "elapsed_minutes": round(elapsed_minutes, 2),
+        "new_usage_events": len(new_events),
+        "qa_usage_events": len(qa_events),
+        "qa_api_calls": qa_api_calls,
+        "qa_models_seen": sorted(
+            {
+                str(event.get("model"))
+                for event in qa_events
+                if event.get("model") is not None
+            }
+        ),
+        "unexpected_routes": unexpected_routes,
+        "expect_call": expect_call,
+    }
+    return result, updated
+
+
+def check_shift(
+    *,
+    archive: Path,
+    expect_call: bool,
+    repo_root: Path = REPO_ROOT,
+    usage_reader: UsageReader = _read_usage,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Run and persist one fail-closed usage check."""
+
+    archive = archive.resolve()
+    state = _load_state(archive)
+    current_time = now or datetime.now(timezone.utc)
+    usage_payload = usage_reader(repo_root)
+    result, updated = evaluate_check(
+        state=state,
+        usage_payload=usage_payload,
+        expect_call=expect_call,
+        now=current_time,
+    )
+    _atomic_write_json(archive / STATE_FILE, updated)
+    _append_jsonl(
+        archive / CHECKS_FILE,
+        {
+            "kind": "post_call" if expect_call else "pre_call",
+            "at": _utc_text(current_time),
+            **result,
+        },
+    )
+    return result
+
+
+def finish_shift(
+    *,
+    archive: Path,
+    exit_condition: str,
+    repo_root: Path = REPO_ROOT,
+    usage_reader: UsageReader = _read_usage,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Capture final usage and close the shift state."""
+
+    archive = archive.resolve()
+    state = _load_state(archive)
+    current_time = now or datetime.now(timezone.utc)
+    usage_payload = usage_reader(repo_root)
+    usage = _usage_snapshot(usage_payload)
+    _atomic_write_json(archive / "usage_end.json", usage_payload)
+
+    final_delta = max(0, usage["total"] - int(state["last_total"]))
+    final_state = dict(state)
+    final_state.update(
+        {
+            "status": "finished",
+            "ended_at": _utc_text(current_time),
+            "exit_condition": exit_condition,
+            "final_total": usage["total"],
+            "final_unknown_usage_events": usage["unknown"],
+            "shift_openai_total": max(0, usage["total"] - int(state["baseline_total"])),
+            "max_command_delta": max(int(state["max_command_delta"]), final_delta),
+        }
+    )
+    _atomic_write_json(archive / STATE_FILE, final_state)
+    result = {
+        "status": "finished",
+        "exit_condition": exit_condition,
+        "quota_day": usage["day"],
+        "daily_total": usage["total"],
+        "shift_openai_total": final_state["shift_openai_total"],
+        "max_command_delta": final_state["max_command_delta"],
+        "unknown_usage_events": usage["unknown"],
+        "archive": str(archive),
+    }
+    _append_jsonl(
+        archive / CHECKS_FILE,
+        {"kind": "finish", "at": _utc_text(current_time), **result},
+    )
+    return result
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Prepare and guard a native Codex NEXUS QA shift"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    config_parser = subparsers.add_parser("config", help="Print effective settings")
+    config_parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG_PATH,
+        help="Tracked QA shift TOML",
+    )
+
+    begin_parser = subparsers.add_parser("begin", help="Create a guarded run")
+    begin_parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG_PATH,
+        help="Tracked QA shift TOML",
+    )
+
+    check_parser = subparsers.add_parser("check", help="Check the token fence")
+    check_parser.add_argument("archive", type=Path, help="Run archive from begin")
+    check_parser.add_argument(
+        "--expect-call",
+        action="store_true",
+        help="Fail closed unless the QA slot recorded a target-model event",
+    )
+
+    finish_parser = subparsers.add_parser("finish", help="Capture final usage")
+    finish_parser.add_argument("archive", type=Path, help="Run archive from begin")
+    finish_parser.add_argument(
+        "--exit-condition",
+        required=True,
+        choices=(
+            "issue_budget",
+            "dry_well",
+            "token_fence",
+            "wall_clock",
+            "blocked",
+            "manual",
+        ),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the QA shift helper CLI."""
+
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "config":
+            result = _config_payload(load_shift_config(args.config))
+        elif args.command == "begin":
+            result = begin_shift(config=load_shift_config(args.config))
+        elif args.command == "check":
+            result = check_shift(
+                archive=args.archive,
+                expect_call=args.expect_call,
+            )
+        elif args.command == "finish":
+            result = finish_shift(
+                archive=args.archive,
+                exit_condition=args.exit_condition,
+            )
+        else:
+            raise AssertionError(f"Unhandled command {args.command}")
+    except ShiftError as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}, indent=2))
+        return 1
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if args.command == "check" and result["status"] == "stop":
+        return STOP_EXIT_CODE
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qa_shift/qa_shift.py
+++ b/scripts/qa_shift/qa_shift.py
@@ -55,7 +55,7 @@ class ShiftConfig:
         return self.daily_token_limit - self.reserve_tokens
 
 
-UsageReader = Callable[[Path], dict[str, Any]]
+UsageReader = Callable[[Path, str | None], dict[str, Any]]
 
 
 def _required_int(table: Mapping[str, Any], key: str) -> int:
@@ -126,12 +126,15 @@ def _config_payload(config: ShiftConfig) -> dict[str, Any]:
     return payload
 
 
-def _read_usage(repo_root: Path) -> dict[str, Any]:
+def _read_usage(repo_root: Path, day: str | None = None) -> dict[str, Any]:
     """Read exact provider-reported usage through the public NEXUS CLI."""
 
+    command = ["nexus", "usage", "--json"]
+    if day is not None:
+        command.extend(["--day", day])
     try:
         completed = subprocess.run(
-            ["nexus", "usage", "--json"],
+            command,
             cwd=repo_root,
             check=False,
             capture_output=True,
@@ -241,20 +244,27 @@ def _write_runtime_config(
             for entry in openai["models"]
             if isinstance(entry, dict) and isinstance(entry.get("id"), str)
         }
+        if config.target_model not in registered:
+            raise ShiftError(
+                f"Target model {config.target_model!r} is not registered in {source}"
+            )
+
+        model["default_slot_model"] = config.target_model
+        openai["roles"]["default"] = config.target_model
+        openai["roles"]["gaia"] = config.target_model
+        dynamic_document["usage"]["daily_allowance"][
+            "openai"
+        ] = config.daily_token_limit
+    except ShiftError:
+        raise
     except (KeyError, OSError, TypeError, tomlkit.exceptions.ParseError) as exc:
         raise ShiftError(f"Cannot derive isolated config from {source}: {exc}") from exc
-    if config.target_model not in registered:
-        raise ShiftError(
-            f"Target model {config.target_model!r} is not registered in {source}"
-        )
-
-    model["default_slot_model"] = config.target_model
-    openai["roles"]["default"] = config.target_model
-    openai["roles"]["gaia"] = config.target_model
-    dynamic_document["usage"]["daily_allowance"]["openai"] = config.daily_token_limit
 
     destination = archive / "nexus.qa.toml"
-    destination.write_text(tomlkit.dumps(document), encoding="utf-8")
+    try:
+        destination.write_text(tomlkit.dumps(document), encoding="utf-8")
+    except (OSError, TypeError) as exc:
+        raise ShiftError(f"Cannot write isolated config {destination}: {exc}") from exc
     return destination
 
 
@@ -290,7 +300,7 @@ def begin_shift(
     """Create a shift archive, isolated config, and usage baseline."""
 
     current_time = now or datetime.now(timezone.utc)
-    usage_payload = usage_reader(repo_root)
+    usage_payload = usage_reader(repo_root, None)
     usage = _usage_snapshot(usage_payload)
     if usage["unknown"]:
         raise ShiftError(
@@ -387,18 +397,21 @@ def evaluate_check(
     reasons: list[str] = []
     previous_total = int(state["last_total"])
     previous_events = int(state["last_event_count"])
-    raw_delta = usage["total"] - previous_total
-    delta = max(0, raw_delta)
+    same_quota_day = usage["day"] == state["quota_day"]
+    raw_delta = usage["total"] - previous_total if same_quota_day else None
+    delta = max(0, raw_delta) if raw_delta is not None else None
 
-    if usage["day"] != state["quota_day"]:
+    if not same_quota_day:
         reasons.append("quota_day_changed")
-    if raw_delta < 0:
+    if raw_delta is not None and raw_delta < 0:
         reasons.append("daily_total_decreased")
-    if len(usage["events"]) < previous_events:
+    if same_quota_day and len(usage["events"]) < previous_events:
         reasons.append("event_count_decreased")
         new_events: list[Any] = []
-    else:
+    elif same_quota_day:
         new_events = usage["events"][previous_events:]
+    else:
+        new_events = usage["events"]
 
     slot = int(config["slot"])
     target_model = str(config["target_model"])
@@ -456,14 +469,27 @@ def evaluate_check(
     updated = dict(state)
     updated.update(
         {
-            "last_total": usage["total"],
-            "last_event_count": len(usage["events"]),
             "last_unknown_usage_events": usage["unknown"],
             "last_checked_at": _utc_text(now),
             "checks": int(state["checks"]) + 1,
-            "max_command_delta": max(int(state["max_command_delta"]), delta),
+            "max_command_delta": (
+                max(int(state["max_command_delta"]), delta)
+                if delta is not None
+                else int(state["max_command_delta"])
+            ),
         }
     )
+    if same_quota_day:
+        updated["last_total"] = usage["total"]
+        updated["last_event_count"] = len(usage["events"])
+    else:
+        updated.update(
+            {
+                "rollover_seen_at": _utc_text(now),
+                "rollover_day": usage["day"],
+                "rollover_day_total": usage["total"],
+            }
+        )
     result = {
         "status": "stop" if reasons else "continue",
         "reasons": reasons,
@@ -474,7 +500,11 @@ def evaluate_check(
         "token_fence": token_fence,
         "tokens_before_fence": max(0, token_fence - usage["total"]),
         "openai_delta_since_last_check": delta,
-        "shift_openai_total": max(0, usage["total"] - int(state["baseline_total"])),
+        "shift_openai_total": (
+            max(0, usage["total"] - int(state["baseline_total"]))
+            if same_quota_day
+            else None
+        ),
         "max_command_delta": updated["max_command_delta"],
         "elapsed_minutes": round(elapsed_minutes, 2),
         "new_usage_events": len(new_events),
@@ -506,7 +536,7 @@ def check_shift(
     archive = archive.resolve()
     state = _load_state(archive)
     current_time = now or datetime.now(timezone.utc)
-    usage_payload = usage_reader(repo_root)
+    usage_payload = usage_reader(repo_root, None)
     result, updated = evaluate_check(
         state=state,
         usage_payload=usage_payload,
@@ -538,8 +568,14 @@ def finish_shift(
     archive = archive.resolve()
     state = _load_state(archive)
     current_time = now or datetime.now(timezone.utc)
-    usage_payload = usage_reader(repo_root)
+    quota_day = str(state["quota_day"])
+    usage_payload = usage_reader(repo_root, quota_day)
     usage = _usage_snapshot(usage_payload)
+    if usage["day"] != quota_day:
+        raise ShiftError(
+            "Final usage reader returned the wrong quota day "
+            f"({usage['day']} != {quota_day})."
+        )
     _atomic_write_json(archive / "usage_end.json", usage_payload)
 
     final_delta = max(0, usage["total"] - int(state["last_total"]))
@@ -550,7 +586,11 @@ def finish_shift(
             "ended_at": _utc_text(current_time),
             "exit_condition": exit_condition,
             "final_total": usage["total"],
+            "final_usage_day": usage["day"],
             "final_unknown_usage_events": usage["unknown"],
+            "finished_after_quota_rollover": (
+                current_time.astimezone(timezone.utc).date().isoformat() != quota_day
+            ),
             "shift_openai_total": max(0, usage["total"] - int(state["baseline_total"])),
             "max_command_delta": max(int(state["max_command_delta"]), final_delta),
         }

--- a/scripts/qa_shift/qa_shift.toml
+++ b/scripts/qa_shift/qa_shift.toml
@@ -1,0 +1,24 @@
+[shift]
+# Slot 3 and port 8012 are the disposable QA lane. Never point this utility at
+# the normal port-8002 runtime.
+slot = 3
+gateway_port = 8012
+target_model = "gpt-5.6-terra" # pin: complimentary QA model group
+
+# The issue budget is a ceiling, not pressure to manufacture findings.
+issue_budget = 5
+minimum_probe_families = 5
+dry_well_families = 3
+wall_clock_minutes = 60
+
+# Run artifacts remain intentionally transient even though this utility is
+# tracked. Paths are resolved from the repository root.
+archive_root = "temp"
+
+[usage]
+# Working allowance for the owner's current complimentary-token enrollment.
+# Reconfirm current program terms before changing this value or target_model.
+# The guard stops one million tokens early so a multi-call NEXUS command cannot
+# casually cross the allowance before its post-command check.
+daily_token_limit = 10000000
+reserve_tokens = 1000000

--- a/tests/test_qa_shift.py
+++ b/tests/test_qa_shift.py
@@ -108,7 +108,7 @@ def test_begin_creates_archive_and_pins_every_openai_role(
     config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
     result = qa_shift.begin_shift(
         config=config,
-        usage_reader=lambda _root: _usage(total=123),
+        usage_reader=lambda _root, _day: _usage(total=123),
         now=NOW,
     )
 
@@ -129,6 +129,30 @@ def test_begin_creates_archive_and_pins_every_openai_role(
     assert (archive / "mission_report.md").exists()
 
 
+@pytest.mark.parametrize("missing_table", ("roles", "daily_allowance"))
+def test_runtime_config_shape_errors_are_clean_shift_errors(
+    tmp_path: Path,
+    missing_table: str,
+) -> None:
+    repo = tmp_path / "repo"
+    archive = tmp_path / "archive"
+    repo.mkdir()
+    archive.mkdir()
+    document = tomlkit.parse((qa_shift.REPO_ROOT / "nexus.toml").read_text())
+    if missing_table == "roles":
+        del document["global"]["model"]["api_models"]["openai"]["roles"]
+    else:
+        del document["usage"]["daily_allowance"]
+    (repo / "nexus.toml").write_text(tomlkit.dumps(document))
+
+    with pytest.raises(qa_shift.ShiftError, match="Cannot derive isolated config"):
+        qa_shift._write_runtime_config(
+            repo_root=repo,
+            archive=archive,
+            config=qa_shift.load_shift_config(),
+        )
+
+
 def test_begin_refuses_untrustworthy_or_exhausted_usage(tmp_path: Path) -> None:
     config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
 
@@ -139,7 +163,7 @@ def test_begin_refuses_untrustworthy_or_exhausted_usage(tmp_path: Path) -> None:
         with pytest.raises(qa_shift.ShiftError):
             qa_shift.begin_shift(
                 config=config,
-                usage_reader=lambda _root, value=payload: value,
+                usage_reader=lambda _root, _day, value=payload: value,
                 now=NOW,
             )
 
@@ -221,7 +245,7 @@ def test_check_fails_closed_at_token_time_day_and_unknown_boundaries() -> None:
         expect_call=False,
         now=NOW + timedelta(minutes=60),
     )
-    rolled, _ = qa_shift.evaluate_check(
+    rolled, rolled_state = qa_shift.evaluate_check(
         state=state,
         usage_payload=_usage(total=100, day="2026-07-31"),
         expect_call=False,
@@ -237,6 +261,10 @@ def test_check_fails_closed_at_token_time_day_and_unknown_boundaries() -> None:
     assert "token_fence_reached" in fenced["reasons"]
     assert "wall_clock_reached" in timed["reasons"]
     assert "quota_day_changed" in rolled["reasons"]
+    assert rolled["shift_openai_total"] is None
+    assert rolled["openai_delta_since_last_check"] is None
+    assert rolled_state["last_total"] == 100
+    assert rolled_state["rollover_day"] == "2026-07-31"
     assert "unknown_openai_usage" in unknown["reasons"]
 
 
@@ -244,7 +272,7 @@ def test_check_and_finish_persist_end_to_end_tally(tmp_path: Path) -> None:
     config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
     begin = qa_shift.begin_shift(
         config=config,
-        usage_reader=lambda _root: _usage(total=100),
+        usage_reader=lambda _root, _day: _usage(total=100),
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -253,13 +281,13 @@ def test_check_and_finish_persist_end_to_end_tally(tmp_path: Path) -> None:
     check = qa_shift.check_shift(
         archive=archive,
         expect_call=True,
-        usage_reader=lambda _root: _usage(total=300, events=[first_event]),
+        usage_reader=lambda _root, _day: _usage(total=300, events=[first_event]),
         now=NOW + timedelta(minutes=1),
     )
     finish = qa_shift.finish_shift(
         archive=archive,
         exit_condition="dry_well",
-        usage_reader=lambda _root: _usage(total=350, events=[first_event]),
+        usage_reader=lambda _root, _day: _usage(total=350, events=[first_event]),
         now=NOW + timedelta(minutes=2),
     )
 
@@ -279,3 +307,44 @@ def test_check_and_finish_persist_end_to_end_tally(tmp_path: Path) -> None:
         "post_call",
         "finish",
     ]
+
+
+def test_finish_reads_original_quota_day_after_rollover(tmp_path: Path) -> None:
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+    begin = qa_shift.begin_shift(
+        config=config,
+        usage_reader=lambda _root, _day: _usage(total=100),
+        now=NOW,
+    )
+    archive = Path(begin["archive"])
+
+    rollover = qa_shift.check_shift(
+        archive=archive,
+        expect_call=False,
+        usage_reader=lambda _root, _day: _usage(
+            total=40,
+            day="2026-07-31",
+        ),
+        now=datetime(2026, 7, 31, 0, 1, tzinfo=timezone.utc),
+    )
+    requested_days: list[str | None] = []
+
+    def read_original_day(_root: Path, day: str | None) -> dict[str, object]:
+        requested_days.append(day)
+        return _usage(total=350, day="2026-07-30")
+
+    finish = qa_shift.finish_shift(
+        archive=archive,
+        exit_condition="token_fence",
+        usage_reader=read_original_day,
+        now=datetime(2026, 7, 31, 0, 2, tzinfo=timezone.utc),
+    )
+    state = json.loads((archive / "shift_state.json").read_text())
+
+    assert rollover["status"] == "stop"
+    assert "quota_day_changed" in rollover["reasons"]
+    assert requested_days == ["2026-07-30"]
+    assert finish["quota_day"] == "2026-07-30"
+    assert finish["shift_openai_total"] == 250
+    assert state["final_usage_day"] == "2026-07-30"
+    assert state["finished_after_quota_rollover"] is True

--- a/tests/test_qa_shift.py
+++ b/tests/test_qa_shift.py
@@ -1,0 +1,281 @@
+"""Regression tests for the tracked adversarial QA shift utility."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+
+import pytest
+import tomlkit
+
+from scripts.qa_shift import qa_shift
+
+
+NOW = datetime(2026, 7, 30, 4, 30, tzinfo=timezone.utc)
+
+
+def _event(
+    *,
+    model: str = "gpt-5.6-terra",
+    provider: str = "openai",
+    slot: int | None = 3,
+    total: int | None = 100,
+) -> dict[str, object]:
+    return {
+        "ts": "2026-07-30T04:31:00Z",
+        "quota_day": "2026-07-30",
+        "provider": provider,
+        "model": model,
+        "seat": "skald_single_pass",
+        "slot": slot,
+        "run_id": "run-one",
+        "attempt": 1,
+        "outcome": "accepted",
+        "transport": "responses",
+        "request_id": "resp-one",
+        "input_tokens": None if total is None else total - 10,
+        "output_tokens": None if total is None else 10,
+        "total_tokens": total,
+        "cached_input_tokens": None,
+        "cache_creation_tokens": None,
+        "reasoning_tokens": None,
+        "service_tier": "default",
+        "aggregate": False,
+        "requests": None,
+    }
+
+
+def _usage(
+    *,
+    total: int = 100,
+    unknown: int = 0,
+    events: list[dict[str, object]] | None = None,
+    day: str = "2026-07-30",
+) -> dict[str, object]:
+    return {
+        "success": True,
+        "usage": {
+            "day": day,
+            "events": events or [],
+            "providers": {},
+            "seats": {},
+            "openai_day_total": {
+                "total_tokens": total,
+                "unknown_usage_events": unknown,
+            },
+            "allowance": {},
+        },
+    }
+
+
+def _state(config: qa_shift.ShiftConfig) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "status": "active",
+        "started_at": "2026-07-30T04:30:00Z",
+        "quota_day": "2026-07-30",
+        "baseline_total": 100,
+        "last_total": 100,
+        "baseline_event_count": 0,
+        "last_event_count": 0,
+        "last_unknown_usage_events": 0,
+        "checks": 0,
+        "max_command_delta": 0,
+        "config": qa_shift._config_payload(config),
+    }
+
+
+def test_tracked_config_encodes_bounded_completion_policy() -> None:
+    config = qa_shift.load_shift_config()
+
+    assert config.slot == 3
+    assert config.gateway_port == 8012
+    assert config.target_model == "gpt-5.6-terra"
+    assert config.issue_budget == 5
+    assert config.minimum_probe_families == 5
+    assert config.dry_well_families == 3
+    assert config.wall_clock_minutes == 60
+    assert config.daily_token_limit == 10_000_000
+    assert config.reserve_tokens == 1_000_000
+    assert config.token_fence == 9_000_000
+
+
+def test_begin_creates_archive_and_pins_every_openai_role(
+    tmp_path: Path,
+) -> None:
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+    result = qa_shift.begin_shift(
+        config=config,
+        usage_reader=lambda _root: _usage(total=123),
+        now=NOW,
+    )
+
+    archive = Path(result["archive"])
+    state = json.loads((archive / "shift_state.json").read_text())
+    document = tomlkit.parse((archive / "nexus.qa.toml").read_text())
+    model = document["global"]["model"]
+    roles = model["api_models"]["openai"]["roles"]
+
+    assert state["baseline_total"] == 123
+    assert state["status"] == "active"
+    assert model["default_slot_model"] == "gpt-5.6-terra"
+    assert roles["default"] == "gpt-5.6-terra"
+    assert roles["gaia"] == "gpt-5.6-terra"
+    assert document["usage"]["daily_allowance"]["openai"] == 10_000_000
+    assert (archive / "runtime_env.sh").exists()
+    assert (archive / "probe_ledger.md").exists()
+    assert (archive / "mission_report.md").exists()
+
+
+def test_begin_refuses_untrustworthy_or_exhausted_usage(tmp_path: Path) -> None:
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+
+    for payload in (
+        _usage(total=100, unknown=1),
+        _usage(total=config.token_fence),
+    ):
+        with pytest.raises(qa_shift.ShiftError):
+            qa_shift.begin_shift(
+                config=config,
+                usage_reader=lambda _root, value=payload: value,
+                now=NOW,
+            )
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_post_call_check_reports_exact_delta_and_route() -> None:
+    config = qa_shift.load_shift_config()
+    event = _event(total=321)
+
+    result, updated = qa_shift.evaluate_check(
+        state=_state(config),
+        usage_payload=_usage(total=421, events=[event]),
+        expect_call=True,
+        now=NOW + timedelta(minutes=1),
+    )
+
+    assert result["status"] == "continue"
+    assert result["openai_delta_since_last_check"] == 321
+    assert result["shift_openai_total"] == 321
+    assert result["max_command_delta"] == 321
+    assert result["qa_models_seen"] == ["gpt-5.6-terra"]
+    assert result["unexpected_routes"] == []
+    assert result["qa_api_calls"] == [
+        {
+            "request_id": "resp-one",
+            "run_id": "run-one",
+            "seat": "skald_single_pass",
+            "provider": "openai",
+            "model": "gpt-5.6-terra",
+            "attempt": 1,
+            "outcome": "accepted",
+            "input_tokens": 311,
+            "output_tokens": 10,
+            "total_tokens": 321,
+        }
+    ]
+    assert updated["last_total"] == 421
+
+
+def test_post_call_check_fails_closed_on_missing_or_wrong_route() -> None:
+    config = qa_shift.load_shift_config()
+
+    missing, _ = qa_shift.evaluate_check(
+        state=_state(config),
+        usage_payload=_usage(total=100),
+        expect_call=True,
+        now=NOW + timedelta(minutes=1),
+    )
+    wrong, _ = qa_shift.evaluate_check(
+        state=_state(config),
+        usage_payload=_usage(
+            total=200,
+            events=[_event(model="gpt-5.6-sol")],
+        ),
+        expect_call=True,
+        now=NOW + timedelta(minutes=1),
+    )
+
+    assert missing["status"] == "stop"
+    assert "expected_usage_event_missing" in missing["reasons"]
+    assert wrong["status"] == "stop"
+    assert "unexpected_qa_model_route" in wrong["reasons"]
+
+
+def test_check_fails_closed_at_token_time_day_and_unknown_boundaries() -> None:
+    config = qa_shift.load_shift_config()
+    state = _state(config)
+
+    fenced, _ = qa_shift.evaluate_check(
+        state=state,
+        usage_payload=_usage(total=9_000_000),
+        expect_call=False,
+        now=NOW + timedelta(minutes=1),
+    )
+    timed, _ = qa_shift.evaluate_check(
+        state=state,
+        usage_payload=_usage(total=100),
+        expect_call=False,
+        now=NOW + timedelta(minutes=60),
+    )
+    rolled, _ = qa_shift.evaluate_check(
+        state=state,
+        usage_payload=_usage(total=100, day="2026-07-31"),
+        expect_call=False,
+        now=NOW + timedelta(minutes=1),
+    )
+    unknown, _ = qa_shift.evaluate_check(
+        state=state,
+        usage_payload=_usage(total=100, unknown=1),
+        expect_call=False,
+        now=NOW + timedelta(minutes=1),
+    )
+
+    assert "token_fence_reached" in fenced["reasons"]
+    assert "wall_clock_reached" in timed["reasons"]
+    assert "quota_day_changed" in rolled["reasons"]
+    assert "unknown_openai_usage" in unknown["reasons"]
+
+
+def test_check_and_finish_persist_end_to_end_tally(tmp_path: Path) -> None:
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+    begin = qa_shift.begin_shift(
+        config=config,
+        usage_reader=lambda _root: _usage(total=100),
+        now=NOW,
+    )
+    archive = Path(begin["archive"])
+    first_event = _event(total=200)
+
+    check = qa_shift.check_shift(
+        archive=archive,
+        expect_call=True,
+        usage_reader=lambda _root: _usage(total=300, events=[first_event]),
+        now=NOW + timedelta(minutes=1),
+    )
+    finish = qa_shift.finish_shift(
+        archive=archive,
+        exit_condition="dry_well",
+        usage_reader=lambda _root: _usage(total=350, events=[first_event]),
+        now=NOW + timedelta(minutes=2),
+    )
+
+    state = json.loads((archive / "shift_state.json").read_text())
+    checks = [
+        json.loads(line)
+        for line in (archive / "usage_checks.jsonl").read_text().splitlines()
+    ]
+    assert check["openai_delta_since_last_check"] == 200
+    assert finish["shift_openai_total"] == 250
+    assert finish["max_command_delta"] == 200
+    assert state["status"] == "finished"
+    assert state["exit_condition"] == "dry_well"
+    assert (archive / "usage_end.json").exists()
+    assert [entry["kind"] for entry in checks] == [
+        "begin",
+        "post_call",
+        "finish",
+    ]


### PR DESCRIPTION
## Summary

- replace the ignored one-off QA bundle with a tracked `scripts/qa_shift/` utility for native Codex Scheduled tasks
- add a configurable five-issue ceiling, five-family/three-dry-family completion policy, 60-minute wall clock, and 10M daily token budget with a 1M reserve
- wrap `nexus usage --json` with pre/post-call checks that persist per-response token fields, command deltas, shift totals, max command usage, model routing, UTC rollover, and fail-closed conditions
- generate an isolated runtime config that pins the disposable slot, default role, and Gaia role to the configured QA model without editing `nexus.toml`
- add durable mission/report/probe templates and scheduling documentation; remove the nested `codex exec`/launchd design

## Why

The previous assets were useful operational tooling but lived only under ignored `temp/`. A native scheduled task should read a versioned, reviewable mission contract while leaving only run evidence transient. The usage guard makes PR #627 actionable after every model-generating command and keeps the issue budget from becoming pressure to manufacture findings.

## Validation

- `poetry run pytest -q` — 2,016 passed, 461 skipped
- `poetry run pytest -q tests/test_qa_shift.py tests/test_usage_recorder.py` — 23 passed
- `poetry run black scripts/qa_shift/qa_shift.py tests/test_qa_shift.py`
- `poetry run flake8 scripts/qa_shift/qa_shift.py tests/test_qa_shift.py`
- `poetry run mypy scripts/qa_shift/qa_shift.py`
- commit hooks: Orrery package catalog and model-ID drift validation passed

## Configuration and data impact

No schema or canonical data changes. `scripts/qa_shift/qa_shift.toml` is the tracked policy surface. Each run writes ignored evidence under `temp/qa_night_*`, generates an isolated config copy, touches only disposable slot 3 / gateway 8012, and leaves the final slot state available with a checksummed pre-shift dump.

The usage fence is exact for calls recorded by this NEXUS checkout, not an organization-wide Platform meter; the documentation calls out concurrent and non-NEXUS traffic explicitly. UTC-rollover teardown re-reads the archived quota day so the final tally cannot silently mix two daily counters.

Codex — GPT-5.6-Sol