### PR TITLE
Use slot 4 for night QA

### DIFF
--- a/scripts/qa_shift/README.md
+++ b/scripts/qa_shift/README.md
@@ -89,7 +89,7 @@ the new day’s cumulative total with the old baseline.
 
 ## Safety boundary
 
-The configured lane is disposable slot 3 on port 8012. The mission prompt
+The configured lane is disposable slot 4 on port 8012. The mission prompt
 forbids touching the normal port-8002 runtime, changing tracked source, or
 filing anything weaker than a reproduced and deduplicated issue. A pre-shift
 database dump is retained because the final QA state is intentionally left

--- a/scripts/qa_shift/mission_prompt.md
+++ b/scripts/qa_shift/mission_prompt.md
@@ -61,7 +61,7 @@ issue, dry-well, wall-clock, and token settings.
 5. Run the default pytest suite against the checked-in config (explicitly
    without `NEXUS_RUNTIME_CONFIG`) and save its complete output in the archive.
    A baseline failure is a candidate, not permission to patch it.
-6. Stop only the isolated QA lane if it is stale. Back up `save_03` with
+6. Stop only the isolated QA lane if it is stale. Back up `save_04` with
    `pg_dump -Fc`, checksum the dump, reset only the configured slot through
    `scripts/new_story_setup.py --force`, start the isolated gateway, and verify
    its health and effective model. Save the commands and outputs.

--- a/scripts/qa_shift/mission_report_template.md
+++ b/scripts/qa_shift/mission_report_template.md
@@ -22,7 +22,7 @@ Summarize both failures and negative results from `probe_ledger.md`.
 ## Preserved evidence
 
 - `gateway-8012.log`:
-- `save_03_before.dump`:
+- `save_04_before.dump`:
 - Additional payloads/traces:
 
 ## Usage

--- a/scripts/qa_shift/qa_shift.toml
+++ b/scripts/qa_shift/qa_shift.toml
@@ -1,7 +1,7 @@
 [shift]
-# Slot 3 and port 8012 are the disposable QA lane. Never point this utility at
+# Slot 4 and port 8012 are the disposable QA lane. Never point this utility at
 # the normal port-8002 runtime.
-slot = 3
+slot = 4
 gateway_port = 8012
 target_model = "gpt-5.6-terra" # pin: complimentary QA model group
 

--- a/tests/test_qa_shift.py
+++ b/tests/test_qa_shift.py
@@ -20,7 +20,7 @@ def _event(
     *,
     model: str = "gpt-5.6-terra",
     provider: str = "openai",
-    slot: int | None = 3,
+    slot: int | None = 4,
     total: int | None = 100,
 ) -> dict[str, object]:
     return {
@@ -90,7 +90,7 @@ def _state(config: qa_shift.ShiftConfig) -> dict[str, object]:
 def test_tracked_config_encodes_bounded_completion_policy() -> None:
     config = qa_shift.load_shift_config()
 
-    assert config.slot == 3
+    assert config.slot == 4
     assert config.gateway_port == 8012
     assert config.target_model == "gpt-5.6-terra"
     assert config.issue_budget == 5


### PR DESCRIPTION
## Summary
- move the nightly adversarial QA lane from slot 3 to slot 4
- update the backup/report guidance to use `save_04`
- keep the isolated gateway on port 8012
- update the QA utility regression fixture and contract assertion

## Validation
- `poetry run pytest tests/test_qa_shift.py -q` (10 passed)
- `poetry run python scripts/qa_shift/qa_shift.py config` (reports slot 4)
- `git diff --check`

## Impact
No schema changes. The scheduled task will reset and exercise disposable slot 4 while leaving the normal port-8002 runtime and other slots untouched.

Codex — GPT-5.6-Sol