### PR TITLE
Fix correspondence compaction and faction update validation

### DIFF
--- a/nexus/agents/logon/orrery_tag_validation.py
+++ b/nexus/agents/logon/orrery_tag_validation.py
@@ -1,4 +1,4 @@
-"""Generation-time registry validation for storyteller Orrery vocabulary.
+"""Generation-time registry validation for storyteller output.
 
 Skald freely invents tag names (often ``category:name`` composites) when
 updating state or emitting ``new_entities`` declaration hints. The
@@ -6,9 +6,11 @@ closed-vocabulary tag writers hard-error on unknown names -- but they run
 inside the chunk COMMIT transaction, where the only outcome is a dead player
 turn (M9 gate finding).
 
-This module walks a parsed storyteller response and validates every sparse tag
-delta and declaration hint against the live registry, so LOGON's structured
-output validator can hand issues back to the model while it still owns the turn.
+Faction update names have the same failure mode: prose aliases can look valid
+while failing the commit handler's exact canonical lookup. This module walks a
+parsed storyteller response and validates both identity and vocabulary fields
+against live registries, so LOGON's structured-output validator can hand issues
+back to the model while it still owns the turn.
 """
 
 from __future__ import annotations
@@ -120,6 +122,113 @@ def _bestowal_sites(response: Any) -> List[Tuple[str, str, OrreryTagBestowal]]:
     return sites
 
 
+def _faction_update_sites(
+    response: Any,
+) -> List[Tuple[str, Optional[int], Optional[str]]]:
+    """Return faction update identities from wire or hydrated responses."""
+
+    sites: List[Tuple[str, Optional[int], Optional[str]]] = []
+    updates = getattr(response, "updates", None)
+    if updates is not None:
+        for index, update in enumerate(getattr(updates, "factions", []) or []):
+            sites.append(
+                (
+                    f"updates.factions[{index}]",
+                    getattr(update, "id", None),
+                    getattr(update, "name", None),
+                )
+            )
+
+    state_updates = getattr(response, "state_updates", None)
+    if state_updates is not None:
+        for index, update in enumerate(getattr(state_updates, "factions", []) or []):
+            sites.append(
+                (
+                    f"state_updates.factions[{index}]",
+                    getattr(update, "faction_id", None),
+                    getattr(update, "faction_name", None),
+                )
+            )
+    return sites
+
+
+def collect_faction_identity_issues(
+    response: Any,
+    cur: Any,
+    *,
+    suggestion_limit: int = 3,
+) -> List[str]:
+    """Validate faction update identities before a draft reaches incubation.
+
+    Exact same-response faction declarations are allowed because the commit
+    transaction creates their canonical stubs before resolving state updates.
+    Every other update must resolve to an existing faction by exact name, and
+    a supplied ID/name pair must identify the same canonical row.
+    """
+
+    sites = _faction_update_sites(response)
+    if not sites:
+        return []
+
+    cur.execute("SELECT id, name FROM factions ORDER BY name, id")
+    rows = cur.fetchall()
+    names_by_id = {
+        int(_row_value(row, "id", 0)): str(_row_value(row, "name", 1)) for row in rows
+    }
+    ids_by_name: dict[str, List[int]] = {}
+    for catalog_id, catalog_name in names_by_id.items():
+        ids_by_name.setdefault(catalog_name, []).append(catalog_id)
+
+    declared_names = {
+        str(getattr(declaration, "name", ""))
+        for declaration in (getattr(response, "new_entities", None) or [])
+        if getattr(declaration, "kind", None) == "faction"
+    }
+    canonical_names = frozenset(ids_by_name)
+    issues: List[str] = []
+    for path, faction_id, faction_name in sites:
+        if faction_id is not None:
+            matched_name = names_by_id.get(faction_id)
+            if matched_name is None:
+                issues.append(f"{path}: Unknown canonical faction id {faction_id!r}")
+                continue
+            if faction_name != matched_name:
+                issues.append(
+                    f"{path}: Faction id {faction_id!r} is canonically named "
+                    f"{matched_name!r}, not {faction_name!r}"
+                )
+            continue
+
+        if not faction_name:
+            issues.append(f"{path}: Faction update requires an exact id or name")
+            continue
+        matching_ids = ids_by_name.get(faction_name, [])
+        if len(matching_ids) == 1:
+            continue
+        if len(matching_ids) > 1:
+            issues.append(
+                f"{path}: Canonical faction name {faction_name!r} is ambiguous; "
+                "supply its exact id"
+            )
+            continue
+        if faction_name in declared_names:
+            continue
+        issue = (
+            f"{path}: Unknown canonical faction name {faction_name!r}; use an "
+            "exact persisted name or declare a genuinely new faction in "
+            "new_entities"
+        )
+        issues.append(
+            _with_near_misses(
+                issue,
+                value=faction_name,
+                candidates=canonical_names,
+                suggestion_limit=suggestion_limit,
+            )
+        )
+    return issues
+
+
 def _validate_bestowal_against_vocabulary(
     *,
     entity_kind: str,
@@ -182,6 +291,14 @@ def _with_near_misses(
     if not matches:
         return issue
     return f"{issue}; did you mean: {', '.join(matches)}"
+
+
+def _row_value(row: Any, key: str, index: int) -> Any:
+    """Read one field from tuple- or mapping-shaped database rows."""
+
+    if hasattr(row, "get"):
+        return row[key]
+    return row[index]
 
 
 def _annotate_declaration_issues(
@@ -328,12 +445,12 @@ def build_storyteller_tag_validator(
     *,
     suggestion_limit: int = 3,
 ) -> Optional[Any]:
-    """Return an async pydantic_ai output validator bound to ``dbname``.
+    """Return an async registry output validator bound to ``dbname``.
 
     Returns ``None`` when no slot database is in scope (nothing to validate
-    against). The validator opens a short-lived pooled connection per
-    generation attempt and raises ``ModelRetry`` listing every invalid tag so
-    the model repairs the bestowal instead of killing the commit later.
+    against). The validator opens a short-lived pooled connection per generation
+    attempt and raises ``ModelRetry`` listing invalid vocabulary and faction
+    identities so the model repairs them instead of killing the commit later.
     """
 
     if not dbname:
@@ -355,20 +472,31 @@ def build_storyteller_tag_validator(
                     vocabulary=vocabulary,
                     suggestion_limit=suggestion_limit,
                 )
+                issues.extend(
+                    collect_faction_identity_issues(
+                        output,
+                        cur,
+                        suggestion_limit=suggestion_limit,
+                    )
+                )
         if issues:
             formatted = "\n".join(f"- {issue}" for issue in issues)
             logger.info(
-                "Storyteller Orrery vocabulary failed registry validation "
+                "Storyteller output failed registry validation "
                 "(%s issues); requesting model retry",
                 len(issues),
             )
             raise ModelRetry(
-                "Your Orrery tags, new-entity declaration hints, or replacement "
-                "event types failed closed-registry validation. For tags_add, "
-                "tags_clear, and tag_hints, use bare registered tag names only "
-                "(e.g. 'comfortable'), never 'category:name' composites. For "
-                "pair_tag_hints, use the exact registered pair-tag name; pair tags "
-                "may contain colons (e.g. 'contact:social'). For "
+                "Your Orrery tags, new-entity declaration hints, replacement "
+                "event types, or faction update identities failed closed-registry "
+                "validation. For faction updates, use an exact persisted name "
+                "shown in the ENTITY DOSSIER (and its matching canonical id when "
+                "supplying one), or declare a genuinely new faction in "
+                "new_entities; drop an update with no canonical equivalent. "
+                "For tags_add, tags_clear, and tag_hints, use bare registered tag "
+                "names only (e.g. 'comfortable'), never 'category:name' "
+                "composites. For pair_tag_hints, use the exact registered pair-tag "
+                "name; pair tags may contain colons (e.g. 'contact:social'). For "
                 "replacement_event_type, use an exact registered event type. Drop "
                 "any value with no registered equivalent. A tags_add issue that "
                 "requires duration_override is not expressible on the storyteller "

--- a/nexus/agents/logon/orrery_tag_validation.py
+++ b/nexus/agents/logon/orrery_tag_validation.py
@@ -157,13 +157,15 @@ def collect_faction_identity_issues(
     cur: Any,
     *,
     suggestion_limit: int = 3,
+    allow_same_turn_faction_declarations: bool = False,
 ) -> List[str]:
     """Validate faction update identities before a draft reaches incubation.
 
-    Exact same-response faction declarations are allowed because the commit
-    transaction creates their canonical stubs before resolving state updates.
-    Every other update must resolve to an existing faction by exact name, and
-    a supplied ID/name pair must identify the same canonical row.
+    When runtime maturation is enabled, exact same-response faction declarations
+    are allowed because the commit transaction creates their canonical stubs
+    before resolving state updates. Every other update must resolve to an
+    existing faction by exact name, and a supplied ID/name pair must identify
+    the same canonical row.
     """
 
     sites = _faction_update_sites(response)
@@ -179,11 +181,15 @@ def collect_faction_identity_issues(
     for catalog_id, catalog_name in names_by_id.items():
         ids_by_name.setdefault(catalog_name, []).append(catalog_id)
 
-    declared_names = {
-        str(getattr(declaration, "name", ""))
-        for declaration in (getattr(response, "new_entities", None) or [])
-        if getattr(declaration, "kind", None) == "faction"
-    }
+    declared_names = (
+        {
+            str(getattr(declaration, "name", ""))
+            for declaration in (getattr(response, "new_entities", None) or [])
+            if getattr(declaration, "kind", None) == "faction"
+        }
+        if allow_same_turn_faction_declarations
+        else set()
+    )
     canonical_names = frozenset(ids_by_name)
     issues: List[str] = []
     for path, faction_id, faction_name in sites:
@@ -213,11 +219,10 @@ def collect_faction_identity_issues(
             continue
         if faction_name in declared_names:
             continue
-        issue = (
-            f"{path}: Unknown canonical faction name {faction_name!r}; use an "
-            "exact persisted name or declare a genuinely new faction in "
-            "new_entities"
-        )
+        resolution = "use an exact persisted name"
+        if allow_same_turn_faction_declarations:
+            resolution += " or declare a genuinely new faction in new_entities"
+        issue = f"{path}: Unknown canonical faction name {faction_name!r}; {resolution}"
         issues.append(
             _with_near_misses(
                 issue,
@@ -444,6 +449,7 @@ def build_storyteller_tag_validator(
     dbname: Optional[str],
     *,
     suggestion_limit: int = 3,
+    allow_same_turn_faction_declarations: bool = False,
 ) -> Optional[Any]:
     """Return an async registry output validator bound to ``dbname``.
 
@@ -477,10 +483,21 @@ def build_storyteller_tag_validator(
                         output,
                         cur,
                         suggestion_limit=suggestion_limit,
+                        allow_same_turn_faction_declarations=(
+                            allow_same_turn_faction_declarations
+                        ),
                     )
                 )
         if issues:
             formatted = "\n".join(f"- {issue}" for issue in issues)
+            declaration_guidance = (
+                "or declare a genuinely new faction in new_entities; "
+                if allow_same_turn_faction_declarations
+                else (
+                    "same-turn declarations cannot back faction updates while "
+                    "runtime maturation is disabled; "
+                )
+            )
             logger.info(
                 "Storyteller output failed registry validation "
                 "(%s issues); requesting model retry",
@@ -491,8 +508,8 @@ def build_storyteller_tag_validator(
                 "event types, or faction update identities failed closed-registry "
                 "validation. For faction updates, use an exact persisted name "
                 "shown in the ENTITY DOSSIER (and its matching canonical id when "
-                "supplying one), or declare a genuinely new faction in "
-                "new_entities; drop an update with no canonical equivalent. "
+                f"supplying one), {declaration_guidance}drop an update with no "
+                "canonical equivalent. "
                 "For tags_add, tags_clear, and tag_hints, use bare registered tag "
                 "names only (e.g. 'comfortable'), never 'category:name' "
                 "composites. For pair_tag_hints, use the exact registered pair-tag "

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -640,9 +640,10 @@ class LogonUtility:
 
         structured_output_retries = apex_settings.get("structured_output_retries", 3)
 
-        # Generation-time registry validation for Skald's orrery_tags: invalid
-        # names become a ModelRetry while the model still owns the turn,
-        # instead of a dead commit later (M9 gate finding).
+        # Generation-time registry validation for Skald's durable fields:
+        # invalid Orrery vocabulary and unresolved faction update identities
+        # become a ModelRetry while the model still owns the turn, instead of
+        # a dead commit later (M9 gate finding and issue #634).
         from nexus.agents.logon.orrery_tag_validation import (
             build_storyteller_tag_validator,
         )

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -51,6 +51,9 @@ from nexus.agents.orrery.tag_library import (  # noqa: E402
     format_tag_library_for_prompt,
 )
 from nexus.config.loader import get_provider_for_model, resolve_model_ref  # noqa: E402
+from nexus.config.settings_models import (  # noqa: E402
+    OrreryRetrogradeMaturationSettings,
+)
 from nexus.memory.context_state import is_retrograde_summary  # noqa: E402
 from nexus.memory.correspondence import (  # noqa: E402
     CorrespondenceDigestWire,
@@ -657,9 +660,18 @@ class LogonUtility:
         except Exception:
             validation_dbname = None
         tag_library_settings = apex_settings.get("tag_library") or {}
+        maturation_settings = OrreryRetrogradeMaturationSettings.model_validate(
+            (
+                ((self.settings.get("orrery") or {}).get("retrograde") or {}).get(
+                    "maturation"
+                )
+            )
+            or {}
+        )
         tag_output_validator = build_storyteller_tag_validator(
             validation_dbname,
             suggestion_limit=int(tag_library_settings.get("suggestion_limit", 3)),
+            allow_same_turn_faction_declarations=maturation_settings.enabled,
         )
         output_validator = tag_output_validator
         if not provider_bootstrap_mode:

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -670,7 +670,10 @@ def commit_incubator_to_database_sync(
             )
 
     if incubator.get("correspondence_writer_letter") is not None:
-        compact_accepted_correspondence_sync(conn, accepting_chunk_id=chunk_id)
+        _compact_accepted_correspondence_best_effort(
+            conn,
+            accepting_chunk_id=chunk_id,
+        )
 
     # Post-commit presence-roster drift audit (issue #567): read-only
     # diagnostics over the committed chunk, outside the transaction.
@@ -688,6 +691,35 @@ def commit_incubator_to_database_sync(
 
     logger.info("Successfully committed chunk %s from session %s", chunk_id, session_id)
     return chunk_id
+
+
+def _compact_accepted_correspondence_best_effort(
+    conn: Any,
+    *,
+    accepting_chunk_id: int,
+) -> bool:
+    """Compact after acceptance without misreporting the durable commit.
+
+    Compaction is derived from the append-only accepted correspondence journal.
+    If the provider or persistence step fails, leaving the digest absent is a
+    deterministic retry marker: the next accepted correspondence turn plans
+    compaction from the same uncompacted exchanges. The accepted narrative and
+    cleared incubator must therefore remain a successful commit.
+    """
+
+    try:
+        return compact_accepted_correspondence_sync(
+            conn,
+            accepting_chunk_id=accepting_chunk_id,
+        )
+    except Exception:
+        logger.exception(
+            "Correspondence compaction failed after chunk %s was durably "
+            "accepted; leaving the uncompacted journal intact for retry on "
+            "the next accepted correspondence turn",
+            accepting_chunk_id,
+        )
+        return False
 
 
 def compact_accepted_correspondence_sync(

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -326,6 +326,7 @@ def commit_incubator_to_database_sync(
                            llm_response_id, generation_model, status
                     FROM incubator
                     WHERE session_id = %s
+                    FOR UPDATE
                 """,
                     (session_id,),
                 )
@@ -654,6 +655,11 @@ def commit_incubator_to_database_sync(
                 cur.execute(
                     "DELETE FROM incubator WHERE session_id = %s", (session_id,)
                 )
+                if cur.rowcount != 1:
+                    raise RuntimeError(
+                        "Incubator ownership changed while committing session "
+                        f"{session_id}."
+                    )
                 logger.info("Cleared incubator for session %s", session_id)
 
     except Exception as e:

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -625,7 +625,7 @@ def _abandon_generation_owner(
         conn.close()
 
 
-async def _resolve_and_approve_pending(
+def _resolve_and_approve_pending_sync(
     *,
     slot: Optional[int],
     session_id: str,
@@ -633,9 +633,9 @@ async def _resolve_and_approve_pending(
     user_text: str,
     choice: Optional[int],
     accept_fate: bool,
-    background_tasks: BackgroundTasks,
 ) -> tuple[str, int]:
-    """Resolve a pending choice and approve it off the event-loop thread."""
+    """Resolve and approve a pending choice with worker-owned connection life."""
+
     from nexus.api.commit_handler_sync import commit_incubator_to_database_sync
 
     conn = get_db_connection(slot)
@@ -650,13 +650,7 @@ async def _resolve_and_approve_pending(
             connection=conn,
             incubator_session_id=session_id,
         )
-        approved_chunk_id = await asyncio.to_thread(
-            commit_incubator_to_database_sync,
-            conn,
-            session_id,
-            slot,
-        )
-        background_tasks.add_task(_run_post_commit_orrery_work, slot)
+        approved_chunk_id = commit_incubator_to_database_sync(conn, session_id, slot)
         return resolved_user_text, approved_chunk_id
     except HTTPException:
         conn.rollback()
@@ -670,6 +664,31 @@ async def _resolve_and_approve_pending(
         ) from exc
     finally:
         conn.close()
+
+
+async def _resolve_and_approve_pending(
+    *,
+    slot: Optional[int],
+    session_id: str,
+    chunk_id: int,
+    user_text: str,
+    choice: Optional[int],
+    accept_fate: bool,
+    background_tasks: BackgroundTasks,
+) -> tuple[str, int]:
+    """Resolve and approve without exposing the worker connection to cancellation."""
+
+    result = await asyncio.to_thread(
+        _resolve_and_approve_pending_sync,
+        slot=slot,
+        session_id=session_id,
+        chunk_id=chunk_id,
+        user_text=user_text,
+        choice=choice,
+        accept_fate=accept_fate,
+    )
+    background_tasks.add_task(_run_post_commit_orrery_work, slot)
+    return result
 
 
 # API Endpoints
@@ -1158,13 +1177,13 @@ def _run_post_commit_orrery_work(slot: Optional[int]) -> None:
     ).start()
 
 
-async def _approve_narrative_impl(
+def _approve_narrative_sync(
     session_id: str,
     commit: bool,
     slot: Optional[int],
-    background_tasks: Optional[BackgroundTasks] = None,
-):
-    """Internal implementation for approve narrative."""
+) -> Dict[str, Any]:
+    """Read or commit one incubator row with a worker-owned connection."""
+
     conn = get_db_connection(slot)
     try:
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
@@ -1182,16 +1201,7 @@ async def _approve_narrative_impl(
             from nexus.api.commit_handler_sync import commit_incubator_to_database_sync
 
             try:
-                # Commit to database
-                chunk_id = await asyncio.to_thread(
-                    commit_incubator_to_database_sync,
-                    conn,
-                    session_id,
-                    slot,
-                )
-                if background_tasks is not None:
-                    background_tasks.add_task(_run_post_commit_orrery_work, slot)
-
+                chunk_id = commit_incubator_to_database_sync(conn, session_id, slot)
                 return {
                     "status": "committed",
                     "message": f"Narrative committed as chunk {chunk_id}",
@@ -1212,6 +1222,25 @@ async def _approve_narrative_impl(
 
     finally:
         conn.close()
+
+
+async def _approve_narrative_impl(
+    session_id: str,
+    commit: bool,
+    slot: Optional[int],
+    background_tasks: Optional[BackgroundTasks] = None,
+):
+    """Approve a narrative without exposing the worker connection to cancellation."""
+
+    result = await asyncio.to_thread(
+        _approve_narrative_sync,
+        session_id,
+        commit,
+        slot,
+    )
+    if commit and background_tasks is not None:
+        background_tasks.add_task(_run_post_commit_orrery_work, slot)
+    return result
 
 
 @app.post("/api/narrative/select-choice", response_model=SelectChoiceResponse)

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -625,6 +625,28 @@ def _abandon_generation_owner(
         conn.close()
 
 
+def _abandon_unscheduled_generation_owner(
+    *,
+    slot: Optional[int],
+    session_id: str,
+    error: str,
+) -> None:
+    """Best-effort cleanup for a route that never scheduled its generator."""
+
+    try:
+        _abandon_generation_owner(
+            slot=slot,
+            session_id=session_id,
+            error=error,
+        )
+    except Exception as release_exc:
+        logger.error(
+            "Failed to abandon generation lease %s: %s",
+            session_id,
+            release_exc,
+        )
+
+
 def _resolve_and_approve_pending_sync(
     *,
     slot: Optional[int],
@@ -633,12 +655,14 @@ def _resolve_and_approve_pending_sync(
     user_text: str,
     choice: Optional[int],
     accept_fate: bool,
-) -> tuple[str, int]:
+) -> tuple[str, int, Optional[threading.Thread]]:
     """Resolve and approve a pending choice with worker-owned connection life."""
 
     from nexus.api.commit_handler_sync import commit_incubator_to_database_sync
 
     conn = get_db_connection(slot)
+    resolved_user_text: str
+    approved_chunk_id: int
     try:
         resolved_user_text = _record_player_response_for_chunk(
             slot=slot,
@@ -651,7 +675,6 @@ def _resolve_and_approve_pending_sync(
             incubator_session_id=session_id,
         )
         approved_chunk_id = commit_incubator_to_database_sync(conn, session_id, slot)
-        return resolved_user_text, approved_chunk_id
     except HTTPException:
         conn.rollback()
         raise
@@ -664,6 +687,9 @@ def _resolve_and_approve_pending_sync(
         ) from exc
     finally:
         conn.close()
+
+    post_commit_thread = _start_post_commit_orrery_work(slot)
+    return resolved_user_text, approved_chunk_id, post_commit_thread
 
 
 async def _resolve_and_approve_pending(
@@ -678,7 +704,7 @@ async def _resolve_and_approve_pending(
 ) -> tuple[str, int]:
     """Resolve and approve without exposing the worker connection to cancellation."""
 
-    result = await asyncio.to_thread(
+    resolved_user_text, approved_chunk_id, post_commit_thread = await asyncio.to_thread(
         _resolve_and_approve_pending_sync,
         slot=slot,
         session_id=session_id,
@@ -687,8 +713,9 @@ async def _resolve_and_approve_pending(
         choice=choice,
         accept_fate=accept_fate,
     )
-    background_tasks.add_task(_run_post_commit_orrery_work, slot)
-    return result
+    if post_commit_thread is not None:
+        background_tasks.add_task(post_commit_thread.join)
+    return resolved_user_text, approved_chunk_id
 
 
 # API Endpoints
@@ -767,6 +794,7 @@ async def continue_narrative(
         operation="continue",
     )
     scheduled = False
+    failure_reason = "Narrative request ended before generation was scheduled."
     try:
         if request.chunk_id is None and state is not None:
             if state.narrative_state is not None:
@@ -893,21 +921,19 @@ async def continue_narrative(
             status="processing",
             message=message,
         )
-    except Exception as exc:
-        if not scheduled:
-            try:
-                _abandon_generation_owner(
-                    slot=request.slot,
-                    session_id=session_id,
-                    error=str(exc),
-                )
-            except Exception as release_exc:
-                logger.error(
-                    "Failed to abandon generation lease %s: %s",
-                    session_id,
-                    release_exc,
-                )
+    except asyncio.CancelledError:
+        failure_reason = "CancelledError"
         raise
+    except Exception as exc:
+        failure_reason = str(exc) or type(exc).__name__
+        raise
+    finally:
+        if not scheduled:
+            _abandon_unscheduled_generation_owner(
+                slot=request.slot,
+                session_id=session_id,
+                error=failure_reason,
+            )
 
 
 @app.get("/api/narrative/status/{session_id}", response_model=NarrativeStatus)
@@ -1026,6 +1052,7 @@ async def regenerate_narrative(
         operation="regenerate",
     )
     scheduled = False
+    failure_reason = "Regeneration request ended before generation was scheduled."
     try:
         _bind_generation_owner(
             slot=request.slot,
@@ -1074,27 +1101,23 @@ async def regenerate_narrative(
             status="processing",
             message=f"Regenerating chunk {chunk_id}",
         )
-    except Exception as exc:
-        if not scheduled:
-            try:
-                _abandon_generation_owner(
-                    slot=request.slot,
-                    session_id=session_id,
-                    error=str(exc),
-                )
-            except Exception as release_exc:
-                logger.error(
-                    "Failed to abandon regeneration lease %s: %s",
-                    session_id,
-                    release_exc,
-                )
+    except asyncio.CancelledError:
+        failure_reason = "CancelledError"
         raise
+    except Exception as exc:
+        failure_reason = str(exc) or type(exc).__name__
+        raise
+    finally:
+        if not scheduled:
+            _abandon_unscheduled_generation_owner(
+                slot=request.slot,
+                session_id=session_id,
+                error=failure_reason,
+            )
 
 
 @app.post("/api/narrative/approve")
-async def approve_narrative_unified(
-    request: ApproveNarrativeRequest, background_tasks: BackgroundTasks
-):
+async def approve_narrative_unified(request: ApproveNarrativeRequest):
     """
     Approve narrative and optionally commit to database.
 
@@ -1129,15 +1152,12 @@ async def approve_narrative_unified(
                 )
 
     # Now call the implementation
-    return await _approve_narrative_impl(
-        session_id, request.commit, slot, background_tasks
-    )
+    return await _approve_narrative_impl(session_id, request.commit, slot)
 
 
 @app.post("/api/narrative/approve/{session_id}")
 async def approve_narrative(
     session_id: str,
-    background_tasks: BackgroundTasks,
     request: Optional[ApproveNarrativeRequest] = None,
     slot: Optional[int] = None,
 ):
@@ -1146,9 +1166,7 @@ async def approve_narrative(
     """
     should_commit = request.commit if request else True
     effective_slot = request.slot if request and request.slot else slot
-    return await _approve_narrative_impl(
-        session_id, should_commit, effective_slot, background_tasks
-    )
+    return await _approve_narrative_impl(session_id, should_commit, effective_slot)
 
 
 def _run_post_commit_orrery_work(slot: Optional[int]) -> None:
@@ -1177,11 +1195,52 @@ def _run_post_commit_orrery_work(slot: Optional[int]) -> None:
     ).start()
 
 
+def _run_post_commit_orrery_work_safely(slot: Optional[int]) -> None:
+    """Drain durable post-commit work without changing an accepted response."""
+
+    try:
+        _run_post_commit_orrery_work(slot)
+    except Exception:
+        logger.exception(
+            "Post-commit Orrery work failed for slot %s; durable queues remain.",
+            slot,
+        )
+
+
+def _start_post_commit_orrery_work(
+    slot: Optional[int],
+) -> Optional[threading.Thread]:
+    """Hand durable Orrery work off before a cancellable await can resume.
+
+    The quick outbox drain is deliberately non-daemon so graceful server
+    shutdown cannot strand it. ``_run_post_commit_orrery_work`` detaches only
+    the potentially multi-minute maturation drain.
+    """
+
+    try:
+        thread = threading.Thread(
+            target=_run_post_commit_orrery_work_safely,
+            args=(slot,),
+            name=f"orrery-post-commit-slot-{slot}",
+            daemon=False,
+        )
+        thread.start()
+        return thread
+    except Exception:
+        logger.exception(
+            "Could not start post-commit Orrery worker for slot %s; "
+            "running the drain inline.",
+            slot,
+        )
+        _run_post_commit_orrery_work_safely(slot)
+        return None
+
+
 def _approve_narrative_sync(
     session_id: str,
     commit: bool,
     slot: Optional[int],
-) -> Dict[str, Any]:
+) -> tuple[Dict[str, Any], Optional[threading.Thread]]:
     """Read or commit one incubator row with a worker-owned connection."""
 
     conn = get_db_connection(slot)
@@ -1202,7 +1261,7 @@ def _approve_narrative_sync(
 
             try:
                 chunk_id = commit_incubator_to_database_sync(conn, session_id, slot)
-                return {
+                result = {
                     "status": "committed",
                     "message": f"Narrative committed as chunk {chunk_id}",
                     "chunk_id": chunk_id,
@@ -1214,7 +1273,7 @@ def _approve_narrative_sync(
                 )
         else:
             # Just mark as reviewed
-            return {
+            result = {
                 "status": "reviewed",
                 "message": "Narrative reviewed but not committed",
                 "chunk_id": incubator_data["chunk_id"],
@@ -1223,23 +1282,23 @@ def _approve_narrative_sync(
     finally:
         conn.close()
 
+    post_commit_thread = _start_post_commit_orrery_work(slot) if commit else None
+    return result, post_commit_thread
+
 
 async def _approve_narrative_impl(
     session_id: str,
     commit: bool,
     slot: Optional[int],
-    background_tasks: Optional[BackgroundTasks] = None,
 ):
     """Approve a narrative without exposing the worker connection to cancellation."""
 
-    result = await asyncio.to_thread(
+    result, _post_commit_thread = await asyncio.to_thread(
         _approve_narrative_sync,
         session_id,
         commit,
         slot,
     )
-    if commit and background_tasks is not None:
-        background_tasks.add_task(_run_post_commit_orrery_work, slot)
     return result
 
 

--- a/nexus/api/narrative.py
+++ b/nexus/api/narrative.py
@@ -625,7 +625,7 @@ def _abandon_generation_owner(
         conn.close()
 
 
-def _resolve_and_approve_pending(
+async def _resolve_and_approve_pending(
     *,
     slot: Optional[int],
     session_id: str,
@@ -635,7 +635,7 @@ def _resolve_and_approve_pending(
     accept_fate: bool,
     background_tasks: BackgroundTasks,
 ) -> tuple[str, int]:
-    """Resolve the pending choice and approve it in one transaction."""
+    """Resolve a pending choice and approve it off the event-loop thread."""
     from nexus.api.commit_handler_sync import commit_incubator_to_database_sync
 
     conn = get_db_connection(slot)
@@ -650,7 +650,12 @@ def _resolve_and_approve_pending(
             connection=conn,
             incubator_session_id=session_id,
         )
-        approved_chunk_id = commit_incubator_to_database_sync(conn, session_id, slot)
+        approved_chunk_id = await asyncio.to_thread(
+            commit_incubator_to_database_sync,
+            conn,
+            session_id,
+            slot,
+        )
         background_tasks.add_task(_run_post_commit_orrery_work, slot)
         return resolved_user_text, approved_chunk_id
     except HTTPException:
@@ -762,7 +767,7 @@ async def continue_narrative(
                         request.slot,
                     )
                     resolved_user_text, approved_chunk_id = (
-                        _resolve_and_approve_pending(
+                        await _resolve_and_approve_pending(
                             slot=request.slot,
                             session_id=narrative_state.session_id,
                             chunk_id=narrative_state.current_chunk_id,
@@ -1178,7 +1183,12 @@ async def _approve_narrative_impl(
 
             try:
                 # Commit to database
-                chunk_id = commit_incubator_to_database_sync(conn, session_id, slot)
+                chunk_id = await asyncio.to_thread(
+                    commit_incubator_to_database_sync,
+                    conn,
+                    session_id,
+                    slot,
+                )
                 if background_tasks is not None:
                     background_tasks.add_task(_run_post_commit_orrery_work, slot)
 

--- a/tests/test_api/test_correspondence_pg.py
+++ b/tests/test_api/test_correspondence_pg.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import os
 import threading
+import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -100,6 +102,151 @@ def _seed_chunks(cur: Any, count: int) -> list[int]:
             (chunk_id, index, f"S01E01_{index:03d}"),
         )
     return ids
+
+
+def test_parallel_approvals_claim_incubator_row_once(
+    disposable_correspondence_db: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second commit waits on the row claim and cannot replay the turn."""
+
+    dbname = disposable_correspondence_db
+    first_commit_reached_orrery = threading.Event()
+    release_first_commit = threading.Event()
+    orrery_calls: list[int] = []
+
+    def blocking_orrery(
+        conn: Any, *_args: Any, **_kwargs: Any
+    ) -> CommitOrreryTickResult:
+        orrery_calls.append(id(conn))
+        if len(orrery_calls) == 1:
+            first_commit_reached_orrery.set()
+            assert release_first_commit.wait(timeout=5)
+        return CommitOrreryTickResult()
+
+    monkeypatch.setattr(
+        commit_handler_sync,
+        "commit_orrery_tick_sync",
+        blocking_orrery,
+    )
+    monkeypatch.setattr(
+        commit_handler_sync,
+        "_orrery_checkpoint_interval",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        "nexus.api.presence_audit.presence_audit_enabled",
+        lambda: False,
+    )
+
+    session_id = "00000000-0000-0000-0000-000000000635"
+    storyteller_text = "Only one approval may make this scene canonical."
+    with _connect(dbname) as seed_conn:
+        with seed_conn.cursor() as cur:
+            cur.execute(
+                """
+                TRUNCATE incubator, narrative_chunks
+                RESTART IDENTITY CASCADE
+                """
+            )
+            parent_chunk_id = _seed_chunks(cur, 1)[0]
+            cur.execute(
+                """
+                INSERT INTO incubator (
+                    id, chunk_id, parent_chunk_id, user_text, storyteller_text,
+                    generation_model, metadata_updates, entity_updates,
+                    reference_updates, orrery_adjudications, new_entities,
+                    session_id, llm_response_id, status
+                ) VALUES (
+                    TRUE, 2, %s, 'continue', %s, 'TEST',
+                    '{}'::jsonb, '{}'::jsonb, '{}'::jsonb,
+                    '[]'::jsonb, '[]'::jsonb, %s, 'parallel-approval',
+                    'provisional'
+                )
+                """,
+                (parent_chunk_id, storyteller_text, session_id),
+            )
+
+    first_conn = _connect(dbname)
+    second_conn = _connect(dbname)
+    monitor_conn = _connect(dbname, dict_cursor=True)
+    monitor_conn.autocommit = True
+    with second_conn.cursor() as cur:
+        cur.execute("SELECT pg_backend_pid()")
+        second_backend_pid = int(cur.fetchone()[0])
+    second_conn.commit()
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(
+                commit_handler_sync.commit_incubator_to_database_sync,
+                first_conn,
+                session_id,
+                None,
+            )
+            assert first_commit_reached_orrery.wait(timeout=2)
+            second = executor.submit(
+                commit_handler_sync.commit_incubator_to_database_sync,
+                second_conn,
+                session_id,
+                None,
+            )
+
+            lock_query = None
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                with monitor_conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT wait_event_type, query
+                        FROM pg_stat_activity
+                        WHERE pid = %s
+                        """,
+                        (second_backend_pid,),
+                    )
+                    activity = cur.fetchone()
+                if activity and activity["wait_event_type"] == "Lock":
+                    lock_query = " ".join(activity["query"].split())
+                    break
+                time.sleep(0.01)
+
+            assert lock_query is not None
+            assert "FROM incubator" in lock_query
+            assert "FOR UPDATE" in lock_query
+            assert not second.done()
+
+            release_first_commit.set()
+            accepted_chunk_id = first.result(timeout=5)
+            with pytest.raises(
+                ValueError,
+                match=f"No incubator data found for session {session_id}",
+            ):
+                second.result(timeout=5)
+    finally:
+        release_first_commit.set()
+        first_conn.close()
+        second_conn.close()
+        monitor_conn.close()
+
+    assert orrery_calls == [id(first_conn)]
+    with _connect(dbname) as verify_conn:
+        with verify_conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT count(*)
+                FROM narrative_chunks
+                WHERE storyteller_text = %s
+                """,
+                (storyteller_text,),
+            )
+            assert cur.fetchone()[0] == 1
+            cur.execute("SELECT count(*) FROM incubator")
+            assert cur.fetchone()[0] == 0
+            cur.execute(
+                "SELECT storyteller_text FROM narrative_chunks WHERE id = %s",
+                (accepted_chunk_id,),
+            )
+            assert cur.fetchone()[0] == storyteller_text
 
 
 def test_accept_reject_hysteresis_and_digest_undo(

--- a/tests/test_api/test_correspondence_pg.py
+++ b/tests/test_api/test_correspondence_pg.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 import uuid
 from pathlib import Path
 from typing import Any, Iterator
@@ -14,7 +15,7 @@ from psycopg2 import sql
 from psycopg2.extras import RealDictCursor
 
 from nexus.agents.orrery.events import CommitOrreryTickResult
-from nexus.api import commit_handler_sync
+from nexus.api import commit_handler_sync, narrative
 from nexus.api.narrative_generation import write_to_incubator
 from nexus.memory.correspondence import (
     persist_staged_correspondence,
@@ -116,13 +117,30 @@ def test_accept_reject_hysteresis_and_digest_undo(
         "_orrery_checkpoint_interval",
         lambda: 0,
     )
-    compaction_triggers: list[int] = []
+    compaction_calls: list[dict[str, Any]] = []
+
+    def compact_without_event_loop(
+        _utility: Any,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        max_digest_tokens: int,
+    ) -> str:
+        with pytest.raises(RuntimeError):
+            asyncio.get_running_loop()
+        compaction_calls.append(
+            {
+                "thread": threading.get_ident(),
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "max_digest_tokens": max_digest_tokens,
+            }
+        )
+        return "Durable digest produced across the FastAPI worker boundary."
+
     monkeypatch.setattr(
-        commit_handler_sync,
-        "compact_accepted_correspondence_sync",
-        lambda _conn, *, accepting_chunk_id: (
-            compaction_triggers.append(accepting_chunk_id) or False
-        ),
+        "nexus.agents.lore.logon_utility.LogonUtility.compact_correspondence",
+        compact_without_event_loop,
     )
     monkeypatch.setattr(
         "nexus.api.presence_audit.presence_audit_enabled",
@@ -255,16 +273,25 @@ def test_accept_reject_hysteresis_and_digest_undo(
                 },
             )
         )
-        accept_conn = _connect(dbname)
-        try:
-            accepting_chunk_id = commit_handler_sync.commit_incubator_to_database_sync(
-                accept_conn,
+        event_loop_thread = threading.get_ident()
+        monkeypatch.setattr(
+            narrative,
+            "get_db_connection",
+            lambda _slot: _connect(dbname),
+        )
+        approval = asyncio.run(
+            narrative._approve_narrative_impl(
                 session_id,
-                slot=None,
+                True,
+                None,
             )
-        finally:
-            accept_conn.close()
-        assert compaction_triggers == [accepting_chunk_id]
+        )
+        accepting_chunk_id = int(approval["chunk_id"])
+        assert approval["status"] == "committed"
+        assert len(compaction_calls) == 1
+        assert compaction_calls[0]["thread"] != event_loop_thread
+        assert "writer secret 5" in compaction_calls[0]["user_prompt"]
+        assert "writer secret 11" in compaction_calls[0]["user_prompt"]
 
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
             cur.execute(
@@ -294,16 +321,21 @@ def test_accept_reject_hysteresis_and_digest_undo(
                 {"seat": "gaia", "body": "gaia secret 11"},
             ]
 
-            plan = plan_correspondence_compaction(
-                cur,
-                accepting_chunk_id=accepting_chunk_id,
-                floor_turns=5,
-                ceiling_turns=10,
+            cur.execute(
+                """
+                SELECT digest, compacted_through_chunk_id
+                FROM storyteller_correspondence_digest_versions
+                WHERE accepting_chunk_id = %s
+                """,
+                (accepting_chunk_id,),
             )
-            assert plan is not None
-            assert len(plan.aging_exchanges) == 5
-            assert len(plan.recent_exchanges) == 6
-            assert all(len(exchange.letters) == 2 for exchange in plan.aging_exchanges)
+            digest = cur.fetchone()
+            assert digest == {
+                "digest": (
+                    "Durable digest produced across the FastAPI worker boundary."
+                ),
+                "compacted_through_chunk_id": chunk_ids[4],
+            }
 
             # Two immutable versions make chunk undo observable: deleting the
             # accepting chunk cascades its letters/current digest, revealing
@@ -313,16 +345,14 @@ def test_accept_reject_hysteresis_and_digest_undo(
                 INSERT INTO storyteller_correspondence_digest_versions (
                     accepting_chunk_id, compacted_through_chunk_id, digest
                 )
-                VALUES (%s, %s, 'prior digest'), (%s, %s, 'current digest')
+                VALUES (%s, %s, 'prior digest')
                 """,
                 (
                     chunk_ids[9],
                     chunk_ids[3],
-                    accepting_chunk_id,
-                    chunk_ids[4],
                 ),
             )
-            assert read_accepted_correspondence(cur).digest == "current digest"
+            assert read_accepted_correspondence(cur).digest == digest["digest"]
             cur.execute(
                 "DELETE FROM narrative_chunks WHERE id = %s",
                 (accepting_chunk_id,),

--- a/tests/test_api/test_correspondence_pg.py
+++ b/tests/test_api/test_correspondence_pg.py
@@ -279,6 +279,11 @@ def test_accept_reject_hysteresis_and_digest_undo(
             "get_db_connection",
             lambda _slot: _connect(dbname),
         )
+        monkeypatch.setattr(
+            narrative,
+            "_start_post_commit_orrery_work",
+            lambda _slot: None,
+        )
         approval = asyncio.run(
             narrative._approve_narrative_impl(
                 session_id,

--- a/tests/test_api/test_narrative_post_commit.py
+++ b/tests/test_api/test_narrative_post_commit.py
@@ -9,8 +9,14 @@ multi-minute frontier calls, so it must detach from that chain
 
 from __future__ import annotations
 
+import asyncio
+import threading
 from typing import Any
 
+import pytest
+from fastapi import BackgroundTasks
+
+from nexus.api import commit_handler_sync
 from nexus.api import narrative
 
 
@@ -62,3 +68,123 @@ def test_post_commit_orrery_work_detaches_maturation(monkeypatch) -> None:
     assert started["target"] is fake_drain
     assert started["args"] == (2,)
     assert started["daemon"] is True
+
+
+@pytest.mark.asyncio
+async def test_auto_approval_runs_commit_and_compaction_off_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The continue route's approval seam isolates the synchronous provider."""
+
+    event_loop_thread = threading.get_ident()
+    connection = type(
+        "Connection",
+        (),
+        {
+            "rollback": lambda self: None,
+            "close": lambda self: setattr(self, "closed", True),
+        },
+    )()
+    commit_threads: list[int] = []
+
+    def commit_in_worker(_conn: Any, session_id: str, slot: int | None) -> int:
+        assert session_id == "pending-session"
+        assert slot == 4
+        with pytest.raises(RuntimeError):
+            asyncio.get_running_loop()
+        commit_threads.append(threading.get_ident())
+        return 42
+
+    monkeypatch.setattr(narrative, "get_db_connection", lambda _slot: connection)
+    monkeypatch.setattr(
+        narrative,
+        "_record_player_response_for_chunk",
+        lambda **_kwargs: "resolved player response",
+    )
+    monkeypatch.setattr(
+        commit_handler_sync,
+        "commit_incubator_to_database_sync",
+        commit_in_worker,
+    )
+    background_tasks = BackgroundTasks()
+
+    result = await narrative._resolve_and_approve_pending(
+        slot=4,
+        session_id="pending-session",
+        chunk_id=41,
+        user_text="Take the left stair.",
+        choice=1,
+        accept_fate=False,
+        background_tasks=background_tasks,
+    )
+
+    assert result == ("resolved player response", 42)
+    assert commit_threads and commit_threads[0] != event_loop_thread
+    assert connection.closed is True
+    assert len(background_tasks.tasks) == 1
+
+
+class _PendingCursor:
+    """Serve one pending row to the explicit approval endpoint."""
+
+    def __enter__(self) -> "_PendingCursor":
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def execute(self, _query: str, _params: Any) -> None:
+        return None
+
+    def fetchone(self) -> dict[str, int]:
+        return {"chunk_id": 41}
+
+
+class _PendingConnection:
+    """Small approval-route connection double."""
+
+    closed = False
+
+    def cursor(self, **_kwargs: Any) -> _PendingCursor:
+        return _PendingCursor()
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_explicit_approval_runs_commit_and_compaction_off_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The standalone approval route uses the same worker boundary."""
+
+    event_loop_thread = threading.get_ident()
+    connection = _PendingConnection()
+    commit_threads: list[int] = []
+
+    def commit_in_worker(_conn: Any, _session_id: str, _slot: int | None) -> int:
+        with pytest.raises(RuntimeError):
+            asyncio.get_running_loop()
+        commit_threads.append(threading.get_ident())
+        return 42
+
+    monkeypatch.setattr(narrative, "get_db_connection", lambda _slot: connection)
+    monkeypatch.setattr(
+        commit_handler_sync,
+        "commit_incubator_to_database_sync",
+        commit_in_worker,
+    )
+
+    result = await narrative._approve_narrative_impl(
+        "pending-session",
+        True,
+        4,
+    )
+
+    assert result == {
+        "status": "committed",
+        "message": "Narrative committed as chunk 42",
+        "chunk_id": 42,
+    }
+    assert commit_threads and commit_threads[0] != event_loop_thread
+    assert connection.closed is True

--- a/tests/test_api/test_narrative_post_commit.py
+++ b/tests/test_api/test_narrative_post_commit.py
@@ -188,3 +188,57 @@ async def test_explicit_approval_runs_commit_and_compaction_off_event_loop(
     }
     assert commit_threads and commit_threads[0] != event_loop_thread
     assert connection.closed is True
+
+
+@pytest.mark.asyncio
+async def test_cancelled_approval_leaves_worker_connection_owned_until_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation cannot close a connection underneath the commit worker."""
+
+    commit_started = threading.Event()
+    release_commit = threading.Event()
+    connection_closed = threading.Event()
+    commit_threads: list[int] = []
+    close_threads: list[int] = []
+
+    class BlockingConnection(_PendingConnection):
+        def close(self) -> None:
+            close_threads.append(threading.get_ident())
+            connection_closed.set()
+
+    connection = BlockingConnection()
+
+    def blocking_commit(_conn: Any, _session_id: str, _slot: int | None) -> int:
+        commit_threads.append(threading.get_ident())
+        commit_started.set()
+        assert release_commit.wait(timeout=5)
+        assert not connection_closed.is_set()
+        return 42
+
+    monkeypatch.setattr(narrative, "get_db_connection", lambda _slot: connection)
+    monkeypatch.setattr(
+        commit_handler_sync,
+        "commit_incubator_to_database_sync",
+        blocking_commit,
+    )
+    approval_task = asyncio.create_task(
+        narrative._approve_narrative_impl(
+            "pending-session",
+            True,
+            4,
+        )
+    )
+
+    try:
+        assert await asyncio.to_thread(commit_started.wait, 2)
+        approval_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await approval_task
+        assert not connection_closed.is_set()
+    finally:
+        release_commit.set()
+
+    assert await asyncio.to_thread(connection_closed.wait, 2)
+    assert commit_threads
+    assert close_threads == commit_threads

--- a/tests/test_api/test_narrative_post_commit.py
+++ b/tests/test_api/test_narrative_post_commit.py
@@ -20,6 +20,16 @@ from nexus.api import commit_handler_sync
 from nexus.api import narrative
 
 
+class _PostCommitHandle:
+    """Small joinable handoff double for approval-route tests."""
+
+    def __init__(self) -> None:
+        self.joined = False
+
+    def join(self) -> None:
+        self.joined = True
+
+
 def test_post_commit_orrery_work_detaches_maturation(monkeypatch) -> None:
     """Quick outbox work runs inline with maturation excluded; the
     maturation drain starts on a detached daemon thread instead."""
@@ -106,6 +116,12 @@ async def test_auto_approval_runs_commit_and_compaction_off_event_loop(
         "commit_incubator_to_database_sync",
         commit_in_worker,
     )
+    post_commit_handle = _PostCommitHandle()
+    monkeypatch.setattr(
+        narrative,
+        "_start_post_commit_orrery_work",
+        lambda _slot: post_commit_handle,
+    )
     background_tasks = BackgroundTasks()
 
     result = await narrative._resolve_and_approve_pending(
@@ -122,6 +138,8 @@ async def test_auto_approval_runs_commit_and_compaction_off_event_loop(
     assert commit_threads and commit_threads[0] != event_loop_thread
     assert connection.closed is True
     assert len(background_tasks.tasks) == 1
+    await background_tasks()
+    assert post_commit_handle.joined is True
 
 
 class _PendingCursor:
@@ -174,6 +192,11 @@ async def test_explicit_approval_runs_commit_and_compaction_off_event_loop(
         "commit_incubator_to_database_sync",
         commit_in_worker,
     )
+    monkeypatch.setattr(
+        narrative,
+        "_start_post_commit_orrery_work",
+        lambda _slot: _PostCommitHandle(),
+    )
 
     result = await narrative._approve_narrative_impl(
         "pending-session",
@@ -199,6 +222,7 @@ async def test_cancelled_approval_leaves_worker_connection_owned_until_exit(
     commit_started = threading.Event()
     release_commit = threading.Event()
     connection_closed = threading.Event()
+    post_commit_finished = threading.Event()
     commit_threads: list[int] = []
     close_threads: list[int] = []
 
@@ -222,6 +246,11 @@ async def test_cancelled_approval_leaves_worker_connection_owned_until_exit(
         "commit_incubator_to_database_sync",
         blocking_commit,
     )
+    monkeypatch.setattr(
+        narrative,
+        "_run_post_commit_orrery_work",
+        lambda _slot: post_commit_finished.set(),
+    )
     approval_task = asyncio.create_task(
         narrative._approve_narrative_impl(
             "pending-session",
@@ -240,5 +269,109 @@ async def test_cancelled_approval_leaves_worker_connection_owned_until_exit(
         release_commit.set()
 
     assert await asyncio.to_thread(connection_closed.wait, 2)
+    assert await asyncio.to_thread(post_commit_finished.wait, 2)
     assert commit_threads
     assert close_threads == commit_threads
+
+
+@pytest.mark.asyncio
+async def test_cancelled_auto_approval_releases_lease_and_hands_off_post_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation releases the new lease while the accepted turn drains."""
+
+    commit_started = threading.Event()
+    release_commit = threading.Event()
+    connection_closed = threading.Event()
+    post_commit_finished = threading.Event()
+    acquired_sessions: list[str] = []
+    abandoned_sessions: list[tuple[str, str]] = []
+
+    class BlockingConnection:
+        def rollback(self) -> None:
+            return None
+
+        def close(self) -> None:
+            connection_closed.set()
+
+    def blocking_commit(_conn: Any, _session_id: str, _slot: int | None) -> int:
+        commit_started.set()
+        assert release_commit.wait(timeout=5)
+        assert not connection_closed.is_set()
+        return 42
+
+    pending_state = type(
+        "PendingState",
+        (),
+        {
+            "is_wizard_mode": False,
+            "narrative_state": type(
+                "NarrativeState",
+                (),
+                {
+                    "has_pending": True,
+                    "session_id": "pending-session",
+                    "current_chunk_id": 41,
+                    "choices": ["Take the left stair."],
+                },
+            )(),
+        },
+    )()
+
+    monkeypatch.setattr(
+        "nexus.api.slot_state.get_slot_state",
+        lambda _slot: pending_state,
+    )
+    monkeypatch.setattr(
+        narrative,
+        "_acquire_generation_owner",
+        lambda **kwargs: acquired_sessions.append(kwargs["session_id"]),
+    )
+    monkeypatch.setattr(
+        narrative,
+        "_abandon_generation_owner",
+        lambda **kwargs: abandoned_sessions.append(
+            (kwargs["session_id"], kwargs["error"])
+        ),
+    )
+    monkeypatch.setattr(
+        narrative,
+        "get_db_connection",
+        lambda _slot: BlockingConnection(),
+    )
+    monkeypatch.setattr(
+        narrative,
+        "_record_player_response_for_chunk",
+        lambda **_kwargs: "resolved player response",
+    )
+    monkeypatch.setattr(
+        commit_handler_sync,
+        "commit_incubator_to_database_sync",
+        blocking_commit,
+    )
+    monkeypatch.setattr(
+        narrative,
+        "_run_post_commit_orrery_work",
+        lambda _slot: post_commit_finished.set(),
+    )
+
+    continue_task = asyncio.create_task(
+        narrative.continue_narrative(
+            narrative.ContinueNarrativeRequest(slot=4, choice=1),
+            BackgroundTasks(),
+        )
+    )
+
+    try:
+        assert await asyncio.to_thread(commit_started.wait, 2)
+        continue_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await continue_task
+        assert acquired_sessions
+        assert abandoned_sessions == [(acquired_sessions[0], "CancelledError")]
+        assert not connection_closed.is_set()
+    finally:
+        release_commit.set()
+
+    assert await asyncio.to_thread(connection_closed.wait, 2)
+    assert await asyncio.to_thread(post_commit_finished.wait, 2)

--- a/tests/test_commit_handler_sync.py
+++ b/tests/test_commit_handler_sync.py
@@ -385,6 +385,45 @@ def test_sync_commit_aborts_on_unresolvable_state_update_name(monkeypatch):
     )
 
 
+def test_post_commit_compaction_failure_preserves_success_and_retries(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Derived compaction cannot turn a durable acceptance into a false 500."""
+
+    attempts = []
+
+    def flaky_compaction(_conn, *, accepting_chunk_id):
+        attempts.append(accepting_chunk_id)
+        if len(attempts) == 1:
+            raise RuntimeError("provider unavailable")
+        return True
+
+    monkeypatch.setattr(
+        commit_handler_sync,
+        "compact_accepted_correspondence_sync",
+        flaky_compaction,
+    )
+    connection = object()
+
+    assert (
+        commit_handler_sync._compact_accepted_correspondence_best_effort(
+            connection,
+            accepting_chunk_id=11,
+        )
+        is False
+    )
+    assert (
+        commit_handler_sync._compact_accepted_correspondence_best_effort(
+            connection,
+            accepting_chunk_id=12,
+        )
+        is True
+    )
+    assert attempts == [11, 12]
+    assert "leaving the uncompacted journal intact for retry" in caplog.text
+
+
 def test_bootstrap_commit_seeds_setting_for_next_presence_baseline(
     monkeypatch,
 ) -> None:

--- a/tests/test_commit_handler_sync.py
+++ b/tests/test_commit_handler_sync.py
@@ -75,6 +75,7 @@ class CommitCursor:
     def __init__(self, connection):
         self.connection = connection
         self.result = None
+        self.rowcount = 0
 
     def __enter__(self):
         return self
@@ -85,7 +86,11 @@ class CommitCursor:
     def execute(self, sql, params=None):
         normalized = " ".join(sql.split())
         self.connection.statements.append((normalized, params))
-        if "FROM incubator" in normalized:
+        self.rowcount = 0
+        if normalized.startswith("DELETE FROM incubator"):
+            self.rowcount = 1
+            self.result = None
+        elif "FROM incubator" in normalized:
             self.result = self.connection.incubator
         elif "FROM chunk_metadata" in normalized:
             self.result = self.connection.parent_metadata
@@ -251,6 +256,10 @@ def test_sync_commit_links_same_turn_character_declaration(monkeypatch):
 
     assert chunk_id == conn.chunk_id
     assert conn.character_junctions == [(conn.chunk_id, 71, "present")]
+    assert any(
+        "FROM incubator" in sql and "FOR UPDATE" in sql
+        for sql, _params in conn.statements
+    )
 
 
 def _patch_sync_commit_runtime(monkeypatch) -> None:

--- a/tests/test_lore/test_logon_lazy_init.py
+++ b/tests/test_lore/test_logon_lazy_init.py
@@ -201,9 +201,13 @@ def test_anthropic_storyteller_transport_and_guide_follow_settings(
         "nexus.config.get_openai_compatible_endpoint",
         lambda _model, _path=None: None,
     )
+
+    def capture_registry_validator(*_args: Any, **kwargs: Any) -> None:
+        captured["registry_validator_kwargs"] = kwargs
+
     monkeypatch.setattr(
         "nexus.agents.logon.orrery_tag_validation." "build_storyteller_tag_validator",
-        lambda *_args, **_kwargs: None,
+        capture_registry_validator,
     )
     monkeypatch.setattr(
         LogonUtility,
@@ -235,6 +239,7 @@ def test_anthropic_storyteller_transport_and_guide_follow_settings(
                 "max_rendered_tokens": 12000,
             }
         },
+        "orrery": {"retrograde": {"maturation": {"enabled": False}}},
     }
     utility = LogonUtility(settings, model_override="claude-sonnet-4-5")
 
@@ -242,6 +247,10 @@ def test_anthropic_storyteller_transport_and_guide_follow_settings(
 
     assert captured["structured_transport"] == expected_transport
     assert captured["reasoning_effort"] == "medium"
+    assert (
+        captured["registry_validator_kwargs"]["allow_same_turn_faction_declarations"]
+        is False
+    )
     expected_system = (
         f"Core prompt\n\n{skald_wire_prompt_guide()}" if has_guide else "Core prompt"
     )

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -297,8 +297,8 @@ def test_unpersisted_faction_aliases_fail_before_incubation(alias: str) -> None:
     assert f"Unknown canonical faction name {alias!r}" in issues[0]
 
 
-def test_faction_update_identity_accepts_exact_row_or_same_turn_declaration() -> None:
-    """Canonical rows and deliberately declared factions remain writable."""
+def test_faction_update_identity_honors_same_turn_maturation_gate() -> None:
+    """Declared factions are writable only when commit-time stubs are enabled."""
 
     canonical = _storyteller_response(
         updates=_updates_block(
@@ -331,7 +331,19 @@ def test_faction_update_identity_accepts_exact_row_or_same_turn_declaration() ->
     cursor = FakeRegistryCursor()
 
     assert collect_faction_identity_issues(canonical, cursor) == []
-    assert collect_faction_identity_issues(declared, cursor) == []
+    disabled_issues = collect_faction_identity_issues(declared, cursor)
+    assert len(disabled_issues) == 1
+    assert (
+        "Unknown canonical faction name 'The Lantern Delegation'" in disabled_issues[0]
+    )
+    assert (
+        collect_faction_identity_issues(
+            declared,
+            cursor,
+            allow_same_turn_faction_declarations=True,
+        )
+        == []
+    )
 
 
 def test_faction_update_id_and_name_must_identify_the_same_row() -> None:

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -19,6 +19,7 @@ from nexus.agents.logon.apex_schema import (
 from nexus.agents.logon.orrery_tag_validation import (
     StorytellerVocabulary,
     build_storyteller_tag_validator,
+    collect_faction_identity_issues,
     collect_orrery_tag_issues,
 )
 from nexus.agents.logon.skald_wire import SkaldTurnWire
@@ -35,6 +36,7 @@ class FakeRegistryCursor:
         self,
         *,
         entities_by_name: Optional[dict[str, list[str]]] = None,
+        faction_ids_by_name: Optional[dict[str, int]] = None,
     ) -> None:
         # tag -> (id, category, is_ephemeral, reapplication_policy)
         self.tags = {
@@ -63,6 +65,15 @@ class FakeRegistryCursor:
             if entities_by_name is None
             else entities_by_name
         )
+        self.faction_ids_by_name = (
+            {
+                "Office of Civic Continuity": 91,
+                "The Sluice Guild": 92,
+                "Quay Witness Circle": 93,
+            }
+            if faction_ids_by_name is None
+            else faction_ids_by_name
+        )
         self.categories_by_kind = {
             "character": {"bodyform", "disposition"},
             "place": {"place_class"},
@@ -81,6 +92,12 @@ class FakeRegistryCursor:
         if "SELECT entity_kind" in sql:
             self._result = [
                 (kind,) for kind in self.entities_by_name.get(str(params[0]), [])
+            ]
+            self._one = self._result[0] if self._result else None
+        elif "SELECT id, name FROM factions" in sql:
+            self._result = [
+                (faction_id, name)
+                for name, faction_id in sorted(self.faction_ids_by_name.items())
             ]
             self._one = self._result[0] if self._result else None
         elif "tag_category_registry" in sql:
@@ -189,21 +206,26 @@ def _storyteller_response(
     pair_tag_hints: Optional[List[dict[str, str]]] = None,
     updates: Optional[dict[str, List[dict[str, Any]]]] = None,
     orrery_adjudications: Optional[List[dict[str, Any]]] = None,
+    new_entities: Optional[List[dict[str, Any]]] = None,
 ) -> SkaldTurnWire:
     payload: dict[str, Any] = {
         "narrative": "Marra Kest steps out from behind the sluice gate.",
         "choices": ["Question Marra.", "Keep walking."],
         "letter": "Keep Marra's divided loyalty private for the next beat.",
         "orrery_adjudications": orrery_adjudications or [],
-        "new_entities": [
-            {
-                "kind": "character",
-                "name": "Marra Kest",
-                "summary": "A sluice keeper with divided loyalties.",
-                "tag_hints": tag_hints or [],
-                "pair_tag_hints": pair_tag_hints or [],
-            }
-        ],
+        "new_entities": (
+            [
+                {
+                    "kind": "character",
+                    "name": "Marra Kest",
+                    "summary": "A sluice keeper with divided loyalties.",
+                    "tag_hints": tag_hints or [],
+                    "pair_tag_hints": pair_tag_hints or [],
+                }
+            ]
+            if new_entities is None
+            else new_entities
+        ),
     }
     if updates is not None:
         payload["updates"] = updates
@@ -245,6 +267,94 @@ def _updates_block_with_tag(
         "faction": "factions",
     }[kind]
     return _updates_block(**{array_name: [{"name": name, wire_field: [tag_name]}]})
+
+
+@pytest.mark.parametrize(
+    "alias",
+    [
+        "Civic Continuity Office",
+        "Blackwake Assembly",
+    ],
+)
+def test_unpersisted_faction_aliases_fail_before_incubation(alias: str) -> None:
+    """Live-reproduced prose aliases are not valid durable update identities."""
+
+    response = _storyteller_response(
+        updates=_updates_block(
+            factions=[
+                {
+                    "name": alias,
+                    "action": "tightens its control of the quay",
+                }
+            ]
+        )
+    )
+
+    issues = collect_faction_identity_issues(response, FakeRegistryCursor())
+
+    assert len(issues) == 1
+    assert issues[0].startswith("updates.factions[0]:")
+    assert f"Unknown canonical faction name {alias!r}" in issues[0]
+
+
+def test_faction_update_identity_accepts_exact_row_or_same_turn_declaration() -> None:
+    """Canonical rows and deliberately declared factions remain writable."""
+
+    canonical = _storyteller_response(
+        updates=_updates_block(
+            factions=[
+                {
+                    "id": 91,
+                    "name": "Office of Civic Continuity",
+                    "action": "opens a formal inquiry",
+                }
+            ]
+        )
+    )
+    declared = _storyteller_response(
+        updates=_updates_block(
+            factions=[
+                {
+                    "name": "The Lantern Delegation",
+                    "action": "announces its first assembly",
+                }
+            ]
+        ),
+        new_entities=[
+            {
+                "kind": "faction",
+                "name": "The Lantern Delegation",
+                "summary": "A new delegation from the outer quay.",
+            }
+        ],
+    )
+    cursor = FakeRegistryCursor()
+
+    assert collect_faction_identity_issues(canonical, cursor) == []
+    assert collect_faction_identity_issues(declared, cursor) == []
+
+
+def test_faction_update_id_and_name_must_identify_the_same_row() -> None:
+    """An ID cannot silently bless a conflicting prose alias."""
+
+    response = _storyteller_response(
+        updates=_updates_block(
+            factions=[
+                {
+                    "id": 91,
+                    "name": "Civic Continuity Office",
+                    "action": "opens a formal inquiry",
+                }
+            ]
+        )
+    )
+
+    issues = collect_faction_identity_issues(response, FakeRegistryCursor())
+
+    assert issues == [
+        "updates.factions[0]: Faction id 91 is canonically named "
+        "'Office of Civic Continuity', not 'Civic Continuity Office'"
+    ]
 
 
 def test_valid_bestowals_produce_no_issues() -> None:
@@ -1041,6 +1151,27 @@ def _retry_boundary_response(
                 "loyalist" if valid else "perceptive",
             )
         )
+    if boundary == "faction_identity":
+        return _storyteller_response(
+            updates=_updates_block(
+                factions=(
+                    [
+                        {
+                            "id": 91,
+                            "name": "Office of Civic Continuity",
+                            "action": "opens a formal inquiry",
+                        }
+                    ]
+                    if valid
+                    else [
+                        {
+                            "name": "Civic Continuity Office",
+                            "action": "opens a formal inquiry",
+                        }
+                    ]
+                )
+            )
+        )
     if boundary == "tag_hints":
         return _storyteller_response(tag_hints=["human" if valid else "humam"])
     if boundary == "pair_tag_hints":
@@ -1073,6 +1204,11 @@ def _retry_boundary_response(
         ("character_applied_tags", "updates.characters[0]", "human"),
         ("place_tags_to_clear", "updates.places[0]", None),
         ("faction_applied_tags", "updates.factions[0]", None),
+        (
+            "faction_identity",
+            "updates.factions[0]",
+            "Office of Civic Continuity",
+        ),
         ("tag_hints", "new_entities[0].tag_hints", "human"),
         ("pair_tag_hints", "new_entities[0].pair_tag_hints[0].tag", "protects"),
         (


### PR DESCRIPTION
## Summary

- run synchronous narrative acceptance and correspondence compaction in worker-owned connection lifecycles outside FastAPI event-loop threads
- release unscheduled generation leases on request cancellation and hand post-commit Orrery work off before cancellation can interrupt delivery
- serialize parallel approvals by transactionally claiming the incubator row before applying canonical turn effects
- keep durable narrative acceptance successful when derived compaction fails, leaving the journal intact for deterministic retry
- validate faction update IDs and names against the live canonical table inside the bounded storyteller repair loop
- allow exact same-turn faction declarations only when runtime maturation can materialize their stubs; otherwise require persisted canonical identity

## Validation

- `poetry run pytest -q` — 2,026 passed, 462 skipped
- `NEXUS_RUN_POSTGRES=1 poetry run pytest -q tests/test_api/test_correspondence_pg.py` — 2 passed; verified the 10→11 digest boundary and observed a second approval backend waiting on the first transaction's incubator row claim
- focused `flake8` on changed implementation/test modules — passed (excluding `nexus/api/narrative.py`, which retains pre-existing repository lint findings)
- `poetry run mypy nexus/agents/logon/orrery_tag_validation.py nexus/api/commit_handler_sync.py` — passed

## Data impact

No schema, migration, or configuration changes. Failed compaction leaves the accepted correspondence journal untouched and retries on the next accepted correspondence turn. Post-commit Orrery queues remain durable across worker failures.

Closes #633
Closes #634

Codex — gpt-5.6-sol