### PR TITLE
Pin every remote model route in the QA lane and rotate probe depth

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -1148,7 +1148,10 @@ usage_dir = ".nexus/runtime/usage"  # relative paths resolve against the repo ro
 [usage.daily_allowance]
 # Per-provider daily API-token allowances (UTC day), used for readout only —
 # measurement, never enforcement. Providers without an entry show no allowance.
-openai = 2500000
+# Owner is OpenAI usage tier 4: 10M/day complimentary for the Terra-class
+# model group (Sol/o3-class premium models have a separate 1M/24h pool this
+# readout does not track).
+openai = 10000000
 
 # =============================================================================
 # Managed Runtime (issue #396) — nexus up / down / restart / status / logs

--- a/scripts/qa_shift/README.md
+++ b/scripts/qa_shift/README.md
@@ -46,6 +46,17 @@ discovery mechanism. Reconfirm the organization’s current complimentary-token
 enrollment and eligible model group before raising it or changing
 `target_model`.
 
+## Seeds
+
+Shallow single-request probes stop finding bugs once the early-game surface
+hardens; state-threshold defects (compaction, alias accumulation) only appear
+deep into a campaign. Drop a checksummed mid-campaign `pg_dump -Fc` dump into
+`temp/qa_seeds/` (ignored, conventionally preserved) and the shift seeds the
+disposable slot from the newest one instead of a bare reset, then owes at
+least two deep-state probe families per `mission_prompt.md`. Prune stale
+seeds whenever the schema or campaign shape they capture stops being
+representative.
+
 ## Usage guard
 
 Run the helper through Poetry:

--- a/scripts/qa_shift/mission_prompt.md
+++ b/scripts/qa_shift/mission_prompt.md
@@ -70,9 +70,17 @@ issue, dry-well, wall-clock, and token settings.
    without `NEXUS_RUNTIME_CONFIG`) and save its complete output in the archive.
    A baseline failure is a candidate, not permission to patch it.
 6. Stop only the isolated QA lane if it is stale. Back up `save_04` with
-   `pg_dump -Fc`, checksum the dump, reset only the configured slot through
-   `scripts/new_story_setup.py --force`, start the isolated gateway, and verify
-   its health and effective model. Save the commands and outputs.
+   `pg_dump -Fc` and checksum the dump. Then initialize the slot:
+   - If `temp/qa_seeds/` holds at least one `.dump` file, seed from the newest
+     instead of a bare reset: drop and recreate only the configured slot
+     database, restore with `pg_restore --no-owner`, then apply pending
+     migrations with `scripts/migrate.py --slot N`. Record the seed path and
+     its sha256.
+   - Otherwise reset only the configured slot through
+     `scripts/new_story_setup.py --force`.
+
+   Start the isolated gateway and verify its health and effective model. Save
+   the commands and outputs.
 
 If any preflight step fails, write the blocker into the mission report, perform
 the applicable teardown, and stop.
@@ -108,6 +116,16 @@ Behave like an unhinged, unpredictable, but honest user. Vary malformed,
 contradictory, free-text, adversarial, concurrency, undo/regenerate, and
 continuity-sensitive inputs. A probe family is distinct only when it tests a
 different public contract or state transition, not a cosmetic prompt variant.
+
+Rotate depth as well as surface. When the slot was seeded from a mid-campaign
+dump, at least two completed probe families must target deep-state mechanics:
+correspondence compaction triggers and digest fidelity, entity/alias
+accumulation at commit time, long-horizon constraint persistence,
+undo/regenerate against a mature journal, or Orrery behavior under sustained
+ticks. Single-request contract probes against early-wizard surfaces cannot
+fill the whole roster when depth is available; the 2026-07-30 shift ran dry
+on shallow families the same night a deep campaign on the same commit hit two
+commit-path defects.
 
 For every family:
 
@@ -146,7 +164,8 @@ Always complete teardown, including early exits:
 3. Run
    `poetry run python scripts/qa_shift/qa_shift.py finish ARCHIVE
    --exit-condition CONDITION`, selecting the truthful configured condition.
-4. Complete `mission_report.md` with checkout and suite baseline, issue links,
+4. Complete `mission_report.md` with checkout and suite baseline, slot
+   initialization (seed dump path and sha256, or fresh reset), issue links,
    probe-family negative results, evidence inventory, start/end/delta/max
    usage, exit condition, and final lane/slot disposition.
 5. Return a concise scheduled-task result with the report path and issue links.

--- a/scripts/qa_shift/mission_prompt.md
+++ b/scripts/qa_shift/mission_prompt.md
@@ -75,7 +75,13 @@ issue, dry-well, wall-clock, and token settings.
      instead of a bare reset: drop and recreate only the configured slot
      database, restore with `pg_restore --no-owner`, then apply pending
      migrations with `scripts/migrate.py --slot N`. Record the seed path and
-     its sha256.
+     its sha256. Then align the restored state with this lane before starting
+     the gateway: set `global_variables.model` and
+     `global_variables.slot_number` to the configured target model and slot,
+     and delete queued job rows carried in from the source lane
+     (`orrery_narration_jobs`, `orrery_maturation_jobs`). Setup-phase SQL is
+     acceptable for this alignment; record the statements and affected row
+     counts.
    - Otherwise reset only the configured slot through
      `scripts/new_story_setup.py --force`.
 

--- a/scripts/qa_shift/qa_shift.py
+++ b/scripts/qa_shift/qa_shift.py
@@ -250,8 +250,8 @@ def _write_runtime_config(
             )
 
         model["default_slot_model"] = config.target_model
-        openai["roles"]["default"] = config.target_model
-        openai["roles"]["gaia"] = config.target_model
+        for role in openai["roles"]:
+            openai["roles"][role] = config.target_model
         # Remote routes not expressed as @openai.<role> refs escape the role
         # pins above and need direct pins; tests/test_qa_shift.py enforces the
         # full route roster against drift.

--- a/scripts/qa_shift/qa_shift.py
+++ b/scripts/qa_shift/qa_shift.py
@@ -252,6 +252,13 @@ def _write_runtime_config(
         model["default_slot_model"] = config.target_model
         openai["roles"]["default"] = config.target_model
         openai["roles"]["gaia"] = config.target_model
+        # Remote routes not expressed as @openai.<role> refs escape the role
+        # pins above and need direct pins; tests/test_qa_shift.py enforces the
+        # full route roster against drift.
+        dynamic_document["wizard"]["fallback_model"] = "@openai.default"
+        narration = dynamic_document["orrery"]["narration"]
+        narration["provider"] = "openai"
+        narration["model_ref"] = "@openai.default"
         dynamic_document["usage"]["daily_allowance"][
             "openai"
         ] = config.daily_token_limit

--- a/tests/test_qa_shift.py
+++ b/tests/test_qa_shift.py
@@ -6,6 +6,8 @@ from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
+import tomllib
+from typing import Any, Mapping
 
 import pytest
 import tomlkit
@@ -123,13 +125,16 @@ def test_begin_creates_archive_and_pins_every_openai_role(
     assert model["default_slot_model"] == "gpt-5.6-terra"
     assert roles["default"] == "gpt-5.6-terra"
     assert roles["gaia"] == "gpt-5.6-terra"
+    assert document["wizard"]["fallback_model"] == "@openai.default"
+    assert document["orrery"]["narration"]["provider"] == "openai"
+    assert document["orrery"]["narration"]["model_ref"] == "@openai.default"
     assert document["usage"]["daily_allowance"]["openai"] == 10_000_000
     assert (archive / "runtime_env.sh").exists()
     assert (archive / "probe_ledger.md").exists()
     assert (archive / "mission_report.md").exists()
 
 
-@pytest.mark.parametrize("missing_table", ("roles", "daily_allowance"))
+@pytest.mark.parametrize("missing_table", ("roles", "daily_allowance", "narration"))
 def test_runtime_config_shape_errors_are_clean_shift_errors(
     tmp_path: Path,
     missing_table: str,
@@ -141,6 +146,8 @@ def test_runtime_config_shape_errors_are_clean_shift_errors(
     document = tomlkit.parse((qa_shift.REPO_ROOT / "nexus.toml").read_text())
     if missing_table == "roles":
         del document["global"]["model"]["api_models"]["openai"]["roles"]
+    elif missing_table == "narration":
+        del document["orrery"]["narration"]
     else:
         del document["usage"]["daily_allowance"]
     (repo / "nexus.toml").write_text(tomlkit.dumps(document))
@@ -150,6 +157,69 @@ def test_runtime_config_shape_errors_are_clean_shift_errors(
             repo_root=repo,
             archive=archive,
             config=qa_shift.load_shift_config(),
+        )
+
+
+MODEL_ROUTE_KEYS = {
+    "compaction_model",
+    "default_model",
+    "default_slot_model",
+    "fallback_model",
+    "gaia_model",
+    "model_ref",
+    "target_model",
+}
+
+DIRECTLY_PINNED_ROUTES = {
+    "global.model.default_slot_model",
+    "orrery.narration.model_ref",
+    "wizard.fallback_model",
+}
+
+NON_REMOTE_ROUTES = {
+    # Local embedding retriever; never a provider API call.
+    "memnon.retrieval.hybrid_search.target_model",
+}
+
+
+def _collect_model_routes(table: Mapping[str, Any], prefix: str = "") -> dict[str, str]:
+    routes: dict[str, str] = {}
+    for key, value in table.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            routes.update(_collect_model_routes(value, path))
+        elif isinstance(value, str) and key in MODEL_ROUTE_KEYS:
+            routes[path] = value
+    return routes
+
+
+def test_every_tracked_model_route_is_pinned_or_role_indirect() -> None:
+    """Every remote model route in nexus.toml must be covered by the QA lane.
+
+    The lane rewrites the openai roles table, so any ``@openai.<role>`` ref is
+    pinned by indirection. Every other route must be pinned directly in
+    ``_write_runtime_config`` (or be a non-remote local route). An unclassified
+    route means the isolated lane silently leaks calls to an unpinned
+    provider — the Orrery-narration leak the 2026-07-30 scratchpad audit
+    caught live, and the wizard-fallback leak found while closing it.
+    """
+    document = tomllib.loads(
+        (qa_shift.REPO_ROOT / "nexus.toml").read_text(encoding="utf-8")
+    )
+    routes = _collect_model_routes(document)
+
+    missing = (DIRECTLY_PINNED_ROUTES | NON_REMOTE_ROUTES) - set(routes)
+    assert not missing, (
+        f"Routes {sorted(missing)} vanished from nexus.toml; update the pin "
+        "roster and _write_runtime_config together"
+    )
+    for path, value in routes.items():
+        if path in DIRECTLY_PINNED_ROUTES | NON_REMOTE_ROUTES:
+            continue
+        assert value.startswith("@openai."), (
+            f"{path} = {value!r} is not covered by the QA lane's openai role "
+            "pins; pin it in _write_runtime_config and add it to "
+            "DIRECTLY_PINNED_ROUTES"
         )
 
 

--- a/tests/test_qa_shift.py
+++ b/tests/test_qa_shift.py
@@ -123,8 +123,8 @@ def test_begin_creates_archive_and_pins_every_openai_role(
     assert state["baseline_total"] == 123
     assert state["status"] == "active"
     assert model["default_slot_model"] == "gpt-5.6-terra"
-    assert roles["default"] == "gpt-5.6-terra"
-    assert roles["gaia"] == "gpt-5.6-terra"
+    assert set(roles) >= {"default", "gaia"}
+    assert all(value == "gpt-5.6-terra" for value in roles.values())
     assert document["wizard"]["fallback_model"] == "@openai.default"
     assert document["orrery"]["narration"]["provider"] == "openai"
     assert document["orrery"]["narration"]["model_ref"] == "@openai.default"
@@ -166,6 +166,7 @@ MODEL_ROUTE_KEYS = {
     "default_slot_model",
     "fallback_model",
     "gaia_model",
+    "model",
     "model_ref",
     "target_model",
 }
@@ -213,6 +214,7 @@ def test_every_tracked_model_route_is_pinned_or_role_indirect() -> None:
         f"Routes {sorted(missing)} vanished from nexus.toml; update the pin "
         "roster and _write_runtime_config together"
     )
+    openai_roles = document["global"]["model"]["api_models"]["openai"]["roles"]
     for path, value in routes.items():
         if path in DIRECTLY_PINNED_ROUTES | NON_REMOTE_ROUTES:
             continue
@@ -220,6 +222,12 @@ def test_every_tracked_model_route_is_pinned_or_role_indirect() -> None:
             f"{path} = {value!r} is not covered by the QA lane's openai role "
             "pins; pin it in _write_runtime_config and add it to "
             "DIRECTLY_PINNED_ROUTES"
+        )
+        role = value.removeprefix("@openai.")
+        assert role in openai_roles, (
+            f"{path} = {value!r} references openai role {role!r}, which is "
+            "absent from the roles table _write_runtime_config rewrites; the "
+            "lane would leave it unpinned"
         )
 
 


### PR DESCRIPTION
## Summary

Closes the isolated-lane model-route leak the 2026-07-30 scratchpad audit caught live, plus a second leak found while closing it, and rotates the nightly QA shift's probe charter toward the depth band where bugs actually surfaced.

- **Route pinning**: `_write_runtime_config` now pins `wizard.fallback_model` and `[orrery.narration]` (provider + model_ref) into the generated lane config. The audit observed two async Orrery narration jobs escaping to the tracked Anthropic route; the wizard fallback had the identical exposure but no fallback happened to fire that night.
- **Drift-guard roster test**: walks `nexus.toml`, collects every model-route key, and requires each to be directly pinned, `@openai.<role>`-indirect (covered by the roles-table rewrite), or explicitly non-remote. A future route added without lane coverage fails the suite at commit time instead of leaking during an unattended shift.
- **Depth rotation** (`mission_prompt.md`): optional seed-based slot initialization from `temp/qa_seeds/` (newest checksummed dump, then `migrate.py`), and a requirement that at least two probe families target deep-state mechanics when seeded. Rationale: the first automated shift hit its dry-well exit on shallow families the same night a deep campaign on the same commit produced #633/#634.
- **Allowance correction**: `[usage.daily_allowance] openai` 2.5M → 10M (owner is tier 4; the old figure was the tiers-1–2 number). Readout-only, never enforcement.

## Testing

- `tests/test_qa_shift.py`: 12 passed (new: narration shape-error case, route-roster drift guard; extended: lane-pin assertions).
- Full suite in the worktree: 2027 passed, 463 skipped.
- mypy: no new error classes (the file's 12 pre-existing tomlkit `Item | Container` errors remain the established idiom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gEoexyFZe1M6tQDqBsK5p