### PR TITLE
Log Every Rejected Structured-Output Attempt with Sanitized Error Text

### DIFF
--- a/nexus/agents/logon/orrery_tag_validation.py
+++ b/nexus/agents/logon/orrery_tag_validation.py
@@ -500,8 +500,9 @@ def build_storyteller_tag_validator(
             )
             logger.info(
                 "Storyteller output failed registry validation "
-                "(%s issues); requesting model retry",
+                "(%s issues); requesting model retry:\n%s",
                 len(issues),
+                formatted,
             )
             raise ModelRetry(
                 "Your Orrery tags, new-entity declaration hints, replacement "

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -50,6 +50,9 @@ from nexus.agents.orrery.tag_library import (  # noqa: E402
     format_contextual_tag_library,
     format_tag_library_for_prompt,
 )
+from nexus.api.native_structured_output import (  # noqa: E402
+    structured_output_error_text,
+)
 from nexus.config.loader import get_provider_for_model, resolve_model_ref  # noqa: E402
 from nexus.config.settings_models import (  # noqa: E402
     OrreryRetrogradeMaturationSettings,
@@ -874,9 +877,13 @@ class LogonUtility:
                 len(response.narrative),
             )
             return self._stamp_generation_model(response)
-        except Exception:
+        except Exception as exc:
             self._generated_correspondence = None
-            logger.exception("Failed to get structured response")
+            logger.error(
+                "Failed to get structured response: exception=%s error=%s",
+                type(exc).__name__,
+                structured_output_error_text(exc),
+            )
             raise
 
     async def generate_narrative_async(
@@ -939,9 +946,13 @@ class LogonUtility:
                 len(response.narrative),
             )
             return self._stamp_generation_model(response)
-        except Exception:
+        except Exception as exc:
             self._generated_correspondence = None
-            logger.exception("Failed to get structured response")
+            logger.error(
+                "Failed to get structured response: exception=%s error=%s",
+                type(exc).__name__,
+                structured_output_error_text(exc),
+            )
             raise
 
     def take_generated_correspondence(self) -> Optional[GeneratedCorrespondence]:

--- a/nexus/api/native_structured_output.py
+++ b/nexus/api/native_structured_output.py
@@ -11,7 +11,7 @@ import inspect
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Type, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from pydantic_ai import JsonSchemaTransformer
 
 
@@ -276,6 +276,20 @@ def retry_prompt(prompt: str, message: str) -> str:
         "empty arrays for absent optional values instead of omitting required "
         "strict-schema keys."
     )
+
+
+def structured_output_error_text(exc: BaseException) -> str:
+    """Render a complete structured-output error without Pydantic input values."""
+
+    if not isinstance(exc, ValidationError):
+        message = getattr(exc, "message", None)
+        return message if isinstance(message, str) else str(exc)
+
+    formatted_errors = []
+    for error in exc.errors(include_input=False, include_url=False):
+        location = ".".join(str(part) for part in error["loc"]) or "<root>"
+        formatted_errors.append(f"{location}: {error['msg']} ({error['type']})")
+    return "; ".join(formatted_errors)
 
 
 async def run_output_validator(

--- a/nexus/api/native_structured_output.py
+++ b/nexus/api/native_structured_output.py
@@ -281,6 +281,9 @@ def retry_prompt(prompt: str, message: str) -> str:
 def structured_output_error_text(exc: BaseException) -> str:
     """Render a complete structured-output error without Pydantic input values."""
 
+    # Privacy contract: validator-authored messages must never interpolate
+    # payload prose. The wire and LOGON sentinel-sweep tests enforce this for
+    # both Pydantic error messages and ModelRetry output-validator guidance.
     if not isinstance(exc, ValidationError):
         message = getattr(exc, "message", None)
         return message if isinstance(message, str) else str(exc)

--- a/scripts/api_anthropic.py
+++ b/scripts/api_anthropic.py
@@ -81,6 +81,7 @@ from nexus.api.native_structured_output import (
     anthropic_output_config,
     retry_prompt,
     run_output_validator,
+    structured_output_error_text,
 )
 from nexus.telemetry.usage import record_anthropic_response
 
@@ -622,6 +623,40 @@ class AnthropicProvider(LLMProvider):
             f"event loop; use AnthropicProvider.{async_method_name}() instead."
         )
 
+    def _log_structured_output_rejection(
+        self,
+        *,
+        transport: Literal["native", "prompted", "tool_envelope"],
+        attempt: int,
+        exc: BaseException,
+    ) -> None:
+        """Log one validation rejection and any terminal retry exhaustion."""
+
+        attempt_number = attempt + 1
+        error_text = structured_output_error_text(exc)
+        exception_name = type(exc).__name__
+        logger.warning(
+            "structured-output rejected transport=%s model=%s seat=%s "
+            "attempt=%d exception=%s error=%s",
+            transport,
+            self.model,
+            self.usage_seat,
+            attempt_number,
+            exception_name,
+            error_text,
+        )
+        if attempt >= self.structured_output_retries:
+            logger.warning(
+                "structured-output retries exhausted transport=%s model=%s "
+                "seat=%s attempt=%d exception=%s error=%s action=propagate",
+                transport,
+                self.model,
+                self.usage_seat,
+                attempt_number,
+                exception_name,
+                error_text,
+            )
+
     def _get_structured_completion_native_sync(
         self,
         prompt: str,
@@ -696,12 +731,22 @@ class AnthropicProvider(LLMProvider):
             except ModelRetry as exc:
                 last_error = exc
                 usage_outcome = "rejected_validation"
+                self._log_structured_output_rejection(
+                    transport="native",
+                    attempt=attempt,
+                    exc=exc,
+                )
                 if attempt >= self.structured_output_retries:
                     raise
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
                 usage_outcome = "rejected_validation"
+                self._log_structured_output_rejection(
+                    transport="native",
+                    attempt=attempt,
+                    exc=exc,
+                )
                 if attempt >= self.structured_output_retries:
                     raise
                 active_prompt = retry_prompt(prompt, str(exc))
@@ -762,12 +807,22 @@ class AnthropicProvider(LLMProvider):
             except ModelRetry as exc:
                 last_error = exc
                 usage_outcome = "rejected_validation"
+                self._log_structured_output_rejection(
+                    transport="tool_envelope",
+                    attempt=attempt,
+                    exc=exc,
+                )
                 if attempt >= self.structured_output_retries:
                     raise
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
                 usage_outcome = "rejected_validation"
+                self._log_structured_output_rejection(
+                    transport="tool_envelope",
+                    attempt=attempt,
+                    exc=exc,
+                )
                 if attempt >= self.structured_output_retries:
                     raise
                 active_prompt = retry_prompt(prompt, str(exc))
@@ -822,12 +877,22 @@ class AnthropicProvider(LLMProvider):
             except ModelRetry as exc:
                 last_error = exc
                 usage_outcome = "rejected_validation"
+                self._log_structured_output_rejection(
+                    transport="prompted",
+                    attempt=attempt,
+                    exc=exc,
+                )
                 if attempt >= self.structured_output_retries:
                     raise
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
                 usage_outcome = "rejected_validation"
+                self._log_structured_output_rejection(
+                    transport="prompted",
+                    attempt=attempt,
+                    exc=exc,
+                )
                 if attempt >= self.structured_output_retries:
                     raise
                 active_prompt = retry_prompt(prompt, str(exc))

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -87,6 +87,7 @@ from nexus.api.native_structured_output import (
     openai_response_text_format,
     retry_prompt,
     run_output_validator,
+    structured_output_error_text,
 )
 from nexus.telemetry.usage import (
     provider_name_from_base_url,
@@ -498,6 +499,40 @@ class OpenAIProvider(LLMProvider):
             f"event loop; use OpenAIProvider.{async_method_name}() instead."
         )
 
+    def _log_structured_output_rejection(
+        self,
+        *,
+        transport: Literal["responses", "chat_completions"],
+        attempt: int,
+        exc: BaseException,
+    ) -> None:
+        """Log one validation rejection and any terminal retry exhaustion."""
+
+        attempt_number = attempt + 1
+        error_text = structured_output_error_text(exc)
+        exception_name = type(exc).__name__
+        logger.warning(
+            "structured-output rejected transport=%s model=%s seat=%s "
+            "attempt=%d exception=%s error=%s",
+            transport,
+            self.model,
+            self.usage_seat,
+            attempt_number,
+            exception_name,
+            error_text,
+        )
+        if attempt >= self.structured_output_retries:
+            logger.warning(
+                "structured-output retries exhausted transport=%s model=%s "
+                "seat=%s attempt=%d exception=%s error=%s action=propagate",
+                transport,
+                self.model,
+                self.usage_seat,
+                attempt_number,
+                exception_name,
+                error_text,
+            )
+
     def _get_structured_completion_native_sync(
         self,
         prompt: str,
@@ -553,12 +588,22 @@ class OpenAIProvider(LLMProvider):
             except ModelRetry as exc:
                 last_error = exc
                 usage_outcome = "rejected_validation"
+                self._log_structured_output_rejection(
+                    transport="responses",
+                    attempt=attempt,
+                    exc=exc,
+                )
                 if attempt >= self.structured_output_retries:
                     raise
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
                 usage_outcome = "rejected_validation"
+                self._log_structured_output_rejection(
+                    transport="responses",
+                    attempt=attempt,
+                    exc=exc,
+                )
                 if attempt >= self.structured_output_retries:
                     raise
                 active_prompt = retry_prompt(prompt, str(exc))
@@ -654,12 +699,22 @@ class OpenAIProvider(LLMProvider):
             except ModelRetry as exc:
                 last_error = exc
                 usage_outcome = "rejected_validation"
+                self._log_structured_output_rejection(
+                    transport="chat_completions",
+                    attempt=attempt,
+                    exc=exc,
+                )
                 if attempt >= self.structured_output_retries:
                     raise
                 active_prompt = retry_prompt(prompt, exc.message)
             except (ValidationError, json.JSONDecodeError, ValueError) as exc:
                 last_error = exc
                 usage_outcome = "rejected_validation"
+                self._log_structured_output_rejection(
+                    transport="chat_completions",
+                    attempt=attempt,
+                    exc=exc,
+                )
                 if attempt >= self.structured_output_retries:
                     raise
                 active_prompt = retry_prompt(prompt, str(exc))

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 from types import SimpleNamespace
+from typing import Any, Callable, cast, Literal
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 from pydantic import ValidationError
+from pydantic_ai import ModelRetry
 
 from nexus.agents.logon.apex_schema import (
     StorytellerResponseBootstrap,
@@ -56,8 +60,59 @@ def _wire_response() -> SkaldTurnWire:
     )
 
 
+def _writer_response() -> SkaldWriterWire:
+    return SkaldWriterWire(
+        narrative="[TEST MODE] Writer structured output.",
+        choices=["Continue", "Wait"],
+        letter="Keep the next beat private.",
+    )
+
+
 def _gaia_response() -> SkaldGaiaWire:
     return SkaldGaiaWire(letter="I will make room for it.")
+
+
+def _reject_first_structured_output(
+    rejection_kind: Literal["model_retry", "validation_error"],
+) -> tuple[
+    Callable[[Any, SkaldWriterWire], SkaldWriterWire],
+    str,
+    str,
+    str,
+]:
+    """Build a one-shot validator rejection, including a private-input error."""
+
+    sentinel = "PRIVATE-LETTER-637"
+    try:
+        SkaldWriterWire.model_validate(
+            {
+                "narrative": "N",
+                "letter": sentinel,
+            }
+        )
+    except ValidationError as exc:
+        validation_error = exc
+    else:
+        raise AssertionError("The deliberately incomplete writer payload was valid")
+
+    assert sentinel in str(validation_error)
+    model_retry_message = "writer registry validator rejected the response"
+
+    def validator(ctx: Any, output: SkaldWriterWire) -> SkaldWriterWire:
+        if ctx.retry == 0:
+            if rejection_kind == "model_retry":
+                raise ModelRetry(model_retry_message)
+            raise validation_error
+        return output
+
+    if rejection_kind == "model_retry":
+        return validator, sentinel, "ModelRetry", model_retry_message
+    return (
+        validator,
+        sentinel,
+        "ValidationError",
+        "choices: Field required (missing)",
+    )
 
 
 def _contains_key(value: object, key: str) -> bool:
@@ -679,6 +734,105 @@ def test_openai_provider_uses_responses_parse_text_format() -> None:
     assert captured["max_output_tokens"] == 1234
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ["responses", "chat_completions"])
+@pytest.mark.parametrize("call_style", ["sync", "async"])
+@pytest.mark.parametrize("rejection_kind", ["model_retry", "validation_error"])
+async def test_openai_rejection_logs_cover_every_transport_branch_without_input_leaks(
+    caplog: pytest.LogCaptureFixture,
+    transport: Literal["responses", "chat_completions"],
+    call_style: Literal["sync", "async"],
+    rejection_kind: Literal["model_retry", "validation_error"],
+) -> None:
+    """OpenAI sync/async transports log every rejected branch without letters."""
+
+    expected = _writer_response()
+    validator, sentinel, exception_name, error_text = _reject_first_structured_output(
+        rejection_kind
+    )
+    prompts: list[str] = []
+
+    class FakeResponses:
+        def parse(self, **kwargs: Any) -> Any:
+            prompts.append(kwargs["input"][-1]["content"])
+            return SimpleNamespace(
+                output_parsed=expected,
+                output_text=expected.model_dump_json(),
+                usage=SimpleNamespace(input_tokens=11, output_tokens=22),
+            )
+
+    class FakeChatCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            prompts.append(kwargs["messages"][-1]["content"])
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content=expected.model_dump_json())
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=11, completion_tokens=22),
+            )
+
+    provider = OpenAIProvider(
+        model="openai-log-test-model",
+        api_key="test-key",
+        base_url=(
+            "https://structured-output.invalid/v1"
+            if transport == "chat_completions"
+            else None
+        ),
+        structured_transport=transport,
+        structured_output_retries=1,
+        output_validator=validator,
+        usage_seat="writer",
+    )
+    provider.client = cast(
+        Any,
+        SimpleNamespace(
+            responses=FakeResponses(),
+            chat=SimpleNamespace(completions=FakeChatCompletions()),
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="nexus.metadata"):
+        if call_style == "sync":
+            parsed, _llm_response = await asyncio.to_thread(
+                provider.get_structured_completion,
+                "Write the next beat.",
+                SkaldWriterWire,
+            )
+        else:
+            parsed, _llm_response = await provider.get_structured_completion_async(
+                "Write the next beat.",
+                SkaldWriterWire,
+            )
+
+    assert parsed == expected
+    assert len(prompts) == 2
+    rejection_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("structured-output rejected")
+    ]
+    assert len(rejection_logs) == 1
+    rejection_log = rejection_logs[0]
+    assert f"transport={transport}" in rejection_log
+    assert "model=openai-log-test-model" in rejection_log
+    assert "seat=writer" in rejection_log
+    assert "attempt=1" in rejection_log
+    assert f"exception={exception_name}" in rejection_log
+    assert f"error={error_text}" in rejection_log
+    assert sentinel not in caplog.text
+    assert not any(
+        record.getMessage().startswith("structured-output retries exhausted")
+        for record in caplog.records
+    )
+    if rejection_kind == "validation_error":
+        assert sentinel in prompts[1]
+    else:
+        assert error_text in prompts[1]
+
+
 def test_openai_provider_accepts_native_text_format_override() -> None:
     """Runtime-mutated schemas ride text.format and still parse to Pydantic."""
 
@@ -881,6 +1035,98 @@ def test_anthropic_provider_uses_native_output_format() -> None:
     assert "tools" not in captured
     assert captured["system"] == "System prompt"
     assert captured["max_tokens"] == 5678
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ["native", "prompted", "tool_envelope"])
+@pytest.mark.parametrize("call_style", ["sync", "async"])
+@pytest.mark.parametrize("rejection_kind", ["model_retry", "validation_error"])
+async def test_anthropic_rejection_logs_cover_every_transport_branch_without_input_leaks(
+    caplog: pytest.LogCaptureFixture,
+    transport: Literal["native", "prompted", "tool_envelope"],
+    call_style: Literal["sync", "async"],
+    rejection_kind: Literal["model_retry", "validation_error"],
+) -> None:
+    """Anthropic sync/async transports log rejected branches without letters."""
+
+    expected = _writer_response()
+    validator, sentinel, exception_name, error_text = _reject_first_structured_output(
+        rejection_kind
+    )
+    prompts: list[str] = []
+
+    class FakeMessages:
+        def create(self, **kwargs: Any) -> Any:
+            prompts.append(kwargs["messages"][-1]["content"])
+            if transport == "tool_envelope":
+                content = [
+                    SimpleNamespace(
+                        type="tool_use",
+                        name="submit_structured_response",
+                        input=expected.model_dump(mode="json"),
+                    )
+                ]
+            else:
+                content = [
+                    SimpleNamespace(type="text", text=expected.model_dump_json())
+                ]
+            return SimpleNamespace(
+                content=content,
+                usage=SimpleNamespace(input_tokens=33, output_tokens=44),
+            )
+
+    provider = AnthropicProvider(
+        model="anthropic-log-test-model",
+        api_key="test-key",
+        structured_transport=transport,
+        structured_output_retries=1,
+        output_validator=validator,
+        usage_seat="writer",
+    )
+    provider.client = cast(
+        Any,
+        SimpleNamespace(
+            beta=SimpleNamespace(messages=FakeMessages()),
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="nexus.metadata"):
+        if call_style == "sync":
+            parsed, _llm_response = await asyncio.to_thread(
+                provider.get_structured_completion,
+                "Write the next beat.",
+                SkaldWriterWire,
+            )
+        else:
+            parsed, _llm_response = await provider.get_structured_completion_async(
+                "Write the next beat.",
+                SkaldWriterWire,
+            )
+
+    assert parsed == expected
+    assert len(prompts) == 2
+    rejection_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("structured-output rejected")
+    ]
+    assert len(rejection_logs) == 1
+    rejection_log = rejection_logs[0]
+    assert f"transport={transport}" in rejection_log
+    assert "model=anthropic-log-test-model" in rejection_log
+    assert "seat=writer" in rejection_log
+    assert "attempt=1" in rejection_log
+    assert f"exception={exception_name}" in rejection_log
+    assert f"error={error_text}" in rejection_log
+    assert sentinel not in caplog.text
+    assert not any(
+        record.getMessage().startswith("structured-output retries exhausted")
+        for record in caplog.records
+    )
+    if rejection_kind == "validation_error":
+        assert sentinel in prompts[1]
+    else:
+        assert error_text in prompts[1]
 
 
 def test_anthropic_provider_rejects_unknown_structured_transport() -> None:
@@ -1192,7 +1438,9 @@ async def test_anthropic_prompted_transport_async_parses_bare_fence() -> None:
     assert "output_format" not in calls[0]
 
 
-def test_anthropic_prompted_transport_repairs_then_raises_on_garbage() -> None:
+def test_anthropic_prompted_transport_repairs_then_raises_on_garbage(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     calls = []
 
     class FakeMessages:
@@ -1208,16 +1456,39 @@ def test_anthropic_prompted_transport_repairs_then_raises_on_garbage() -> None:
         api_key="test-key",
         structured_transport="prompted",
         structured_output_retries=1,
+        usage_seat="storyteller",
     )
     provider.client = SimpleNamespace(beta=SimpleNamespace(messages=FakeMessages()))
 
-    with pytest.raises(ValidationError, match="Invalid JSON"):
-        provider.get_structured_completion("Prompt", StorytellerResponseBootstrap)
+    with caplog.at_level(logging.WARNING, logger="nexus.metadata"):
+        with pytest.raises(ValidationError, match="Invalid JSON"):
+            provider.get_structured_completion("Prompt", StorytellerResponseBootstrap)
 
     assert len(calls) == 2
     assert calls[0]["messages"][0]["content"] == "Prompt"
     assert "=== STRUCTURED OUTPUT RETRY ===" in calls[1]["messages"][0]["content"]
     assert all("output_config" not in request for request in calls)
+    rejection_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("structured-output rejected")
+    ]
+    assert len(rejection_logs) == 2
+    assert "attempt=1" in rejection_logs[0]
+    assert "attempt=2" in rejection_logs[1]
+    exhaustion_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("structured-output retries exhausted")
+    ]
+    assert len(exhaustion_logs) == 1
+    assert "transport=prompted" in exhaustion_logs[0]
+    assert "model=claude-sonnet-4-5" in exhaustion_logs[0]
+    assert "seat=storyteller" in exhaustion_logs[0]
+    assert "attempt=2" in exhaustion_logs[0]
+    assert "exception=ValidationError" in exhaustion_logs[0]
+    assert "action=propagate" in exhaustion_logs[0]
+    assert "persistent garbage" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, cast, Literal
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from pydantic_ai import ModelRetry
 
 from nexus.agents.logon.apex_schema import (
@@ -37,7 +37,9 @@ from nexus.api.native_structured_output import (
     build_native_structured_provider,
     de_null_schema,
     openai_response_text_format,
+    retry_prompt,
     strict_json_schema,
+    structured_output_error_text,
 )
 from nexus.config import resolve_model_ref
 from scripts import api_openai
@@ -60,34 +62,38 @@ def _wire_response() -> SkaldTurnWire:
     )
 
 
-def _writer_response() -> SkaldWriterWire:
-    return SkaldWriterWire(
-        narrative="[TEST MODE] Writer structured output.",
-        choices=["Continue", "Wait"],
-        letter="Keep the next beat private.",
-    )
-
-
 def _gaia_response() -> SkaldGaiaWire:
     return SkaldGaiaWire(letter="I will make room for it.")
 
 
 def _reject_first_structured_output(
-    rejection_kind: Literal["model_retry", "validation_error"],
+    rejection_kind: Literal[
+        "model_retry",
+        "validation_error",
+        "value_error",
+        "json_decode_error",
+    ],
 ) -> tuple[
     Callable[[Any, SkaldWriterWire], SkaldWriterWire],
+    SkaldWriterWire,
+    str,
     str,
     str,
     str,
 ]:
-    """Build a one-shot validator rejection, including a private-input error."""
+    """Build a one-shot rejection for every provider repair-loop branch."""
 
-    sentinel = "PRIVATE-LETTER-637"
+    sentinel = "PRIV637"
+    expected = SkaldWriterWire(
+        narrative=f"{sentinel} narrative",
+        choices=[f"{sentinel} choice one", f"{sentinel} choice two"],
+        letter=f"{sentinel} letter",
+    )
     try:
         SkaldWriterWire.model_validate(
             {
-                "narrative": "N",
-                "letter": sentinel,
+                "narrative": f"{sentinel} narrative",
+                "letter": f"{sentinel} letter",
             }
         )
     except ValidationError as exc:
@@ -97,22 +103,158 @@ def _reject_first_structured_output(
 
     assert sentinel in str(validation_error)
     model_retry_message = "writer registry validator rejected the response"
+    value_error_message = "writer semantic validator rejected the response"
+    json_error_message = "writer response was not valid JSON"
+
+    if rejection_kind == "model_retry":
+        rejection: BaseException = ModelRetry(model_retry_message)
+        error_text = model_retry_message
+    elif rejection_kind == "validation_error":
+        rejection = validation_error
+        error_text = "choices: Field required (missing)"
+    elif rejection_kind == "value_error":
+        rejection = ValueError(value_error_message)
+        error_text = value_error_message
+    else:
+        rejection = json.JSONDecodeError(json_error_message, sentinel, 0)
+        error_text = f"{json_error_message}: line 1 column 1 (char 0)"
 
     def validator(ctx: Any, output: SkaldWriterWire) -> SkaldWriterWire:
         if ctx.retry == 0:
-            if rejection_kind == "model_retry":
-                raise ModelRetry(model_retry_message)
-            raise validation_error
+            raise rejection
         return output
 
-    if rejection_kind == "model_retry":
-        return validator, sentinel, "ModelRetry", model_retry_message
+    retry_error_text = (
+        rejection.message if isinstance(rejection, ModelRetry) else str(rejection)
+    )
     return (
         validator,
+        expected,
         sentinel,
-        "ValidationError",
-        "choices: Field required (missing)",
+        type(rejection).__name__,
+        error_text,
+        retry_error_text,
     )
+
+
+_WIRE_PROSE_SENTINEL = "PROSE637"
+
+
+def _wire_prose_payload(wire_model: type[BaseModel]) -> dict[str, Any]:
+    """Return a minimal wire payload with the sentinel in every prose field."""
+
+    if wire_model is SkaldGaiaWire:
+        return {"letter": f"{_WIRE_PROSE_SENTINEL} letter"}
+    return {
+        "narrative": f"{_WIRE_PROSE_SENTINEL} narrative",
+        "choices": [
+            f"{_WIRE_PROSE_SENTINEL} choice one",
+            f"{_WIRE_PROSE_SENTINEL} choice two",
+        ],
+        "letter": f"{_WIRE_PROSE_SENTINEL} letter",
+    }
+
+
+def _identity_only_updates(namespace: str) -> dict[str, list[dict[str, str]]]:
+    """Build one invalid substantive-update arm carrying the sentinel."""
+
+    updates: dict[str, list[dict[str, str]]] = {
+        "characters": [],
+        "places": [],
+        "factions": [],
+        "relationships": [],
+    }
+    if namespace == "relationships":
+        updates[namespace] = [
+            {
+                "name": _WIRE_PROSE_SENTINEL,
+                "other_name": _WIRE_PROSE_SENTINEL,
+            }
+        ]
+    else:
+        updates[namespace] = [{"name": _WIRE_PROSE_SENTINEL}]
+    return updates
+
+
+def _wire_validator_sentinel_cases() -> (
+    list[tuple[type[BaseModel], str, dict[str, Any]]]
+):
+    """Cover every prose-adjacent wire validator family."""
+
+    cases: list[tuple[type[BaseModel], str, dict[str, Any]]] = []
+
+    for presence_wire_model in (SkaldWriterWire, SkaldTurnWire):
+        presence = _wire_prose_payload(presence_wire_model)
+        presence["presence"] = {
+            "enter": [{"kind": "place", "name": _WIRE_PROSE_SENTINEL}]
+        }
+        cases.append((presence_wire_model, "presence_ontology", presence))
+
+        scene = _wire_prose_payload(presence_wire_model)
+        scene["presence"] = {
+            "scene_reset": {
+                "place": {"kind": "character", "name": _WIRE_PROSE_SENTINEL},
+            }
+        }
+        cases.append((presence_wire_model, "scene_ontology", scene))
+
+    for letter_wire_model in (SkaldWriterWire, SkaldTurnWire):
+        letter_null = _wire_prose_payload(letter_wire_model)
+        letter_null["letter"] = None
+        cases.append((letter_wire_model, "letter_null", letter_null))
+
+    gaia_letter_null = _wire_prose_payload(SkaldGaiaWire)
+    gaia_letter_null["letter"] = None
+    # Gaia has no narrative or choices, so retain prose in a nested summary
+    # while the required null letter triggers the model-level validator.
+    gaia_letter_null["new_entities"] = [
+        {
+            "kind": "character",
+            "name": _WIRE_PROSE_SENTINEL,
+            "summary": _WIRE_PROSE_SENTINEL,
+        }
+    ]
+    cases.append((SkaldGaiaWire, "letter_null", gaia_letter_null))
+
+    for update_wire_model in (SkaldGaiaWire, SkaldTurnWire):
+        for namespace in ("characters", "places", "factions", "relationships"):
+            substantive = _wire_prose_payload(update_wire_model)
+            substantive["updates"] = _identity_only_updates(namespace)
+            cases.append(
+                (
+                    update_wire_model,
+                    f"{namespace}_substantive_field",
+                    substantive,
+                )
+            )
+
+    for choice_wire_model in (SkaldWriterWire, SkaldTurnWire):
+        choices = _wire_prose_payload(choice_wire_model)
+        choices["choices"] = [f"{_WIRE_PROSE_SENTINEL} only choice"]
+        cases.append((choice_wire_model, "choices", choices))
+
+    return cases
+
+
+@pytest.mark.parametrize(
+    ("wire_model", "validator_family", "payload"),
+    _wire_validator_sentinel_cases(),
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_structured_output_error_text_omits_wire_payload_prose(
+    wire_model: type[BaseModel],
+    validator_family: str,
+    payload: dict[str, Any],
+) -> None:
+    """Wire validation diagnostics never render private prose input values."""
+
+    with pytest.raises(ValidationError) as exc_info:
+        wire_model.model_validate(payload)
+
+    assert _WIRE_PROSE_SENTINEL in str(exc_info.value), validator_family
+    assert _WIRE_PROSE_SENTINEL not in structured_output_error_text(
+        exc_info.value
+    ), validator_family
 
 
 def _contains_key(value: object, key: str) -> bool:
@@ -737,19 +879,37 @@ def test_openai_provider_uses_responses_parse_text_format() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", ["responses", "chat_completions"])
 @pytest.mark.parametrize("call_style", ["sync", "async"])
-@pytest.mark.parametrize("rejection_kind", ["model_retry", "validation_error"])
+@pytest.mark.parametrize(
+    "rejection_kind",
+    [
+        "model_retry",
+        "validation_error",
+        "value_error",
+        "json_decode_error",
+    ],
+)
 async def test_openai_rejection_logs_cover_every_transport_branch_without_input_leaks(
     caplog: pytest.LogCaptureFixture,
     transport: Literal["responses", "chat_completions"],
     call_style: Literal["sync", "async"],
-    rejection_kind: Literal["model_retry", "validation_error"],
+    rejection_kind: Literal[
+        "model_retry",
+        "validation_error",
+        "value_error",
+        "json_decode_error",
+    ],
 ) -> None:
     """OpenAI sync/async transports log every rejected branch without letters."""
 
-    expected = _writer_response()
-    validator, sentinel, exception_name, error_text = _reject_first_structured_output(
-        rejection_kind
-    )
+    (
+        validator,
+        expected,
+        sentinel,
+        exception_name,
+        error_text,
+        retry_error_text,
+    ) = _reject_first_structured_output(rejection_kind)
+    prompt = "Write the next beat."
     prompts: list[str] = []
 
     class FakeResponses:
@@ -798,17 +958,17 @@ async def test_openai_rejection_logs_cover_every_transport_branch_without_input_
         if call_style == "sync":
             parsed, _llm_response = await asyncio.to_thread(
                 provider.get_structured_completion,
-                "Write the next beat.",
+                prompt,
                 SkaldWriterWire,
             )
         else:
             parsed, _llm_response = await provider.get_structured_completion_async(
-                "Write the next beat.",
+                prompt,
                 SkaldWriterWire,
             )
 
     assert parsed == expected
-    assert len(prompts) == 2
+    assert prompts == [prompt, retry_prompt(prompt, retry_error_text)]
     rejection_logs = [
         record.getMessage()
         for record in caplog.records
@@ -827,10 +987,86 @@ async def test_openai_rejection_logs_cover_every_transport_branch_without_input_
         record.getMessage().startswith("structured-output retries exhausted")
         for record in caplog.records
     )
-    if rejection_kind == "validation_error":
-        assert sentinel in prompts[1]
-    else:
-        assert error_text in prompts[1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call_style", ["sync", "async"])
+async def test_logon_terminal_validation_propagation_logs_no_payload_prose(
+    caplog: pytest.LogCaptureFixture,
+    call_style: Literal["sync", "async"],
+) -> None:
+    """Exhausted wire validation remains private through LOGON's caller catch."""
+
+    sentinel = "TERM637"
+    invalid_output = {
+        "narrative": f"{sentinel} narrative",
+        "choices": [f"{sentinel} only choice"],
+        "letter": f"{sentinel} letter",
+    }
+    prompts: list[str] = []
+
+    class FakeResponses:
+        def parse(self, **kwargs: Any) -> Any:
+            prompts.append(kwargs["input"][-1]["content"])
+            return SimpleNamespace(
+                output_parsed=None,
+                output_text=json.dumps(invalid_output),
+                usage=SimpleNamespace(input_tokens=11, output_tokens=22),
+            )
+
+    provider = OpenAIProvider(
+        model="terminal-propagation-test-model",
+        api_key="test-key",
+        structured_output_retries=1,
+        usage_seat="skald_single_pass",
+    )
+    provider.client = cast(Any, SimpleNamespace(responses=FakeResponses()))
+    utility = LogonUtility(
+        {"API Settings": {"apex": {"turn_pipeline": "single_pass"}}},
+        model_override=provider.model,
+    )
+    utility.provider = provider
+    utility._provider_bootstrap_mode = False
+    utility._provider_wire_type = "openai"
+    utility._provider_type_name = "openai"
+    utility._system_prompt = "System prompt"
+    context = {
+        "user_input": "Continue.",
+        "warm_slice": {"chunks": []},
+        "entity_data": {},
+        "retrieved_passages": {"results": []},
+    }
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(ValidationError) as exc_info:
+            if call_style == "sync":
+                await asyncio.to_thread(
+                    utility.generate_narrative,
+                    context,
+                    effective_context_window=75_000,
+                )
+            else:
+                await utility.generate_narrative_async(
+                    context,
+                    effective_context_window=75_000,
+                )
+
+    assert len(prompts) == 2
+    assert sentinel in str(exc_info.value)
+    assert sentinel not in caplog.text
+    caller_logs = [
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("Failed to get structured response")
+    ]
+    assert len(caller_logs) == 1
+    assert "exception=ValidationError" in caller_logs[0].getMessage()
+    assert (
+        "error=choices: List should have at least 2 items"
+        in caller_logs[0].getMessage()
+    )
+    assert caller_logs[0].exc_info is None
 
 
 def test_openai_provider_accepts_native_text_format_override() -> None:
@@ -1040,19 +1276,37 @@ def test_anthropic_provider_uses_native_output_format() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", ["native", "prompted", "tool_envelope"])
 @pytest.mark.parametrize("call_style", ["sync", "async"])
-@pytest.mark.parametrize("rejection_kind", ["model_retry", "validation_error"])
+@pytest.mark.parametrize(
+    "rejection_kind",
+    [
+        "model_retry",
+        "validation_error",
+        "value_error",
+        "json_decode_error",
+    ],
+)
 async def test_anthropic_rejection_logs_cover_every_transport_branch_without_input_leaks(
     caplog: pytest.LogCaptureFixture,
     transport: Literal["native", "prompted", "tool_envelope"],
     call_style: Literal["sync", "async"],
-    rejection_kind: Literal["model_retry", "validation_error"],
+    rejection_kind: Literal[
+        "model_retry",
+        "validation_error",
+        "value_error",
+        "json_decode_error",
+    ],
 ) -> None:
     """Anthropic sync/async transports log rejected branches without letters."""
 
-    expected = _writer_response()
-    validator, sentinel, exception_name, error_text = _reject_first_structured_output(
-        rejection_kind
-    )
+    (
+        validator,
+        expected,
+        sentinel,
+        exception_name,
+        error_text,
+        retry_error_text,
+    ) = _reject_first_structured_output(rejection_kind)
+    prompt = "Write the next beat."
     prompts: list[str] = []
 
     class FakeMessages:
@@ -1094,17 +1348,17 @@ async def test_anthropic_rejection_logs_cover_every_transport_branch_without_inp
         if call_style == "sync":
             parsed, _llm_response = await asyncio.to_thread(
                 provider.get_structured_completion,
-                "Write the next beat.",
+                prompt,
                 SkaldWriterWire,
             )
         else:
             parsed, _llm_response = await provider.get_structured_completion_async(
-                "Write the next beat.",
+                prompt,
                 SkaldWriterWire,
             )
 
     assert parsed == expected
-    assert len(prompts) == 2
+    assert prompts == [prompt, retry_prompt(prompt, retry_error_text)]
     rejection_logs = [
         record.getMessage()
         for record in caplog.records
@@ -1123,10 +1377,6 @@ async def test_anthropic_rejection_logs_cover_every_transport_branch_without_inp
         record.getMessage().startswith("structured-output retries exhausted")
         for record in caplog.records
     )
-    if rejection_kind == "validation_error":
-        assert sentinel in prompts[1]
-    else:
-        assert error_text in prompts[1]
 
 
 def test_anthropic_provider_rejects_unknown_structured_transport() -> None:

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast, List, Literal, Optional, Tuple
@@ -768,6 +769,7 @@ def test_declaration_schema_describes_generation_and_commit_validation() -> None
 
 @pytest.mark.asyncio
 async def test_storyteller_validator_attributes_declaration_failure_to_model_retry(
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from nexus.api import db_pool
@@ -781,26 +783,40 @@ async def test_storyteller_validator_attributes_declaration_failure_to_model_ret
     validator = build_storyteller_tag_validator("test_slot")
     assert validator is not None
 
-    with pytest.raises(ModelRetry) as exc_info:
-        await validator(
-            SimpleNamespace(retry=0),
-            _storyteller_response(
-                tag_hints=["invented:tag"],
-                pair_tag_hints=[
-                    {
-                        "tag": "contact:social",
-                        "other_entity_name": "Brena Tideloft",
-                        "declared_entity_role": "subject",
-                    }
-                ],
-            ),
-        )
+    with caplog.at_level(
+        logging.INFO,
+        logger="nexus.logon.orrery_tag_validation",
+    ):
+        with pytest.raises(ModelRetry) as exc_info:
+            await validator(
+                SimpleNamespace(retry=0),
+                _storyteller_response(
+                    tag_hints=["invented:tag"],
+                    pair_tag_hints=[
+                        {
+                            "tag": "contact:social",
+                            "other_entity_name": "Brena Tideloft",
+                            "declared_entity_role": "subject",
+                        }
+                    ],
+                ),
+            )
 
     assert "new_entities[0].tag_hints" in exc_info.value.message
     assert "For tags_add, tags_clear, and tag_hints" in exc_info.value.message
     assert "pair tags may contain colons" in exc_info.value.message
     assert "'contact:social'" in exc_info.value.message
     assert "resubmit the complete response" in exc_info.value.message
+    validation_log = next(
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith(
+            "Storyteller output failed registry validation"
+        )
+    )
+    formatted_issues = exc_info.value.message.rsplit(":\n", maxsplit=1)[1]
+    assert "requesting model retry:\n- new_entities[0].tag_hints:" in validation_log
+    assert validation_log.endswith(formatted_issues)
 
 
 @pytest.mark.asyncio

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -26,6 +26,7 @@ from nexus.agents.logon.orrery_tag_validation import (
 from nexus.agents.logon.skald_wire import SkaldTurnWire
 from nexus.agents.orrery.tag_library import TagLibraryEntry
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
+from nexus.api.native_structured_output import structured_output_error_text
 from scripts.api_anthropic import AnthropicProvider
 from scripts.api_openai import OpenAIProvider
 
@@ -817,6 +818,43 @@ async def test_storyteller_validator_attributes_declaration_failure_to_model_ret
     formatted_issues = exc_info.value.message.rsplit(":\n", maxsplit=1)[1]
     assert "requesting model retry:\n- new_entities[0].tag_hints:" in validation_log
     assert validation_log.endswith(formatted_issues)
+
+
+@pytest.mark.asyncio
+async def test_storyteller_validator_model_retry_text_omits_wire_payload_prose(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LOGON registry retry guidance never copies narrative correspondence."""
+
+    from nexus.api import db_pool
+
+    sentinel = "RETRY637"
+    monkeypatch.setattr(
+        db_pool,
+        "get_connection",
+        lambda _dbname: FakeRegistryConnection(FakeRegistryCursor()),
+    )
+    validator = build_storyteller_tag_validator("test_slot")
+    assert validator is not None
+    response = _storyteller_response(tag_hints=["invented:tag"]).model_copy(
+        update={
+            "narrative": f"{sentinel} narrative",
+            "choices": [
+                f"{sentinel} choice one",
+                f"{sentinel} choice two",
+            ],
+            "letter": f"{sentinel} letter",
+        }
+    )
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(ModelRetry) as exc_info:
+            await validator(SimpleNamespace(retry=0), response)
+
+    assert sentinel not in structured_output_error_text(exc_info.value)
+    assert sentinel not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #637.

## What

- Every rejected structured-output attempt (and final exhaustion) now logs a `structured-output rejected` line naming transport, model, seat, attempt, exception class, and the full error text — across all OpenAI repair loops (responses/chat_completions, sync/async) and all three Anthropic transports.
- `orrery_tag_validation` now logs the complete formatted issue list, not just the count.
- New shared helper `structured_output_error_text()` renders Pydantic errors with `include_input=False` so correspondence letter content can never leak into logs (the wire retry prompt is unchanged — the model still sees the full error).

## Why

Forensic mining of the 2026-07-30 audits had to reconstruct rejection causes from retry-prompt token-delta arithmetic because rejected branches logged nothing (67k tokens of repair waste were attributable only to a candidate set). A future repair-tax audit can now classify 100% of rejections from logs alone. Observability only — zero behavior change.

## Testing

- 118 passed across `tests/test_native_structured_output.py` and `tests/test_orrery_tag_validation.py`, including a sentinel-based letter-redaction test proving log lines name the failure without carrying letter text.
- Black clean; mypy: zero new errors (42 pre-existing baseline in the two script files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gEoexyFZe1M6tQDqBsK5p