### PR TITLE
Anchor Need Clocks to the Story Clock, Never Wall Time

### DIFF
--- a/docs/orrery_packages.md
+++ b/docs/orrery_packages.md
@@ -3720,6 +3720,7 @@ the seeding migrations to confirm catalog ↔ schema agreement:
 - `migrations/059_orrery_social_travel_event.py`
 - `migrations/063_orrery_adjudication_history.sql`
 - `migrations/067_rename_orrery_templates.sql`
+- `migrations/100_orrery_need_clock_anchor.sql`
 
 ### Tags queried as durable (via `has_tag` / `lacks_tag` / `has_any_tag`)
 

--- a/migrations/100_orrery_need_clock_anchor.sql
+++ b/migrations/100_orrery_need_clock_anchor.sql
@@ -1,0 +1,134 @@
+-- Anchor Orrery need clocks to canonical story time and repair wall-time rows.
+
+CREATE OR REPLACE FUNCTION orrery_sync_character_need_states(
+    p_character_entity_id bigint
+)
+RETURNS integer AS $$
+DECLARE
+    active_tags text[];
+    anchor_world_time timestamptz;
+    affected integer := 0;
+    row_count integer := 0;
+BEGIN
+    IF p_character_entity_id IS NULL THEN
+        RETURN 0;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM entities e
+        WHERE e.id = p_character_entity_id
+          AND e.kind = 'character'
+          AND e.is_active = true
+    ) THEN
+        RETURN 0;
+    END IF;
+
+    SELECT orrery_active_character_tag_names(p_character_entity_id)
+    INTO active_tags;
+
+    anchor_world_time := COALESCE(
+        (SELECT MAX(world_time) FROM chunk_metadata),
+        (SELECT base_timestamp FROM global_variables)
+    );
+    IF anchor_world_time IS NULL THEN
+        RAISE EXCEPTION
+            'need-clock anchor unavailable: no canonical world time or base_timestamp';
+    END IF;
+
+    INSERT INTO character_need_states (
+        character_entity_id,
+        need_type,
+        debt_score,
+        last_evaluated_at,
+        metadata
+    )
+    SELECT p_character_entity_id,
+           needs.need_type::character_need_type,
+           0,
+           anchor_world_time,
+           '{"synced_by": "need_applicability"}'::jsonb
+    FROM (
+        VALUES
+            ('sleep'),
+            ('hunger'),
+            ('thirst'),
+            ('socialize'),
+            ('intimacy')
+    ) AS needs(need_type)
+    WHERE orrery_need_applies_to_tags(
+        needs.need_type::character_need_type,
+        active_tags
+    )
+    ON CONFLICT (character_entity_id, need_type) DO NOTHING;
+    GET DIAGNOSTICS row_count = ROW_COUNT;
+    affected := affected + row_count;
+
+    DELETE FROM character_need_states cns
+    WHERE cns.character_entity_id = p_character_entity_id
+      AND NOT orrery_need_applies_to_tags(cns.need_type, active_tags);
+    GET DIAGNOSTICS row_count = ROW_COUNT;
+    affected := affected + row_count;
+
+    UPDATE entity_tags et
+    SET cleared_at = now()
+    FROM tags t,
+         (
+            VALUES
+                ('sleep', 'sleep_deprived'),
+                ('hunger', 'hungry'),
+                ('thirst', 'thirsty'),
+                ('socialize', 'under_socialized'),
+                ('intimacy', 'intimacy_starved')
+         ) AS severity(need_type, prefix)
+    WHERE et.entity_id = p_character_entity_id
+      AND et.tag_id = t.id
+      AND et.cleared_at IS NULL
+      AND t.tag LIKE severity.prefix || '\_%'
+      AND NOT orrery_need_applies_to_tags(
+          severity.need_type::character_need_type,
+          active_tags
+      );
+    GET DIAGNOSTICS row_count = ROW_COUNT;
+    affected := affected + row_count;
+
+    RETURN affected;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION orrery_sync_character_need_states(bigint) IS
+    'Synchronizes applicable character need rows and anchors new clocks to canonical story time; raises when neither chunk world time nor the story base timestamp exists.';
+
+DO $$
+DECLARE
+    canonical_base_timestamp timestamptz;
+    reconciliation_anchor timestamptz;
+    evaluated_row_count integer := 0;
+    fulfilled_row_count integer := 0;
+BEGIN
+    SELECT base_timestamp
+    INTO canonical_base_timestamp
+    FROM global_variables;
+
+    IF canonical_base_timestamp IS NOT NULL THEN
+        SELECT COALESCE(MAX(world_time), canonical_base_timestamp)
+        INTO reconciliation_anchor
+        FROM chunk_metadata;
+
+        UPDATE character_need_states
+        SET last_evaluated_at = reconciliation_anchor
+        WHERE last_evaluated_at < canonical_base_timestamp;
+        GET DIAGNOSTICS evaluated_row_count = ROW_COUNT;
+
+        UPDATE character_need_states
+        SET last_fulfilled_at = reconciliation_anchor
+        WHERE last_fulfilled_at < canonical_base_timestamp;
+        GET DIAGNOSTICS fulfilled_row_count = ROW_COUNT;
+    END IF;
+
+    RAISE NOTICE
+        'need-clock reconciliation: last_evaluated_at rows=%, last_fulfilled_at rows=%',
+        evaluated_row_count,
+        fulfilled_row_count;
+END;
+$$;

--- a/migrations/100_orrery_need_clock_anchor.sql
+++ b/migrations/100_orrery_need_clock_anchor.sql
@@ -1,5 +1,71 @@
 -- Anchor Orrery need clocks to canonical story time and repair wall-time rows.
 
+CREATE TABLE IF NOT EXISTS character_need_state_reconciliations (
+    character_entity_id bigint NOT NULL,
+    need_type character_need_type NOT NULL,
+    field text NOT NULL,
+    prior_value timestamptz NOT NULL,
+    new_value timestamptz NOT NULL,
+    debt_score_pre_image numeric(8, 2) NOT NULL,
+    reconciled_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT character_need_state_reconciliations_pkey
+        PRIMARY KEY (character_entity_id, need_type, field),
+    CONSTRAINT character_need_state_reconciliations_field_check
+        CHECK (field IN ('last_evaluated_at', 'last_fulfilled_at')),
+    CONSTRAINT character_need_state_reconciliations_value_change_check
+        CHECK (prior_value IS DISTINCT FROM new_value)
+);
+
+COMMENT ON TABLE character_need_state_reconciliations IS
+    'Immutable migration-100 audit ledger. One row records each need-clock field restamped from an unreproducible wall-time value; it deliberately has no foreign key to the mutable need-state row so applicability deletion and reinsertion cannot erase replay authority.';
+COMMENT ON COLUMN character_need_state_reconciliations.character_entity_id IS
+    'Entity-spine character identifier of the need row as it existed when migration 100 reconciled it.';
+COMMENT ON COLUMN character_need_state_reconciliations.need_type IS
+    'Need dimension of the reconciled row.';
+COMMENT ON COLUMN character_need_state_reconciliations.field IS
+    'Restamped timestamp field: last_evaluated_at or last_fulfilled_at.';
+COMMENT ON COLUMN character_need_state_reconciliations.prior_value IS
+    'Exact timestamp pre-image replaced by migration 100.';
+COMMENT ON COLUMN character_need_state_reconciliations.new_value IS
+    'Exact canonical story-clock timestamp written by migration 100.';
+COMMENT ON COLUMN character_need_state_reconciliations.debt_score_pre_image IS
+    'Exact stored debt_score observed before this field was restamped; legacy wall-clock accrual remains opaque to replay.';
+COMMENT ON COLUMN character_need_state_reconciliations.reconciled_at IS
+    'Database transaction time when migration 100 inserted this immutable audit record.';
+COMMENT ON CONSTRAINT character_need_state_reconciliations_pkey
+    ON character_need_state_reconciliations IS
+    'Permits at most one immutable reconciliation record per character, need, and field.';
+COMMENT ON CONSTRAINT character_need_state_reconciliations_field_check
+    ON character_need_state_reconciliations IS
+    'Restricts audit rows to the two need-clock fields migration 100 can restamp.';
+COMMENT ON CONSTRAINT character_need_state_reconciliations_value_change_check
+    ON character_need_state_reconciliations IS
+    'Requires every audit row to describe an actual timestamp change.';
+
+CREATE OR REPLACE FUNCTION reject_character_need_state_reconciliation_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION
+        'character need state reconciliation audit rows are immutable';
+END;
+$$;
+
+COMMENT ON FUNCTION reject_character_need_state_reconciliation_mutation() IS
+    'Rejects UPDATE and DELETE so migration-100 replay provenance remains append-only.';
+
+DROP TRIGGER IF EXISTS character_need_state_reconciliations_immutable
+    ON character_need_state_reconciliations;
+CREATE TRIGGER character_need_state_reconciliations_immutable
+BEFORE UPDATE OR DELETE ON character_need_state_reconciliations
+FOR EACH ROW
+EXECUTE FUNCTION reject_character_need_state_reconciliation_mutation();
+
+COMMENT ON TRIGGER character_need_state_reconciliations_immutable
+    ON character_need_state_reconciliations IS
+    'Protects reconciliation audit rows from mutation after their migration transaction commits.';
+
 CREATE OR REPLACE FUNCTION orrery_sync_character_need_states(
     p_character_entity_id bigint
 )
@@ -115,35 +181,104 @@ BEGIN
         INTO reconciliation_anchor
         FROM chunk_metadata;
 
-        -- Persist both the pre-image and exact result on every touched row.
-        -- Replay can then rebase a checkpoint baseline without inferring the
-        -- migration boundary from transaction timestamps.
-        UPDATE character_need_states
+        -- Lock each pre-image, insert its durable audit row, and apply the
+        -- reconciliation in one data-modifying statement. A prior audit row
+        -- wins permanently; on an ordinary re-run the candidate predicate is
+        -- empty because every touched clock already equals the anchor.
+        WITH candidates AS MATERIALIZED (
+            SELECT character_entity_id,
+                   need_type,
+                   last_evaluated_at AS prior_value,
+                   debt_score
+            FROM character_need_states
+            WHERE last_evaluated_at < canonical_base_timestamp
+               OR last_evaluated_at > reconciliation_anchor
+            FOR UPDATE
+        ),
+        inserted AS (
+            INSERT INTO character_need_state_reconciliations (
+                character_entity_id,
+                need_type,
+                field,
+                prior_value,
+                new_value,
+                debt_score_pre_image
+            )
+            SELECT character_entity_id,
+                   need_type,
+                   'last_evaluated_at',
+                   prior_value,
+                   reconciliation_anchor,
+                   debt_score
+            FROM candidates
+            ON CONFLICT (character_entity_id, need_type, field) DO NOTHING
+            RETURNING character_entity_id, need_type, field
+        )
+        UPDATE character_need_states AS cns
         SET last_evaluated_at = reconciliation_anchor,
-            metadata = metadata || jsonb_build_object(
+            metadata = cns.metadata || jsonb_build_object(
                 'reconciled_by',
                 'migration_100',
                 'reconciled_last_evaluated_from',
-                last_evaluated_at::text,
+                candidates.prior_value::text,
                 'reconciled_last_evaluated_to',
                 reconciliation_anchor::text
             )
-        WHERE last_evaluated_at < canonical_base_timestamp
-           OR last_evaluated_at > reconciliation_anchor;
+        FROM candidates
+        JOIN inserted
+          ON inserted.character_entity_id = candidates.character_entity_id
+         AND inserted.need_type = candidates.need_type
+         AND inserted.field = 'last_evaluated_at'
+        WHERE cns.character_entity_id = candidates.character_entity_id
+          AND cns.need_type = candidates.need_type;
         GET DIAGNOSTICS evaluated_row_count = ROW_COUNT;
 
-        UPDATE character_need_states
+        WITH candidates AS MATERIALIZED (
+            SELECT character_entity_id,
+                   need_type,
+                   last_fulfilled_at AS prior_value,
+                   debt_score
+            FROM character_need_states
+            WHERE last_fulfilled_at < canonical_base_timestamp
+               OR last_fulfilled_at > reconciliation_anchor
+            FOR UPDATE
+        ),
+        inserted AS (
+            INSERT INTO character_need_state_reconciliations (
+                character_entity_id,
+                need_type,
+                field,
+                prior_value,
+                new_value,
+                debt_score_pre_image
+            )
+            SELECT character_entity_id,
+                   need_type,
+                   'last_fulfilled_at',
+                   prior_value,
+                   reconciliation_anchor,
+                   debt_score
+            FROM candidates
+            ON CONFLICT (character_entity_id, need_type, field) DO NOTHING
+            RETURNING character_entity_id, need_type, field
+        )
+        UPDATE character_need_states AS cns
         SET last_fulfilled_at = reconciliation_anchor,
-            metadata = metadata || jsonb_build_object(
+            metadata = cns.metadata || jsonb_build_object(
                 'reconciled_by',
                 'migration_100',
                 'reconciled_last_fulfilled_from',
-                last_fulfilled_at::text,
+                candidates.prior_value::text,
                 'reconciled_last_fulfilled_to',
                 reconciliation_anchor::text
             )
-        WHERE last_fulfilled_at < canonical_base_timestamp
-           OR last_fulfilled_at > reconciliation_anchor;
+        FROM candidates
+        JOIN inserted
+          ON inserted.character_entity_id = candidates.character_entity_id
+         AND inserted.need_type = candidates.need_type
+         AND inserted.field = 'last_fulfilled_at'
+        WHERE cns.character_entity_id = candidates.character_entity_id
+          AND cns.need_type = candidates.need_type;
         GET DIAGNOSTICS fulfilled_row_count = ROW_COUNT;
     END IF;
 

--- a/migrations/100_orrery_need_clock_anchor.sql
+++ b/migrations/100_orrery_need_clock_anchor.sql
@@ -117,12 +117,14 @@ BEGIN
 
         UPDATE character_need_states
         SET last_evaluated_at = reconciliation_anchor
-        WHERE last_evaluated_at < canonical_base_timestamp;
+        WHERE last_evaluated_at < canonical_base_timestamp
+           OR last_evaluated_at > reconciliation_anchor;
         GET DIAGNOSTICS evaluated_row_count = ROW_COUNT;
 
         UPDATE character_need_states
         SET last_fulfilled_at = reconciliation_anchor
-        WHERE last_fulfilled_at < canonical_base_timestamp;
+        WHERE last_fulfilled_at < canonical_base_timestamp
+           OR last_fulfilled_at > reconciliation_anchor;
         GET DIAGNOSTICS fulfilled_row_count = ROW_COUNT;
     END IF;
 

--- a/migrations/100_orrery_need_clock_anchor.sql
+++ b/migrations/100_orrery_need_clock_anchor.sql
@@ -115,14 +115,33 @@ BEGIN
         INTO reconciliation_anchor
         FROM chunk_metadata;
 
+        -- Persist both the pre-image and exact result on every touched row.
+        -- Replay can then rebase a checkpoint baseline without inferring the
+        -- migration boundary from transaction timestamps.
         UPDATE character_need_states
-        SET last_evaluated_at = reconciliation_anchor
+        SET last_evaluated_at = reconciliation_anchor,
+            metadata = metadata || jsonb_build_object(
+                'reconciled_by',
+                'migration_100',
+                'reconciled_last_evaluated_from',
+                last_evaluated_at::text,
+                'reconciled_last_evaluated_to',
+                reconciliation_anchor::text
+            )
         WHERE last_evaluated_at < canonical_base_timestamp
            OR last_evaluated_at > reconciliation_anchor;
         GET DIAGNOSTICS evaluated_row_count = ROW_COUNT;
 
         UPDATE character_need_states
-        SET last_fulfilled_at = reconciliation_anchor
+        SET last_fulfilled_at = reconciliation_anchor,
+            metadata = metadata || jsonb_build_object(
+                'reconciled_by',
+                'migration_100',
+                'reconciled_last_fulfilled_from',
+                last_fulfilled_at::text,
+                'reconciled_last_fulfilled_to',
+                reconciliation_anchor::text
+            )
         WHERE last_fulfilled_at < canonical_base_timestamp
            OR last_fulfilled_at > reconciliation_anchor;
         GET DIAGNOSTICS fulfilled_row_count = ROW_COUNT;

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field, replace
-from hashlib import sha256
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from hashlib import sha256
 import json
 from typing import Any, Mapping, Optional
 
@@ -104,6 +105,8 @@ SUPPORTED_STATE_DELTA_KEYS = frozenset(
 )
 ADJUDICATION_ACTIONS = frozenset({"defer", "replace", "void"})
 ADJUDICATION_SOURCES = frozenset({"explicit", "structured_state_update"})
+NEED_DEBT_SCORE_ABSOLUTE_LIMIT = Decimal("1000000")
+NEED_DEBT_SCORE_QUANTUM = Decimal("0.01")
 REPLACEMENT_STATE_DELTA_ALIASES = {
     "character_current_activity": "character.current_activity",
     "entity_tags_add": "entity_tags.add",
@@ -117,6 +120,10 @@ REPLACEMENT_STATE_DELTA_ALIASES = {
     "mood_set": "mood.set",
     "status_bestow": "status.bestow",
 }
+
+
+class NeedDebtScoreDomainError(ValueError):
+    """A fulfilled need debt cannot be stored in numeric(8,2)."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -2614,6 +2621,38 @@ def _coerce_need_fulfillment(raw: Any) -> dict[str, Any]:
     return payload
 
 
+def _validate_need_debt_score_domain(
+    *,
+    actor_entity_id: int,
+    need_type: str,
+    debt_score: float,
+) -> None:
+    """Raise a named diagnostic before PostgreSQL rejects numeric(8,2)."""
+
+    try:
+        decimal_value = Decimal(str(debt_score))
+        if (
+            not decimal_value.is_finite()
+            or abs(decimal_value) >= NEED_DEBT_SCORE_ABSOLUTE_LIMIT
+        ):
+            raise InvalidOperation
+        stored_value = decimal_value.quantize(
+            NEED_DEBT_SCORE_QUANTUM,
+            rounding=ROUND_HALF_UP,
+        )
+    except InvalidOperation as exc:
+        raise NeedDebtScoreDomainError(
+            "need debt score outside numeric(8,2) domain: "
+            f"character={actor_entity_id}, need={need_type}, value={debt_score!r}"
+        ) from exc
+
+    if abs(stored_value) >= NEED_DEBT_SCORE_ABSOLUTE_LIMIT:
+        raise NeedDebtScoreDomainError(
+            "need debt score outside numeric(8,2) domain: "
+            f"character={actor_entity_id}, need={need_type}, value={debt_score!r}"
+        )
+
+
 def _apply_need_fulfillment_sync(
     cur: Any,
     *,
@@ -2639,6 +2678,11 @@ def _apply_need_fulfillment_sync(
         need_tuning=need_tuning,
     )
     new_debt = max(0.0, current_debt - float(payload["discharge_debt"]))
+    _validate_need_debt_score_domain(
+        actor_entity_id=actor_entity_id,
+        need_type=need_type,
+        debt_score=new_debt,
+    )
     cur.execute(
         """
         UPDATE character_need_states
@@ -2697,6 +2741,11 @@ async def _apply_need_fulfillment_async(
         need_tuning=need_tuning,
     )
     new_debt = max(0.0, current_debt - float(payload["discharge_debt"]))
+    _validate_need_debt_score_domain(
+        actor_entity_id=actor_entity_id,
+        need_type=need_type,
+        debt_score=new_debt,
+    )
     await conn.execute(
         """
         UPDATE character_need_states

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -126,6 +126,10 @@ class NeedDebtScoreDomainError(ValueError):
     """A fulfilled need debt cannot be stored in numeric(8,2)."""
 
 
+class OrreryWorldClockUnavailableError(RuntimeError):
+    """No canonical primary-world clock is available for a diegetic write."""
+
+
 @dataclass(frozen=True, slots=True)
 class MoodPolicy:
     """Commit-time mechanical mood policy."""
@@ -2670,7 +2674,7 @@ def _apply_need_fulfillment_sync(
     payload = _coerce_need_fulfillment(fulfillment)
     need_type = payload["type"]
     world_time = _tick_world_time_sync(cur, source_chunk_id)
-    current_debt = _load_or_create_need_debt_sync(
+    current_debt = _load_need_debt_sync(
         cur,
         actor_entity_id=actor_entity_id,
         need_type=need_type,
@@ -2682,6 +2686,12 @@ def _apply_need_fulfillment_sync(
         actor_entity_id=actor_entity_id,
         need_type=need_type,
         debt_score=new_debt,
+    )
+    _ensure_need_debt_state_sync(
+        cur,
+        actor_entity_id=actor_entity_id,
+        need_type=need_type,
+        world_time=world_time,
     )
     cur.execute(
         """
@@ -2733,7 +2743,7 @@ async def _apply_need_fulfillment_async(
     payload = _coerce_need_fulfillment(fulfillment)
     need_type = payload["type"]
     world_time = await _tick_world_time_async(conn, source_chunk_id)
-    current_debt = await _load_or_create_need_debt_async(
+    current_debt = await _load_need_debt_async(
         conn,
         actor_entity_id=actor_entity_id,
         need_type=need_type,
@@ -2745,6 +2755,12 @@ async def _apply_need_fulfillment_async(
         actor_entity_id=actor_entity_id,
         need_type=need_type,
         debt_score=new_debt,
+    )
+    await _ensure_need_debt_state_async(
+        conn,
+        actor_entity_id=actor_entity_id,
+        need_type=need_type,
+        world_time=world_time,
     )
     await conn.execute(
         """
@@ -5092,8 +5108,28 @@ def _tick_world_time_sync(cur: Any, source_chunk_id: int) -> Any:
     row = cur.fetchone()
     if row and _row_get(row, "world_time", 0) is not None:
         return _row_get(row, "world_time", 0)
-    cur.execute("SELECT now() AS world_time")
-    return _row_get(cur.fetchone(), "world_time", 0)
+    # Need pressure and every other tick-derived world-time write use the
+    # primary-layer clock even while narration is in a flashback or another
+    # non-primary layer whose source chunk legitimately has no world_time.
+    cur.execute(
+        """
+        SELECT COALESCE(
+            (SELECT MAX(world_time) FROM chunk_metadata),
+            (
+                SELECT base_timestamp
+                FROM global_variables
+                WHERE id = true
+            )
+        ) AS world_time
+        """
+    )
+    canonical_row = cur.fetchone()
+    canonical_time = _row_get(canonical_row, "world_time", 0) if canonical_row else None
+    if canonical_time is None:
+        raise OrreryWorldClockUnavailableError(
+            "Orrery world clock unavailable: no primary world_time or " "base_timestamp"
+        )
+    return canonical_time
 
 
 async def _tick_world_time_async(conn: Any, source_chunk_id: int) -> Any:
@@ -5103,10 +5139,29 @@ async def _tick_world_time_async(conn: Any, source_chunk_id: int) -> Any:
     )
     if world_time is not None:
         return world_time
-    return await conn.fetchval("SELECT now()")
+    # Need pressure and every other tick-derived world-time write use the
+    # primary-layer clock even while narration is in a flashback or another
+    # non-primary layer whose source chunk legitimately has no world_time.
+    canonical_time = await conn.fetchval(
+        """
+        SELECT COALESCE(
+            (SELECT MAX(world_time) FROM chunk_metadata),
+            (
+                SELECT base_timestamp
+                FROM global_variables
+                WHERE id = true
+            )
+        )
+        """
+    )
+    if canonical_time is None:
+        raise OrreryWorldClockUnavailableError(
+            "Orrery world clock unavailable: no primary world_time or " "base_timestamp"
+        )
+    return canonical_time
 
 
-def _load_or_create_need_debt_sync(
+def _load_need_debt_sync(
     cur: Any,
     *,
     actor_entity_id: int,
@@ -5126,17 +5181,6 @@ def _load_or_create_need_debt_sync(
 
     cur.execute(
         """
-        INSERT INTO character_need_states (
-            character_entity_id, need_type, debt_score, last_evaluated_at
-        ) VALUES (
-            %s, %s::character_need_type, 0, %s
-        )
-        ON CONFLICT (character_entity_id, need_type) DO NOTHING
-        """,
-        (actor_entity_id, need_type, world_time),
-    )
-    cur.execute(
-        """
         SELECT debt_score, last_evaluated_at
         FROM character_need_states
         WHERE character_entity_id = %s
@@ -5146,9 +5190,7 @@ def _load_or_create_need_debt_sync(
     )
     row = cur.fetchone()
     if row is None:
-        raise ValueError(
-            f"Orrery need state missing for actor {actor_entity_id} {need_type}"
-        )
+        return 0.0
     # Route through the same world-time accrual authority the resolver reads
     # with before discharging the fulfillment.
     return effective_debt_score(
@@ -5160,7 +5202,29 @@ def _load_or_create_need_debt_sync(
     )
 
 
-async def _load_or_create_need_debt_async(
+def _ensure_need_debt_state_sync(
+    cur: Any,
+    *,
+    actor_entity_id: int,
+    need_type: str,
+    world_time: Any,
+) -> None:
+    """Create a missing need row after all fallible domain validation."""
+
+    cur.execute(
+        """
+        INSERT INTO character_need_states (
+            character_entity_id, need_type, debt_score, last_evaluated_at
+        ) VALUES (
+            %s, %s::character_need_type, 0, %s
+        )
+        ON CONFLICT (character_entity_id, need_type) DO NOTHING
+        """,
+        (actor_entity_id, need_type, world_time),
+    )
+
+
+async def _load_need_debt_async(
     conn: Any,
     *,
     actor_entity_id: int,
@@ -5178,6 +5242,36 @@ async def _load_or_create_need_debt_async(
             f"Orrery need {need_type!r} does not apply to actor {actor_entity_id}"
         )
 
+    row = await conn.fetchrow(
+        """
+        SELECT debt_score, last_evaluated_at
+        FROM character_need_states
+        WHERE character_entity_id = $1
+          AND need_type = $2::character_need_type
+        """,
+        actor_entity_id,
+        need_type,
+    )
+    if row is None:
+        return 0.0
+    return effective_debt_score(
+        need_type,
+        float(_row_get(row, "debt_score", 0) or 0.0),
+        last_evaluated_at=_row_get(row, "last_evaluated_at", 1),
+        current_world_time=world_time,
+        tuning=need_tuning,
+    )
+
+
+async def _ensure_need_debt_state_async(
+    conn: Any,
+    *,
+    actor_entity_id: int,
+    need_type: str,
+    world_time: Any,
+) -> None:
+    """Create a missing need row after all fallible domain validation."""
+
     await conn.execute(
         """
         INSERT INTO character_need_states (
@@ -5190,27 +5284,6 @@ async def _load_or_create_need_debt_async(
         actor_entity_id,
         need_type,
         world_time,
-    )
-    row = await conn.fetchrow(
-        """
-        SELECT debt_score, last_evaluated_at
-        FROM character_need_states
-        WHERE character_entity_id = $1
-          AND need_type = $2::character_need_type
-        """,
-        actor_entity_id,
-        need_type,
-    )
-    if row is None:
-        raise ValueError(
-            f"Orrery need state missing for actor {actor_entity_id} {need_type}"
-        )
-    return effective_debt_score(
-        need_type,
-        float(_row_get(row, "debt_score", 0) or 0.0),
-        last_evaluated_at=_row_get(row, "last_evaluated_at", 1),
-        current_world_time=world_time,
-        tuning=need_tuning,
     )
 
 

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -19,9 +19,11 @@ produces. Sections and their replay sources:
   ``orrery_resolutions.state_delta`` are deliberately ignored: the same
   commit already wrote them to the provenance tables (double-entry), and
   ``need.fulfill``'s derived severity tags exist *only* in provenance.
-  ``mood.set`` additionally reapplies its exact entity-tag snapshot, repairing
-  the known provenance gap where replace-policy reapplication overwrites a
-  live row's source chunk in place.
+  ``mood.set`` additionally reapplies its exact entity-tag snapshot. During
+  checkpoint verification, a target-visible row whose ``replace``/
+  ``extend_expiry`` provenance was destructively overwritten after the target
+  is reported as a row-presence remainder rather than a false missing-row
+  drift.
 - the three relationship tables — backward from the *current* rows,
   unwinding ``relationship_versions`` pre-images (``id DESC``), then
   dropping rows whose ``created_at`` postdates chunk N (INSERTs never fire
@@ -37,13 +39,16 @@ produces. Sections and their replay sources:
   toggled off-and-back inside the window are reset to the trigger's
   fresh-insert shape (detected chronologically from chunk-keyed
   immunity-tag events). Migration 100's deterministic primary-clock anchors
-  replay from chunk-keyed ledger state. Its one-time reconciliation rebases
-  only a checkpoint baseline carrying recorded row provenance, before window
-  events replay; markerless values that current rules cannot derive become
-  narrow field-level remainders instead of inferred legacy behavior.
+  replay from chunk-keyed ledger state. Its immutable reconciliation audit
+  rebases checkpoint baselines from exact pre-images before window events
+  replay. Audit-row debt, legacy NULL-clock outcomes, and markerless values
+  that current rules cannot derive become narrow field-level remainders
+  instead of inferred legacy behavior.
 - ``character_travel_states`` — forward for explicit payloads;
   ``travel.start`` resolves destinations and routes from live state at
-  commit time, so windows containing travel deltas are approximate.
+  commit time, so windows containing travel deltas are approximate. NULL-clock
+  resolutions committed before migration 100 retain timestamp remainders;
+  only post-fix resolutions use the current deterministic primary clock.
 - ``character_project_states`` — forward from the five ``project.*``
   transitions. Every transition carries the exact applied project projection,
   so cadence and applier-derived values are independent of current tuning;
@@ -58,10 +63,10 @@ produces. Sections and their replay sources:
 - ``backstory_secrets`` — lifecycle rows rebuilt from
   ``backstory_secret_authored`` and ``backstory_revealed`` world events.
 
-Known undetectable gaps: (1) reapplication policies ``replace`` and
-``extend_expiry`` overwrite a live tag row's ``source_chunk_id`` in place
-with no history row — a tag bestowed inside the window and re-applied
-after N reads as bestowed later and drops out of the reconstruction;
+Known undetectable gaps: (1) arbitrary, non-checkpoint reconstruction cannot
+recognize a tag whose ``replace``/``extend_expiry`` reapplication overwrote
+its only source provenance after N; checkpoint verification can identify that
+specific destroyed-history shape and reports it as unreproducible;
 (2) a manual checkpoint taken long after its chunk committed snapshots
 capture-time state, but replay correlates wall-clock evidence against the
 chunk's created_at — offline edits in that gap blur the boundary.
@@ -244,12 +249,11 @@ class ReplayResult:
     # (section, row_key, column) triples replay could not reproduce
     # (e.g. timestamps from a NULL-world-time tick); verify skips these.
     unreproducible: set[tuple[str, str, str]] = field(default_factory=set)
-    # (section, row_key) pairs whose PRESENCE at the target is undecidable:
-    # Step 8.6 of the commit (maturation stubs + tag hints) runs after the
-    # Step 8.55 checkpoint inside one transaction, and now() is constant
-    # across it, so wall-clock bounds cannot split "before capture" from
-    # "after capture" at the target chunk. Verify skips presence mismatches
-    # on these rows instead of reporting phantom drift.
+    # (section, row_key) pairs whose PRESENCE cannot be reconstructed:
+    # Step 8.6's same-transaction checkpoint boundary is undecidable, while a
+    # later replace/extend tag reapplication can destroy the target row's only
+    # source provenance. Verify skips these narrow presence mismatches instead
+    # of reporting phantom drift.
     uncertain_rows: set[tuple[str, str]] = field(default_factory=set)
 
     def add_note(self, section: str, note: str, *, approximate: bool) -> None:
@@ -286,6 +290,26 @@ class _NeedApplicabilityTransitions:
     went_inapplicable: set[tuple[int, str]]
     first_made_applicable_chunk: dict[tuple[int, str], int]
     last_made_applicable_chunk: dict[tuple[int, str], int]
+
+
+@dataclass(frozen=True)
+class _NeedClockReconciliation:
+    """One immutable migration-100 field audit record."""
+
+    prior_value: datetime
+    new_value: datetime
+    prior_text: str
+    new_text: str
+    debt_score_pre_image: Decimal
+
+
+@dataclass
+class _NeedClockRebase:
+    """Counts and opaque debt ancestry introduced by an audit rebase."""
+
+    evaluated_rows: int = 0
+    fulfilled_rows: int = 0
+    debt_row_keys: set[str] = field(default_factory=set)
 
 
 def _as_document(value: Any) -> dict[str, Any]:
@@ -428,50 +452,61 @@ def _canonical_need_clock_at_chunk(cur: Any, chunk_id: int) -> Optional[datetime
     return _row_value(row, 0) if row is not None else None
 
 
-def _need_clock_provenance(metadata: Any) -> dict[str, Any]:
-    """Extract and validate migration 100's field-level row provenance."""
+def _need_clock_fix_applied_at(cur: Any) -> Optional[datetime]:
+    """Return the deployment boundary used only to classify NULL-clock events."""
 
-    document = dict(_as_document(metadata) or {})
-    if document.get("reconciled_by") != NEED_CLOCK_RECONCILIATION_MARKER:
-        return {}
-    provenance: dict[str, Any] = {"reconciled_by": NEED_CLOCK_RECONCILIATION_MARKER}
-    for column in NEED_CLOCK_RECONCILIATION_COLUMNS:
-        field_name = column.removesuffix("_at")
-        from_key = f"reconciled_{field_name}_from"
-        to_key = f"reconciled_{field_name}_to"
-        has_from = from_key in document
-        has_to = to_key in document
-        if has_from != has_to:
-            raise ValueError(
-                "Migration 100 need-clock provenance has an incomplete "
-                f"{column} pre-image/result pair"
-            )
-        if has_from:
-            provenance[from_key] = document[from_key]
-            provenance[to_key] = document[to_key]
-    if len(provenance) == 1:
-        raise ValueError(
-            "Migration 100 need-clock provenance names no reconciled field"
-        )
-    return provenance
+    cur.execute("SELECT applied_at FROM schema_migrations WHERE version = '100'")
+    row = cur.fetchone()
+    return _row_value(row, 0) if row is not None else None
 
 
-def _live_need_clock_provenance(
+def _need_clock_reconciliation_audit(
     cur: Any,
-) -> dict[tuple[int, str], dict[str, Any]]:
-    """Load the exact reconciliation evidence retained on current rows."""
+) -> dict[tuple[int, str], dict[str, _NeedClockReconciliation]]:
+    """Load migration 100's immutable authority, never live-row metadata."""
 
+    cur.execute("SELECT to_regclass('public.character_need_state_reconciliations')")
+    table_row = cur.fetchone()
+    if table_row is None or _row_value(table_row, 0) is None:
+        return {}
     cur.execute(
         """
-        SELECT character_entity_id, need_type::text, metadata
-        FROM character_need_states
-        WHERE metadata ->> 'reconciled_by' = 'migration_100'
+        SELECT character_entity_id,
+               need_type::text,
+               field,
+               prior_value,
+               new_value,
+               prior_value::text,
+               new_value::text,
+               debt_score_pre_image
+        FROM character_need_state_reconciliations
+        ORDER BY character_entity_id, need_type::text, field
         """
     )
-    return {
-        (int(entity_id), str(need_type)): _need_clock_provenance(metadata)
-        for entity_id, need_type, metadata in cur.fetchall()
-    }
+    audit: dict[tuple[int, str], dict[str, _NeedClockReconciliation]] = {}
+    for (
+        entity_id,
+        need_type,
+        column,
+        prior_value,
+        new_value,
+        prior_text,
+        new_text,
+        debt_score_pre_image,
+    ) in cur.fetchall():
+        if column not in NEED_CLOCK_RECONCILIATION_COLUMNS:
+            raise ValueError(
+                f"Migration 100 audit names unsupported need-clock field {column!r}"
+            )
+        key = (int(entity_id), str(need_type))
+        audit.setdefault(key, {})[str(column)] = _NeedClockReconciliation(
+            prior_value=prior_value,
+            new_value=new_value,
+            prior_text=str(prior_text),
+            new_text=str(new_text),
+            debt_score_pre_image=Decimal(debt_score_pre_image),
+        )
+    return {key: dict(field_audit) for key, field_audit in audit.items()}
 
 
 def _rebase_reconciled_need_clock_baseline(
@@ -479,41 +514,72 @@ def _rebase_reconciled_need_clock_baseline(
     rows: list[dict[str, Any]],
     *,
     target_rows: Optional[list[dict[str, Any]]] = None,
-) -> tuple[int, int]:
+) -> _NeedClockRebase:
     """Apply recorded migration results to a baseline, before event replay."""
 
-    live_provenance = _live_need_clock_provenance(cur)
-    target_marker_keys: Optional[set[tuple[int, str]]] = None
+    audit = _need_clock_reconciliation_audit(cur)
+    target_by_key: Optional[dict[tuple[int, str], dict[str, Any]]] = None
     if target_rows is not None:
-        # A later live marker must not rewrite checkpoint pairs whose target
-        # still predates the reconciliation. The target's own copied marker is
-        # recorded proof that this baseline-to-target window crossed it.
-        target_marker_keys = {
-            (int(row["character_entity_id"]), str(row["need_type"]))
+        target_by_key = {
+            (int(row["character_entity_id"]), str(row["need_type"])): row
             for row in target_rows
-            if _need_clock_provenance(row.get("metadata"))
         }
 
-    counts = {"last_evaluated_at": 0, "last_fulfilled_at": 0}
+    result = _NeedClockRebase(
+        debt_row_keys={
+            f"{character_entity_id}:{need_type}"
+            for character_entity_id, need_type in audit
+        }
+    )
     for row in rows:
         key = (int(row["character_entity_id"]), str(row["need_type"]))
-        provenance = live_provenance.get(key)
-        if provenance is None or (
-            target_marker_keys is not None and key not in target_marker_keys
-        ):
+        field_audit = audit.get(key)
+        target = target_by_key.get(key) if target_by_key is not None else None
+        if field_audit is None or (target_by_key is not None and target is None):
             continue
         baseline_metadata = dict(_as_document(row.get("metadata")) or {})
-        if baseline_metadata.get("reconciled_by") == NEED_CLOCK_RECONCILIATION_MARKER:
-            continue
+        applied: list[_NeedClockReconciliation] = []
         for column in NEED_CLOCK_RECONCILIATION_COLUMNS:
+            reconciliation = field_audit.get(column)
+            if reconciliation is None:
+                continue
+            if canonicalize(row.get(column)) != canonicalize(
+                reconciliation.prior_value
+            ):
+                continue
+            # The immutable audit exists after migration forever. A target that
+            # still carries the exact pre-image proves this earlier checkpoint
+            # pair did not cross the one-time write.
+            if target is not None and canonicalize(target.get(column)) == canonicalize(
+                reconciliation.prior_value
+            ):
+                continue
+            row[column] = _isoformat(reconciliation.new_value)
             field_name = column.removesuffix("_at")
+            baseline_metadata["reconciled_by"] = NEED_CLOCK_RECONCILIATION_MARKER
+            baseline_metadata[f"reconciled_{field_name}_from"] = (
+                reconciliation.prior_text
+            )
             to_key = f"reconciled_{field_name}_to"
-            if to_key in provenance:
-                row[column] = provenance[to_key]
-                counts[column] += 1
-        baseline_metadata.update(provenance)
+            baseline_metadata[to_key] = reconciliation.new_text
+            if column == "last_evaluated_at":
+                result.evaluated_rows += 1
+            else:
+                result.fulfilled_rows += 1
+            applied.append(reconciliation)
+        if not applied:
+            continue
+        debt_pre_images = {
+            reconciliation.debt_score_pre_image for reconciliation in applied
+        }
+        if len(debt_pre_images) != 1:
+            raise ValueError(
+                "Migration 100 audit has inconsistent debt_score pre-images "
+                f"for character {key[0]} need {key[1]}"
+            )
+        row["debt_score"] = float(next(iter(debt_pre_images)))
         row["metadata"] = baseline_metadata
-    return counts["last_evaluated_at"], counts["last_fulfilled_at"]
+    return result
 
 
 def _coerce_need_payload(raw: Any) -> dict[str, Any]:
@@ -577,8 +643,10 @@ class _Replayer:
         self.target_created_at = _fetch_chunk_created_at(cur, target_chunk_id)
         self.need_tuning = load_need_tuning()
         self.project_policy = _load_project_policy()
+        self.need_clock_fix_applied_at = _need_clock_fix_applied_at(cur)
         self.missing_base_sections: set[str] = set()
-        self.need_clock_remainder_candidates: set[tuple[str, str]] = set()
+        self.clock_remainder_candidates: set[tuple[str, str, str]] = set()
+        self.absolute_clock_remainders: set[tuple[str, str, str]] = set()
         # Resolved in replay() once the base document is loaded; None means
         # legacy chunk-window behavior (issue #552).
         self.maturation_gate: Optional[frozenset[int]] = None
@@ -600,6 +668,14 @@ class _Replayer:
                 "Replay could not resolve migration 100's canonical need clock"
             )
         return anchor
+
+    def _uses_current_null_clock_rule(self, created_at: datetime) -> bool:
+        """Whether a resolution was committed under migration 100's helper."""
+
+        return (
+            self.need_clock_fix_applied_at is not None
+            and created_at >= self.need_clock_fix_applied_at
+        )
 
     def load_base_checkpoint(
         self, base_checkpoint_id: Optional[int]
@@ -893,18 +969,24 @@ class _Replayer:
             if self.target_checkpoint_id is not None
             else None
         )
-        evaluated, fulfilled = _rebase_reconciled_need_clock_baseline(
+        rebase = _rebase_reconciled_need_clock_baseline(
             self.cur,
             list(needs.values()),
             target_rows=target_need_rows,
         )
-        if evaluated or fulfilled:
+        self.absolute_clock_remainders.update(
+            {
+                ("character_need_states", row_key, "debt_score")
+                for row_key in rebase.debt_row_keys
+            }
+        )
+        if rebase.evaluated_rows or rebase.fulfilled_rows:
             result.add_note(
                 "character_need_states",
-                "migration 100 provenance rebased the checkpoint baseline "
+                "migration 100 audit rebased the checkpoint baseline "
                 "before event replay: "
-                f"last_evaluated_at rows={evaluated}, "
-                f"last_fulfilled_at rows={fulfilled}",
+                f"last_evaluated_at rows={rebase.evaluated_rows}, "
+                f"last_fulfilled_at rows={rebase.fulfilled_rows}",
                 approximate=False,
             )
         travel = {
@@ -963,6 +1045,10 @@ class _Replayer:
         tag_workings, tag_touched_entities = self._replay_tags(
             base_chunk, base_created_at, base_state, result
         )
+        self._mark_overwritten_entity_tag_presence_remainders(
+            tag_workings["entity_tags"],
+            result,
+        )
         self._sync_need_applicability(
             born_entities | tag_touched_entities,
             characters,
@@ -989,7 +1075,6 @@ class _Replayer:
         result.state["character_need_states"] = [
             needs[key] for key in sorted(needs, key=lambda k: (k[0], k[1]))
         ]
-        self._mark_need_clock_remainder(result)
         result.state["character_travel_states"] = [
             travel[key] for key in sorted(travel)
         ]
@@ -1001,6 +1086,7 @@ class _Replayer:
                 row.get("id") or -1,
             ),
         )
+        self._mark_clock_remainder(result)
         result.state["character_routine_anchors"] = sorted(
             (dict(row) for row in base_state["character_routine_anchors"]),
             key=lambda r: r["id"],
@@ -1661,23 +1747,29 @@ class _Replayer:
     ) -> None:
         self.cur.execute(
             """
-            SELECT id, actor_entity_id, state_delta FROM orrery_resolutions
+            SELECT id, actor_entity_id, state_delta, created_at
+            FROM orrery_resolutions
             WHERE tick_chunk_id = %s ORDER BY id
             """,
             (chunk_id,),
         )
         resolutions = [
-            (row[0], row[1], _as_document(row[2])) for row in self.cur.fetchall()
+            (row[0], row[1], _as_document(row[2]), row[3])
+            for row in self.cur.fetchall()
         ]
         if not resolutions:
             return
         source_world_time = _fetch_world_time(self.cur, chunk_id)
         used_primary_clock_fallback = source_world_time is None
-        world_time = source_world_time
-        if used_primary_clock_fallback:
-            world_time = self._deterministic_need_clock(chunk_id)
         by_entity = {row["entity_id"]: row for row in characters.values()}
-        for resolution_id, actor_entity_id, delta in resolutions:
+        for resolution_id, actor_entity_id, delta, created_at in resolutions:
+            current_null_clock_rule = (
+                used_primary_clock_fallback
+                and self._uses_current_null_clock_rule(created_at)
+            )
+            world_time = source_world_time
+            if current_null_clock_rule:
+                world_time = self._deterministic_need_clock(chunk_id)
             unknown = set(delta) - REPLAYED_DELTA_KEYS - TAG_DELTA_KEYS
             if unknown:
                 raise ValueError(
@@ -1697,11 +1789,17 @@ class _Replayer:
                     ("characters", str(row["id"]), "current_activity")
                 )
             if "need.fulfill" in delta:
+                # Legacy need outcomes are compared against the current rule
+                # only to identify a narrow markerless remainder. They are
+                # never claimed as exact; audit debt is absolute below.
+                need_world_time = world_time
+                if need_world_time is None:
+                    need_world_time = self._deterministic_need_clock(chunk_id)
                 self._replay_need_fulfill(
                     chunk_id,
                     actor_entity_id,
                     delta["need.fulfill"],
-                    world_time,
+                    need_world_time,
                     needs,
                     actor_entity_id in born_entities,
                     need_transitions,
@@ -2086,7 +2184,9 @@ class _Replayer:
                 ),
             }
             if born_in_window or tag_initialized:
-                self.need_clock_remainder_candidates.add((row_key, "debt_score"))
+                self.clock_remainder_candidates.add(
+                    ("character_need_states", row_key, "debt_score")
+                )
         row = needs[key]
         last_evaluated = row.get("last_evaluated_at")
         if isinstance(last_evaluated, str):
@@ -2114,7 +2214,9 @@ class _Replayer:
                 "last_fulfilled_at",
                 "debt_score",
             ):
-                self.need_clock_remainder_candidates.add((row_key, column))
+                self.clock_remainder_candidates.add(
+                    ("character_need_states", row_key, column)
+                )
         result.add_note(
             "character_need_states",
             "need.fulfill replayed through effective_debt_score with the "
@@ -2123,48 +2225,47 @@ class _Replayer:
             approximate=False,
         )
 
-    def _mark_need_clock_remainder(self, result: ReplayResult) -> None:
-        """Skip only markerless need fields current replay cannot derive."""
+    def _mark_clock_remainder(self, result: ReplayResult) -> None:
+        """Build the unified, absolute clock remainder.
 
-        if (
-            self.target_checkpoint_id is None
-            or not self.need_clock_remainder_candidates
-        ):
-            return
-        target_rows = _load_checkpoint_state(self.cur, self.target_checkpoint_id)[
-            "character_need_states"
-        ]
-        target_by_key = {
-            f"{row['character_entity_id']}:{row['need_type']}": row
-            for row in target_rows
-        }
-        replayed_by_key = {
-            f"{row['character_entity_id']}:{row['need_type']}": row
-            for row in result.state["character_need_states"]
-        }
-        skipped: list[tuple[str, str]] = []
-        for row_key, column in sorted(self.need_clock_remainder_candidates):
-            target = target_by_key.get(row_key)
-            replayed = replayed_by_key.get(row_key)
-            if target is None or replayed is None:
-                continue
-            if _need_clock_provenance(target.get("metadata")):
-                continue
-            if canonicalize(target.get(column)) == canonicalize(replayed.get(column)):
-                continue
-            # Remainder rule: markerless rows replay under the current,
-            # chunk-keyed deterministic helper. Only a concrete target field
-            # that rule cannot derive is unreproducible; never guess which
-            # historical helper version wrote it from wall-clock timestamps.
-            result.unreproducible.add(("character_need_states", row_key, column))
-            skipped.append((row_key, column))
-        if skipped:
-            result.add_note(
-                "character_need_states",
-                "markerless need-clock remainder under the current "
-                f"deterministic rule: {len(skipped)} field(s) unreproducible",
-                approximate=True,
-            )
+        A stored (row, field) is unreproducible whenever the *current*
+        chunk-keyed deterministic rule cannot derive it from ledger state.
+        Migration-100 audit debt and legacy NULL-clock travel timestamps are
+        absolute because their old wall-time inputs were never ledgered.
+        Markerless need fields retain the round-2 rule: skip only a concrete
+        target value that differs from current deterministic replay.
+        """
+
+        before = set(result.unreproducible)
+        result.unreproducible.update(self.absolute_clock_remainders)
+        if self.target_checkpoint_id is not None:
+            target_state = _load_checkpoint_state(self.cur, self.target_checkpoint_id)
+            for section, row_key, column in sorted(self.clock_remainder_candidates):
+                key_fn = _section_key_fn(section)
+                target_by_key = {str(key_fn(row)): row for row in target_state[section]}
+                replayed_by_key = {
+                    str(key_fn(row)): row for row in result.state[section]
+                }
+                target = target_by_key.get(row_key)
+                replayed = replayed_by_key.get(row_key)
+                if target is None or replayed is None:
+                    continue
+                if canonicalize(target.get(column)) == canonicalize(
+                    replayed.get(column)
+                ):
+                    continue
+                result.unreproducible.add((section, row_key, column))
+        added = result.unreproducible - before
+        if added:
+            by_section: dict[str, int] = {}
+            for section, _row_key, _column in added:
+                by_section[section] = by_section.get(section, 0) + 1
+            for section, count in sorted(by_section.items()):
+                result.add_note(
+                    section,
+                    "current-rule clock remainder: " f"{count} field(s) unreproducible",
+                    approximate=True,
+                )
 
     def _replay_travel(
         self,
@@ -2179,16 +2280,32 @@ class _Replayer:
     ) -> None:
         payload = _coerce_travel_payload(raw_payload)
         row = travel.get(actor_entity_id)
+        row_key = str(actor_entity_id)
         if world_time is None:
-            # No chunk-keyed primary-clock input exists on this replay path;
-            # retain a narrow remainder instead of inventing wall time.
+            # A pre-100 NULL-clock resolution used an unledgered wall clock.
+            # Preserve its written columns as unknown instead of fabricating
+            # today's deterministic primary-clock result.
             time_columns = ["updated_at_world_time"]
             if delta_key == "travel.start":
                 time_columns.append("started_at_world_time")
             for column in time_columns:
-                result.unreproducible.add(
-                    ("character_travel_states", str(actor_entity_id), column)
+                self.absolute_clock_remainders.add(
+                    ("character_travel_states", row_key, column)
                 )
+        else:
+            self.absolute_clock_remainders.discard(
+                ("character_travel_states", row_key, "updated_at_world_time")
+            )
+            if delta_key == "travel.start":
+                self.absolute_clock_remainders.discard(
+                    ("character_travel_states", row_key, "started_at_world_time")
+                )
+        if delta_key == "travel.arrive":
+            # Arrival always writes a literal NULL, independent of either
+            # historical clock rule.
+            self.absolute_clock_remainders.discard(
+                ("character_travel_states", row_key, "started_at_world_time")
+            )
         if delta_key == "travel.start":
             destination = payload.get("destination_place_id")
             origin = payload.get("origin_place_id") or (
@@ -2420,6 +2537,67 @@ class _Replayer:
             workings[section] = working
         return workings, touched_entities
 
+    def _mark_overwritten_entity_tag_presence_remainders(
+        self,
+        working: dict[int, dict[str, Any]],
+        result: ReplayResult,
+    ) -> None:
+        """Recognize target rows hidden by a later destructive reapplication.
+
+        ``replace`` and ``extend_expiry`` update an active row in place,
+        destroying its earlier ``source_chunk_id``. The immutable target
+        checkpoint plus the current row's stable identity and later source
+        chunk prove that the target row's history existed but is no longer
+        replayable. This is a presence remainder, not evidence for fabricating
+        the old projection. Arbitrary reconstruction has no target document
+        and deliberately cannot use this exception.
+        """
+
+        if self.target_checkpoint_id is None:
+            return
+        target_rows = _load_checkpoint_state(self.cur, self.target_checkpoint_id)[
+            "entity_tags"
+        ]
+        target_by_id = {int(row["id"]): row for row in target_rows}
+        self.cur.execute(
+            """
+            SELECT et.id, et.entity_id, et.tag_id, et.source_chunk_id
+            FROM entity_tags AS et
+            JOIN tags AS t ON t.id = et.tag_id
+            WHERE et.cleared_at IS NULL
+              AND et.source_chunk_id > %s
+              AND t.reapplication_policy IN ('replace', 'extend_expiry')
+            ORDER BY et.id
+            """,
+            (self.target_chunk_id,),
+        )
+        remainder_count = 0
+        for row_id, entity_id, tag_id, _source_chunk_id in self.cur.fetchall():
+            row_id = int(row_id)
+            target = target_by_id.get(row_id)
+            if target is None or row_id in working:
+                continue
+            if int(target["entity_id"]) != int(entity_id) or int(
+                target["tag_id"]
+            ) != int(tag_id):
+                continue
+            target_source_chunk_id = target.get("source_chunk_id")
+            if (
+                target_source_chunk_id is None
+                or int(target_source_chunk_id) > self.target_chunk_id
+            ):
+                continue
+            result.uncertain_rows.add(("entity_tags", str(row_id)))
+            remainder_count += 1
+        if remainder_count:
+            result.add_note(
+                "entity_tags",
+                f"{remainder_count} target-visible row(s) have "
+                "replace/extend_expiry provenance overwritten after the "
+                "target; row presence is unreproducible",
+                approximate=True,
+            )
+
     def _replay_entity_tag_events(
         self,
         working: dict[int, dict[str, Any]],
@@ -2616,7 +2794,9 @@ class _Replayer:
             result.unreproducible.discard(
                 ("character_need_states", row_key, "last_evaluated_at")
             )
-            self.need_clock_remainder_candidates.add((row_key, "last_evaluated_at"))
+            self.clock_remainder_candidates.add(
+                ("character_need_states", row_key, "last_evaluated_at")
+            )
         else:
             # Character birth is not chunk-ledgered, so the current trigger's
             # primary-clock input cannot be positioned for this fresh row.
@@ -3145,17 +3325,21 @@ def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:
             base_stored = _load_checkpoint_state(cur, base_id)
             target_stored = _load_checkpoint_state(cur, target_id)
             boundary_notes: dict[str, list[str]] = {}
-            evaluated, fulfilled = _rebase_reconciled_need_clock_baseline(
+            rebase = _rebase_reconciled_need_clock_baseline(
                 cur,
                 base_stored["character_need_states"],
                 target_rows=target_stored["character_need_states"],
             )
-            if evaluated or fulfilled:
+            reconciliation_remainders = {
+                ("character_need_states", row_key, "debt_score")
+                for row_key in rebase.debt_row_keys
+            }
+            if rebase.evaluated_rows or rebase.fulfilled_rows:
                 boundary_notes["character_need_states"] = [
-                    "migration 100 provenance rebased the same-chunk "
+                    "migration 100 audit rebased the same-chunk "
                     "checkpoint baseline: "
-                    f"last_evaluated_at rows={evaluated}, "
-                    f"last_fulfilled_at rows={fulfilled}"
+                    f"last_evaluated_at rows={rebase.evaluated_rows}, "
+                    f"last_fulfilled_at rows={rebase.fulfilled_rows}"
                 ]
             missing_sections = _missing_checkpoint_sections(
                 cur, base_id
@@ -3168,15 +3352,16 @@ def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:
                         len(base_stored[section]), len(target_stored[section]), 1
                     )
                     continue
-                section_drifts, _ = _diff_section(
+                section_drifts, section_skipped = _diff_section(
                     section,
                     base_stored[section],
                     target_stored[section],
                     _section_key_fn(section),
-                    set(),
+                    reconciliation_remainders,
                     set(),
                 )
                 drifts.extend(section_drifts)
+                skipped += section_skipped
             verdicts.append(
                 CheckpointPairVerdict(
                     base_checkpoint_id=base_id,

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -37,8 +37,10 @@ produces. Sections and their replay sources:
   toggled off-and-back inside the window are reset to the trigger's
   fresh-insert shape (detected chronologically from chunk-keyed
   immunity-tag events). Migration 100's deterministic primary-clock anchors
-  and one-time reconciliation are mirrored at their physical schema boundary;
-  only genuinely pre-100 wall-clock rows remain unreproducible.
+  replay from chunk-keyed ledger state. Its one-time reconciliation rebases
+  only a checkpoint baseline carrying recorded row provenance, before window
+  events replay; markerless values that current rules cannot derive become
+  narrow field-level remainders instead of inferred legacy behavior.
 - ``character_travel_states`` — forward for explicit payloads;
   ``travel.start`` resolves destinations and routes from live state at
   commit time, so windows containing travel deltas are approximate.
@@ -165,6 +167,12 @@ VOLATILE_COLUMNS: dict[str, frozenset[str]] = {
     "character_project_states": frozenset({"id", "created_at", "updated_at"}),
 }
 
+NEED_CLOCK_RECONCILIATION_MARKER = "migration_100"
+NEED_CLOCK_RECONCILIATION_COLUMNS = (
+    "last_evaluated_at",
+    "last_fulfilled_at",
+)
+
 SKALD_SCALAR_FIELDS = frozenset(
     {
         "characters.emotional_state",
@@ -277,8 +285,7 @@ class _NeedApplicabilityTransitions:
 
     went_inapplicable: set[tuple[int, str]]
     first_made_applicable_chunk: dict[tuple[int, str], int]
-    first_made_applicable_at: dict[tuple[int, str], datetime]
-    last_made_applicable_at: dict[tuple[int, str], datetime]
+    last_made_applicable_chunk: dict[tuple[int, str], int]
 
 
 def _as_document(value: Any) -> dict[str, Any]:
@@ -397,49 +404,16 @@ def canonicalize(value: Any) -> Any:
     return value
 
 
-def _as_datetime(value: Any) -> Optional[datetime]:
-    """Return a checkpoint timestamp leaf as a datetime when present."""
-
-    if value is None or isinstance(value, datetime):
-        return value
-    if isinstance(value, str):
-        return datetime.fromisoformat(value)
-    raise TypeError(f"Expected a timestamp value, got {value!r}")
-
-
-def _need_clock_migration_applied_at(cur: Any) -> Optional[datetime]:
-    """Return migration 100's physical boundary when it is installed."""
-
-    cur.execute("SELECT applied_at FROM schema_migrations WHERE version = '100'")
-    row = cur.fetchone()
-    return _row_value(row, 0) if row is not None else None
-
-
-def _checkpoint_created_at(cur: Any, checkpoint_id: int) -> datetime:
-    cur.execute(
-        "SELECT created_at FROM state_checkpoints WHERE id = %s",
-        (checkpoint_id,),
-    )
-    row = cur.fetchone()
-    if row is None:
-        raise ValueError(f"Checkpoint {checkpoint_id} does not exist")
-    return _row_value(row, 0)
-
-
-def _canonical_need_clock_as_of(
-    cur: Any, physical_time: datetime
-) -> Optional[datetime]:
-    """Rebuild migration 100's primary-clock authority at a physical boundary."""
+def _canonical_need_clock_at_chunk(cur: Any, chunk_id: int) -> Optional[datetime]:
+    """Resolve the current primary need clock from chunk-keyed ledger state."""
 
     cur.execute(
         """
         SELECT COALESCE(
             (
-                SELECT MAX(cm.world_time)
-                FROM chunk_metadata AS cm
-                JOIN narrative_chunks AS nc ON nc.id = cm.chunk_id
-                WHERE nc.created_at IS NOT NULL
-                  AND nc.created_at <= %s
+                SELECT MAX(world_time)
+                FROM chunk_metadata
+                WHERE chunk_id <= %s
             ),
             (
                 SELECT base_timestamp
@@ -448,55 +422,97 @@ def _canonical_need_clock_as_of(
             )
         )
         """,
-        (physical_time,),
+        (chunk_id,),
     )
     row = cur.fetchone()
     return _row_value(row, 0) if row is not None else None
 
 
-def _need_clock_reconciliation_authority(
+def _need_clock_provenance(metadata: Any) -> dict[str, Any]:
+    """Extract and validate migration 100's field-level row provenance."""
+
+    document = dict(_as_document(metadata) or {})
+    if document.get("reconciled_by") != NEED_CLOCK_RECONCILIATION_MARKER:
+        return {}
+    provenance: dict[str, Any] = {"reconciled_by": NEED_CLOCK_RECONCILIATION_MARKER}
+    for column in NEED_CLOCK_RECONCILIATION_COLUMNS:
+        field_name = column.removesuffix("_at")
+        from_key = f"reconciled_{field_name}_from"
+        to_key = f"reconciled_{field_name}_to"
+        has_from = from_key in document
+        has_to = to_key in document
+        if has_from != has_to:
+            raise ValueError(
+                "Migration 100 need-clock provenance has an incomplete "
+                f"{column} pre-image/result pair"
+            )
+        if has_from:
+            provenance[from_key] = document[from_key]
+            provenance[to_key] = document[to_key]
+    if len(provenance) == 1:
+        raise ValueError(
+            "Migration 100 need-clock provenance names no reconciled field"
+        )
+    return provenance
+
+
+def _live_need_clock_provenance(
     cur: Any,
-    *,
-    base_checkpoint_created_at: datetime,
-    target_checkpoint_created_at: datetime,
-) -> Optional[tuple[datetime, datetime]]:
-    """Return (base, ceiling) when migration 100 crossed this capture pair."""
+) -> dict[tuple[int, str], dict[str, Any]]:
+    """Load the exact reconciliation evidence retained on current rows."""
 
-    applied_at = _need_clock_migration_applied_at(cur)
-    if (
-        applied_at is None
-        or applied_at <= base_checkpoint_created_at
-        or applied_at > target_checkpoint_created_at
-    ):
-        return None
-    cur.execute("SELECT base_timestamp FROM global_variables WHERE id = true")
-    row = cur.fetchone()
-    canonical_base = _row_value(row, 0) if row is not None else None
-    if canonical_base is None:
-        return None
-    ceiling = _canonical_need_clock_as_of(cur, applied_at)
-    if ceiling is None:
-        return None
-    return canonical_base, ceiling
+    cur.execute(
+        """
+        SELECT character_entity_id, need_type::text, metadata
+        FROM character_need_states
+        WHERE metadata ->> 'reconciled_by' = 'migration_100'
+        """
+    )
+    return {
+        (int(entity_id), str(need_type)): _need_clock_provenance(metadata)
+        for entity_id, need_type, metadata in cur.fetchall()
+    }
 
 
-def _reconcile_need_clock_rows(
+def _rebase_reconciled_need_clock_baseline(
+    cur: Any,
     rows: list[dict[str, Any]],
     *,
-    canonical_base: datetime,
-    canonical_ceiling: datetime,
+    target_rows: Optional[list[dict[str, Any]]] = None,
 ) -> tuple[int, int]:
-    """Apply migration 100's deterministic restamp to replay working rows."""
+    """Apply recorded migration results to a baseline, before event replay."""
+
+    live_provenance = _live_need_clock_provenance(cur)
+    target_marker_keys: Optional[set[tuple[int, str]]] = None
+    if target_rows is not None:
+        # A later live marker must not rewrite checkpoint pairs whose target
+        # still predates the reconciliation. The target's own copied marker is
+        # recorded proof that this baseline-to-target window crossed it.
+        target_marker_keys = {
+            (int(row["character_entity_id"]), str(row["need_type"]))
+            for row in target_rows
+            if _need_clock_provenance(row.get("metadata"))
+        }
 
     counts = {"last_evaluated_at": 0, "last_fulfilled_at": 0}
     for row in rows:
-        for column in counts:
-            value = _as_datetime(row.get(column))
-            if value is not None and (
-                value < canonical_base or value > canonical_ceiling
-            ):
-                row[column] = _isoformat(canonical_ceiling)
+        key = (int(row["character_entity_id"]), str(row["need_type"]))
+        provenance = live_provenance.get(key)
+        if provenance is None or (
+            target_marker_keys is not None and key not in target_marker_keys
+        ):
+            continue
+        baseline_metadata = dict(_as_document(row.get("metadata")) or {})
+        if baseline_metadata.get("reconciled_by") == NEED_CLOCK_RECONCILIATION_MARKER:
+            continue
+        for column in NEED_CLOCK_RECONCILIATION_COLUMNS:
+            field_name = column.removesuffix("_at")
+            to_key = f"reconciled_{field_name}_to"
+            if to_key in provenance:
+                row[column] = provenance[to_key]
                 counts[column] += 1
+        baseline_metadata.update(provenance)
+        row["metadata"] = baseline_metadata
     return counts["last_evaluated_at"], counts["last_fulfilled_at"]
 
 
@@ -561,8 +577,8 @@ class _Replayer:
         self.target_created_at = _fetch_chunk_created_at(cur, target_chunk_id)
         self.need_tuning = load_need_tuning()
         self.project_policy = _load_project_policy()
-        self.need_clock_migration_applied_at = _need_clock_migration_applied_at(cur)
         self.missing_base_sections: set[str] = set()
+        self.need_clock_remainder_candidates: set[tuple[str, str]] = set()
         # Resolved in replay() once the base document is loaded; None means
         # legacy chunk-window behavior (issue #552).
         self.maturation_gate: Optional[frozenset[int]] = None
@@ -575,58 +591,15 @@ class _Replayer:
 
     # -- base checkpoint ---------------------------------------------------
 
-    def _uses_deterministic_need_clock(self, physical_time: datetime) -> bool:
-        """Whether migration 100 governed a write at this physical instant."""
+    def _deterministic_need_clock(self, chunk_id: int) -> datetime:
+        """Resolve the current tick/trigger anchor from chunk provenance."""
 
-        return (
-            self.need_clock_migration_applied_at is not None
-            and physical_time >= self.need_clock_migration_applied_at
-        )
-
-    def _deterministic_need_clock(self, physical_time: datetime) -> datetime:
-        """Resolve a post-migration tick/trigger anchor or fail closed."""
-
-        anchor = _canonical_need_clock_as_of(self.cur, physical_time)
+        anchor = _canonical_need_clock_at_chunk(self.cur, chunk_id)
         if anchor is None:
             raise ValueError(
                 "Replay could not resolve migration 100's canonical need clock"
             )
         return anchor
-
-    def _reconcile_need_clocks_at_migration_boundary(
-        self,
-        needs: dict[tuple[int, str], dict[str, Any]],
-        *,
-        base_checkpoint_created_at: datetime,
-        result: ReplayResult,
-    ) -> None:
-        """Mirror migration 100's unledgered repair between checkpoints."""
-
-        if self.target_checkpoint_id is None:
-            return
-        target_checkpoint_created_at = _checkpoint_created_at(
-            self.cur, self.target_checkpoint_id
-        )
-        authority = _need_clock_reconciliation_authority(
-            self.cur,
-            base_checkpoint_created_at=base_checkpoint_created_at,
-            target_checkpoint_created_at=target_checkpoint_created_at,
-        )
-        if authority is None:
-            return
-        canonical_base, canonical_ceiling = authority
-        evaluated, fulfilled = _reconcile_need_clock_rows(
-            list(needs.values()),
-            canonical_base=canonical_base,
-            canonical_ceiling=canonical_ceiling,
-        )
-        result.add_note(
-            "character_need_states",
-            "migration 100 reconciliation mirrored at the checkpoint boundary: "
-            f"last_evaluated_at rows={evaluated}, "
-            f"last_fulfilled_at rows={fulfilled}",
-            approximate=False,
-        )
 
     def load_base_checkpoint(
         self, base_checkpoint_id: Optional[int]
@@ -913,6 +886,27 @@ class _Replayer:
             (row["character_entity_id"], row["need_type"]): dict(row)
             for row in base_state["character_need_states"]
         }
+        target_need_rows = (
+            _load_checkpoint_state(self.cur, self.target_checkpoint_id)[
+                "character_need_states"
+            ]
+            if self.target_checkpoint_id is not None
+            else None
+        )
+        evaluated, fulfilled = _rebase_reconciled_need_clock_baseline(
+            self.cur,
+            list(needs.values()),
+            target_rows=target_need_rows,
+        )
+        if evaluated or fulfilled:
+            result.add_note(
+                "character_need_states",
+                "migration 100 provenance rebased the checkpoint baseline "
+                "before event replay: "
+                f"last_evaluated_at rows={evaluated}, "
+                f"last_fulfilled_at rows={fulfilled}",
+                approximate=False,
+            )
         travel = {
             row["character_entity_id"]: dict(row)
             for row in base_state["character_travel_states"]
@@ -926,8 +920,7 @@ class _Replayer:
 
         if "entities" not in self.missing_base_sections:
             self._seed_window_entity_births(entities, result)
-        born_entity_times = self._seed_window_births(characters, places, result)
-        born_entities = set(born_entity_times)
+        born_entities = self._seed_window_births(characters, places, result)
         character_entities = {
             row["entity_id"]
             for row in characters.values()
@@ -947,7 +940,7 @@ class _Replayer:
                         needs,
                         travel,
                         projects,
-                        born_entity_times,
+                        born_entities,
                         need_transitions,
                         result,
                     )
@@ -976,14 +969,8 @@ class _Replayer:
             tag_workings["entity_tags"],
             needs,
             base_chunk,
-            born_entity_times,
             need_transitions,
             result,
-        )
-        self._reconcile_need_clocks_at_migration_boundary(
-            needs,
-            base_checkpoint_created_at=base_created_at,
-            result=result,
         )
         for section, working in tag_workings.items():
             result.state[section] = sorted(working.values(), key=lambda r: r["id"])
@@ -1002,6 +989,7 @@ class _Replayer:
         result.state["character_need_states"] = [
             needs[key] for key in sorted(needs, key=lambda k: (k[0], k[1]))
         ]
+        self._mark_need_clock_remainder(result)
         result.state["character_travel_states"] = [
             travel[key] for key in sorted(travel)
         ]
@@ -1568,7 +1556,7 @@ class _Replayer:
         characters: dict[int, dict[str, Any]],
         places: dict[int, dict[str, Any]],
         result: ReplayResult,
-    ) -> dict[int, datetime]:
+    ) -> set[int]:
         """Entities INSERTed between checkpoint and N are un-ledgered.
 
         Their existence is seeded (wall-clock bounded) but their initial
@@ -1578,11 +1566,11 @@ class _Replayer:
         start ``None`` and are marked unreproducible; a ledgered write in
         the window clears the mark for the column it sets. Rows whose
         created_at equals the target chunk's are presence-uncertain (the
-        Step 8.6 stub-creation ambiguity). Returns born character entity
-        creation times for the need-applicability sync.
+        Step 8.6 stub-creation ambiguity). Returns born character entity ids
+        for the need-applicability sync.
         """
 
-        born_entity_times: dict[int, datetime] = {}
+        born_entities: set[int] = set()
         for section, sql, columns in (
             (
                 "characters",
@@ -1614,7 +1602,7 @@ class _Replayer:
                 if created_at == self.target_created_at:
                     result.uncertain_rows.add((section, str(row_id)))
                 if section == "characters" and entity_id is not None:
-                    born_entity_times[entity_id] = created_at
+                    born_entities.add(entity_id)
             if births:
                 result.add_note(
                     section,
@@ -1623,7 +1611,7 @@ class _Replayer:
                     "ledgered writes",
                     approximate=True,
                 )
-        return born_entity_times
+        return born_entities
 
     def _apply_skald_rows(
         self,
@@ -1667,30 +1655,29 @@ class _Replayer:
         needs: dict[tuple[int, str], dict[str, Any]],
         travel: dict[int, dict[str, Any]],
         projects: dict[Any, dict[str, Any]],
-        born_entity_times: dict[int, datetime],
+        born_entities: set[int],
         need_transitions: _NeedApplicabilityTransitions,
         result: ReplayResult,
     ) -> None:
         self.cur.execute(
             """
-            SELECT id, actor_entity_id, state_delta, created_at
-            FROM orrery_resolutions
+            SELECT id, actor_entity_id, state_delta FROM orrery_resolutions
             WHERE tick_chunk_id = %s ORDER BY id
             """,
             (chunk_id,),
         )
         resolutions = [
-            (row[0], row[1], _as_document(row[2]), row[3])
-            for row in self.cur.fetchall()
+            (row[0], row[1], _as_document(row[2])) for row in self.cur.fetchall()
         ]
         if not resolutions:
             return
         source_world_time = _fetch_world_time(self.cur, chunk_id)
+        used_primary_clock_fallback = source_world_time is None
+        world_time = source_world_time
+        if used_primary_clock_fallback:
+            world_time = self._deterministic_need_clock(chunk_id)
         by_entity = {row["entity_id"]: row for row in characters.values()}
-        for resolution_id, actor_entity_id, delta, committed_at in resolutions:
-            world_time = source_world_time
-            if world_time is None and self._uses_deterministic_need_clock(committed_at):
-                world_time = self._deterministic_need_clock(committed_at)
+        for resolution_id, actor_entity_id, delta in resolutions:
             unknown = set(delta) - REPLAYED_DELTA_KEYS - TAG_DELTA_KEYS
             if unknown:
                 raise ValueError(
@@ -1716,8 +1703,9 @@ class _Replayer:
                     delta["need.fulfill"],
                     world_time,
                     needs,
-                    born_entity_times,
+                    actor_entity_id in born_entities,
                     need_transitions,
+                    used_primary_clock_fallback,
                     result,
                 )
             for project_key in (
@@ -2059,10 +2047,15 @@ class _Replayer:
         raw_payload: Any,
         world_time: Optional[datetime],
         needs: dict[tuple[int, str], dict[str, Any]],
-        born_entity_times: dict[int, datetime],
+        born_in_window: bool,
         transitions: _NeedApplicabilityTransitions,
+        used_primary_clock_fallback: bool,
         result: ReplayResult,
     ) -> None:
+        if world_time is None:
+            raise ValueError(
+                f"Need fulfillment at chunk {chunk_id} has no deterministic clock"
+            )
         payload = _coerce_need_payload(raw_payload)
         need_type = payload["type"]
         key = (actor_entity_id, need_type)
@@ -2072,19 +2065,9 @@ class _Replayer:
             tag_initialized = (
                 activation_chunk is not None and activation_chunk <= chunk_id
             )
-            born_in_window = actor_entity_id in born_entity_times
-            initialized_at = (
-                transitions.first_made_applicable_at.get(key)
-                if tag_initialized
-                else born_entity_times.get(actor_entity_id)
-            )
             initial_anchor = world_time
-            deterministic_initialization = (
-                initialized_at is not None
-                and self._uses_deterministic_need_clock(initialized_at)
-            )
-            if deterministic_initialization and initialized_at is not None:
-                initial_anchor = self._deterministic_need_clock(initialized_at)
+            if tag_initialized and activation_chunk is not None:
+                initial_anchor = self._deterministic_need_clock(activation_chunk)
             needs[key] = {
                 "character_entity_id": actor_entity_id,
                 "need_type": need_type,
@@ -2102,25 +2085,8 @@ class _Replayer:
                     else {}
                 ),
             }
-            if (
-                tag_initialized
-                and activation_chunk is not None
-                and activation_chunk < chunk_id
-                and not deterministic_initialization
-            ):
-                # Migration-057-era trigger anchors came from wall time. The
-                # same post-100 path is exact because initialized_at resolves
-                # the primary clock at the trigger boundary.
-                result.unreproducible.add(
-                    ("character_need_states", row_key, "debt_score")
-                )
-                result.add_note(
-                    "character_need_states",
-                    f"pre-migration tag applicability initialized {row_key} "
-                    f"before chunk {chunk_id}; pre-fulfillment debt accrual "
-                    "is unreproducible",
-                    approximate=True,
-                )
+            if born_in_window or tag_initialized:
+                self.need_clock_remainder_candidates.add((row_key, "debt_score"))
         row = needs[key]
         last_evaluated = row.get("last_evaluated_at")
         if isinstance(last_evaluated, str):
@@ -2140,23 +2106,15 @@ class _Replayer:
         metadata = dict(row.get("metadata") or {})
         metadata["last_fulfillment"] = payload
         row["metadata"] = metadata
-        if world_time is None:
-            # Legacy pre-migration production fell back to wall-clock now()
-            # and accrued debt against it. Migration-100-era rows take the
-            # deterministic primary clock above; only the legacy history
-            # remains genuinely unreproducible.
-            for column in ("last_evaluated_at", "last_fulfilled_at", "debt_score"):
-                result.unreproducible.add(("character_need_states", row_key, column))
-            result.add_note(
-                "character_need_states",
-                f"chunk {chunk_id} has NULL world_time and predates migration "
-                f"100; legacy wall-clock need state on {row_key} is "
-                "unreproducible",
-                approximate=True,
-            )
-        else:
-            row["last_evaluated_at"] = _isoformat(world_time)
-            row["last_fulfilled_at"] = _isoformat(world_time)
+        row["last_evaluated_at"] = _isoformat(world_time)
+        row["last_fulfilled_at"] = _isoformat(world_time)
+        if used_primary_clock_fallback:
+            for column in (
+                "last_evaluated_at",
+                "last_fulfilled_at",
+                "debt_score",
+            ):
+                self.need_clock_remainder_candidates.add((row_key, column))
         result.add_note(
             "character_need_states",
             "need.fulfill replayed through effective_debt_score with the "
@@ -2164,6 +2122,49 @@ class _Replayer:
             "matches its value at original commit",
             approximate=False,
         )
+
+    def _mark_need_clock_remainder(self, result: ReplayResult) -> None:
+        """Skip only markerless need fields current replay cannot derive."""
+
+        if (
+            self.target_checkpoint_id is None
+            or not self.need_clock_remainder_candidates
+        ):
+            return
+        target_rows = _load_checkpoint_state(self.cur, self.target_checkpoint_id)[
+            "character_need_states"
+        ]
+        target_by_key = {
+            f"{row['character_entity_id']}:{row['need_type']}": row
+            for row in target_rows
+        }
+        replayed_by_key = {
+            f"{row['character_entity_id']}:{row['need_type']}": row
+            for row in result.state["character_need_states"]
+        }
+        skipped: list[tuple[str, str]] = []
+        for row_key, column in sorted(self.need_clock_remainder_candidates):
+            target = target_by_key.get(row_key)
+            replayed = replayed_by_key.get(row_key)
+            if target is None or replayed is None:
+                continue
+            if _need_clock_provenance(target.get("metadata")):
+                continue
+            if canonicalize(target.get(column)) == canonicalize(replayed.get(column)):
+                continue
+            # Remainder rule: markerless rows replay under the current,
+            # chunk-keyed deterministic helper. Only a concrete target field
+            # that rule cannot derive is unreproducible; never guess which
+            # historical helper version wrote it from wall-clock timestamps.
+            result.unreproducible.add(("character_need_states", row_key, column))
+            skipped.append((row_key, column))
+        if skipped:
+            result.add_note(
+                "character_need_states",
+                "markerless need-clock remainder under the current "
+                f"deterministic rule: {len(skipped)} field(s) unreproducible",
+                approximate=True,
+            )
 
     def _replay_travel(
         self,
@@ -2179,8 +2180,8 @@ class _Replayer:
         payload = _coerce_travel_payload(raw_payload)
         row = travel.get(actor_entity_id)
         if world_time is None:
-            # Only legacy pre-migration NULL-clock ticks reached wall time.
-            # Post-migration ticks resolve the deterministic primary clock.
+            # No chunk-keyed primary-clock input exists on this replay path;
+            # retain a narrow remainder instead of inventing wall time.
             time_columns = ["updated_at_world_time"]
             if delta_key == "travel.start":
                 time_columns.append("started_at_world_time")
@@ -2601,21 +2602,24 @@ class _Replayer:
         *,
         entity_id: int,
         need: str,
-        created_at: Optional[datetime],
+        anchor_chunk_id: Optional[int],
         result: ReplayResult,
     ) -> dict[str, Any]:
-        """Build the trigger's fresh row with the correct clock-era contract."""
+        """Build a fresh trigger row from chunk provenance when available."""
 
         row_key = f"{entity_id}:{need}"
         last_evaluated_at = None
-        if created_at is not None and self._uses_deterministic_need_clock(created_at):
-            last_evaluated_at = _isoformat(self._deterministic_need_clock(created_at))
+        if anchor_chunk_id is not None:
+            last_evaluated_at = _isoformat(
+                self._deterministic_need_clock(anchor_chunk_id)
+            )
             result.unreproducible.discard(
                 ("character_need_states", row_key, "last_evaluated_at")
             )
+            self.need_clock_remainder_candidates.add((row_key, "last_evaluated_at"))
         else:
-            # Migration 057 used wall-clock now(); only rows proven to have
-            # been created before migration 100 retain this honest skip.
+            # Character birth is not chunk-ledgered, so the current trigger's
+            # primary-clock input cannot be positioned for this fresh row.
             result.unreproducible.add(
                 ("character_need_states", row_key, "last_evaluated_at")
             )
@@ -2629,24 +2633,24 @@ class _Replayer:
             "metadata": {"synced_by": "need_applicability"},
         }
 
-    def _need_sync_trigger_times(
+    def _need_sync_trigger_chunks(
         self, entities: set[int], base_chunk: int
-    ) -> dict[int, datetime]:
-        """Return each entity's first tag-trigger instant in this window."""
+    ) -> dict[int, int]:
+        """Return each entity's first chunk-keyed tag trigger in this window."""
 
         if not entities:
             return {}
         self.cur.execute(
             """
-            SELECT entity_id, MIN(triggered_at)
+            SELECT entity_id, MIN(trigger_chunk)
             FROM (
-                SELECT et.entity_id, et.applied_at AS triggered_at
+                SELECT et.entity_id, et.source_chunk_id AS trigger_chunk
                 FROM entity_tags AS et
                 WHERE et.entity_id = ANY(%s)
                   AND et.source_chunk_id > %s
                   AND et.source_chunk_id <= %s
                 UNION ALL
-                SELECT et.entity_id, log.cleared_at AS triggered_at
+                SELECT et.entity_id, log.source_chunk_id AS trigger_chunk
                 FROM tag_clearance_log AS log
                 JOIN entity_tags AS et ON et.id = log.entity_tag_id
                 WHERE et.entity_id = ANY(%s)
@@ -2665,9 +2669,9 @@ class _Replayer:
             ),
         )
         return {
-            int(entity_id): triggered_at
-            for entity_id, triggered_at in self.cur.fetchall()
-            if triggered_at is not None
+            int(entity_id): int(trigger_chunk)
+            for entity_id, trigger_chunk in self.cur.fetchall()
+            if trigger_chunk is not None
         }
 
     def _sync_need_applicability(
@@ -2677,7 +2681,6 @@ class _Replayer:
         entity_tags_working: dict[int, dict[str, Any]],
         needs: dict[tuple[int, str], dict[str, Any]],
         base_chunk: int,
-        born_entity_times: dict[int, datetime],
         transitions: _NeedApplicabilityTransitions,
         result: ReplayResult,
     ) -> None:
@@ -2690,9 +2693,9 @@ class _Replayer:
         pure function of the final active tag set; row CONTENTS are not —
         an applicability toggle (immunity tag applied then cleared inside
         one window) makes production delete and re-insert a FRESH row, so
-        toggled rows are reset to the fresh-insert shape here. Migration 100
-        makes the fresh anchor deterministic for post-boundary rows; only
-        legacy pre-migration rows keep an unreproducible timestamp.
+        toggled rows are reset to the fresh-insert shape here. Chunk-keyed
+        tag provenance reconstructs the current deterministic anchor; an
+        un-ledgered character birth retains a narrow timestamp remainder.
         """
 
         if not affected_entities:
@@ -2714,7 +2717,7 @@ class _Replayer:
                 (list(tag_ids),),
             )
             tag_names = dict(self.cur.fetchall())
-        trigger_times = self._need_sync_trigger_times(
+        trigger_chunks = self._need_sync_trigger_chunks(
             affected_entities & character_entities, base_chunk
         )
 
@@ -2735,15 +2738,13 @@ class _Replayer:
                 key = (entity_id, need)
                 row_key = f"{entity_id}:{need}"
                 if need in applicable and key not in needs:
-                    created_at = (
-                        transitions.last_made_applicable_at.get(key)
-                        or born_entity_times.get(entity_id)
-                        or trigger_times.get(entity_id)
-                    )
+                    anchor_chunk_id = transitions.last_made_applicable_chunk.get(
+                        key
+                    ) or trigger_chunks.get(entity_id)
                     needs[key] = self._fresh_need_state(
                         entity_id=entity_id,
                         need=need,
-                        created_at=created_at,
+                        anchor_chunk_id=anchor_chunk_id,
                         result=result,
                     )
                     synthesized += 1
@@ -2758,7 +2759,9 @@ class _Replayer:
                         needs[key] = self._fresh_need_state(
                             entity_id=entity_id,
                             need=need,
-                            created_at=transitions.last_made_applicable_at.get(key),
+                            anchor_chunk_id=(
+                                transitions.last_made_applicable_chunk.get(key)
+                            ),
                             result=result,
                         )
                         reset += 1
@@ -2815,7 +2818,7 @@ class _Replayer:
         """
 
         if not entities:
-            return _NeedApplicabilityTransitions(set(), {}, {}, {})
+            return _NeedApplicabilityTransitions(set(), {}, {})
         all_immunity = frozenset().union(*NEED_IMMUNITY_TAGS.values())
         self.cur.execute(
             "SELECT id, tag FROM tags WHERE tag = ANY(%s)",
@@ -2823,7 +2826,7 @@ class _Replayer:
         )
         immunity_by_id: dict[int, str] = dict(self.cur.fetchall())
         if not immunity_by_id:
-            return _NeedApplicabilityTransitions(set(), {}, {}, {})
+            return _NeedApplicabilityTransitions(set(), {}, {})
 
         current: dict[int, set[str]] = {entity: set() for entity in entities}
         for row in base_state["entity_tags"]:
@@ -2836,7 +2839,7 @@ class _Replayer:
         def _event(entity: int, chunk: int) -> dict[str, Any]:
             return events.setdefault(
                 (entity, chunk),
-                {"added": set(), "cleared": set(), "cleared_at": None},
+                {"added": set(), "cleared": set()},
             )
 
         self.cur.execute(
@@ -2856,7 +2859,7 @@ class _Replayer:
             _event(entity_id, chunk)["added"].add(immunity_by_id[tag_id])
         self.cur.execute(
             """
-            SELECT et.entity_id, et.tag_id, l.source_chunk_id, l.cleared_at
+            SELECT et.entity_id, et.tag_id, l.source_chunk_id
             FROM tag_clearance_log l
             JOIN entity_tags et ON et.id = l.entity_tag_id
             WHERE et.entity_id = ANY(%s) AND et.tag_id = ANY(%s)
@@ -2869,18 +2872,13 @@ class _Replayer:
                 self.target_chunk_id,
             ),
         )
-        for entity_id, tag_id, chunk, cleared_at in self.cur.fetchall():
+        for entity_id, tag_id, chunk in self.cur.fetchall():
             event = _event(entity_id, chunk)
             event["cleared"].add(immunity_by_id[tag_id])
-            if cleared_at is not None and (
-                event["cleared_at"] is None or cleared_at > event["cleared_at"]
-            ):
-                event["cleared_at"] = cleared_at
 
         went_inapplicable: set[tuple[int, str]] = set()
         first_made_applicable_chunk: dict[tuple[int, str], int] = {}
-        first_made_applicable_at: dict[tuple[int, str], datetime] = {}
-        last_made_applicable_at: dict[tuple[int, str], datetime] = {}
+        last_made_applicable_chunk: dict[tuple[int, str], int] = {}
         for (entity_id, chunk), event in sorted(
             events.items(), key=lambda item: (item[0][0], item[0][1])
         ):
@@ -2906,14 +2904,11 @@ class _Replayer:
                     not applicable_before[need] or transiently_inapplicable
                 ):
                     first_made_applicable_chunk.setdefault(key, chunk)
-                    if event["cleared_at"] is not None:
-                        first_made_applicable_at.setdefault(key, event["cleared_at"])
-                        last_made_applicable_at[key] = event["cleared_at"]
+                    last_made_applicable_chunk[key] = chunk
         return _NeedApplicabilityTransitions(
             went_inapplicable,
             first_made_applicable_chunk,
-            first_made_applicable_at,
-            last_made_applicable_at,
+            last_made_applicable_chunk,
         )
 
     # -- relationship unwind ---------------------------------------------------
@@ -3145,26 +3140,20 @@ def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:
     ):
         if base_chunk == target_chunk:
             # Same-chunk captures must be identical documents; diff them
-            # directly, except for deterministic schema-boundary authorities
-            # whose writes are intentionally mirrored by replay.
+            # directly after applying any recorded migration-100 row
+            # provenance to the baseline.
             base_stored = _load_checkpoint_state(cur, base_id)
             target_stored = _load_checkpoint_state(cur, target_id)
             boundary_notes: dict[str, list[str]] = {}
-            authority = _need_clock_reconciliation_authority(
+            evaluated, fulfilled = _rebase_reconciled_need_clock_baseline(
                 cur,
-                base_checkpoint_created_at=_checkpoint_created_at(cur, base_id),
-                target_checkpoint_created_at=_checkpoint_created_at(cur, target_id),
+                base_stored["character_need_states"],
+                target_rows=target_stored["character_need_states"],
             )
-            if authority is not None:
-                canonical_base, canonical_ceiling = authority
-                evaluated, fulfilled = _reconcile_need_clock_rows(
-                    base_stored["character_need_states"],
-                    canonical_base=canonical_base,
-                    canonical_ceiling=canonical_ceiling,
-                )
+            if evaluated or fulfilled:
                 boundary_notes["character_need_states"] = [
-                    "migration 100 reconciliation mirrored at the same-chunk "
-                    "checkpoint boundary: "
+                    "migration 100 provenance rebased the same-chunk "
+                    "checkpoint baseline: "
                     f"last_evaluated_at rows={evaluated}, "
                     f"last_fulfilled_at rows={fulfilled}"
                 ]

--- a/nexus/agents/orrery/replay.py
+++ b/nexus/agents/orrery/replay.py
@@ -36,7 +36,9 @@ produces. Sections and their replay sources:
   row presence follows the final tag set, and rows whose applicability
   toggled off-and-back inside the window are reset to the trigger's
   fresh-insert shape (detected chronologically from chunk-keyed
-  immunity-tag events).
+  immunity-tag events). Migration 100's deterministic primary-clock anchors
+  and one-time reconciliation are mirrored at their physical schema boundary;
+  only genuinely pre-100 wall-clock rows remain unreproducible.
 - ``character_travel_states`` — forward for explicit payloads;
   ``travel.start`` resolves destinations and routes from live state at
   commit time, so windows containing travel deltas are approximate.
@@ -269,6 +271,16 @@ class CheckpointPairVerdict:
     notes: dict[str, list[str]]
 
 
+@dataclass
+class _NeedApplicabilityTransitions:
+    """Replay evidence for need rows deleted and recreated by tag triggers."""
+
+    went_inapplicable: set[tuple[int, str]]
+    first_made_applicable_chunk: dict[tuple[int, str], int]
+    first_made_applicable_at: dict[tuple[int, str], datetime]
+    last_made_applicable_at: dict[tuple[int, str], datetime]
+
+
 def _as_document(value: Any) -> dict[str, Any]:
     if isinstance(value, str):
         return json.loads(value)
@@ -385,6 +397,109 @@ def canonicalize(value: Any) -> Any:
     return value
 
 
+def _as_datetime(value: Any) -> Optional[datetime]:
+    """Return a checkpoint timestamp leaf as a datetime when present."""
+
+    if value is None or isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value)
+    raise TypeError(f"Expected a timestamp value, got {value!r}")
+
+
+def _need_clock_migration_applied_at(cur: Any) -> Optional[datetime]:
+    """Return migration 100's physical boundary when it is installed."""
+
+    cur.execute("SELECT applied_at FROM schema_migrations WHERE version = '100'")
+    row = cur.fetchone()
+    return _row_value(row, 0) if row is not None else None
+
+
+def _checkpoint_created_at(cur: Any, checkpoint_id: int) -> datetime:
+    cur.execute(
+        "SELECT created_at FROM state_checkpoints WHERE id = %s",
+        (checkpoint_id,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"Checkpoint {checkpoint_id} does not exist")
+    return _row_value(row, 0)
+
+
+def _canonical_need_clock_as_of(
+    cur: Any, physical_time: datetime
+) -> Optional[datetime]:
+    """Rebuild migration 100's primary-clock authority at a physical boundary."""
+
+    cur.execute(
+        """
+        SELECT COALESCE(
+            (
+                SELECT MAX(cm.world_time)
+                FROM chunk_metadata AS cm
+                JOIN narrative_chunks AS nc ON nc.id = cm.chunk_id
+                WHERE nc.created_at IS NOT NULL
+                  AND nc.created_at <= %s
+            ),
+            (
+                SELECT base_timestamp
+                FROM global_variables
+                WHERE id = true
+            )
+        )
+        """,
+        (physical_time,),
+    )
+    row = cur.fetchone()
+    return _row_value(row, 0) if row is not None else None
+
+
+def _need_clock_reconciliation_authority(
+    cur: Any,
+    *,
+    base_checkpoint_created_at: datetime,
+    target_checkpoint_created_at: datetime,
+) -> Optional[tuple[datetime, datetime]]:
+    """Return (base, ceiling) when migration 100 crossed this capture pair."""
+
+    applied_at = _need_clock_migration_applied_at(cur)
+    if (
+        applied_at is None
+        or applied_at <= base_checkpoint_created_at
+        or applied_at > target_checkpoint_created_at
+    ):
+        return None
+    cur.execute("SELECT base_timestamp FROM global_variables WHERE id = true")
+    row = cur.fetchone()
+    canonical_base = _row_value(row, 0) if row is not None else None
+    if canonical_base is None:
+        return None
+    ceiling = _canonical_need_clock_as_of(cur, applied_at)
+    if ceiling is None:
+        return None
+    return canonical_base, ceiling
+
+
+def _reconcile_need_clock_rows(
+    rows: list[dict[str, Any]],
+    *,
+    canonical_base: datetime,
+    canonical_ceiling: datetime,
+) -> tuple[int, int]:
+    """Apply migration 100's deterministic restamp to replay working rows."""
+
+    counts = {"last_evaluated_at": 0, "last_fulfilled_at": 0}
+    for row in rows:
+        for column in counts:
+            value = _as_datetime(row.get(column))
+            if value is not None and (
+                value < canonical_base or value > canonical_ceiling
+            ):
+                row[column] = _isoformat(canonical_ceiling)
+                counts[column] += 1
+    return counts["last_evaluated_at"], counts["last_fulfilled_at"]
+
+
 def _coerce_need_payload(raw: Any) -> dict[str, Any]:
     """Mirror events._coerce_need_fulfillment for byte-identical metadata."""
 
@@ -446,6 +561,7 @@ class _Replayer:
         self.target_created_at = _fetch_chunk_created_at(cur, target_chunk_id)
         self.need_tuning = load_need_tuning()
         self.project_policy = _load_project_policy()
+        self.need_clock_migration_applied_at = _need_clock_migration_applied_at(cur)
         self.missing_base_sections: set[str] = set()
         # Resolved in replay() once the base document is loaded; None means
         # legacy chunk-window behavior (issue #552).
@@ -458,6 +574,59 @@ class _Replayer:
         self.delayed_maturation_chunks: frozenset[int] = frozenset()
 
     # -- base checkpoint ---------------------------------------------------
+
+    def _uses_deterministic_need_clock(self, physical_time: datetime) -> bool:
+        """Whether migration 100 governed a write at this physical instant."""
+
+        return (
+            self.need_clock_migration_applied_at is not None
+            and physical_time >= self.need_clock_migration_applied_at
+        )
+
+    def _deterministic_need_clock(self, physical_time: datetime) -> datetime:
+        """Resolve a post-migration tick/trigger anchor or fail closed."""
+
+        anchor = _canonical_need_clock_as_of(self.cur, physical_time)
+        if anchor is None:
+            raise ValueError(
+                "Replay could not resolve migration 100's canonical need clock"
+            )
+        return anchor
+
+    def _reconcile_need_clocks_at_migration_boundary(
+        self,
+        needs: dict[tuple[int, str], dict[str, Any]],
+        *,
+        base_checkpoint_created_at: datetime,
+        result: ReplayResult,
+    ) -> None:
+        """Mirror migration 100's unledgered repair between checkpoints."""
+
+        if self.target_checkpoint_id is None:
+            return
+        target_checkpoint_created_at = _checkpoint_created_at(
+            self.cur, self.target_checkpoint_id
+        )
+        authority = _need_clock_reconciliation_authority(
+            self.cur,
+            base_checkpoint_created_at=base_checkpoint_created_at,
+            target_checkpoint_created_at=target_checkpoint_created_at,
+        )
+        if authority is None:
+            return
+        canonical_base, canonical_ceiling = authority
+        evaluated, fulfilled = _reconcile_need_clock_rows(
+            list(needs.values()),
+            canonical_base=canonical_base,
+            canonical_ceiling=canonical_ceiling,
+        )
+        result.add_note(
+            "character_need_states",
+            "migration 100 reconciliation mirrored at the checkpoint boundary: "
+            f"last_evaluated_at rows={evaluated}, "
+            f"last_fulfilled_at rows={fulfilled}",
+            approximate=False,
+        )
 
     def load_base_checkpoint(
         self, base_checkpoint_id: Optional[int]
@@ -757,13 +926,14 @@ class _Replayer:
 
         if "entities" not in self.missing_base_sections:
             self._seed_window_entity_births(entities, result)
-        born_entities = self._seed_window_births(characters, places, result)
+        born_entity_times = self._seed_window_births(characters, places, result)
+        born_entities = set(born_entity_times)
         character_entities = {
             row["entity_id"]
             for row in characters.values()
             if row.get("entity_id") is not None
         }
-        _, made_applicable_at = self._need_applicability_transitions(
+        need_transitions = self._need_applicability_transitions(
             character_entities, base_chunk, base_state
         )
 
@@ -777,8 +947,8 @@ class _Replayer:
                         needs,
                         travel,
                         projects,
-                        born_entities,
-                        made_applicable_at,
+                        born_entity_times,
+                        need_transitions,
                         result,
                     )
                 if "entities" not in self.missing_base_sections:
@@ -806,8 +976,14 @@ class _Replayer:
             tag_workings["entity_tags"],
             needs,
             base_chunk,
-            base_state,
+            born_entity_times,
+            need_transitions,
             result,
+        )
+        self._reconcile_need_clocks_at_migration_boundary(
+            needs,
+            base_checkpoint_created_at=base_created_at,
+            result=result,
         )
         for section, working in tag_workings.items():
             result.state[section] = sorted(working.values(), key=lambda r: r["id"])
@@ -1392,7 +1568,7 @@ class _Replayer:
         characters: dict[int, dict[str, Any]],
         places: dict[int, dict[str, Any]],
         result: ReplayResult,
-    ) -> set[int]:
+    ) -> dict[int, datetime]:
         """Entities INSERTed between checkpoint and N are un-ledgered.
 
         Their existence is seeded (wall-clock bounded) but their initial
@@ -1403,10 +1579,10 @@ class _Replayer:
         the window clears the mark for the column it sets. Rows whose
         created_at equals the target chunk's are presence-uncertain (the
         Step 8.6 stub-creation ambiguity). Returns born character entity
-        ids for the need-applicability sync.
+        creation times for the need-applicability sync.
         """
 
-        born_entities: set[int] = set()
+        born_entity_times: dict[int, datetime] = {}
         for section, sql, columns in (
             (
                 "characters",
@@ -1438,7 +1614,7 @@ class _Replayer:
                 if created_at == self.target_created_at:
                     result.uncertain_rows.add((section, str(row_id)))
                 if section == "characters" and entity_id is not None:
-                    born_entities.add(entity_id)
+                    born_entity_times[entity_id] = created_at
             if births:
                 result.add_note(
                     section,
@@ -1447,7 +1623,7 @@ class _Replayer:
                     "ledgered writes",
                     approximate=True,
                 )
-        return born_entities
+        return born_entity_times
 
     def _apply_skald_rows(
         self,
@@ -1491,25 +1667,30 @@ class _Replayer:
         needs: dict[tuple[int, str], dict[str, Any]],
         travel: dict[int, dict[str, Any]],
         projects: dict[Any, dict[str, Any]],
-        born_entities: set[int],
-        made_applicable_at: dict[tuple[int, str], int],
+        born_entity_times: dict[int, datetime],
+        need_transitions: _NeedApplicabilityTransitions,
         result: ReplayResult,
     ) -> None:
         self.cur.execute(
             """
-            SELECT id, actor_entity_id, state_delta FROM orrery_resolutions
+            SELECT id, actor_entity_id, state_delta, created_at
+            FROM orrery_resolutions
             WHERE tick_chunk_id = %s ORDER BY id
             """,
             (chunk_id,),
         )
         resolutions = [
-            (row[0], row[1], _as_document(row[2])) for row in self.cur.fetchall()
+            (row[0], row[1], _as_document(row[2]), row[3])
+            for row in self.cur.fetchall()
         ]
         if not resolutions:
             return
-        world_time = _fetch_world_time(self.cur, chunk_id)
+        source_world_time = _fetch_world_time(self.cur, chunk_id)
         by_entity = {row["entity_id"]: row for row in characters.values()}
-        for resolution_id, actor_entity_id, delta in resolutions:
+        for resolution_id, actor_entity_id, delta, committed_at in resolutions:
+            world_time = source_world_time
+            if world_time is None and self._uses_deterministic_need_clock(committed_at):
+                world_time = self._deterministic_need_clock(committed_at)
             unknown = set(delta) - REPLAYED_DELTA_KEYS - TAG_DELTA_KEYS
             if unknown:
                 raise ValueError(
@@ -1535,8 +1716,8 @@ class _Replayer:
                     delta["need.fulfill"],
                     world_time,
                     needs,
-                    actor_entity_id in born_entities,
-                    made_applicable_at,
+                    born_entity_times,
+                    need_transitions,
                     result,
                 )
             for project_key in (
@@ -1878,8 +2059,8 @@ class _Replayer:
         raw_payload: Any,
         world_time: Optional[datetime],
         needs: dict[tuple[int, str], dict[str, Any]],
-        born_in_window: bool,
-        made_applicable_at: dict[tuple[int, str], int],
+        born_entity_times: dict[int, datetime],
+        transitions: _NeedApplicabilityTransitions,
         result: ReplayResult,
     ) -> None:
         payload = _coerce_need_payload(raw_payload)
@@ -1887,15 +2068,28 @@ class _Replayer:
         key = (actor_entity_id, need_type)
         row_key = f"{actor_entity_id}:{need_type}"
         if key not in needs:
-            activation_chunk = made_applicable_at.get(key)
+            activation_chunk = transitions.first_made_applicable_chunk.get(key)
             tag_initialized = (
                 activation_chunk is not None and activation_chunk <= chunk_id
             )
+            born_in_window = actor_entity_id in born_entity_times
+            initialized_at = (
+                transitions.first_made_applicable_at.get(key)
+                if tag_initialized
+                else born_entity_times.get(actor_entity_id)
+            )
+            initial_anchor = world_time
+            deterministic_initialization = (
+                initialized_at is not None
+                and self._uses_deterministic_need_clock(initialized_at)
+            )
+            if deterministic_initialization and initialized_at is not None:
+                initial_anchor = self._deterministic_need_clock(initialized_at)
             needs[key] = {
                 "character_entity_id": actor_entity_id,
                 "need_type": need_type,
                 "debt_score": 0.0,
-                "last_evaluated_at": _isoformat(world_time),
+                "last_evaluated_at": _isoformat(initial_anchor),
                 "last_evaluated_chunk_id": None,
                 "last_fulfilled_at": None,
                 # Production's character INSERT and tag-change triggers create
@@ -1912,19 +2106,19 @@ class _Replayer:
                 tag_initialized
                 and activation_chunk is not None
                 and activation_chunk < chunk_id
+                and not deterministic_initialization
             ):
-                # The tag trigger anchored the fresh row to MAX(world_time)
-                # at its un-ledgered firing instant. Static replay cannot know
-                # which future chunk_metadata rows existed at that instant,
-                # so the debt accrued before this fulfillment is unknowable.
+                # Migration-057-era trigger anchors came from wall time. The
+                # same post-100 path is exact because initialized_at resolves
+                # the primary clock at the trigger boundary.
                 result.unreproducible.add(
                     ("character_need_states", row_key, "debt_score")
                 )
                 result.add_note(
                     "character_need_states",
-                    f"tag applicability initialized {row_key} before chunk "
-                    f"{chunk_id}; pre-fulfillment debt accrual is "
-                    "unreproducible",
+                    f"pre-migration tag applicability initialized {row_key} "
+                    f"before chunk {chunk_id}; pre-fulfillment debt accrual "
+                    "is unreproducible",
                     approximate=True,
                 )
         row = needs[key]
@@ -1947,17 +2141,17 @@ class _Replayer:
         metadata["last_fulfillment"] = payload
         row["metadata"] = metadata
         if world_time is None:
-            # Production fell back to wall-clock now() at commit time and
-            # accrued debt against it — the timestamps AND the debt math are
-            # unreproducible; leave prior timestamp values and flag all three
-            # columns.
+            # Legacy pre-migration production fell back to wall-clock now()
+            # and accrued debt against it. Migration-100-era rows take the
+            # deterministic primary clock above; only the legacy history
+            # remains genuinely unreproducible.
             for column in ("last_evaluated_at", "last_fulfilled_at", "debt_score"):
                 result.unreproducible.add(("character_need_states", row_key, column))
             result.add_note(
                 "character_need_states",
-                f"chunk {chunk_id} has NULL world_time; production stamped "
-                f"wall-clock now() on {row_key} — timestamps and accrued "
-                "debt unreproducible",
+                f"chunk {chunk_id} has NULL world_time and predates migration "
+                f"100; legacy wall-clock need state on {row_key} is "
+                "unreproducible",
                 approximate=True,
             )
         else:
@@ -1985,8 +2179,8 @@ class _Replayer:
         payload = _coerce_travel_payload(raw_payload)
         row = travel.get(actor_entity_id)
         if world_time is None:
-            # Production stamped wall-clock now() on this tick's travel
-            # world-time columns; replay writes NULLs it cannot back.
+            # Only legacy pre-migration NULL-clock ticks reached wall time.
+            # Post-migration ticks resolve the deterministic primary clock.
             time_columns = ["updated_at_world_time"]
             if delta_key == "travel.start":
                 time_columns.append("started_at_world_time")
@@ -2402,6 +2596,80 @@ class _Replayer:
 
     # -- need-applicability trigger mirror ------------------------------------
 
+    def _fresh_need_state(
+        self,
+        *,
+        entity_id: int,
+        need: str,
+        created_at: Optional[datetime],
+        result: ReplayResult,
+    ) -> dict[str, Any]:
+        """Build the trigger's fresh row with the correct clock-era contract."""
+
+        row_key = f"{entity_id}:{need}"
+        last_evaluated_at = None
+        if created_at is not None and self._uses_deterministic_need_clock(created_at):
+            last_evaluated_at = _isoformat(self._deterministic_need_clock(created_at))
+            result.unreproducible.discard(
+                ("character_need_states", row_key, "last_evaluated_at")
+            )
+        else:
+            # Migration 057 used wall-clock now(); only rows proven to have
+            # been created before migration 100 retain this honest skip.
+            result.unreproducible.add(
+                ("character_need_states", row_key, "last_evaluated_at")
+            )
+        return {
+            "character_entity_id": entity_id,
+            "need_type": need,
+            "debt_score": 0.0,
+            "last_evaluated_at": last_evaluated_at,
+            "last_evaluated_chunk_id": None,
+            "last_fulfilled_at": None,
+            "metadata": {"synced_by": "need_applicability"},
+        }
+
+    def _need_sync_trigger_times(
+        self, entities: set[int], base_chunk: int
+    ) -> dict[int, datetime]:
+        """Return each entity's first tag-trigger instant in this window."""
+
+        if not entities:
+            return {}
+        self.cur.execute(
+            """
+            SELECT entity_id, MIN(triggered_at)
+            FROM (
+                SELECT et.entity_id, et.applied_at AS triggered_at
+                FROM entity_tags AS et
+                WHERE et.entity_id = ANY(%s)
+                  AND et.source_chunk_id > %s
+                  AND et.source_chunk_id <= %s
+                UNION ALL
+                SELECT et.entity_id, log.cleared_at AS triggered_at
+                FROM tag_clearance_log AS log
+                JOIN entity_tags AS et ON et.id = log.entity_tag_id
+                WHERE et.entity_id = ANY(%s)
+                  AND log.source_chunk_id > %s
+                  AND log.source_chunk_id <= %s
+            ) AS triggers
+            GROUP BY entity_id
+            """,
+            (
+                list(entities),
+                base_chunk,
+                self.target_chunk_id,
+                list(entities),
+                base_chunk,
+                self.target_chunk_id,
+            ),
+        )
+        return {
+            int(entity_id): triggered_at
+            for entity_id, triggered_at in self.cur.fetchall()
+            if triggered_at is not None
+        }
+
     def _sync_need_applicability(
         self,
         affected_entities: set[int],
@@ -2409,10 +2677,11 @@ class _Replayer:
         entity_tags_working: dict[int, dict[str, Any]],
         needs: dict[tuple[int, str], dict[str, Any]],
         base_chunk: int,
-        base_state: dict[str, Any],
+        born_entity_times: dict[int, datetime],
+        transitions: _NeedApplicabilityTransitions,
         result: ReplayResult,
     ) -> None:
-        """Mirror ``orrery_sync_character_need_states`` (migration 057).
+        """Mirror ``orrery_sync_character_need_states`` (migrations 057/100).
 
         Production triggers on entity_tags changes (and character INSERTs)
         ensure need rows for every applicable need type, DELETE rows for
@@ -2421,10 +2690,9 @@ class _Replayer:
         pure function of the final active tag set; row CONTENTS are not —
         an applicability toggle (immunity tag applied then cleared inside
         one window) makes production delete and re-insert a FRESH row, so
-        toggled rows are reset to the fresh-insert shape here with their
-        wall-clock-dependent columns flagged unreproducible. Toggles are
-        detected by walking the window's chunk-keyed immunity-tag events
-        chronologically.
+        toggled rows are reset to the fresh-insert shape here. Migration 100
+        makes the fresh anchor deterministic for post-boundary rows; only
+        legacy pre-migration rows keep an unreproducible timestamp.
         """
 
         if not affected_entities:
@@ -2446,8 +2714,8 @@ class _Replayer:
                 (list(tag_ids),),
             )
             tag_names = dict(self.cur.fetchall())
-        went_inapplicable, _ = self._need_applicability_transitions(
-            affected_entities & character_entities, base_chunk, base_state
+        trigger_times = self._need_sync_trigger_times(
+            affected_entities & character_entities, base_chunk
         )
 
         synthesized = 0
@@ -2467,40 +2735,34 @@ class _Replayer:
                 key = (entity_id, need)
                 row_key = f"{entity_id}:{need}"
                 if need in applicable and key not in needs:
-                    needs[key] = {
-                        "character_entity_id": entity_id,
-                        "need_type": need,
-                        "debt_score": 0.0,
-                        "last_evaluated_at": None,
-                        "last_evaluated_chunk_id": None,
-                        "last_fulfilled_at": None,
-                        "metadata": {"synced_by": "need_applicability"},
-                    }
-                    synthesized += 1
-                    # The trigger stamps MAX(chunk_metadata.world_time) at
-                    # firing time — not reconstructable after the fact.
-                    result.unreproducible.add(
-                        ("character_need_states", row_key, "last_evaluated_at")
+                    created_at = (
+                        transitions.last_made_applicable_at.get(key)
+                        or born_entity_times.get(entity_id)
+                        or trigger_times.get(entity_id)
                     )
+                    needs[key] = self._fresh_need_state(
+                        entity_id=entity_id,
+                        need=need,
+                        created_at=created_at,
+                        result=result,
+                    )
+                    synthesized += 1
                 elif need in applicable and key in needs:
-                    if key in went_inapplicable:
+                    if key in transitions.went_inapplicable:
                         # Applicability toggled off then back on inside the
                         # window: production deleted the row and re-inserted a
                         # FRESH one; the checkpoint-inherited contents are stale.
                         fulfilled_after = (
                             needs[key].get("last_evaluated_chunk_id") or 0
                         ) > base_chunk
-                        needs[key] = {
-                            "character_entity_id": entity_id,
-                            "need_type": need,
-                            "debt_score": 0.0,
-                            "last_evaluated_at": None,
-                            "last_evaluated_chunk_id": None,
-                            "last_fulfilled_at": None,
-                            "metadata": {"synced_by": "need_applicability"},
-                        }
+                        needs[key] = self._fresh_need_state(
+                            entity_id=entity_id,
+                            need=need,
+                            created_at=transitions.last_made_applicable_at.get(key),
+                            result=result,
+                        )
                         reset += 1
-                        columns = ["last_evaluated_at"]
+                        columns: list[str] = []
                         if fulfilled_after:
                             # A need.fulfill also landed in the window; whether
                             # it hit the pre-toggle or post-toggle row is not
@@ -2544,7 +2806,7 @@ class _Replayer:
         entities: set[int],
         base_chunk: int,
         base_state: dict[str, Any],
-    ) -> tuple[set[tuple[int, str]], dict[tuple[int, str], int]]:
+    ) -> _NeedApplicabilityTransitions:
         """Return false transitions and first later applicability chunks.
 
         The chronological walk uses chunk-keyed immunity-tag bestowals and
@@ -2553,7 +2815,7 @@ class _Replayer:
         """
 
         if not entities:
-            return set(), {}
+            return _NeedApplicabilityTransitions(set(), {}, {}, {})
         all_immunity = frozenset().union(*NEED_IMMUNITY_TAGS.values())
         self.cur.execute(
             "SELECT id, tag FROM tags WHERE tag = ANY(%s)",
@@ -2561,7 +2823,7 @@ class _Replayer:
         )
         immunity_by_id: dict[int, str] = dict(self.cur.fetchall())
         if not immunity_by_id:
-            return set(), {}
+            return _NeedApplicabilityTransitions(set(), {}, {}, {})
 
         current: dict[int, set[str]] = {entity: set() for entity in entities}
         for row in base_state["entity_tags"]:
@@ -2569,10 +2831,13 @@ class _Replayer:
             if name is not None and row["entity_id"] in current:
                 current[row["entity_id"]].add(name)
 
-        events: dict[tuple[int, int], tuple[set[str], set[str]]] = {}
+        events: dict[tuple[int, int], dict[str, Any]] = {}
 
-        def _event(entity: int, chunk: int) -> tuple[set[str], set[str]]:
-            return events.setdefault((entity, chunk), (set(), set()))
+        def _event(entity: int, chunk: int) -> dict[str, Any]:
+            return events.setdefault(
+                (entity, chunk),
+                {"added": set(), "cleared": set(), "cleared_at": None},
+            )
 
         self.cur.execute(
             """
@@ -2588,10 +2853,10 @@ class _Replayer:
             ),
         )
         for entity_id, tag_id, chunk in self.cur.fetchall():
-            _event(entity_id, chunk)[0].add(immunity_by_id[tag_id])
+            _event(entity_id, chunk)["added"].add(immunity_by_id[tag_id])
         self.cur.execute(
             """
-            SELECT et.entity_id, et.tag_id, l.source_chunk_id
+            SELECT et.entity_id, et.tag_id, l.source_chunk_id, l.cleared_at
             FROM tag_clearance_log l
             JOIN entity_tags et ON et.id = l.entity_tag_id
             WHERE et.entity_id = ANY(%s) AND et.tag_id = ANY(%s)
@@ -2604,14 +2869,23 @@ class _Replayer:
                 self.target_chunk_id,
             ),
         )
-        for entity_id, tag_id, chunk in self.cur.fetchall():
-            _event(entity_id, chunk)[1].add(immunity_by_id[tag_id])
+        for entity_id, tag_id, chunk, cleared_at in self.cur.fetchall():
+            event = _event(entity_id, chunk)
+            event["cleared"].add(immunity_by_id[tag_id])
+            if cleared_at is not None and (
+                event["cleared_at"] is None or cleared_at > event["cleared_at"]
+            ):
+                event["cleared_at"] = cleared_at
 
         went_inapplicable: set[tuple[int, str]] = set()
-        made_applicable_at: dict[tuple[int, str], int] = {}
-        for (entity_id, chunk), (added, cleared) in sorted(
+        first_made_applicable_chunk: dict[tuple[int, str], int] = {}
+        first_made_applicable_at: dict[tuple[int, str], datetime] = {}
+        last_made_applicable_at: dict[tuple[int, str], datetime] = {}
+        for (entity_id, chunk), event in sorted(
             events.items(), key=lambda item: (item[0][0], item[0][1])
         ):
+            added = event["added"]
+            cleared = event["cleared"]
             transient = added & cleared
             state = current[entity_id]
             applicable_before = {
@@ -2631,8 +2905,16 @@ class _Replayer:
                 if applicable_after and (
                     not applicable_before[need] or transiently_inapplicable
                 ):
-                    made_applicable_at.setdefault(key, chunk)
-        return went_inapplicable, made_applicable_at
+                    first_made_applicable_chunk.setdefault(key, chunk)
+                    if event["cleared_at"] is not None:
+                        first_made_applicable_at.setdefault(key, event["cleared_at"])
+                        last_made_applicable_at[key] = event["cleared_at"]
+        return _NeedApplicabilityTransitions(
+            went_inapplicable,
+            first_made_applicable_chunk,
+            first_made_applicable_at,
+            last_made_applicable_at,
+        )
 
     # -- relationship unwind ---------------------------------------------------
 
@@ -2863,9 +3145,29 @@ def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:
     ):
         if base_chunk == target_chunk:
             # Same-chunk captures must be identical documents; diff them
-            # directly, no replay involved.
+            # directly, except for deterministic schema-boundary authorities
+            # whose writes are intentionally mirrored by replay.
             base_stored = _load_checkpoint_state(cur, base_id)
             target_stored = _load_checkpoint_state(cur, target_id)
+            boundary_notes: dict[str, list[str]] = {}
+            authority = _need_clock_reconciliation_authority(
+                cur,
+                base_checkpoint_created_at=_checkpoint_created_at(cur, base_id),
+                target_checkpoint_created_at=_checkpoint_created_at(cur, target_id),
+            )
+            if authority is not None:
+                canonical_base, canonical_ceiling = authority
+                evaluated, fulfilled = _reconcile_need_clock_rows(
+                    base_stored["character_need_states"],
+                    canonical_base=canonical_base,
+                    canonical_ceiling=canonical_ceiling,
+                )
+                boundary_notes["character_need_states"] = [
+                    "migration 100 reconciliation mirrored at the same-chunk "
+                    "checkpoint boundary: "
+                    f"last_evaluated_at rows={evaluated}, "
+                    f"last_fulfilled_at rows={fulfilled}"
+                ]
             missing_sections = _missing_checkpoint_sections(
                 cur, base_id
             ) | _missing_checkpoint_sections(cur, target_id)
@@ -2899,6 +3201,7 @@ def verify_checkpoints_sync(cur: Any) -> list[CheckpointPairVerdict]:
                             "same-chunk captures compared directly "
                             "(stored vs stored)"
                         ],
+                        **boundary_notes,
                         **(
                             {
                                 "entities": [

--- a/nexus/api/new_story_db_mapper.py
+++ b/nexus/api/new_story_db_mapper.py
@@ -654,6 +654,18 @@ class NewStoryDatabaseMapper:
                     self.save_story_seed(transition_data.seed, cursor=cur)
                     logger.debug("Saved story seed to global_variables")
 
+                    # The world clock must exist before any character row because
+                    # the need-state trigger anchors need clocks to it (two-clocks
+                    # doctrine).
+                    cur.execute(
+                        """
+                        UPDATE global_variables
+                        SET base_timestamp = %s
+                        WHERE id = true
+                        """,
+                        (transition_data.base_timestamp,),
+                    )
+
                     # Derive character's initial state from seed context
                     # - current_activity: What they're trying to do (immediate goal)
                     # - emotional_state: How they feel given the stakes/tension
@@ -707,12 +719,6 @@ class NewStoryDatabaseMapper:
                         "Trait compilation for %s: %s",
                         transition_data.character.name,
                         trait_compile_result.counters.model_dump(),
-                    )
-
-                    # Set base timestamp (already a datetime from TransitionData)
-                    cur.execute(
-                        "UPDATE global_variables SET base_timestamp = %s WHERE id = true",
-                        (transition_data.base_timestamp,),
                     )
 
                     if in_transaction is not None:

--- a/nexus/api/new_story_db_mapper.py
+++ b/nexus/api/new_story_db_mapper.py
@@ -547,10 +547,10 @@ class NewStoryDatabaseMapper:
         1. Validates transition data completeness
         2. Saves setting to global_variables
         3. Saves story seed to global_variables
-        4. Creates protagonist character
-        5. Creates complete location hierarchy (layer -> zone -> place)
-        6. Applies typed trait compilation and persists the audit result
-        7. Sets base timestamp
+        4. Sets base timestamp
+        5. Creates protagonist character
+        6. Creates complete location hierarchy (layer -> zone -> place)
+        7. Applies typed trait compilation and persists the audit result
         8. Runs the optional in_transaction hook on the same cursor (used by
            Retrograde wizard-time persistence so generated history commits
            atomically with the world; a raise rolls back everything)

--- a/tests/test_orrery/test_build_venture_replay.py
+++ b/tests/test_orrery/test_build_venture_replay.py
@@ -59,7 +59,8 @@ def _create_schema(cur: Any, schema: str) -> None:
             ON entity_tags (entity_id, tag_id) WHERE cleared_at IS NULL;
         CREATE TABLE orrery_resolutions (
             id bigserial PRIMARY KEY, tick_chunk_id bigint NOT NULL,
-            actor_entity_id bigint, state_delta jsonb NOT NULL
+            actor_entity_id bigint, state_delta jsonb NOT NULL,
+            created_at timestamptz NOT NULL DEFAULT now()
         );
         CREATE TABLE character_project_states (
             id bigserial PRIMARY KEY, character_entity_id bigint NOT NULL,

--- a/tests/test_orrery/test_need_clock_anchor_pg.py
+++ b/tests/test_orrery/test_need_clock_anchor_pg.py
@@ -221,6 +221,33 @@ def _insert_atemporal_chunk(cur: Any) -> int:
     return int(cur.fetchone()[0])
 
 
+def _insert_need_resolution(
+    cur: Any,
+    *,
+    chunk_id: int,
+    entity_id: int,
+    template_id: str,
+    fulfillment: dict[str, Any],
+) -> None:
+    """Persist the ledger peer for an already-applied need fulfillment."""
+
+    cur.execute(
+        """
+        INSERT INTO orrery_resolutions (
+            tick_chunk_id, template_id, binding_hash, actor_entity_id,
+            priority, magnitude, state_delta
+        ) VALUES (%s, %s, %s, %s, 50, 0.5, %s::jsonb)
+        """,
+        (
+            chunk_id,
+            template_id,
+            f"{template_id}-{entity_id}",
+            entity_id,
+            json.dumps({"need.fulfill": fulfillment}),
+        ),
+    )
+
+
 def _build_story_transition(dbname: str) -> Any:
     """Hydrate the checked-in wizard artifact with issue #640's future clock."""
 
@@ -350,7 +377,8 @@ def test_migration_reconciles_poisoned_rows_and_guards_fulfillment_domain(
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT need_type::text, last_evaluated_at, last_fulfilled_at
+                SELECT need_type::text, last_evaluated_at, last_fulfilled_at,
+                       metadata
                 FROM character_need_states
                 WHERE character_entity_id = %s
                 ORDER BY need_type::text
@@ -358,14 +386,23 @@ def test_migration_reconciles_poisoned_rows_and_guards_fulfillment_domain(
                 (entity_id,),
             )
             reconciled = {
-                need_type: (last_evaluated_at, last_fulfilled_at)
-                for need_type, last_evaluated_at, last_fulfilled_at in cur.fetchall()
+                need_type: (last_evaluated_at, last_fulfilled_at, metadata)
+                for (
+                    need_type,
+                    last_evaluated_at,
+                    last_fulfilled_at,
+                    metadata,
+                ) in cur.fetchall()
             }
 
             assert reconciled["intimacy"][0] == STORY_BASE + timedelta(hours=2)
             assert all(
                 evaluated_at == STORY_ANCHOR
-                for need_type, (evaluated_at, _fulfilled_at) in reconciled.items()
+                for need_type, (
+                    evaluated_at,
+                    _fulfilled_at,
+                    _metadata,
+                ) in reconciled.items()
                 if need_type != "intimacy"
             )
             assert reconciled["sleep"][1] == STORY_ANCHOR
@@ -373,6 +410,45 @@ def test_migration_reconciles_poisoned_rows_and_guards_fulfillment_domain(
             assert reconciled["thirst"][1] == STORY_BASE + timedelta(hours=1)
             assert reconciled["socialize"][1] is None
             assert reconciled["intimacy"][1] is None
+            marker_rows = {
+                need_type: metadata
+                for need_type, (_evaluated, _fulfilled, metadata) in reconciled.items()
+                if metadata.get("reconciled_by") == "migration_100"
+            }
+            assert set(marker_rows) == {"hunger", "sleep", "socialize", "thirst"}
+            assert (
+                sum(
+                    "reconciled_last_evaluated_from" in metadata
+                    for metadata in marker_rows.values()
+                )
+                == 4
+            )
+            assert (
+                sum(
+                    "reconciled_last_fulfilled_from" in metadata
+                    for metadata in marker_rows.values()
+                )
+                == 2
+            )
+            assert all(
+                datetime.fromisoformat(metadata["reconciled_last_evaluated_to"])
+                == STORY_ANCHOR
+                for metadata in marker_rows.values()
+            )
+            assert all(
+                datetime.fromisoformat(
+                    marker_rows[need_type]["reconciled_last_fulfilled_from"]
+                )
+                == POISONED_WALL_TIME
+                for need_type in ("hunger", "sleep")
+            )
+            assert all(
+                datetime.fromisoformat(
+                    marker_rows[need_type]["reconciled_last_fulfilled_to"]
+                )
+                == STORY_ANCHOR
+                for need_type in ("hunger", "sleep")
+            )
 
             _apply_need_fulfillment_sync(
                 cur,
@@ -441,6 +517,85 @@ def test_migration_reconciles_poisoned_rows_and_guards_fulfillment_domain(
             stored_debt, evaluated_at = cur.fetchone()
             assert stored_debt == 0
             assert evaluated_at == POISONED_WALL_TIME
+
+
+def test_migration_provenance_counts_and_rerun_are_idempotent(
+    disposable_need_clock_db: str,
+) -> None:
+    """Field markers match reported counts and a rerun changes nothing."""
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, STORY_BASE)
+            entity_id = _insert_character(cur, "Migration Marker Counts")
+            cur.execute(
+                """
+                UPDATE character_need_states
+                SET last_evaluated_at = %s,
+                    last_fulfilled_at = CASE
+                        WHEN need_type = 'sleep' THEN %s
+                        ELSE NULL
+                    END
+                WHERE character_entity_id = %s
+                """,
+                (POISONED_WALL_TIME, POISONED_WALL_TIME, entity_id),
+            )
+            _insert_chunk_at(cur, STORY_ANCHOR)
+
+    notices = _apply_migration_100(disposable_need_clock_db)
+    assert (
+        "need-clock reconciliation: last_evaluated_at rows=5, "
+        "last_fulfilled_at rows=1"
+    ) in "".join(notices)
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT need_type::text, metadata
+                FROM character_need_states
+                WHERE character_entity_id = %s
+                  AND metadata ->> 'reconciled_by' = 'migration_100'
+                ORDER BY need_type::text
+                """,
+                (entity_id,),
+            )
+            marker_snapshot = dict(cur.fetchall())
+            assert len(marker_snapshot) == 5
+            assert (
+                sum(
+                    "reconciled_last_evaluated_from" in metadata
+                    for metadata in marker_snapshot.values()
+                )
+                == 5
+            )
+            assert (
+                sum(
+                    "reconciled_last_fulfilled_from" in metadata
+                    for metadata in marker_snapshot.values()
+                )
+                == 1
+            )
+
+    rerun_notices = _apply_migration_100(disposable_need_clock_db)
+    assert (
+        "need-clock reconciliation: last_evaluated_at rows=0, "
+        "last_fulfilled_at rows=0"
+    ) in "".join(rerun_notices)
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT need_type::text, metadata
+                FROM character_need_states
+                WHERE character_entity_id = %s
+                  AND metadata ->> 'reconciled_by' = 'migration_100'
+                ORDER BY need_type::text
+                """,
+                (entity_id,),
+            )
+            assert dict(cur.fetchall()) == marker_snapshot
 
 
 def test_migration_reconciles_future_poison_in_a_past_set_story(
@@ -609,9 +764,249 @@ def test_replay_mirrors_reconciliation_across_migration_100_boundary(
 
     assert verdict.drifts == []
     assert any(
-        "migration 100 reconciliation mirrored" in note
+        "migration 100 provenance rebased" in note
         for note in verdict.notes["character_need_states"]
     )
+
+
+def test_replay_does_not_restamp_post_migration_fulfillment(
+    disposable_need_clock_db: str,
+) -> None:
+    """Migration provenance rebases the baseline before later events replay."""
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM schema_migrations WHERE version = '100'")
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, STORY_BASE)
+            base_chunk = _insert_chunk_at(cur, STORY_BASE)
+            entity_id = _insert_character(cur, "Post-Migration Fulfillment")
+            cur.execute(
+                """
+                UPDATE character_need_states
+                SET last_evaluated_at = %s
+                WHERE character_entity_id = %s
+                """,
+                (POISONED_WALL_TIME, entity_id),
+            )
+            base_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=base_chunk,
+                label="manual",
+            )
+            assert base_checkpoint_id is not None
+
+    notices = _apply_migration_100(disposable_need_clock_db)
+    assert (
+        "need-clock reconciliation: last_evaluated_at rows=5, "
+        "last_fulfilled_at rows=0"
+    ) in "".join(notices)
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            target_chunk = _insert_chunk_at(cur, STORY_ANCHOR)
+            fulfillment = {"type": "hunger", "discharge_debt": 0.0}
+            _apply_need_fulfillment_sync(
+                cur,
+                actor_entity_id=entity_id,
+                fulfillment=fulfillment,
+                template_id="issue_640_post_migration_fulfillment",
+                source_chunk_id=target_chunk,
+                need_tuning=load_need_tuning(),
+            )
+            _insert_need_resolution(
+                cur,
+                chunk_id=target_chunk,
+                entity_id=entity_id,
+                template_id="issue_640_post_migration_fulfillment",
+                fulfillment=fulfillment,
+            )
+            target_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=target_chunk,
+                label="manual",
+            )
+            assert target_checkpoint_id is not None
+
+            reconstructed = reconstruct_state_at_sync(
+                cur,
+                target_chunk,
+                base_checkpoint_id=base_checkpoint_id,
+                target_checkpoint_id=target_checkpoint_id,
+            )
+            verdict = next(
+                item
+                for item in verify_checkpoints_sync(cur)
+                if item.base_checkpoint_id == base_checkpoint_id
+                and item.target_checkpoint_id == target_checkpoint_id
+            )
+
+    hunger = next(
+        row
+        for row in reconstructed.state["character_need_states"]
+        if row["character_entity_id"] == entity_id and row["need_type"] == "hunger"
+    )
+    assert datetime.fromisoformat(hunger["last_evaluated_at"]) == STORY_ANCHOR
+    assert datetime.fromisoformat(hunger["last_fulfilled_at"]) == STORY_ANCHOR
+    assert verdict.drifts == []
+
+
+def test_replay_uses_marker_result_for_overlapping_post_migration_chunk(
+    disposable_need_clock_db: str,
+) -> None:
+    """A pre-migration transaction timestamp cannot expand migration authority."""
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM schema_migrations WHERE version = '100'")
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, STORY_BASE)
+            base_chunk = _insert_chunk_at(cur, STORY_BASE)
+            entity_id = _insert_character(cur, "Overlapping Chunk Boundary")
+            cur.execute(
+                """
+                UPDATE character_need_states
+                SET last_evaluated_at = %s
+                WHERE character_entity_id = %s
+                """,
+                (POISONED_WALL_TIME, entity_id),
+            )
+            base_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=base_chunk,
+                label="manual",
+            )
+            assert base_checkpoint_id is not None
+
+    overlap = _connect(disposable_need_clock_db)
+    try:
+        with overlap.cursor() as cur:
+            target_chunk = _insert_chunk_at(cur, STORY_ANCHOR)
+        notices = _apply_migration_100(disposable_need_clock_db)
+        assert (
+            "need-clock reconciliation: last_evaluated_at rows=5, "
+            "last_fulfilled_at rows=0"
+        ) in "".join(notices)
+        overlap.commit()
+    except Exception:
+        overlap.rollback()
+        raise
+    finally:
+        overlap.close()
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            target_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=target_chunk,
+                label="manual",
+            )
+            assert target_checkpoint_id is not None
+            cur.execute(
+                """
+                SELECT DISTINCT last_evaluated_at
+                FROM character_need_states
+                WHERE character_entity_id = %s
+                """,
+                (entity_id,),
+            )
+            assert cur.fetchall() == [(STORY_BASE,)]
+            verdict = next(
+                item
+                for item in verify_checkpoints_sync(cur)
+                if item.base_checkpoint_id == base_checkpoint_id
+                and item.target_checkpoint_id == target_checkpoint_id
+            )
+
+    assert verdict.drifts == []
+
+
+def test_markerless_null_clock_mismatch_is_a_field_level_remainder(
+    disposable_need_clock_db: str,
+) -> None:
+    """Current-rule replay skips only the markerless value it cannot derive."""
+
+    _apply_migration_100(disposable_need_clock_db)
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, STORY_BASE)
+            base_chunk = _insert_chunk_at(cur, STORY_BASE)
+            entity_id = _insert_character(cur, "Markerless NULL Clock")
+            base_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=base_chunk,
+                label="manual",
+            )
+            assert base_checkpoint_id is not None
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            _insert_chunk_at(cur, STORY_ANCHOR)
+            target_chunk = _insert_atemporal_chunk(cur)
+            fulfillment = {"type": "thirst", "discharge_debt": 1.0}
+            _apply_need_fulfillment_sync(
+                cur,
+                actor_entity_id=entity_id,
+                fulfillment=fulfillment,
+                template_id="issue_640_markerless_null_clock",
+                source_chunk_id=target_chunk,
+                need_tuning=load_need_tuning(),
+            )
+            _insert_need_resolution(
+                cur,
+                chunk_id=target_chunk,
+                entity_id=entity_id,
+                template_id="issue_640_markerless_null_clock",
+                fulfillment=fulfillment,
+            )
+            in_domain_legacy_value = STORY_BASE + timedelta(minutes=30)
+            cur.execute(
+                """
+                UPDATE character_need_states
+                SET last_evaluated_at = %s,
+                    metadata = metadata - 'reconciled_by'
+                                        - 'reconciled_last_evaluated_from'
+                                        - 'reconciled_last_evaluated_to'
+                                        - 'reconciled_last_fulfilled_from'
+                                        - 'reconciled_last_fulfilled_to'
+                WHERE character_entity_id = %s
+                  AND need_type = 'thirst'
+                """,
+                (in_domain_legacy_value, entity_id),
+            )
+            target_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=target_chunk,
+                label="manual",
+            )
+            assert target_checkpoint_id is not None
+
+            reconstructed = reconstruct_state_at_sync(
+                cur,
+                target_chunk,
+                base_checkpoint_id=base_checkpoint_id,
+                target_checkpoint_id=target_checkpoint_id,
+            )
+            verdict = next(
+                item
+                for item in verify_checkpoints_sync(cur)
+                if item.base_checkpoint_id == base_checkpoint_id
+                and item.target_checkpoint_id == target_checkpoint_id
+            )
+
+    row_key = f"{entity_id}:thirst"
+    need_remainder = {
+        item
+        for item in reconstructed.unreproducible
+        if item[0] == "character_need_states" and item[1] == row_key
+    }
+    assert need_remainder == {("character_need_states", row_key, "last_evaluated_at")}
+    assert verdict.drifts == []
+    assert verdict.skipped_unreproducible >= 1
 
 
 def test_replay_reconstructs_post_migration_trigger_anchor(

--- a/tests/test_orrery/test_need_clock_anchor_pg.py
+++ b/tests/test_orrery/test_need_clock_anchor_pg.py
@@ -20,6 +20,11 @@ from nexus.agents.orrery.events import (
     _apply_need_fulfillment_sync,
 )
 from nexus.agents.orrery.needs import load_need_tuning
+from nexus.agents.orrery.reconstruction import capture_state_checkpoint_sync
+from nexus.agents.orrery.replay import (
+    reconstruct_state_at_sync,
+    verify_checkpoints_sync,
+)
 from nexus.api.db_pool import close_all_pools
 from nexus.api.new_story_cache import read_cache, write_cache
 from nexus.api.new_story_db_mapper import NewStoryDatabaseMapper
@@ -39,6 +44,8 @@ STORY_BASE = datetime(2189, 10, 17, 19, 12, tzinfo=timezone.utc)
 STORY_ANCHOR = STORY_BASE + timedelta(hours=3)
 STALE_STORY_BASE = datetime(2089, 4, 2, 8, 30, tzinfo=timezone.utc)
 POISONED_WALL_TIME = datetime(2026, 7, 30, 5, 55, 20, tzinfo=timezone.utc)
+PAST_STORY_BASE = datetime(1920, 5, 14, 10, 48, tzinfo=timezone.utc)
+PAST_STORY_ANCHOR = PAST_STORY_BASE + timedelta(hours=3)
 
 
 def _connect(dbname: str) -> Any:
@@ -72,6 +79,8 @@ def disposable_need_clock_db() -> Iterator[str]:
     """Yield a NEXUS_template clone whose name cannot collide with a save slot."""
 
     dbname = f"qa640_{uuid.uuid4().hex[:12]}"
+    source_db = os.environ.get("NEXUS_TEST_TEMPLATE_DB", "NEXUS_template")
+    assert source_db == "NEXUS_template" or source_db.startswith("qa640_")
     admin: Any = None
     try:
         try:
@@ -83,7 +92,7 @@ def disposable_need_clock_db() -> Iterator[str]:
             cur.execute(
                 sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
                     sql.Identifier(dbname),
-                    sql.Identifier("NEXUS_template"),
+                    sql.Identifier(source_db),
                 )
             )
         VALID_DBNAMES.add(dbname)
@@ -105,7 +114,7 @@ def disposable_need_clock_db() -> Iterator[str]:
 
 
 def _apply_migration_100(dbname: str) -> tuple[str, ...]:
-    """Apply migration 100 through the managed runner and return its notices."""
+    """Install or idempotently re-run migration 100 and return its notices."""
 
     discovered = {
         (version, name, path.name)
@@ -120,14 +129,23 @@ def _apply_migration_100(dbname: str) -> tuple[str, ...]:
     conn = _connect(dbname)
     try:
         with conn.cursor() as cur:
-            cur.execute("SELECT count(*) FROM schema_migrations WHERE version = '100'")
-            assert cur.fetchone()[0] == 0
-        assert migrate.apply_migration(
-            conn,
-            "100",
-            "orrery_need_clock_anchor",
-            MIGRATION_PATH,
-        )
+            cur.execute(
+                "SELECT EXISTS ("
+                "SELECT 1 FROM schema_migrations WHERE version = '100'"
+                ")"
+            )
+            already_applied = bool(cur.fetchone()[0])
+        if already_applied:
+            with conn.cursor() as cur:
+                cur.execute(MIGRATION_PATH.read_text())
+            conn.commit()
+        else:
+            assert migrate.apply_migration(
+                conn,
+                "100",
+                "orrery_need_clock_anchor",
+                MIGRATION_PATH,
+            )
         notices = tuple(conn.notices)
         with conn.cursor() as cur:
             cur.execute("SELECT name FROM schema_migrations WHERE version = '100'")
@@ -188,6 +206,19 @@ def _insert_chunk_at(cur: Any, world_time: datetime) -> int:
         (world_time, chunk_id),
     )
     return chunk_id
+
+
+def _insert_atemporal_chunk(cur: Any) -> int:
+    """Create a legitimate non-primary-layer chunk with no world clock row."""
+
+    cur.execute(
+        """
+        INSERT INTO narrative_chunks (raw_text, storyteller_text)
+        VALUES ('Issue 640 atemporal probe.', 'Issue 640 atemporal probe.')
+        RETURNING id
+        """
+    )
+    return int(cur.fetchone()[0])
 
 
 def _build_story_transition(dbname: str) -> Any:
@@ -412,6 +443,74 @@ def test_migration_reconciles_poisoned_rows_and_guards_fulfillment_domain(
             assert evaluated_at == POISONED_WALL_TIME
 
 
+def test_migration_reconciles_future_poison_in_a_past_set_story(
+    disposable_need_clock_db: str,
+) -> None:
+    """Wall time after the canon ceiling is as poisoned as time before base."""
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, PAST_STORY_BASE)
+            entity_id = _insert_character(cur, "Past-Set Clock Character")
+            _insert_chunk_at(cur, PAST_STORY_ANCHOR)
+            cur.execute(
+                """
+                UPDATE character_need_states
+                SET last_evaluated_at = CASE
+                        WHEN need_type = 'intimacy' THEN %s
+                        ELSE %s
+                    END,
+                    last_fulfilled_at = CASE
+                        WHEN need_type IN ('sleep', 'hunger') THEN %s
+                        WHEN need_type = 'thirst' THEN %s
+                        ELSE NULL
+                    END
+                WHERE character_entity_id = %s
+                """,
+                (
+                    PAST_STORY_BASE + timedelta(minutes=30),
+                    POISONED_WALL_TIME,
+                    POISONED_WALL_TIME,
+                    PAST_STORY_BASE + timedelta(minutes=15),
+                    entity_id,
+                ),
+            )
+
+    notices = _apply_migration_100(disposable_need_clock_db)
+    assert (
+        "need-clock reconciliation: last_evaluated_at rows=4, "
+        "last_fulfilled_at rows=2"
+    ) in "".join(notices)
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT need_type::text, last_evaluated_at, last_fulfilled_at
+                FROM character_need_states
+                WHERE character_entity_id = %s
+                ORDER BY need_type::text
+                """,
+                (entity_id,),
+            )
+            reconciled = {
+                need_type: (evaluated_at, fulfilled_at)
+                for need_type, evaluated_at, fulfilled_at in cur.fetchall()
+            }
+
+    assert reconciled["intimacy"][0] == PAST_STORY_BASE + timedelta(minutes=30)
+    assert all(
+        evaluated_at == PAST_STORY_ANCHOR
+        for need_type, (evaluated_at, _fulfilled_at) in reconciled.items()
+        if need_type != "intimacy"
+    )
+    assert reconciled["sleep"][1] == PAST_STORY_ANCHOR
+    assert reconciled["hunger"][1] == PAST_STORY_ANCHOR
+    assert reconciled["thirst"][1] == PAST_STORY_BASE + timedelta(minutes=15)
+
+
 def test_migration_reconciliation_noops_without_base_timestamp(
     disposable_need_clock_db: str,
 ) -> None:
@@ -421,8 +520,11 @@ def test_migration_reconciliation_noops_without_base_timestamp(
         with conn.cursor() as cur:
             cur.execute("DELETE FROM character_need_states")
             cur.execute("DELETE FROM chunk_metadata")
-            _set_base_timestamp(cur, None)
+            # Production guarantees clock-before-characters. Seed a valid row,
+            # then remove the singleton clock to exercise migration behavior.
+            _set_base_timestamp(cur, STORY_BASE)
             entity_id = _insert_character(cur, "Unreconciled Clock Character")
+            _set_base_timestamp(cur, None)
             cur.execute(
                 """
                 UPDATE character_need_states
@@ -448,6 +550,243 @@ def test_migration_reconciliation_noops_without_base_timestamp(
                 (entity_id,),
             )
             assert cur.fetchall() == [(POISONED_WALL_TIME,)]
+
+
+def test_replay_mirrors_reconciliation_across_migration_100_boundary(
+    disposable_need_clock_db: str,
+) -> None:
+    """Verification applies migration 100's deterministic repair authority."""
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            # A refreshed template may already carry 100. Remove only its
+            # tracking row in this disposable clone to create a local boundary.
+            cur.execute("DELETE FROM schema_migrations WHERE version = '100'")
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, STORY_BASE)
+            base_chunk = _insert_chunk_at(cur, STORY_BASE)
+            entity_id = _insert_character(cur, "Replay Boundary Character")
+            cur.execute(
+                """
+                UPDATE character_need_states
+                SET last_evaluated_at = %s
+                WHERE character_entity_id = %s
+                """,
+                (POISONED_WALL_TIME, entity_id),
+            )
+            base_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=base_chunk,
+                label="manual",
+            )
+            assert base_checkpoint_id is not None
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            target_chunk = _insert_chunk_at(cur, STORY_ANCHOR)
+
+    notices = _apply_migration_100(disposable_need_clock_db)
+    assert (
+        "need-clock reconciliation: last_evaluated_at rows=5, "
+        "last_fulfilled_at rows=0"
+    ) in "".join(notices)
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            target_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=target_chunk,
+                label="manual",
+            )
+            assert target_checkpoint_id is not None
+            verdict = next(
+                item
+                for item in verify_checkpoints_sync(cur)
+                if item.base_checkpoint_id == base_checkpoint_id
+                and item.target_checkpoint_id == target_checkpoint_id
+            )
+
+    assert verdict.drifts == []
+    assert any(
+        "migration 100 reconciliation mirrored" in note
+        for note in verdict.notes["character_need_states"]
+    )
+
+
+def test_replay_reconstructs_post_migration_trigger_anchor(
+    disposable_need_clock_db: str,
+) -> None:
+    """A post-100 applicability reset has a ledger-reconstructable anchor."""
+
+    _apply_migration_100(disposable_need_clock_db)
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, STORY_BASE)
+            base_chunk = _insert_chunk_at(cur, STORY_BASE)
+            entity_id = _insert_character(cur, "Replay Trigger Character")
+            cur.execute("SELECT id FROM tags WHERE tag = 'inorganic'")
+            immunity_tag_id = int(cur.fetchone()[0])
+            cur.execute(
+                """
+                INSERT INTO entity_tags (
+                    entity_id, tag_id, source_kind, source_chunk_id
+                ) VALUES (%s, %s, 'template', %s)
+                RETURNING id
+                """,
+                (entity_id, immunity_tag_id, base_chunk),
+            )
+            entity_tag_id = int(cur.fetchone()[0])
+            base_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=base_chunk,
+                label="manual",
+            )
+            assert base_checkpoint_id is not None
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            target_chunk = _insert_chunk_at(cur, STORY_ANCHOR)
+            cur.execute(
+                "UPDATE entity_tags SET cleared_at = now() WHERE id = %s",
+                (entity_tag_id,),
+            )
+            cur.execute(
+                """
+                INSERT INTO tag_clearance_log (
+                    entity_tag_id, mechanism, source_chunk_id
+                ) VALUES (%s, 'authored', %s)
+                """,
+                (entity_tag_id, target_chunk),
+            )
+            target_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=target_chunk,
+                label="manual",
+            )
+            assert target_checkpoint_id is not None
+
+            reconstructed = reconstruct_state_at_sync(
+                cur,
+                target_chunk,
+                base_checkpoint_id=base_checkpoint_id,
+                target_checkpoint_id=target_checkpoint_id,
+            )
+            hunger = next(
+                row
+                for row in reconstructed.state["character_need_states"]
+                if row["character_entity_id"] == entity_id
+                and row["need_type"] == "hunger"
+            )
+            verdict = next(
+                item
+                for item in verify_checkpoints_sync(cur)
+                if item.base_checkpoint_id == base_checkpoint_id
+                and item.target_checkpoint_id == target_checkpoint_id
+            )
+
+    assert (
+        datetime.fromisoformat(hunger["last_evaluated_at"]).astimezone(timezone.utc)
+        == STORY_ANCHOR
+    )
+    assert (
+        "character_need_states",
+        f"{entity_id}:hunger",
+        "last_evaluated_at",
+    ) not in reconstructed.unreproducible
+    assert verdict.drifts == []
+
+
+def test_atemporal_need_tick_and_replay_use_primary_world_clock(
+    disposable_need_clock_db: str,
+) -> None:
+    """NULL layer time uses the primary clock in both production and replay."""
+
+    _apply_migration_100(disposable_need_clock_db)
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, STORY_BASE)
+            base_chunk = _insert_chunk_at(cur, STORY_ANCHOR)
+            entity_id = _insert_character(cur, "Atemporal Tick Character")
+            base_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=base_chunk,
+                label="manual",
+            )
+            assert base_checkpoint_id is not None
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            target_chunk = _insert_atemporal_chunk(cur)
+            fulfillment = {"type": "thirst", "discharge_debt": 1.0}
+            _apply_need_fulfillment_sync(
+                cur,
+                actor_entity_id=entity_id,
+                fulfillment=fulfillment,
+                template_id="issue_640_atemporal_tick",
+                source_chunk_id=target_chunk,
+                need_tuning=load_need_tuning(),
+            )
+            cur.execute(
+                """
+                INSERT INTO orrery_resolutions (
+                    tick_chunk_id, template_id, binding_hash, actor_entity_id,
+                    priority, magnitude, state_delta
+                ) VALUES (
+                    %s, 'issue_640_atemporal_tick', 'issue-640-atemporal',
+                    %s, 50, 0.5, %s::jsonb
+                )
+                """,
+                (
+                    target_chunk,
+                    entity_id,
+                    json.dumps({"need.fulfill": fulfillment}),
+                ),
+            )
+            target_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=target_chunk,
+                label="manual",
+            )
+            assert target_checkpoint_id is not None
+
+            reconstructed = reconstruct_state_at_sync(
+                cur,
+                target_chunk,
+                base_checkpoint_id=base_checkpoint_id,
+                target_checkpoint_id=target_checkpoint_id,
+            )
+            verdict = next(
+                item
+                for item in verify_checkpoints_sync(cur)
+                if item.base_checkpoint_id == base_checkpoint_id
+                and item.target_checkpoint_id == target_checkpoint_id
+            )
+            cur.execute(
+                """
+                SELECT last_evaluated_at, last_fulfilled_at
+                FROM character_need_states
+                WHERE character_entity_id = %s
+                  AND need_type = 'thirst'
+                """,
+                (entity_id,),
+            )
+            live_evaluated_at, live_fulfilled_at = cur.fetchone()
+
+    assert live_evaluated_at == STORY_ANCHOR
+    assert live_fulfilled_at == STORY_ANCHOR
+    row_key = f"{entity_id}:thirst"
+    for column in ("last_evaluated_at", "last_fulfilled_at", "debt_score"):
+        assert (
+            "character_need_states",
+            row_key,
+            column,
+        ) not in reconstructed.unreproducible
+    assert verdict.drifts == []
 
 
 def test_atomic_transition_replaces_stale_clock_before_protagonist_trigger(

--- a/tests/test_orrery/test_need_clock_anchor_pg.py
+++ b/tests/test_orrery/test_need_clock_anchor_pg.py
@@ -1,0 +1,488 @@
+"""Real-schema regressions for issue #640's two-clocks doctrine."""
+
+from __future__ import annotations
+
+import copy
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterator
+import uuid
+
+import psycopg2
+from psycopg2 import sql
+import pytest
+
+from nexus.agents.orrery.events import (
+    NeedDebtScoreDomainError,
+    _apply_need_fulfillment_sync,
+)
+from nexus.agents.orrery.needs import load_need_tuning
+from nexus.api.db_pool import close_all_pools
+from nexus.api.new_story_cache import read_cache, write_cache
+from nexus.api.new_story_db_mapper import NewStoryDatabaseMapper
+from nexus.api.new_story_flow import build_transition_data_from_cache
+from nexus.api.slot_utils import VALID_DBNAMES
+from scripts import migrate
+
+
+pytestmark = pytest.mark.requires_postgres
+
+ROOT = Path(__file__).parents[2]
+MIGRATION_PATH = ROOT / "migrations" / "100_orrery_need_clock_anchor.sql"
+WIZARD_FIXTURE_PATH = (
+    ROOT / "tests" / "fixtures" / "slot3_midnight_qa_wizard_cache.json"
+)
+STORY_BASE = datetime(2189, 10, 17, 19, 12, tzinfo=timezone.utc)
+STORY_ANCHOR = STORY_BASE + timedelta(hours=3)
+STALE_STORY_BASE = datetime(2089, 4, 2, 8, 30, tzinfo=timezone.utc)
+POISONED_WALL_TIME = datetime(2026, 7, 30, 5, 55, 20, tzinfo=timezone.utc)
+
+
+def _connect(dbname: str) -> Any:
+    """Open a direct PostgreSQL connection to a disposable clone."""
+
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+@contextmanager
+def _transaction(dbname: str) -> Iterator[Any]:
+    """Commit one clone transaction, rolling it back on failure."""
+
+    conn = _connect(dbname)
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+@pytest.fixture()
+def disposable_need_clock_db() -> Iterator[str]:
+    """Yield a NEXUS_template clone whose name cannot collide with a save slot."""
+
+    dbname = f"qa640_{uuid.uuid4().hex[:12]}"
+    admin: Any = None
+    try:
+        try:
+            admin = _connect("postgres")
+        except psycopg2.Error as exc:
+            pytest.skip(f"PostgreSQL admin connection unavailable: {exc}")
+        admin.autocommit = True
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier("NEXUS_template"),
+                )
+            )
+        VALID_DBNAMES.add(dbname)
+        yield dbname
+    finally:
+        close_all_pools()
+        VALID_DBNAMES.discard(dbname)
+        if admin is not None:
+            with admin.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = %s AND pid <> pg_backend_pid()",
+                    (dbname,),
+                )
+                cur.execute(
+                    sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+                )
+            admin.close()
+
+
+def _apply_migration_100(dbname: str) -> tuple[str, ...]:
+    """Apply migration 100 through the managed runner and return its notices."""
+
+    discovered = {
+        (version, name, path.name)
+        for version, name, path in migrate.discover_migrations()
+    }
+    assert (
+        "100",
+        "orrery_need_clock_anchor",
+        MIGRATION_PATH.name,
+    ) in discovered
+
+    conn = _connect(dbname)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM schema_migrations WHERE version = '100'")
+            assert cur.fetchone()[0] == 0
+        assert migrate.apply_migration(
+            conn,
+            "100",
+            "orrery_need_clock_anchor",
+            MIGRATION_PATH,
+        )
+        notices = tuple(conn.notices)
+        with conn.cursor() as cur:
+            cur.execute("SELECT name FROM schema_migrations WHERE version = '100'")
+            assert cur.fetchone()[0] == "orrery_need_clock_anchor"
+        return notices
+    finally:
+        conn.close()
+
+
+def _set_base_timestamp(cur: Any, value: datetime | None) -> None:
+    """Ensure the singleton global row exists with the requested story clock."""
+
+    cur.execute(
+        """
+        INSERT INTO global_variables (id, new_story, base_timestamp)
+        VALUES (true, true, %s)
+        ON CONFLICT (id) DO UPDATE
+        SET base_timestamp = EXCLUDED.base_timestamp
+        """,
+        (value,),
+    )
+
+
+def _insert_character(cur: Any, name: str) -> int:
+    """Insert one real-schema character and return its entity-spine ID."""
+
+    cur.execute(
+        "INSERT INTO entities (kind, is_active) "
+        "VALUES ('character', true) RETURNING id"
+    )
+    entity_id = int(cur.fetchone()[0])
+    cur.execute(
+        "INSERT INTO characters (name, entity_id) VALUES (%s, %s)",
+        (name, entity_id),
+    )
+    return entity_id
+
+
+def _insert_chunk_at(cur: Any, world_time: datetime) -> int:
+    """Create a real chunk and pin its metadata to an exact test world time."""
+
+    cur.execute(
+        """
+        INSERT INTO narrative_chunks (raw_text, storyteller_text)
+        VALUES ('Issue 640 clock probe.', 'Issue 640 clock probe.')
+        RETURNING id
+        """
+    )
+    chunk_id = int(cur.fetchone()[0])
+    cur.execute(
+        "INSERT INTO chunk_metadata (chunk_id, world_time) VALUES (%s, %s)",
+        (chunk_id, world_time),
+    )
+    # The statement trigger derives world_time from base_timestamp on INSERT.
+    # A world_time-only UPDATE does not retrigger it, matching replay test idioms.
+    cur.execute(
+        "UPDATE chunk_metadata SET world_time = %s WHERE chunk_id = %s",
+        (world_time, chunk_id),
+    )
+    return chunk_id
+
+
+def _build_story_transition(dbname: str) -> Any:
+    """Hydrate the checked-in wizard artifact with issue #640's future clock."""
+
+    payload = copy.deepcopy(json.loads(WIZARD_FIXTURE_PATH.read_text()))
+    seed_bundle = payload["seed"]
+    seed_bundle["story_seed"]["base_timestamp"] = {
+        "year": STORY_BASE.year,
+        "month": STORY_BASE.month,
+        "day": STORY_BASE.day,
+        "hour": STORY_BASE.hour,
+        "minute": STORY_BASE.minute,
+        "second": STORY_BASE.second,
+    }
+    write_cache(
+        thread_id="issue_640_ordering_regression",
+        setting_draft=payload["setting"],
+        character_draft=payload["character"],
+        selected_seed=seed_bundle["story_seed"],
+        layer_draft=seed_bundle["layer"],
+        zone_draft=seed_bundle["zone"],
+        initial_location=seed_bundle["initial_location"],
+        base_timestamp=STORY_BASE.isoformat(),
+        target_slot=3,
+        dbname=dbname,
+    )
+    cache = read_cache(dbname)
+    assert cache is not None
+    assert cache.current_phase() == "ready"
+    return build_transition_data_from_cache(cache)
+
+
+def test_character_need_rows_anchor_to_base_without_chunks(
+    disposable_need_clock_db: str,
+) -> None:
+    """A pre-narrative character uses base_timestamp, never wall time."""
+
+    _apply_migration_100(disposable_need_clock_db)
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, STORY_BASE)
+            entity_id = _insert_character(cur, "Base Clock Character")
+            cur.execute(
+                """
+                SELECT last_evaluated_at
+                FROM character_need_states
+                WHERE character_entity_id = %s
+                ORDER BY need_type::text
+                """,
+                (entity_id,),
+            )
+            anchors = [row[0] for row in cur.fetchall()]
+
+    assert len(anchors) == 5
+    assert set(anchors) == {STORY_BASE}
+
+
+def test_character_need_rows_raise_when_all_clock_sources_are_absent(
+    disposable_need_clock_db: str,
+) -> None:
+    """The database function names the violated world-clock invariant."""
+
+    _apply_migration_100(disposable_need_clock_db)
+    with pytest.raises(
+        psycopg2.errors.RaiseException,
+        match=(
+            "need-clock anchor unavailable: "
+            "no canonical world time or base_timestamp"
+        ),
+    ):
+        with _transaction(disposable_need_clock_db) as conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM character_need_states")
+                cur.execute("DELETE FROM chunk_metadata")
+                _set_base_timestamp(cur, None)
+                _insert_character(cur, "Clockless Character")
+
+
+def test_migration_reconciles_poisoned_rows_and_guards_fulfillment_domain(
+    disposable_need_clock_db: str,
+) -> None:
+    """Repair the real issue shape before fulfillment debt is materialized."""
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, STORY_BASE)
+            entity_id = _insert_character(cur, "Poisoned Clock Character")
+            cur.execute(
+                """
+                UPDATE character_need_states
+                SET last_evaluated_at = %s,
+                    last_fulfilled_at = CASE
+                        WHEN need_type IN ('sleep', 'hunger') THEN %s
+                        WHEN need_type = 'thirst' THEN %s
+                        ELSE NULL
+                    END
+                WHERE character_entity_id = %s
+                """,
+                (
+                    POISONED_WALL_TIME,
+                    POISONED_WALL_TIME,
+                    STORY_BASE + timedelta(hours=1),
+                    entity_id,
+                ),
+            )
+            cur.execute(
+                """
+                UPDATE character_need_states
+                SET last_evaluated_at = %s
+                WHERE character_entity_id = %s
+                  AND need_type = 'intimacy'
+                """,
+                (STORY_BASE + timedelta(hours=2), entity_id),
+            )
+            chunk_id = _insert_chunk_at(cur, STORY_ANCHOR)
+
+    notices = _apply_migration_100(disposable_need_clock_db)
+    assert (
+        "need-clock reconciliation: last_evaluated_at rows=4, "
+        "last_fulfilled_at rows=2"
+    ) in "".join(notices)
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT need_type::text, last_evaluated_at, last_fulfilled_at
+                FROM character_need_states
+                WHERE character_entity_id = %s
+                ORDER BY need_type::text
+                """,
+                (entity_id,),
+            )
+            reconciled = {
+                need_type: (last_evaluated_at, last_fulfilled_at)
+                for need_type, last_evaluated_at, last_fulfilled_at in cur.fetchall()
+            }
+
+            assert reconciled["intimacy"][0] == STORY_BASE + timedelta(hours=2)
+            assert all(
+                evaluated_at == STORY_ANCHOR
+                for need_type, (evaluated_at, _fulfilled_at) in reconciled.items()
+                if need_type != "intimacy"
+            )
+            assert reconciled["sleep"][1] == STORY_ANCHOR
+            assert reconciled["hunger"][1] == STORY_ANCHOR
+            assert reconciled["thirst"][1] == STORY_BASE + timedelta(hours=1)
+            assert reconciled["socialize"][1] is None
+            assert reconciled["intimacy"][1] is None
+
+            _apply_need_fulfillment_sync(
+                cur,
+                actor_entity_id=entity_id,
+                fulfillment={
+                    "type": "thirst",
+                    "quality": "routine",
+                    "discharge_debt": 9999,
+                },
+                template_id="issue_640_reconciled",
+                source_chunk_id=chunk_id,
+                need_tuning=load_need_tuning(),
+            )
+            cur.execute(
+                """
+                SELECT debt_score, last_evaluated_at, last_fulfilled_at
+                FROM character_need_states
+                WHERE character_entity_id = %s
+                  AND need_type = 'thirst'
+                """,
+                (entity_id,),
+            )
+            stored_debt, evaluated_at, fulfilled_at = cur.fetchone()
+            assert stored_debt == 0
+            assert evaluated_at == STORY_ANCHOR
+            assert fulfilled_at == STORY_ANCHOR
+
+            cur.execute(
+                """
+                UPDATE character_need_states
+                SET last_evaluated_at = %s
+                WHERE character_entity_id = %s
+                  AND need_type = 'thirst'
+                """,
+                (POISONED_WALL_TIME, entity_id),
+            )
+            with pytest.raises(
+                NeedDebtScoreDomainError,
+                match=(
+                    r"need debt score outside numeric\(8,2\) domain: "
+                    rf"character={entity_id}, need=thirst, value="
+                ),
+            ):
+                _apply_need_fulfillment_sync(
+                    cur,
+                    actor_entity_id=entity_id,
+                    fulfillment={
+                        "type": "thirst",
+                        "quality": "routine",
+                        "discharge_debt": 0,
+                    },
+                    template_id="issue_640_domain_guard",
+                    source_chunk_id=chunk_id,
+                    need_tuning=load_need_tuning(),
+                )
+
+            cur.execute(
+                """
+                SELECT debt_score, last_evaluated_at
+                FROM character_need_states
+                WHERE character_entity_id = %s
+                  AND need_type = 'thirst'
+                """,
+                (entity_id,),
+            )
+            stored_debt, evaluated_at = cur.fetchone()
+            assert stored_debt == 0
+            assert evaluated_at == POISONED_WALL_TIME
+
+
+def test_migration_reconciliation_noops_without_base_timestamp(
+    disposable_need_clock_db: str,
+) -> None:
+    """Without a canonical base, migration 100 leaves existing clocks untouched."""
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, None)
+            entity_id = _insert_character(cur, "Unreconciled Clock Character")
+            cur.execute(
+                """
+                UPDATE character_need_states
+                SET last_evaluated_at = %s
+                WHERE character_entity_id = %s
+                """,
+                (POISONED_WALL_TIME, entity_id),
+            )
+
+    notices = _apply_migration_100(disposable_need_clock_db)
+    assert (
+        "need-clock reconciliation: last_evaluated_at rows=0, "
+        "last_fulfilled_at rows=0"
+    ) in "".join(notices)
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT DISTINCT last_evaluated_at
+                FROM character_need_states
+                WHERE character_entity_id = %s
+                """,
+                (entity_id,),
+            )
+            assert cur.fetchall() == [(POISONED_WALL_TIME,)]
+
+
+def test_atomic_transition_replaces_stale_clock_before_protagonist_trigger(
+    disposable_need_clock_db: str,
+) -> None:
+    """The wizard transaction exposes the new clock before character creation."""
+
+    _apply_migration_100(disposable_need_clock_db)
+    transition = _build_story_transition(disposable_need_clock_db)
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, STALE_STORY_BASE)
+
+    result = NewStoryDatabaseMapper(dbname=disposable_need_clock_db).perform_transition(
+        transition
+    )
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT base_timestamp FROM global_variables WHERE id = true")
+            assert cur.fetchone()[0] == STORY_BASE
+            cur.execute(
+                """
+                SELECT cns.last_evaluated_at
+                FROM character_need_states cns
+                JOIN characters c ON c.entity_id = cns.character_entity_id
+                WHERE c.id = %s
+                ORDER BY cns.need_type::text
+                """,
+                (result["character_id"],),
+            )
+            anchors = [row[0] for row in cur.fetchall()]
+
+    assert len(anchors) == 5
+    assert set(anchors) == {STORY_BASE}
+    assert STALE_STORY_BASE not in anchors
+    assert POISONED_WALL_TIME not in anchors

--- a/tests/test_orrery/test_need_clock_anchor_pg.py
+++ b/tests/test_orrery/test_need_clock_anchor_pg.py
@@ -184,6 +184,24 @@ def _insert_character(cur: Any, name: str) -> int:
     return entity_id
 
 
+def _insert_place(cur: Any, name: str) -> int:
+    """Insert one real-schema place and return its place-table ID."""
+
+    cur.execute(
+        "INSERT INTO entities (kind, is_active) " "VALUES ('place', true) RETURNING id"
+    )
+    entity_id = int(cur.fetchone()[0])
+    cur.execute(
+        """
+        INSERT INTO places (name, type, entity_id)
+        VALUES (%s, 'fixed_location', %s)
+        RETURNING id
+        """,
+        (name, entity_id),
+    )
+    return int(cur.fetchone()[0])
+
+
 def _insert_chunk_at(cur: Any, world_time: datetime) -> int:
     """Create a real chunk and pin its metadata to an exact test world time."""
 
@@ -577,6 +595,52 @@ def test_migration_provenance_counts_and_rerun_are_idempotent(
                 )
                 == 1
             )
+            cur.execute(
+                """
+                SELECT field, count(*)
+                FROM character_need_state_reconciliations
+                WHERE character_entity_id = %s
+                GROUP BY field
+                ORDER BY field
+                """,
+                (entity_id,),
+            )
+            audit_counts = dict(cur.fetchall())
+            assert audit_counts == {
+                "last_evaluated_at": 5,
+                "last_fulfilled_at": 1,
+            }
+            cur.execute(
+                """
+                SELECT character_entity_id, need_type::text, field,
+                       prior_value, new_value, debt_score_pre_image
+                FROM character_need_state_reconciliations
+                WHERE character_entity_id = %s
+                ORDER BY need_type::text, field
+                """,
+                (entity_id,),
+            )
+            audit_snapshot = cur.fetchall()
+            assert len(audit_snapshot) == sum(audit_counts.values())
+            for statement in (
+                """
+                UPDATE character_need_state_reconciliations
+                SET debt_score_pre_image = debt_score_pre_image
+                WHERE character_entity_id = %s
+                """,
+                """
+                DELETE FROM character_need_state_reconciliations
+                WHERE character_entity_id = %s
+                """,
+            ):
+                cur.execute("SAVEPOINT immutable_audit_probe")
+                with pytest.raises(
+                    psycopg2.errors.RaiseException,
+                    match="reconciliation audit rows are immutable",
+                ):
+                    cur.execute(statement, (entity_id,))
+                cur.execute("ROLLBACK TO SAVEPOINT immutable_audit_probe")
+                cur.execute("RELEASE SAVEPOINT immutable_audit_probe")
 
     rerun_notices = _apply_migration_100(disposable_need_clock_db)
     assert (
@@ -596,6 +660,17 @@ def test_migration_provenance_counts_and_rerun_are_idempotent(
                 (entity_id,),
             )
             assert dict(cur.fetchall()) == marker_snapshot
+            cur.execute(
+                """
+                SELECT character_entity_id, need_type::text, field,
+                       prior_value, new_value, debt_score_pre_image
+                FROM character_need_state_reconciliations
+                WHERE character_entity_id = %s
+                ORDER BY need_type::text, field
+                """,
+                (entity_id,),
+            )
+            assert cur.fetchall() == audit_snapshot
 
 
 def test_migration_reconciles_future_poison_in_a_past_set_story(
@@ -764,7 +839,7 @@ def test_replay_mirrors_reconciliation_across_migration_100_boundary(
 
     assert verdict.drifts == []
     assert any(
-        "migration 100 provenance rebased" in note
+        "migration 100 audit rebased" in note
         for note in verdict.notes["character_need_states"]
     )
 
@@ -1007,6 +1082,314 @@ def test_markerless_null_clock_mismatch_is_a_field_level_remainder(
     assert need_remainder == {("character_need_states", row_key, "last_evaluated_at")}
     assert verdict.drifts == []
     assert verdict.skipped_unreproducible >= 1
+
+
+def test_reconciled_wall_accrued_debt_is_an_absolute_remainder(
+    disposable_need_clock_db: str,
+) -> None:
+    """Migration provenance cannot make unledgered legacy accrual reproducible."""
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM schema_migrations WHERE version = '100'")
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, STORY_BASE)
+            base_chunk = _insert_chunk_at(cur, STORY_BASE)
+            entity_id = _insert_character(cur, "Wall Accrued Debt")
+            cur.execute(
+                """
+                UPDATE character_need_states
+                SET last_evaluated_at = %s
+                WHERE character_entity_id = %s
+                """,
+                (POISONED_WALL_TIME, entity_id),
+            )
+            base_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=base_chunk,
+                label="manual",
+            )
+            assert base_checkpoint_id is not None
+            cur.execute(
+                """
+                UPDATE character_need_states
+                SET debt_score = 729.13
+                WHERE character_entity_id = %s
+                  AND need_type = 'hunger'
+                """,
+                (entity_id,),
+            )
+            target_chunk = _insert_chunk_at(cur, STORY_ANCHOR)
+
+    _apply_migration_100(disposable_need_clock_db)
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            target_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=target_chunk,
+                label="manual",
+            )
+            assert target_checkpoint_id is not None
+            reconstructed = reconstruct_state_at_sync(
+                cur,
+                target_chunk,
+                base_checkpoint_id=base_checkpoint_id,
+                target_checkpoint_id=target_checkpoint_id,
+            )
+            post_migration_chunk = _insert_chunk_at(
+                cur,
+                STORY_ANCHOR + timedelta(hours=1),
+            )
+            post_migration_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=post_migration_chunk,
+                label="manual",
+            )
+            assert post_migration_checkpoint_id is not None
+            post_migration_reconstructed = reconstruct_state_at_sync(
+                cur,
+                post_migration_chunk,
+                base_checkpoint_id=target_checkpoint_id,
+                target_checkpoint_id=post_migration_checkpoint_id,
+            )
+            verdict = next(
+                item
+                for item in verify_checkpoints_sync(cur)
+                if item.base_checkpoint_id == base_checkpoint_id
+                and item.target_checkpoint_id == target_checkpoint_id
+            )
+            post_migration_verdict = next(
+                item
+                for item in verify_checkpoints_sync(cur)
+                if item.base_checkpoint_id == target_checkpoint_id
+                and item.target_checkpoint_id == post_migration_checkpoint_id
+            )
+            cur.execute(
+                """
+                SELECT prior_value, new_value, debt_score_pre_image
+                FROM character_need_state_reconciliations
+                WHERE character_entity_id = %s
+                  AND need_type = 'hunger'
+                  AND field = 'last_evaluated_at'
+                """,
+                (entity_id,),
+            )
+            audit_row = cur.fetchone()
+
+    row_key = f"{entity_id}:hunger"
+    assert audit_row[:2] == (POISONED_WALL_TIME, STORY_ANCHOR)
+    assert float(audit_row[2]) == 729.13
+    assert (
+        "character_need_states",
+        row_key,
+        "debt_score",
+    ) in reconstructed.unreproducible
+    assert (
+        "character_need_states",
+        row_key,
+        "debt_score",
+    ) in post_migration_reconstructed.unreproducible
+    assert verdict.drifts == []
+    assert post_migration_verdict.drifts == []
+
+
+def test_reconciliation_audit_survives_need_row_delete_and_reinsert(
+    disposable_need_clock_db: str,
+) -> None:
+    """A later applicability reset cannot erase an earlier crossing's proof."""
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM schema_migrations WHERE version = '100'")
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, STORY_BASE)
+            base_chunk = _insert_chunk_at(cur, STORY_BASE)
+            entity_id = _insert_character(cur, "Durable Audit Character")
+            cur.execute(
+                """
+                UPDATE character_need_states
+                SET last_evaluated_at = %s
+                WHERE character_entity_id = %s
+                """,
+                (POISONED_WALL_TIME, entity_id),
+            )
+            base_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=base_chunk,
+                label="manual",
+            )
+            assert base_checkpoint_id is not None
+            target_chunk = _insert_chunk_at(cur, STORY_ANCHOR)
+
+    _apply_migration_100(disposable_need_clock_db)
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            target_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=target_chunk,
+                label="manual",
+            )
+            assert target_checkpoint_id is not None
+            post_target_chunk = _insert_chunk_at(cur, STORY_ANCHOR + timedelta(hours=1))
+
+            cur.execute("SELECT id FROM tags WHERE tag = 'inorganic'")
+            immunity_tag_id = int(cur.fetchone()[0])
+            cur.execute(
+                """
+                INSERT INTO entity_tags (
+                    entity_id, tag_id, source_kind, source_chunk_id
+                ) VALUES (%s, %s, 'template', %s)
+                RETURNING id
+                """,
+                (entity_id, immunity_tag_id, post_target_chunk),
+            )
+            immunity_row_id = int(cur.fetchone()[0])
+            cur.execute(
+                "UPDATE entity_tags SET cleared_at = now() WHERE id = %s",
+                (immunity_row_id,),
+            )
+            cur.execute(
+                """
+                INSERT INTO tag_clearance_log (
+                    entity_tag_id, mechanism, source_chunk_id
+                ) VALUES (%s, 'authored', %s)
+                """,
+                (immunity_row_id, post_target_chunk),
+            )
+            cur.execute(
+                """
+                SELECT metadata
+                FROM character_need_states
+                WHERE character_entity_id = %s
+                  AND need_type = 'hunger'
+                """,
+                (entity_id,),
+            )
+            assert cur.fetchone()[0] == {"synced_by": "need_applicability"}
+            cur.execute(
+                """
+                SELECT count(*)
+                FROM character_need_state_reconciliations
+                WHERE character_entity_id = %s
+                  AND field = 'last_evaluated_at'
+                """,
+                (entity_id,),
+            )
+            assert cur.fetchone()[0] == 5
+
+            verdict = next(
+                item
+                for item in verify_checkpoints_sync(cur)
+                if item.base_checkpoint_id == base_checkpoint_id
+                and item.target_checkpoint_id == target_checkpoint_id
+            )
+
+    assert verdict.drifts == []
+
+
+def test_legacy_atemporal_travel_start_keeps_world_times_unreproducible(
+    disposable_need_clock_db: str,
+) -> None:
+    """A pre-100 NULL-clock resolution used wall time, not today's helper."""
+
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM schema_migrations WHERE version = '100'")
+            cur.execute("DELETE FROM character_need_states")
+            cur.execute("DELETE FROM chunk_metadata")
+            _set_base_timestamp(cur, STORY_BASE)
+            base_chunk = _insert_chunk_at(cur, STORY_ANCHOR)
+            origin_id = _insert_place(cur, "Legacy Travel Origin")
+            destination_id = _insert_place(cur, "Legacy Travel Destination")
+            entity_id = _insert_character(cur, "Legacy Atemporal Traveler")
+            cur.execute(
+                "UPDATE characters SET current_location = %s WHERE entity_id = %s",
+                (origin_id, entity_id),
+            )
+            base_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=base_chunk,
+                label="manual",
+            )
+            assert base_checkpoint_id is not None
+
+            target_chunk = _insert_atemporal_chunk(cur)
+            travel_payload = {
+                "origin_place_id": origin_id,
+                "destination_place_id": destination_id,
+            }
+            cur.execute(
+                """
+                INSERT INTO character_travel_states (
+                    character_entity_id, status, anchor_place_id,
+                    origin_place_id, destination_place_id,
+                    started_at_world_time, updated_at_world_time
+                ) VALUES (%s, 'in_transit', %s, %s, %s, %s, %s)
+                """,
+                (
+                    entity_id,
+                    origin_id,
+                    origin_id,
+                    destination_id,
+                    POISONED_WALL_TIME,
+                    POISONED_WALL_TIME,
+                ),
+            )
+            cur.execute(
+                """
+                INSERT INTO orrery_resolutions (
+                    tick_chunk_id, template_id, binding_hash, actor_entity_id,
+                    priority, magnitude, state_delta
+                ) VALUES (
+                    %s, 'issue_640_legacy_travel', 'issue-640-legacy-travel',
+                    %s, 50, 0.5, %s::jsonb
+                )
+                """,
+                (
+                    target_chunk,
+                    entity_id,
+                    json.dumps({"travel.start": travel_payload}),
+                ),
+            )
+
+    _apply_migration_100(disposable_need_clock_db)
+    with _transaction(disposable_need_clock_db) as conn:
+        with conn.cursor() as cur:
+            target_checkpoint_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=target_chunk,
+                label="manual",
+            )
+            assert target_checkpoint_id is not None
+            reconstructed = reconstruct_state_at_sync(
+                cur,
+                target_chunk,
+                base_checkpoint_id=base_checkpoint_id,
+                target_checkpoint_id=target_checkpoint_id,
+            )
+            verdict = next(
+                item
+                for item in verify_checkpoints_sync(cur)
+                if item.base_checkpoint_id == base_checkpoint_id
+                and item.target_checkpoint_id == target_checkpoint_id
+            )
+
+    travel_row = next(
+        row
+        for row in reconstructed.state["character_travel_states"]
+        if row["character_entity_id"] == entity_id
+    )
+    assert travel_row["started_at_world_time"] is None
+    assert travel_row["updated_at_world_time"] is None
+    for column in ("started_at_world_time", "updated_at_world_time"):
+        assert (
+            "character_travel_states",
+            str(entity_id),
+            column,
+        ) in reconstructed.unreproducible
+    assert verdict.drifts == []
 
 
 def test_replay_reconstructs_post_migration_trigger_anchor(

--- a/tests/test_orrery/test_need_debt_domain.py
+++ b/tests/test_orrery/test_need_debt_domain.py
@@ -1,11 +1,109 @@
 """Unit regressions for Orrery need-debt persistence limits."""
 
+from datetime import datetime, timezone
+from typing import Any
+
 import pytest
 
 from nexus.agents.orrery.events import (
     NeedDebtScoreDomainError,
+    OrreryWorldClockUnavailableError,
+    _apply_need_fulfillment_async,
+    _apply_need_fulfillment_sync,
+    _tick_world_time_async,
+    _tick_world_time_sync,
     _validate_need_debt_score_domain,
 )
+from nexus.agents.orrery.needs import load_need_tuning
+
+
+WORLD_TIME = datetime(2189, 10, 17, 22, 12, tzinfo=timezone.utc)
+
+
+class _DomainCursor:
+    """Focused sync double for clock selection and pre-write validation."""
+
+    def __init__(
+        self,
+        *,
+        source_world_time: datetime | None = WORLD_TIME,
+        canonical_world_time: datetime | None = WORLD_TIME,
+        debt_score: float = 0.0,
+    ) -> None:
+        self.source_world_time = source_world_time
+        self.canonical_world_time = canonical_world_time
+        self.debt_score = debt_score
+        self.executed: list[tuple[str, Any]] = []
+        self._fetchone: Any = None
+        self._fetchall: list[Any] = []
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+        normalized = " ".join(str(sql).split())
+        self._fetchone = None
+        self._fetchall = []
+        if normalized.startswith(
+            "SELECT world_time FROM chunk_metadata WHERE chunk_id"
+        ):
+            self._fetchone = {"world_time": self.source_world_time}
+        elif "SELECT COALESCE(" in normalized and "MAX(world_time)" in normalized:
+            self._fetchone = {"world_time": self.canonical_world_time}
+        elif "SELECT etc.tag FROM entity_tags_current" in normalized:
+            self._fetchall = []
+        elif "SELECT debt_score, last_evaluated_at" in normalized:
+            self._fetchone = {
+                "debt_score": self.debt_score,
+                "last_evaluated_at": WORLD_TIME,
+            }
+
+    def fetchone(self) -> Any:
+        return self._fetchone
+
+    def fetchall(self) -> list[Any]:
+        return self._fetchall
+
+
+class _AsyncDomainConnection:
+    """Async twin of :class:`_DomainCursor`."""
+
+    def __init__(
+        self,
+        *,
+        source_world_time: datetime | None = WORLD_TIME,
+        canonical_world_time: datetime | None = WORLD_TIME,
+        debt_score: float = 0.0,
+    ) -> None:
+        self.source_world_time = source_world_time
+        self.canonical_world_time = canonical_world_time
+        self.debt_score = debt_score
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetchval(self, sql: str, *params: Any) -> Any:
+        self.executed.append((sql, params))
+        normalized = " ".join(str(sql).split())
+        if normalized.startswith(
+            "SELECT world_time FROM chunk_metadata WHERE chunk_id"
+        ):
+            return self.source_world_time
+        if "SELECT COALESCE(" in normalized and "MAX(world_time)" in normalized:
+            return self.canonical_world_time
+        raise AssertionError(f"Unexpected fetchval SQL: {normalized}")
+
+    async def fetch(self, sql: str, *params: Any) -> list[Any]:
+        self.executed.append((sql, params))
+        assert "SELECT etc.tag FROM entity_tags_current" in " ".join(str(sql).split())
+        return []
+
+    async def fetchrow(self, sql: str, *params: Any) -> Any:
+        self.executed.append((sql, params))
+        assert "SELECT debt_score, last_evaluated_at" in " ".join(str(sql).split())
+        return {
+            "debt_score": self.debt_score,
+            "last_evaluated_at": WORLD_TIME,
+        }
+
+    async def execute(self, sql: str, *params: Any) -> None:
+        self.executed.append((sql, params))
 
 
 def test_need_debt_domain_guard_matches_postgres_numeric_rounding() -> None:
@@ -29,3 +127,96 @@ def test_need_debt_domain_guard_matches_postgres_numeric_rounding() -> None:
             need_type="thirst",
             debt_score=999999.995,
         )
+
+
+def test_tick_world_time_uses_primary_clock_for_atemporal_chunk() -> None:
+    """A NULL layer clock resolves to the primary canon, never wall time."""
+
+    cursor = _DomainCursor(source_world_time=None)
+
+    assert _tick_world_time_sync(cursor, 41) == WORLD_TIME
+    assert not any("now()" in sql.lower() for sql, _params in cursor.executed)
+
+
+@pytest.mark.asyncio
+async def test_tick_world_time_async_uses_primary_clock_for_atemporal_chunk() -> None:
+    """The async writer follows the same deterministic fallback chain."""
+
+    conn = _AsyncDomainConnection(source_world_time=None)
+
+    assert await _tick_world_time_async(conn, 41) == WORLD_TIME
+    assert not any("now()" in sql.lower() for sql, _params in conn.executed)
+
+
+def test_tick_world_time_raises_named_error_without_canonical_clock() -> None:
+    """Missing both primary clock sources fails closed with a named error."""
+
+    cursor = _DomainCursor(
+        source_world_time=None,
+        canonical_world_time=None,
+    )
+
+    with pytest.raises(
+        OrreryWorldClockUnavailableError,
+        match="no primary world_time or base_timestamp",
+    ):
+        _tick_world_time_sync(cursor, 41)
+
+
+@pytest.mark.asyncio
+async def test_tick_world_time_async_raises_without_canonical_clock() -> None:
+    """The async writer raises the same named missing-clock diagnostic."""
+
+    conn = _AsyncDomainConnection(
+        source_world_time=None,
+        canonical_world_time=None,
+    )
+
+    with pytest.raises(
+        OrreryWorldClockUnavailableError,
+        match="no primary world_time or base_timestamp",
+    ):
+        await _tick_world_time_async(conn, 41)
+
+
+def test_need_domain_guard_precedes_first_sync_write() -> None:
+    """The sync fulfillment arm validates before its load-or-create INSERT."""
+
+    cursor = _DomainCursor(debt_score=999999.995)
+
+    with pytest.raises(NeedDebtScoreDomainError):
+        _apply_need_fulfillment_sync(
+            cursor,
+            actor_entity_id=17,
+            fulfillment={"type": "thirst", "discharge_debt": 0},
+            template_id="domain_ordering_sync",
+            source_chunk_id=41,
+            need_tuning=load_need_tuning(),
+        )
+
+    assert not any(
+        sql.lstrip().upper().startswith(("INSERT", "UPDATE", "DELETE"))
+        for sql, _params in cursor.executed
+    )
+
+
+@pytest.mark.asyncio
+async def test_need_domain_guard_precedes_first_async_write() -> None:
+    """The async fulfillment arm validates before its load-or-create INSERT."""
+
+    conn = _AsyncDomainConnection(debt_score=999999.995)
+
+    with pytest.raises(NeedDebtScoreDomainError):
+        await _apply_need_fulfillment_async(
+            conn,
+            actor_entity_id=17,
+            fulfillment={"type": "thirst", "discharge_debt": 0},
+            template_id="domain_ordering_async",
+            source_chunk_id=41,
+            need_tuning=load_need_tuning(),
+        )
+
+    assert not any(
+        sql.lstrip().upper().startswith(("INSERT", "UPDATE", "DELETE"))
+        for sql, _params in conn.executed
+    )

--- a/tests/test_orrery/test_need_debt_domain.py
+++ b/tests/test_orrery/test_need_debt_domain.py
@@ -1,0 +1,31 @@
+"""Unit regressions for Orrery need-debt persistence limits."""
+
+import pytest
+
+from nexus.agents.orrery.events import (
+    NeedDebtScoreDomainError,
+    _validate_need_debt_score_domain,
+)
+
+
+def test_need_debt_domain_guard_matches_postgres_numeric_rounding() -> None:
+    """Reject values that numeric(8,2) would round out of range."""
+
+    _validate_need_debt_score_domain(
+        actor_entity_id=17,
+        need_type="thirst",
+        debt_score=999999.994,
+    )
+
+    with pytest.raises(
+        NeedDebtScoreDomainError,
+        match=(
+            r"need debt score outside numeric\(8,2\) domain: "
+            r"character=17, need=thirst, value=999999.995"
+        ),
+    ):
+        _validate_need_debt_score_domain(
+            actor_entity_id=17,
+            need_type="thirst",
+            debt_score=999999.995,
+        )

--- a/tests/test_orrery/test_replay.py
+++ b/tests/test_orrery/test_replay.py
@@ -53,6 +53,7 @@ from nexus.agents.orrery.retrograde_persistence import (
     _record_entity_activity_projection,
 )
 from nexus.agents.orrery.substrate import ProjectPolicy
+from nexus.agents.orrery.tag_writer import _insert_entity_tag
 from nexus.api.commit_handler_sync import apply_state_updates_sync
 
 pytestmark = pytest.mark.requires_postgres
@@ -61,9 +62,11 @@ WRITE_SLOT = 5
 
 
 def _connect() -> Any:
+    database = os.environ.get("NEXUS_REPLAY_TEST_DB", f"save_{WRITE_SLOT:02d}")
+    assert database == f"save_{WRITE_SLOT:02d}" or database.startswith("qa640_")
     conn = psycopg2.connect(
         host=os.environ.get("PGHOST", "localhost"),
-        database=f"save_{WRITE_SLOT:02d}",
+        database=database,
         user=os.environ.get("PGUSER", "pythagor"),
         port=os.environ.get("PGPORT", "5432"),
     )
@@ -140,6 +143,30 @@ def _probe_character(cur: Any) -> tuple[int, int, str, Optional[int]]:
         """
     )
     return cur.fetchone()
+
+
+def _project_probe_character(cur: Any) -> tuple[int, int, str, int]:
+    """Return a located character with no open project in the source save."""
+
+    cur.execute(
+        """
+        SELECT c.id, c.entity_id, c.current_activity, c.current_location
+        FROM characters AS c
+        WHERE c.entity_id IS NOT NULL
+          AND c.current_location IS NOT NULL
+          AND NOT EXISTS (
+                SELECT 1
+                FROM character_project_states AS cps
+                WHERE cps.character_entity_id = c.entity_id
+                  AND cps.status IN ('active', 'paused', 'stalled')
+          )
+        ORDER BY c.id
+        LIMIT 1
+        """
+    )
+    row = cur.fetchone()
+    assert row is not None, "replay project tests need one located uncommitted actor"
+    return row
 
 
 def _section_row(rows: list[dict[str, Any]], **match: Any) -> Optional[dict]:
@@ -357,6 +384,130 @@ def test_tag_bestowal_and_clearance_replay_at_exact_chunks() -> None:
             probe_pair = [v for v in verdicts if v.target_chunk_id == clear_chunk]
             assert len(probe_pair) == 1
             assert probe_pair[0].drifts == []
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_post_target_replace_reapplication_is_presence_remainder() -> None:
+    """A later replace must not turn destroyed provenance into false drift."""
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            head = _head_chunk(cur)
+            _, char_entity, _, _ = _probe_character(cur)
+            cur.execute(
+                """
+                SELECT t.id
+                FROM tags AS t
+                JOIN tag_category_registry AS registry
+                  ON registry.category = t.category
+                 AND registry.entity_kind = 'character'
+                WHERE t.reapplication_policy = 'replace'
+                  AND NOT t.deprecated
+                  AND t.synonym_for IS NULL
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM entity_tags AS et
+                      WHERE et.entity_id = %s
+                        AND et.tag_id = t.id
+                        AND et.cleared_at IS NULL
+                  )
+                ORDER BY t.id
+                LIMIT 1
+                """,
+                (char_entity,),
+            )
+            replace_tag_id = cur.fetchone()[0]
+            base_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=head,
+                label="manual",
+            )
+            assert base_id is not None
+
+            target_world_time = _next_world_time(cur)
+            target_chunk = _fabricate_chunk(cur, target_world_time)
+            assert _insert_entity_tag(
+                cur,
+                entity_id=char_entity,
+                tag_id=replace_tag_id,
+                source_kind="template",
+                world_time=target_world_time,
+                duration_override=None,
+                reapplication_policy="replace",
+                source_chunk_id=target_chunk,
+            )
+            cur.execute(
+                """
+                SELECT id
+                FROM entity_tags
+                WHERE entity_id = %s AND tag_id = %s AND cleared_at IS NULL
+                """,
+                (char_entity, replace_tag_id),
+            )
+            tag_row_id = cur.fetchone()[0]
+            target_id = capture_state_checkpoint_sync(
+                cur,
+                chunk_id=target_chunk,
+                label="manual",
+            )
+            assert target_id is not None
+
+            later_world_time = target_world_time + timedelta(hours=1)
+            later_chunk = _fabricate_chunk(cur, later_world_time)
+            assert _insert_entity_tag(
+                cur,
+                entity_id=char_entity,
+                tag_id=replace_tag_id,
+                source_kind="template",
+                world_time=later_world_time,
+                duration_override=None,
+                reapplication_policy="replace",
+                source_chunk_id=later_chunk,
+            )
+            cur.execute(
+                """
+                SELECT et.source_chunk_id, t.reapplication_policy::text,
+                       et.cleared_at
+                FROM entity_tags AS et
+                JOIN tags AS t ON t.id = et.tag_id
+                WHERE et.id = %s
+                """,
+                (tag_row_id,),
+            )
+            assert cur.fetchone() == (later_chunk, "replace", None)
+            cur.execute(
+                "SELECT state -> 'entity_tags' FROM state_checkpoints WHERE id = %s",
+                (target_id,),
+            )
+            target_tags = cur.fetchone()[0]
+            assert [row for row in target_tags if int(row["id"]) == int(tag_row_id)]
+
+            replayed = reconstruct_state_at_sync(
+                cur,
+                target_chunk,
+                base_checkpoint_id=base_id,
+                target_checkpoint_id=target_id,
+            )
+            assert (
+                "entity_tags",
+                str(tag_row_id),
+            ) in replayed.uncertain_rows, replayed.notes
+            assert (
+                _section_row(
+                    replayed.state["entity_tags"],
+                    id=tag_row_id,
+                )
+                is None
+            )
+
+            verdicts = verify_checkpoints_sync(cur)
+            probe_pair = [v for v in verdicts if v.target_chunk_id == target_chunk]
+            assert len(probe_pair) == 1
+            assert probe_pair[0].drifts == []
+            assert probe_pair[0].skipped_unreproducible >= 1
     finally:
         conn.rollback()
         conn.close()
@@ -996,6 +1147,19 @@ def test_reconstruction_refuses_pre_instrumentation_chunks() -> None:
                 "SELECT max(id) FROM narrative_chunks WHERE id < %s", (earliest,)
             )
             ancient = cur.fetchone()[0]
+            if ancient is None:
+                cur.execute(
+                    """
+                    INSERT INTO narrative_chunks (id, raw_text, created_at)
+                    SELECT %s, 'pre-instrumentation replay probe',
+                           created_at - interval '1 second'
+                    FROM narrative_chunks
+                    WHERE id = %s
+                    RETURNING id
+                    """,
+                    (earliest - 1, earliest),
+                )
+                ancient = cur.fetchone()[0]
             with pytest.raises(ValueError, match="instrumentation era"):
                 reconstruct_state_at_sync(cur, ancient)
     finally:
@@ -1142,11 +1306,14 @@ def test_applicability_toggle_resets_need_row_to_fresh_shape() -> None:
             assert row is not None, "hunger must be applicable again at clear_chunk"
             assert row["debt_score"] == 0.0
             assert row["metadata"] == {"synced_by": "need_applicability"}
+            cur.execute("SELECT max(world_time) FROM chunk_metadata")
+            primary_clock = cur.fetchone()[0]
+            assert datetime.fromisoformat(row["last_evaluated_at"]) == primary_clock
             assert (
                 "character_need_states",
                 f"{char_entity}:hunger",
                 "last_evaluated_at",
-            ) in at_clear.unreproducible
+            ) not in at_clear.unreproducible
 
             verdicts = verify_checkpoints_sync(cur)
             probe_pair = [v for v in verdicts if v.target_chunk_id == clear_chunk]
@@ -1355,10 +1522,8 @@ def test_unresolved_arrival_marks_location_unreproducible() -> None:
         conn.close()
 
 
-def test_null_world_time_marks_need_timestamps_unreproducible() -> None:
-    """A tick without world_time makes production stamp wall-clock now();
-    replay must flag those columns instead of guessing — and verify must
-    skip them, not drift."""
+def test_post_fix_null_world_time_uses_primary_clock_exactly() -> None:
+    """Post-100 NULL-layer clocks are exact; audited debt stays opaque."""
 
     conn = _connect()
     try:
@@ -1367,6 +1532,8 @@ def test_null_world_time_marks_need_timestamps_unreproducible() -> None:
             _, char_entity, _, _ = _probe_character(cur)
             base_id = capture_state_checkpoint_sync(cur, chunk_id=head, label="manual")
             probe_chunk = _fabricate_chunk(cur, None)  # world_time NULL
+            cur.execute("SELECT max(world_time) FROM chunk_metadata")
+            primary_clock = cur.fetchone()[0]
 
             _apply_need_fulfillment_sync(
                 cur,
@@ -1388,21 +1555,30 @@ def test_null_world_time_marks_need_timestamps_unreproducible() -> None:
                 cur, probe_chunk, base_checkpoint_id=base_id
             )
             row_key = f"{char_entity}:thirst"
-            for column in ("last_evaluated_at", "last_fulfilled_at", "debt_score"):
+            row = _section_row(
+                at_probe.state["character_need_states"],
+                character_entity_id=char_entity,
+                need_type="thirst",
+            )
+            assert row is not None
+            assert datetime.fromisoformat(row["last_evaluated_at"]) == primary_clock
+            assert datetime.fromisoformat(row["last_fulfilled_at"]) == primary_clock
+            for column in ("last_evaluated_at", "last_fulfilled_at"):
                 assert (
                     "character_need_states",
                     row_key,
                     column,
-                ) in at_probe.unreproducible, (
-                    f"{column} depends on the wall-clock fallback and must be "
-                    "flagged"
-                )
+                ) not in at_probe.unreproducible
+            assert (
+                "character_need_states",
+                row_key,
+                "debt_score",
+            ) in at_probe.unreproducible
 
             verdicts = verify_checkpoints_sync(cur)
             probe_pair = [v for v in verdicts if v.target_chunk_id == probe_chunk]
             assert len(probe_pair) == 1
             assert probe_pair[0].drifts == []
-            assert probe_pair[0].skipped_unreproducible >= 3
     finally:
         conn.rollback()
         conn.close()
@@ -1471,16 +1647,7 @@ def test_project_transition_window_replays_with_zero_checkpoint_drift() -> None:
     try:
         with conn.cursor() as cur:
             _apply_migration_074(cur)
-            cur.execute(
-                """
-                SELECT c.entity_id, c.current_location
-                FROM characters c
-                WHERE c.entity_id IS NOT NULL
-                  AND c.current_location IS NOT NULL
-                ORDER BY c.id LIMIT 1
-                """
-            )
-            actor_entity, origin = cur.fetchone()
+            _, actor_entity, _, origin = _project_probe_character(cur)
             cur.execute(
                 "SELECT id FROM places WHERE id <> %s ORDER BY id LIMIT 1", (origin,)
             )
@@ -1696,16 +1863,7 @@ def test_project_complete_hands_off_and_real_travel_applier_relocates() -> None:
     try:
         with conn.cursor() as cur:
             _apply_migration_074(cur)
-            cur.execute(
-                """
-                SELECT c.entity_id, c.current_location
-                FROM characters c
-                WHERE c.entity_id IS NOT NULL
-                  AND c.current_location IS NOT NULL
-                ORDER BY c.id LIMIT 1
-                """
-            )
-            actor_entity, origin = cur.fetchone()
+            _, actor_entity, _, origin = _project_probe_character(cur)
             cur.execute(
                 "SELECT id FROM places WHERE id <> %s ORDER BY id LIMIT 1", (origin,)
             )
@@ -1789,7 +1947,7 @@ def test_project_applied_ledger_survives_replay_policy_retuning(monkeypatch) -> 
     conn = _connect()
     try:
         with conn.cursor() as cur:
-            _char_id, actor_entity, _activity, _location = _probe_character(cur)
+            _char_id, actor_entity, _activity, _location = _project_probe_character(cur)
             base_time = _next_world_time(cur)
             base_chunk = _fabricate_chunk(cur, base_time)
             base_id = capture_state_checkpoint_sync(

--- a/tests/test_orrery/test_retrograde_constraints_pg.py
+++ b/tests/test_orrery/test_retrograde_constraints_pg.py
@@ -65,7 +65,7 @@ def _connect(dbname: str, *, dict_cursor: bool = False) -> Any:
 def disposable_dbname() -> Iterator[str]:
     """Yield a current-template clone and remove it after the regression."""
 
-    dbname = f"nexus_test_issue_601_{uuid.uuid4().hex[:12]}"
+    dbname = f"qa640_issue601_{uuid.uuid4().hex[:12]}"
     admin: Any = None
     try:
         try:
@@ -88,6 +88,19 @@ def disposable_dbname() -> Iterator[str]:
                     / "097_trait_cold_start_relationship_constraints.sql"
                 )
                 cur.execute(migration.read_text())
+                # Fixture invariant: production persists the canonical clock
+                # before any character INSERT fires need-state initialization.
+                cur.execute(
+                    """
+                    INSERT INTO global_variables (
+                        id, new_story, base_timestamp
+                    ) VALUES (
+                        true, true, '2026-05-14T10:48:00+00:00'::timestamptz
+                    )
+                    ON CONFLICT (id) DO UPDATE
+                    SET base_timestamp = EXCLUDED.base_timestamp
+                    """
+                )
         VALID_DBNAMES.add(dbname)
         yield dbname
     finally:

--- a/tests/test_orrery/test_retrograde_retrieval_pg.py
+++ b/tests/test_orrery/test_retrograde_retrieval_pg.py
@@ -40,7 +40,7 @@ def _connect(dbname: str) -> Any:
 def disposable_cursor() -> Iterator[Any]:
     """Yield a cursor on a temporary template clone, then drop the clone."""
 
-    dbname = f"nexus_test_retrograde_storage_{uuid.uuid4().hex[:12]}"
+    dbname = f"qa640_retrieval_{uuid.uuid4().hex[:12]}"
     admin = None
     conn = None
     try:
@@ -149,6 +149,16 @@ def test_entity_stub_inserts_match_disposable_schema(disposable_cursor: Any) -> 
     """Stub INSERT column lists stay aligned with the migrated template."""
 
     cur = disposable_cursor
+    # Fixture invariant: production always persists the canonical clock before
+    # any character INSERT can fire the need-state initializer.
+    cur.execute(
+        """
+        INSERT INTO global_variables (id, new_story, base_timestamp)
+        VALUES (true, true, '2026-05-14T10:48:00+00:00'::timestamptz)
+        ON CONFLICT (id) DO UPDATE
+        SET base_timestamp = EXCLUDED.base_timestamp
+        """
+    )
     cur.execute("INSERT INTO layers DEFAULT VALUES RETURNING id")
     layer_id = cur.fetchone()["id"]
     cur.execute(

--- a/tests/test_orrery/test_retrograde_summary_migration_pg.py
+++ b/tests/test_orrery/test_retrograde_summary_migration_pg.py
@@ -37,7 +37,7 @@ def _connect(dbname: str) -> Any:
 def disposable_retrograde_db() -> Iterator[Any]:
     """Yield a template clone whose name cannot collide with a save slot."""
 
-    dbname = f"nexus_test_retrograde_078_{uuid.uuid4().hex[:12]}"
+    dbname = f"qa640_retro078_{uuid.uuid4().hex[:12]}"
     admin = None
     conn = None
     try:
@@ -54,6 +54,20 @@ def disposable_retrograde_db() -> Iterator[Any]:
                 )
             )
         conn = _connect(dbname)
+        with conn.cursor() as cur:
+            # Fixture invariant: production persists the canonical clock
+            # before any character INSERT fires need-state initialization.
+            cur.execute(
+                """
+                INSERT INTO global_variables (id, new_story, base_timestamp)
+                VALUES (
+                    true, true, '2026-05-14T10:48:00+00:00'::timestamptz
+                )
+                ON CONFLICT (id) DO UPDATE
+                SET base_timestamp = EXCLUDED.base_timestamp
+                """
+            )
+        conn.commit()
         yield conn
     finally:
         if conn is not None:


### PR DESCRIPTION
Closes #640.

## What

- **Migration 100** redefines `orrery_sync_character_need_states` (the only live function carrying the wall-time fallback — confirmed via `pg_proc.prosrc`): anchor chain is now `MAX(world_time)` → `global_variables.base_timestamp` → a named invariant exception. Never `now()`. Same migration deterministically restamps wall-time-poisoned `last_evaluated_at`/`last_fulfilled_at` rows and reports counts.
- **Wizard ordering fix**: the atomic transition wrote `base_timestamp` *after* `create_protagonist`, so the need-state trigger fired before the world clock existed (and reused slots exposed the prior story's clock). The clock write now precedes protagonist creation in the same transaction, with a comment stating the invariant.
- **Named domain guard**: out-of-domain `debt_score` writes now raise `NeedDebtScoreDomainError` naming character, need, and value — replacing the inscrutable `numeric field overflow` HTTP 500 that blocked the slot-5 compaction audit's first acceptance. No clamping; the failure stays loud.

## Why

Two-clocks doctrine: diegetic state lives on the world clock. A need clock seeded at wall time in a 2189 story derived 1.43M hours of phantom debt and 500'd a normal acceptance (full reproduction in #640).

## Testing

- 95 passed on real template clones (`qa640_*`, dropped after): anchoring with empty `chunk_metadata`, missing-clock invariant failure, reconciliation counts + no-op case, large-gap fulfillment in domain, domain-guard raise, and a stale-clock wizard regression asserting need rows get the NEW story's timestamp.
- Migration runner applies and stamps cleanly; mypy/black clean on touched files.

Post-merge: orchestrator applies migration 100 fleet-wide (slots + template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gEoexyFZe1M6tQDqBsK5p