### PR TITLE
Supervisor Honors NEXUS_RUNTIME_CONFIG for Every Runtime Command

### DIFF
--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -3156,7 +3156,10 @@ Examples:
     def _add_config_arg(p: argparse.ArgumentParser) -> None:
         p.add_argument(
             "--config",
-            help="Path to nexus.toml (default: the repository's nexus.toml)",
+            help=(
+                "Path to nexus.toml (default: NEXUS_RUNTIME_CONFIG, then the "
+                "repository's nexus.toml)"
+            ),
         )
 
     up_parser = subparsers.add_parser(

--- a/nexus/runtime/supervisor.py
+++ b/nexus/runtime/supervisor.py
@@ -197,7 +197,14 @@ class Supervisor:
 
     @classmethod
     def from_config(cls, config_path: Optional[Path] = None) -> "Supervisor":
-        path = Path(config_path) if config_path else repo_root() / "nexus.toml"
+        """Build a supervisor from an explicit, runtime, or repository config."""
+        runtime_config = os.environ.get(RUNTIME_CONFIG_ENV)
+        if config_path is not None:
+            path = Path(config_path)
+        elif runtime_config:
+            path = Path(runtime_config)
+        else:
+            path = repo_root() / "nexus.toml"
         return cls(load_settings(path), path)
 
     # ------------------------------------------------------------------

--- a/tests/test_qa_shift.py
+++ b/tests/test_qa_shift.py
@@ -6,12 +6,14 @@ from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
+import shlex
 import tomllib
 from typing import Any, Mapping
 
 import pytest
 import tomlkit
 
+from nexus.runtime import RUNTIME_CONFIG_ENV, Supervisor
 from scripts.qa_shift import qa_shift
 
 
@@ -132,6 +134,33 @@ def test_begin_creates_archive_and_pins_every_openai_role(
     assert (archive / "runtime_env.sh").exists()
     assert (archive / "probe_ledger.md").exists()
     assert (archive / "mission_report.md").exists()
+
+
+def test_generated_runtime_environment_selects_qa_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The generated shell variable selects the QA config for the supervisor."""
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+    result = qa_shift.begin_shift(
+        config=config,
+        usage_reader=lambda _root, _day: _usage(total=123),
+        now=NOW,
+    )
+    archive = Path(result["archive"])
+    environment_lines = (archive / "runtime_env.sh").read_text().splitlines()
+    runtime_export = next(
+        line
+        for line in environment_lines
+        if line.startswith(f"export {RUNTIME_CONFIG_ENV}=")
+    )
+    assignment = shlex.split(runtime_export)[1]
+    name, value = assignment.split("=", 1)
+    monkeypatch.setenv(name, value)
+
+    supervisor = Supervisor.from_config()
+
+    assert supervisor.config_path == (archive / "nexus.qa.toml").resolve()
 
 
 @pytest.mark.parametrize("missing_table", ("roles", "daily_allowance", "narration"))

--- a/tests/test_runtime/test_supervisor.py
+++ b/tests/test_runtime/test_supervisor.py
@@ -1,0 +1,104 @@
+"""Unit coverage for managed-runtime configuration selection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+from typing import Any, cast
+
+import pytest
+import tomlkit
+
+from nexus import cli
+from nexus.runtime import RUNTIME_CONFIG_ENV, Supervisor
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_CONFIG = REPO_ROOT / "nexus.toml"
+
+
+def _write_config(tmp_path: Path, name: str = "runtime.toml") -> Path:
+    """Write a real temporary runtime config with isolated supervisor state."""
+    document = tomlkit.parse(REPO_CONFIG.read_text(encoding="utf-8"))
+    runtime = cast(Any, document["runtime"])
+    runtime["state_dir"] = str(tmp_path / "state")
+    path = tmp_path / name
+    path.write_text(tomlkit.dumps(document), encoding="utf-8")
+    return path
+
+
+def test_from_config_explicit_path_beats_runtime_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit CLI path remains authoritative over the runtime environment."""
+    explicit_config = _write_config(tmp_path)
+    monkeypatch.setenv(RUNTIME_CONFIG_ENV, str(tmp_path / "missing.toml"))
+
+    supervisor = Supervisor.from_config(explicit_config)
+
+    assert supervisor.config_path == explicit_config.resolve()
+
+
+def test_from_config_uses_runtime_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The managed supervisor honors the invoking shell's runtime config."""
+    runtime_config = _write_config(tmp_path)
+    monkeypatch.setenv(RUNTIME_CONFIG_ENV, str(runtime_config))
+
+    supervisor = Supervisor.from_config()
+
+    assert supervisor.config_path == runtime_config.resolve()
+
+
+@pytest.mark.parametrize("runtime_config", (None, ""), ids=("unset", "empty"))
+def test_from_config_without_runtime_environment_uses_repo_config(
+    runtime_config: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unset or empty runtime variable falls back to repository nexus.toml."""
+    if runtime_config is None:
+        monkeypatch.delenv(RUNTIME_CONFIG_ENV, raising=False)
+    else:
+        monkeypatch.setenv(RUNTIME_CONFIG_ENV, runtime_config)
+
+    supervisor = Supervisor.from_config()
+
+    assert supervisor.config_path == REPO_CONFIG.resolve()
+
+
+def test_from_config_missing_runtime_environment_path_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured but missing runtime path never falls through to the repo."""
+    missing_config = tmp_path / "missing.toml"
+    monkeypatch.setenv(RUNTIME_CONFIG_ENV, str(missing_config))
+
+    with pytest.raises(FileNotFoundError, match=str(missing_config)):
+        Supervisor.from_config()
+
+
+def test_json_status_reports_resolved_runtime_environment_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``nexus --json status`` exposes the environment-selected config path."""
+    runtime_config = _write_config(tmp_path)
+    monkeypatch.setenv(RUNTIME_CONFIG_ENV, str(runtime_config))
+    monkeypatch.delenv("NEXUS_GATEWAY_PORT", raising=False)
+    monkeypatch.setattr(
+        Supervisor,
+        "_fetch_runtime_status",
+        lambda _supervisor: {"error": "network disabled for unit test"},
+    )
+    monkeypatch.setattr(sys, "argv", ["nexus", "--json", "status"])
+
+    assert cli.main() == 0
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["config"] == str(runtime_config.resolve())


### PR DESCRIPTION
Closes #647.

## What

- `Supervisor.from_config` resolution order is now: explicit `--config` → non-empty `NEXUS_RUNTIME_CONFIG` → repository `nexus.toml`. A configured-but-missing path fails loudly (no silent fallback past a configured value).
- All runtime entry points resolve uniformly (`up`/`down`/`restart`/`status`/`logs`), so the lane's up/down pair addresses the same instance the env selected; `nexus --json status` reports the resolved env config — the detection surface the issue used.
- The spawn-env propagation at supervisor.py:308 is now consistent instead of clobbering the caller's export.

## Why

The night-QA mission sources its generated isolated config, but the supervisor ignored the env var and re-exported the repo config path to the spawned gateway — Gaia resolved the repo's deliberate `@openai.gaia` Sol pin and escaped the free-quota lane. The usage guard caught it after one leaked call (55,822 tokens) and blocked the shift. Same defect class as #599, one layer down.

## Testing

19 passed (resolution order, empty-env ignored, missing-path raise, qa_shift runtime_env round-trip; no gateway spawned). Black/flake8/mypy clean, zero new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gEoexyFZe1M6tQDqBsK5p