### PR TITLE
Broaden nightly QA charter

### DIFF
--- a/scripts/qa_shift/README.md
+++ b/scripts/qa_shift/README.md
@@ -40,8 +40,9 @@ Defaults in `qa_shift.toml` deliberately combine independent bounds:
 The issue count is a cap, not a quota. The dry-well rule lets a healthy build
 finish without manufacturing bugs, while the token and time fences remain
 backstops. A seeded run also owes an observed roster transition, one bounded
-concurrency family, two-run family novelty, and classification of every
-current-run structured-output rejection before it may end dry.
+concurrency family, novelty against up to two completed prior runs when that
+history exists, and classification of every current-run structured-output
+rejection before it may end dry.
 
 The 10M figure is operational configuration, not a billing entitlement
 discovery mechanism. Reconfirm the organization’s current complimentary-token
@@ -61,11 +62,17 @@ A dry final state is only a seed candidate. Promotion requires a trustworthy
 usage ledger, no unresolved anomaly, current migrations, zero active generation
 leases, empty Orrery job queues, coherent measured counts, a final public load,
 and a checksummed dump that restores successfully into a disposable verification
-database. Qualified seeds carry an adjacent manifest with their source archive,
-commit, schema/model metadata, exact chunk/exchange/digest counts, known-issue
-hotspots, and sha256. Retain the previous seed; do not silently replace the only
-known-good depth checkpoint. Prune stale seeds only when the schema or campaign
-shape they capture stops being representative.
+database. Write the `.partial`, promoted `.dump`, checksum, and adjacent manifest
+under `temp/qa_seeds/`. The manifest records the source archive, commit,
+schema/model metadata, exact chunk/exchange/digest counts, known-issue hotspots,
+and sha256. Retain the previous seed; do not silently replace the only known-good
+depth checkpoint. Prune stale seeds only when the schema or campaign shape they
+capture stops being representative.
+
+For novelty preflight, a prior archive counts as completed only when its
+`shift_state.json` says `status: "finished"`. Read the newest two qualifying
+archives, or every qualifying archive when fewer than two exist. Zero prior
+archives is valid and contributes an empty coverage history.
 
 ## Usage guard
 
@@ -121,6 +128,11 @@ seat subtotals, and the `skald_writer` tripwire. Teardown enriches it with
 validation classes from only the current gateway process's log slice. A
 recovered retry still represents real cost and latency; a novel class must still
 meet the normal repeatability standard before publication.
+
+The repair-tax percentage is unavailable when final OpenAI usage is unknown or
+a rejection came from an unexpected provider, because those events do not share
+a trustworthy OpenAI denominator. Preserve the attempts and token evidence, and
+report the helper's explicit unavailability reasons instead of estimating.
 
 ## Safety boundary
 

--- a/scripts/qa_shift/README.md
+++ b/scripts/qa_shift/README.md
@@ -39,7 +39,9 @@ Defaults in `qa_shift.toml` deliberately combine independent bounds:
 
 The issue count is a cap, not a quota. The dry-well rule lets a healthy build
 finish without manufacturing bugs, while the token and time fences remain
-backstops.
+backstops. A seeded run also owes an observed roster transition, one bounded
+concurrency family, two-run family novelty, and classification of every
+current-run structured-output rejection before it may end dry.
 
 The 10M figure is operational configuration, not a billing entitlement
 discovery mechanism. Reconfirm the organization’s current complimentary-token
@@ -52,10 +54,18 @@ Shallow single-request probes stop finding bugs once the early-game surface
 hardens; state-threshold defects (compaction, alias accumulation) only appear
 deep into a campaign. Drop a checksummed mid-campaign `pg_dump -Fc` dump into
 `temp/qa_seeds/` (ignored, conventionally preserved) and the shift seeds the
-disposable slot from the newest one instead of a bare reset, then owes at
-least two deep-state probe families per `mission_prompt.md`. Prune stale
-seeds whenever the schema or campaign shape they capture stops being
-representative.
+disposable slot from the newest one instead of a bare reset, then owes the
+deep-state and coverage gates in `mission_prompt.md`.
+
+A dry final state is only a seed candidate. Promotion requires a trustworthy
+usage ledger, no unresolved anomaly, current migrations, zero active generation
+leases, empty Orrery job queues, coherent measured counts, a final public load,
+and a checksummed dump that restores successfully into a disposable verification
+database. Qualified seeds carry an adjacent manifest with their source archive,
+commit, schema/model metadata, exact chunk/exchange/digest counts, known-issue
+hotspots, and sha256. Retain the previous seed; do not silently replace the only
+known-good depth checkpoint. Prune stale seeds only when the schema or campaign
+shape they capture stops being representative.
 
 ## Usage guard
 
@@ -97,6 +107,20 @@ a trustworthy reading, which is also a stop. Checks are appended to
 `usage_end.json` provide the end-to-end tally. If UTC midnight interrupts a
 shift, `finish` explicitly re-reads the archived quota day rather than mixing
 the new day’s cumulative total with the old baseline.
+
+Normal model-generating probes run one public command between checks. A bounded
+concurrency probe may launch at most two public requests from one recorded shell
+invocation, wait for both, and reconcile their complete request-group delta in
+one post-check. Detached requests and process termination with an unaccounted
+provider response remain outside the safe boundary.
+
+The usage delta is also the authoritative rejection ledger. `finish` writes
+`rejection_ledger.json` with every current-run QA-slot
+`rejected_validation` attempt, exact rejected tokens, repair-tax percentage,
+seat subtotals, and the `skald_writer` tripwire. Teardown enriches it with
+validation classes from only the current gateway process's log slice. A
+recovered retry still represents real cost and latency; a novel class must still
+meet the normal repeatability standard before publication.
 
 ## Safety boundary
 

--- a/scripts/qa_shift/mission_prompt.md
+++ b/scripts/qa_shift/mission_prompt.md
@@ -57,12 +57,16 @@ issue, dry-well, wall-clock, and token settings.
    is unavailable or invalid, use the connected GitHub app for those reads and
    for issue publication instead. A working connected app satisfies this
    preflight requirement.
-4. Read `probe_ledger.md` and `mission_report.md` from the two most recent
-   completed `temp/qa_night_*` archives. Add their family coverage to the new
-   run's coverage matrix, including public surface, state transition, seed
-   depth, and outcome. A previously dry family may count again only for a new
-   surface, state transition, or deeper campaign boundary, or as an explicit
-   regression tied to code that changed since that run.
+4. Read `probe_ledger.md` and `mission_report.md` from up to the two most recent
+   completed `temp/qa_night_*` archives. An archive is completed only when its
+   `shift_state.json` has `status: "finished"`; directory timestamps or report
+   prose are not completion evidence. Use every qualifying archive available,
+   including zero or one without treating the missing history as a blocker, and
+   record `none` when there is no prior coverage. Add the available family
+   coverage to the new run's coverage matrix, including public surface, state
+   transition, seed depth, and outcome. A previously dry family may count again
+   only for a new surface, state transition, or deeper campaign boundary, or as
+   an explicit regression tied to code that changed since that run.
 5. Run:
 
    ```text
@@ -230,8 +234,11 @@ Always complete teardown, including early exits:
    seat, attempt, token cost, validation class, matching issue, and disposition
    in `probe_ledger.md`. Never count older lines copied into the persistent log.
 5. Report total rejected-attempt tokens and percentage as the shift's repair
-   tax, with subtotals by seat and class. Compare known-class rates only with a
-   stable denominator, such as rejected attempts per seat attempt and affected
+   tax, with subtotals by seat and class. `finish` leaves the percentage null
+   when the OpenAI denominator has unknown usage or any rejection came from an
+   unexpected provider; report the listed unavailability reasons rather than
+   deriving a percentage. Compare known-class rates only with a stable
+   denominator, such as rejected attempts per seat attempt and affected
    model-generating commands per eligible command. Any current-run
    `seat=skald_writer` rejection is the #639 tripwire: verify and publish the
    recurrence on that issue, reopening it when permitted, with the required
@@ -243,20 +250,23 @@ Always complete teardown, including early exits:
    incubator state, active generation leases, and Orrery queue counts. Require
    current migrations, zero active leases, empty narration/maturation queues,
    coherent foreign keys/invariants, and a successful final public load.
-7. Dump a qualifying database first to a `.partial` path, checksum it, inspect
-   it with `pg_restore --list`, restore it into a uniquely named disposable
-   verification database, and repeat the invariant/count checks there. Drop
-   only that verification database. Then atomically promote the file to
-   `.dump`, write an adjacent manifest containing the measured counts, source
-   archive/commit, migration, model, known-issue hotspots, and sha256, and retain
-   the prior seed. Use unambiguous filename fields such as `42chunks_40ex`; do
-   not infer exchange count from chunk count. If any qualification fails, do
-   not promote the seed—preserve the slot and report why.
+7. Dump a qualifying database first to a `.partial` path under
+   `temp/qa_seeds/`, checksum it, inspect it with `pg_restore --list`, restore
+   it into a uniquely named disposable verification database, and repeat the
+   invariant/count checks there. Drop only that verification database. Then
+   atomically promote the file to a `.dump` in `temp/qa_seeds/`, write an
+   adjacent manifest containing the measured counts, source archive/commit,
+   migration, model, known-issue hotspots, and sha256, and retain the prior
+   seed. Use unambiguous filename fields such as `42chunks_40ex`; do not infer
+   exchange count from chunk count. If any qualification fails, do not promote
+   the seed—preserve the slot and report why.
 8. Complete `mission_report.md` with checkout and suite baseline, slot
    initialization (seed dump path and sha256, or fresh reset), issue links,
    probe-family negative results and coverage gates, rejection classification,
    evidence inventory, start/end/delta/max usage and repair tax, seed-promotion
-   disposition, exit condition, and final lane/slot disposition.
+   disposition, exit condition, and final lane/slot disposition. Replace the
+   report's `Status: in progress` line with `Status: completed — CONDITION`,
+   using the same truthful exit condition supplied to `finish`.
 9. Return a concise scheduled-task result with the report path and issue links.
 
 The report is mandatory even if zero issues are published.

--- a/scripts/qa_shift/mission_prompt.md
+++ b/scripts/qa_shift/mission_prompt.md
@@ -20,9 +20,11 @@ Publish up to the configured verified-issue budget, stopping at the first of:
 The issue budget is a ceiling, not pressure to invent findings. The dry well is
 the co-primary completion rule: it requires the configured number of
 consecutive, distinct probe families with no promotable finding, and it cannot
-fire until the configured minimum number of families has been completed. A
-published issue resets the dry-well streak. An unresolved anomaly is neither a
-finding nor a dry family; resolve it or report it as a blocker.
+fire until the configured minimum number of families and the applicable
+coverage gates below have been completed. Every current-run structured-output
+rejection must also be classified before the run can end dry. A published issue
+resets the dry-well streak. An unresolved anomaly is neither a finding nor a dry
+family; resolve it or report it as a blocker.
 
 Read `scripts/qa_shift/qa_shift.toml` for the authoritative slot, lane, model,
 issue, dry-well, wall-clock, and token settings.
@@ -55,7 +57,13 @@ issue, dry-well, wall-clock, and token settings.
    is unavailable or invalid, use the connected GitHub app for those reads and
    for issue publication instead. A working connected app satisfies this
    preflight requirement.
-4. Run:
+4. Read `probe_ledger.md` and `mission_report.md` from the two most recent
+   completed `temp/qa_night_*` archives. Add their family coverage to the new
+   run's coverage matrix, including public surface, state transition, seed
+   depth, and outcome. A previously dry family may count again only for a new
+   surface, state transition, or deeper campaign boundary, or as an explicit
+   regression tied to code that changed since that run.
+5. Run:
 
    ```text
    poetry run python scripts/qa_shift/qa_shift.py config
@@ -66,10 +74,10 @@ issue, dry-well, wall-clock, and token settings.
    `runtime_env.sh`, the isolated `nexus.qa.toml`, a probe ledger, report
    template, usage baseline, and shift state. Source `runtime_env.sh` in every
    later runtime/QA shell.
-5. Run the default pytest suite against the checked-in config (explicitly
+6. Run the default pytest suite against the checked-in config (explicitly
    without `NEXUS_RUNTIME_CONFIG`) and save its complete output in the archive.
    A baseline failure is a candidate, not permission to patch it.
-6. Stop only the isolated QA lane if it is stale. Back up `save_04` with
+7. Stop only the isolated QA lane if it is stale. Back up `save_04` with
    `pg_dump -Fc` and checksum the dump. Then initialize the slot:
    - If `temp/qa_seeds/` holds at least one `.dump` file, seed from the newest
      instead of a bare reset: drop and recreate only the configured slot
@@ -85,8 +93,11 @@ issue, dry-well, wall-clock, and token settings.
    - Otherwise reset only the configured slot through
      `scripts/new_story_setup.py --force`.
 
-   Start the isolated gateway and verify its health and effective model. Save
-   the commands and outputs.
+   Before starting the isolated gateway, record the source log's byte offset
+   (zero if it does not yet exist). Start the gateway, record its PID and UTC
+   startup time, and verify its health and effective model. Save the commands
+   and outputs. These markers define the current-run log slice; persistent
+   gateway logs can contain earlier shifts and must not be mined as one run.
 
 If any preflight step fails, write the blocker into the mission report, perform
 the applicable teardown, and stop.
@@ -101,11 +112,15 @@ command that can call a remote model:
    before the command.
 2. If its status is not `continue`, make no remote request.
 3. Run one public CLI/API command, explicitly selecting the configured model
-   wherever the surface accepts a model override.
+   wherever the surface accepts a model override. The sole exception is a
+   bounded concurrency family: launch at most two public requests from one
+   recorded shell invocation and wait for both to settle.
 4. Run
    `poetry run python scripts/qa_shift/qa_shift.py check ARCHIVE --expect-call`
    immediately afterward.
-5. Record the returned per-command delta in the probe ledger.
+5. Record the returned per-command delta in the probe ledger. For a bounded
+   concurrency family, record both public responses and treat the complete
+   post-check delta as one request-group delta.
 
 The post-call check fails closed when no matching slot/model event appears,
 when routing leaves the configured provider/model, when any OpenAI response has
@@ -116,12 +131,24 @@ not an organization-wide Platform meter. Count any known non-NEXUS API usage
 against the configured limit before starting. Read-only commands that cannot
 call a model do not need an `--expect-call` check.
 
+Never detach a request or restart/kill the gateway while a provider response is
+unaccounted for. Gateway-restart interruption probes may run only between
+settled operations until the provider ledger can prove usage across process
+termination. If a concurrency group cannot be reconciled exactly, stop under
+the existing unknown-usage rule rather than estimating around it.
+
 ## Probe-family standard
 
 Behave like an unhinged, unpredictable, but honest user. Vary malformed,
 contradictory, free-text, adversarial, concurrency, undo/regenerate, and
 continuity-sensitive inputs. A probe family is distinct only when it tests a
 different public contract or state transition, not a cosmetic prompt variant.
+
+Use the two-run coverage matrix to choose families. A dry family from either
+recent run does not count toward the current dry-well streak unless it adds a
+new public surface, state transition, seed/depth boundary, or a regression tied
+to a relevant change. Prefer the least-recently exercised coverage over prompt
+variants of recent dry families.
 
 Rotate depth as well as surface. When the slot was seeded from a mid-campaign
 dump, at least two completed probe families must target deep-state mechanics:
@@ -133,14 +160,38 @@ fill the whole roster when depth is available; the 2026-07-30 shift ran dry
 on shallow families the same night a deep campaign on the same commit hit two
 commit-path defects.
 
+Before a seeded run may end dry, it must also complete both of these coverage
+gates:
+
+- one roster-transition family that persists a genuinely new named character
+  or faction and crosses an observed arrival, departure, handoff, or scene-cast
+  boundary, exercising `new_entities` and commit-time identity handling; and
+- one bounded concurrency family, such as double submission of the same choice,
+  a second continue racing an in-flight incubation, or generation-lease
+  contention, using the exact request-group usage protocol above.
+
+If an input does not actually produce the intended roster transition, the
+family is incomplete rather than dry. Do not promote ordinary model
+nondeterminism as a defect. A mid-incubation process kill is not a substitute
+for the bounded concurrency gate while it would make usage unprovable.
+
 For every family:
 
 - exercise the public CLI/API and at least one adversarial variant;
 - inspect PostgreSQL and the isolated gateway log for the resulting state;
 - record negative results as well as anomalies in `probe_ledger.md`;
 - compare against all existing issues, open or closed, and relevant recent PRs;
+- treat a recovered structured-output rejection as a cost/latency anomaly and
+  retain its exact validation evidence; and
 - do not promote model taste, expected nondeterminism, or an unreproduced
   oddity.
+
+A previously unknown rejection class is a finding candidate even if a later
+attempt succeeds, but it does not waive the publication standard below: obtain
+a repeatable public reproduction or deterministic contract evidence before
+filing. A recurrence of a known class is not a new issue; report its rate using
+the same denominator as the prior run and add evidence to the existing issue
+only when the change is material and deduplicated.
 
 A publishable issue requires:
 
@@ -163,17 +214,49 @@ publication succeeds.
 
 Always complete teardown, including early exits:
 
-1. Copy the isolated gateway log into the archive before stopping that lane.
+1. Capture one final read-only public load/state response and copy the isolated
+   gateway log into the archive before stopping that lane.
 2. Stop only the configured QA gateway. Do not restore the disposable slot
    automatically; preserve its final state for follow-up and retain the
    checksummed pre-shift dump.
 3. Run
    `poetry run python scripts/qa_shift/qa_shift.py finish ARCHIVE
    --exit-condition CONDITION`, selecting the truthful configured condition.
-4. Complete `mission_report.md` with checkout and suite baseline, slot
+4. Mine the current run's structured-output rejection ledger. `finish` writes
+   `rejection_ledger.json` from the authoritative `usage_start.json` to
+   `usage_end.json` event delta. Use only the gateway-log slice after the
+   recorded byte/PID/time boundary to add validation details. For every
+   `outcome=rejected_validation` event, record family/command, timestamp, exact
+   seat, attempt, token cost, validation class, matching issue, and disposition
+   in `probe_ledger.md`. Never count older lines copied into the persistent log.
+5. Report total rejected-attempt tokens and percentage as the shift's repair
+   tax, with subtotals by seat and class. Compare known-class rates only with a
+   stable denominator, such as rejected attempts per seat attempt and affected
+   model-generating commands per eligible command. Any current-run
+   `seat=skald_writer` rejection is the #639 tripwire: verify and publish the
+   recurrence on that issue, reopening it when permitted, with the required
+   Codex/model signature.
+6. If and only if a seeded run ended `dry_well`, usage is trustworthy, and no
+   anomaly remains unresolved, qualify the preserved final state for seed
+   promotion. Record the current migration, model/slot, committed chunks,
+   correspondence letters/exchanges and visible tail, digest versions,
+   incubator state, active generation leases, and Orrery queue counts. Require
+   current migrations, zero active leases, empty narration/maturation queues,
+   coherent foreign keys/invariants, and a successful final public load.
+7. Dump a qualifying database first to a `.partial` path, checksum it, inspect
+   it with `pg_restore --list`, restore it into a uniquely named disposable
+   verification database, and repeat the invariant/count checks there. Drop
+   only that verification database. Then atomically promote the file to
+   `.dump`, write an adjacent manifest containing the measured counts, source
+   archive/commit, migration, model, known-issue hotspots, and sha256, and retain
+   the prior seed. Use unambiguous filename fields such as `42chunks_40ex`; do
+   not infer exchange count from chunk count. If any qualification fails, do
+   not promote the seed—preserve the slot and report why.
+8. Complete `mission_report.md` with checkout and suite baseline, slot
    initialization (seed dump path and sha256, or fresh reset), issue links,
-   probe-family negative results, evidence inventory, start/end/delta/max
-   usage, exit condition, and final lane/slot disposition.
-5. Return a concise scheduled-task result with the report path and issue links.
+   probe-family negative results and coverage gates, rejection classification,
+   evidence inventory, start/end/delta/max usage and repair tax, seed-promotion
+   disposition, exit condition, and final lane/slot disposition.
+9. Return a concise scheduled-task result with the report path and issue links.
 
 The report is mandatory even if zero issues are published.

--- a/scripts/qa_shift/mission_report_template.md
+++ b/scripts/qa_shift/mission_report_template.md
@@ -7,7 +7,9 @@ Status: in progress.
 - Checkout:
 - Default suite:
 - GitHub issue/PR preflight:
+- Two-run coverage sources:
 - Isolated lane:
+- Gateway log boundary:
 - Pre-shift backup and checksum:
 - Usage at start:
 
@@ -19,10 +21,22 @@ None yet.
 
 Summarize both failures and negative results from `probe_ledger.md`.
 
+- Roster-transition coverage gate:
+- Bounded-concurrency coverage gate:
+
+## Structured-output rejections
+
+- Current-run rejected attempts:
+- Classification and issue matches:
+- Stable-rate comparison:
+- `skald_writer` #639 tripwire:
+
 ## Preserved evidence
 
 - `gateway-8012.log`:
+- `rejection_ledger.json`:
 - `save_04_before.dump`:
+- Promoted seed and manifest:
 - Additional payloads/traces:
 
 ## Usage
@@ -32,6 +46,8 @@ Summarize both failures and negative results from `probe_ledger.md`.
 - End daily total:
 - Shift delta:
 - Largest model-generating command delta:
+- Repair tax (rejected-attempt tokens and percentage):
+- Repair tax by seat/class:
 - Unknown-usage events:
 
 ## Exit
@@ -40,4 +56,6 @@ Summarize both failures and negative results from `probe_ledger.md`.
 - Issue count:
 - Completed probe families:
 - Final dry-well streak:
+- Coverage-gate disposition:
+- Seed-promotion disposition:
 - Slot/gateway disposition:

--- a/scripts/qa_shift/mission_report_template.md
+++ b/scripts/qa_shift/mission_report_template.md
@@ -1,6 +1,6 @@
 # NEXUS Night QA — mission report
 
-Status: in progress.
+Status: in progress. Replace with `completed — EXIT_CONDITION` during teardown.
 
 ## Baseline
 
@@ -47,6 +47,7 @@ Summarize both failures and negative results from `probe_ledger.md`.
 - Shift delta:
 - Largest model-generating command delta:
 - Repair tax (rejected-attempt tokens and percentage):
+- Repair-tax percentage unavailability reasons:
 - Repair tax by seat/class:
 - Unknown-usage events:
 

--- a/scripts/qa_shift/probe_ledger_template.md
+++ b/scripts/qa_shift/probe_ledger_template.md
@@ -3,5 +3,26 @@
 The dry-well streak counts only completed, distinct probe families. An
 unresolved anomaly is not a dry family.
 
+## Recent coverage
+
+| Run | Probe family | Public surface / state transition | Seed depth | Outcome | New axis or regression reason |
+|---|---|---|---|---|---|
+
+## Current probe families
+
 | # | Probe family | Public surface and adversarial variants | DB/log verification | Outcome | Issue |
 |---|---|---|---|---|---|
+
+## Structured-output rejection ledger
+
+Use the current-run usage delta as the authoritative event set and the bounded
+gateway-log slice for validation details.
+
+| Timestamp | Family / command | Seat | Attempt | Rejected tokens | Validation class | Existing issue | Disposition |
+|---|---|---|---|---|---|---|---|
+
+- Repair tax:
+- Repair-tax percentage:
+- By-seat and by-class subtotals:
+- Stable-rate comparison:
+- `skald_writer` #639 tripwire:

--- a/scripts/qa_shift/qa_shift.py
+++ b/scripts/qa_shift/qa_shift.py
@@ -185,6 +185,110 @@ def _usage_snapshot(payload: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _rejection_ledger(
+    *,
+    state: Mapping[str, Any],
+    usage: Mapping[str, Any],
+    shift_openai_total: int,
+) -> dict[str, Any]:
+    """Summarize current-run rejected attempts from the exact usage delta."""
+
+    baseline_event_count = int(state["baseline_event_count"])
+    events = usage["events"]
+    if len(events) < baseline_event_count:
+        raise ShiftError(
+            "Final usage event count is smaller than the shift baseline; "
+            "the rejection ledger cannot be trusted."
+        )
+
+    current_events = [
+        event for event in events[baseline_event_count:] if isinstance(event, dict)
+    ]
+    slot = int(state["config"]["slot"])
+    qa_events = [event for event in current_events if event.get("slot") == slot]
+    rejected_events = [
+        event for event in qa_events if event.get("outcome") == "rejected_validation"
+    ]
+
+    rejection_rows: list[dict[str, Any]] = []
+    by_seat: dict[str, dict[str, Any]] = {}
+    rejected_tokens = 0
+    unknown_token_events = 0
+    for event in rejected_events:
+        raw_tokens = event.get("total_tokens")
+        tokens = (
+            raw_tokens
+            if isinstance(raw_tokens, int) and not isinstance(raw_tokens, bool)
+            else None
+        )
+        if tokens is None:
+            unknown_token_events += 1
+        else:
+            rejected_tokens += tokens
+
+        seat = str(event.get("seat") or "unknown")
+        seat_summary = by_seat.setdefault(
+            seat,
+            {"attempts": 0, "tokens": 0, "unknown_token_events": 0},
+        )
+        seat_summary["attempts"] += 1
+        if tokens is None:
+            seat_summary["unknown_token_events"] += 1
+        else:
+            seat_summary["tokens"] += tokens
+
+        rejection_rows.append(
+            {
+                key: event.get(key)
+                for key in (
+                    "ts",
+                    "request_id",
+                    "run_id",
+                    "seat",
+                    "provider",
+                    "model",
+                    "attempt",
+                    "total_tokens",
+                )
+            }
+        )
+
+    exact_rejected_tokens: int | None = (
+        rejected_tokens if unknown_token_events == 0 else None
+    )
+    repair_tax_percent: float | None
+    if exact_rejected_tokens is None:
+        repair_tax_percent = None
+    elif shift_openai_total == 0:
+        repair_tax_percent = 0.0
+    else:
+        repair_tax_percent = round(
+            exact_rejected_tokens * 100 / shift_openai_total,
+            4,
+        )
+
+    return {
+        "quota_day": usage["day"],
+        "baseline_event_count": baseline_event_count,
+        "final_event_count": len(events),
+        "current_run_events": len(current_events),
+        "qa_slot": slot,
+        "qa_events": len(qa_events),
+        "rejected_attempts": len(rejected_events),
+        "rejected_tokens": exact_rejected_tokens,
+        "unknown_rejected_token_events": unknown_token_events,
+        "repair_tax_percent_of_shift": repair_tax_percent,
+        "shift_openai_total": shift_openai_total,
+        "by_seat": [
+            {"seat": seat, **summary} for seat, summary in sorted(by_seat.items())
+        ],
+        "skald_writer_tripwire": any(
+            event.get("seat") == "skald_writer" for event in rejected_events
+        ),
+        "rejections": rejection_rows,
+    }
+
+
 def _utc_text(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
@@ -586,6 +690,13 @@ def finish_shift(
     _atomic_write_json(archive / "usage_end.json", usage_payload)
 
     final_delta = max(0, usage["total"] - int(state["last_total"]))
+    shift_openai_total = max(0, usage["total"] - int(state["baseline_total"]))
+    rejection_ledger = _rejection_ledger(
+        state=state,
+        usage=usage,
+        shift_openai_total=shift_openai_total,
+    )
+    _atomic_write_json(archive / "rejection_ledger.json", rejection_ledger)
     final_state = dict(state)
     final_state.update(
         {
@@ -598,8 +709,12 @@ def finish_shift(
             "finished_after_quota_rollover": (
                 current_time.astimezone(timezone.utc).date().isoformat() != quota_day
             ),
-            "shift_openai_total": max(0, usage["total"] - int(state["baseline_total"])),
+            "shift_openai_total": shift_openai_total,
             "max_command_delta": max(int(state["max_command_delta"]), final_delta),
+            "rejected_attempts": rejection_ledger["rejected_attempts"],
+            "repair_tax_tokens": rejection_ledger["rejected_tokens"],
+            "repair_tax_percent": rejection_ledger["repair_tax_percent_of_shift"],
+            "skald_writer_tripwire": rejection_ledger["skald_writer_tripwire"],
         }
     )
     _atomic_write_json(archive / STATE_FILE, final_state)
@@ -611,6 +726,11 @@ def finish_shift(
         "shift_openai_total": final_state["shift_openai_total"],
         "max_command_delta": final_state["max_command_delta"],
         "unknown_usage_events": usage["unknown"],
+        "rejected_attempts": rejection_ledger["rejected_attempts"],
+        "repair_tax_tokens": rejection_ledger["rejected_tokens"],
+        "repair_tax_percent": rejection_ledger["repair_tax_percent_of_shift"],
+        "skald_writer_tripwire": rejection_ledger["skald_writer_tripwire"],
+        "rejection_ledger": str(archive / "rejection_ledger.json"),
         "archive": str(archive),
     }
     _append_jsonl(

--- a/scripts/qa_shift/qa_shift.py
+++ b/scripts/qa_shift/qa_shift.py
@@ -256,9 +256,32 @@ def _rejection_ledger(
     exact_rejected_tokens: int | None = (
         rejected_tokens if unknown_token_events == 0 else None
     )
-    repair_tax_percent: float | None
+    unexpected_rejection_providers = sorted(
+        {
+            str(event.get("provider") or "unknown")
+            for event in rejected_events
+            if event.get("provider") != "openai"
+        }
+    )
+    percent_unavailable_reasons: list[str] = []
     if exact_rejected_tokens is None:
+        percent_unavailable_reasons.append("unknown_rejected_attempt_tokens")
+    if int(usage["unknown"]) > 0:
+        percent_unavailable_reasons.append("unknown_openai_usage")
+    if unexpected_rejection_providers:
+        percent_unavailable_reasons.append("unexpected_rejection_provider")
+    if (
+        exact_rejected_tokens is not None
+        and exact_rejected_tokens > 0
+        and shift_openai_total == 0
+    ):
+        percent_unavailable_reasons.append("zero_openai_denominator")
+
+    repair_tax_percent: float | None
+    if percent_unavailable_reasons:
         repair_tax_percent = None
+    elif exact_rejected_tokens is None:
+        raise AssertionError("exact token total missing without an unavailable reason")
     elif shift_openai_total == 0:
         repair_tax_percent = 0.0
     else:
@@ -278,6 +301,8 @@ def _rejection_ledger(
         "rejected_tokens": exact_rejected_tokens,
         "unknown_rejected_token_events": unknown_token_events,
         "repair_tax_percent_of_shift": repair_tax_percent,
+        "repair_tax_percent_unavailable_reasons": percent_unavailable_reasons,
+        "unexpected_rejection_providers": unexpected_rejection_providers,
         "shift_openai_total": shift_openai_total,
         "by_seat": [
             {"seat": seat, **summary} for seat, summary in sorted(by_seat.items())
@@ -714,6 +739,9 @@ def finish_shift(
             "rejected_attempts": rejection_ledger["rejected_attempts"],
             "repair_tax_tokens": rejection_ledger["rejected_tokens"],
             "repair_tax_percent": rejection_ledger["repair_tax_percent_of_shift"],
+            "repair_tax_percent_unavailable_reasons": rejection_ledger[
+                "repair_tax_percent_unavailable_reasons"
+            ],
             "skald_writer_tripwire": rejection_ledger["skald_writer_tripwire"],
         }
     )
@@ -729,6 +757,9 @@ def finish_shift(
         "rejected_attempts": rejection_ledger["rejected_attempts"],
         "repair_tax_tokens": rejection_ledger["rejected_tokens"],
         "repair_tax_percent": rejection_ledger["repair_tax_percent_of_shift"],
+        "repair_tax_percent_unavailable_reasons": rejection_ledger[
+            "repair_tax_percent_unavailable_reasons"
+        ],
         "skald_writer_tripwire": rejection_ledger["skald_writer_tripwire"],
         "rejection_ledger": str(archive / "rejection_ledger.json"),
         "archive": str(archive),

--- a/tests/test_qa_shift.py
+++ b/tests/test_qa_shift.py
@@ -134,6 +134,14 @@ def test_begin_creates_archive_and_pins_every_openai_role(
     assert (archive / "runtime_env.sh").exists()
     assert (archive / "probe_ledger.md").exists()
     assert (archive / "mission_report.md").exists()
+    ledger = (archive / "probe_ledger.md").read_text()
+    report = (archive / "mission_report.md").read_text()
+    assert "## Recent coverage" in ledger
+    assert "## Structured-output rejection ledger" in ledger
+    assert "Repair tax" in ledger
+    assert "## Structured-output rejections" in report
+    assert "Repair tax" in report
+    assert "Seed-promotion disposition" in report
 
 
 def test_generated_runtime_environment_selects_qa_config(
@@ -409,10 +417,85 @@ def test_check_and_finish_persist_end_to_end_tally(tmp_path: Path) -> None:
     assert state["status"] == "finished"
     assert state["exit_condition"] == "dry_well"
     assert (archive / "usage_end.json").exists()
+    assert (archive / "rejection_ledger.json").exists()
+    assert finish["rejected_attempts"] == 0
+    assert finish["repair_tax_tokens"] == 0
+    assert finish["repair_tax_percent"] == 0.0
+    assert finish["skald_writer_tripwire"] is False
     assert [entry["kind"] for entry in checks] == [
         "begin",
         "post_call",
         "finish",
+    ]
+
+
+def test_finish_persists_exact_repair_tax_and_writer_tripwire(
+    tmp_path: Path,
+) -> None:
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+    historical_rejection = {
+        **_event(total=999),
+        "seat": "gaia",
+        "outcome": "rejected_validation",
+        "request_id": "resp-before-shift",
+    }
+    begin = qa_shift.begin_shift(
+        config=config,
+        usage_reader=lambda _root, _day: _usage(
+            total=100,
+            events=[historical_rejection],
+        ),
+        now=NOW,
+    )
+    archive = Path(begin["archive"])
+    writer_rejection = {
+        **_event(total=75),
+        "seat": "skald_writer",
+        "outcome": "rejected_validation",
+        "request_id": "resp-rejected",
+    }
+    accepted_retry = {
+        **_event(total=225),
+        "seat": "skald_writer",
+        "attempt": 2,
+        "request_id": "resp-accepted",
+    }
+
+    finish = qa_shift.finish_shift(
+        archive=archive,
+        exit_condition="dry_well",
+        usage_reader=lambda _root, _day: _usage(
+            total=400,
+            events=[historical_rejection, writer_rejection, accepted_retry],
+        ),
+        now=NOW + timedelta(minutes=2),
+    )
+    ledger = json.loads((archive / "rejection_ledger.json").read_text())
+
+    assert finish["shift_openai_total"] == 300
+    assert finish["rejected_attempts"] == 1
+    assert finish["repair_tax_tokens"] == 75
+    assert finish["repair_tax_percent"] == 25.0
+    assert finish["skald_writer_tripwire"] is True
+    assert ledger["by_seat"] == [
+        {
+            "attempts": 1,
+            "seat": "skald_writer",
+            "tokens": 75,
+            "unknown_token_events": 0,
+        }
+    ]
+    assert ledger["rejections"] == [
+        {
+            "attempt": 1,
+            "model": "gpt-5.6-terra",
+            "provider": "openai",
+            "request_id": "resp-rejected",
+            "run_id": "run-one",
+            "seat": "skald_writer",
+            "total_tokens": 75,
+            "ts": "2026-07-30T04:31:00Z",
+        }
     ]
 
 

--- a/tests/test_qa_shift.py
+++ b/tests/test_qa_shift.py
@@ -421,6 +421,7 @@ def test_check_and_finish_persist_end_to_end_tally(tmp_path: Path) -> None:
     assert finish["rejected_attempts"] == 0
     assert finish["repair_tax_tokens"] == 0
     assert finish["repair_tax_percent"] == 0.0
+    assert finish["repair_tax_percent_unavailable_reasons"] == []
     assert finish["skald_writer_tripwire"] is False
     assert [entry["kind"] for entry in checks] == [
         "begin",
@@ -476,6 +477,7 @@ def test_finish_persists_exact_repair_tax_and_writer_tripwire(
     assert finish["rejected_attempts"] == 1
     assert finish["repair_tax_tokens"] == 75
     assert finish["repair_tax_percent"] == 25.0
+    assert finish["repair_tax_percent_unavailable_reasons"] == []
     assert finish["skald_writer_tripwire"] is True
     assert ledger["by_seat"] == [
         {
@@ -497,6 +499,50 @@ def test_finish_persists_exact_repair_tax_and_writer_tripwire(
             "ts": "2026-07-30T04:31:00Z",
         }
     ]
+
+
+@pytest.mark.parametrize(
+    ("provider", "unknown_usage", "reason"),
+    (
+        ("anthropic", 0, "unexpected_rejection_provider"),
+        ("openai", 1, "unknown_openai_usage"),
+    ),
+)
+def test_finish_withholds_repair_tax_percent_for_untrusted_denominator(
+    tmp_path: Path,
+    provider: str,
+    unknown_usage: int,
+    reason: str,
+) -> None:
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+    begin = qa_shift.begin_shift(
+        config=config,
+        usage_reader=lambda _root, _day: _usage(total=100),
+        now=NOW,
+    )
+    archive = Path(begin["archive"])
+    rejection = {
+        **_event(total=50, provider=provider),
+        "outcome": "rejected_validation",
+    }
+
+    finish = qa_shift.finish_shift(
+        archive=archive,
+        exit_condition="blocked",
+        usage_reader=lambda _root, _day: _usage(
+            total=150,
+            unknown=unknown_usage,
+            events=[rejection],
+        ),
+        now=NOW + timedelta(minutes=2),
+    )
+    ledger = json.loads((archive / "rejection_ledger.json").read_text())
+
+    assert finish["repair_tax_tokens"] == 50
+    assert finish["repair_tax_percent"] is None
+    assert finish["repair_tax_percent_unavailable_reasons"] == [reason]
+    assert ledger["repair_tax_percent_of_shift"] is None
+    assert ledger["repair_tax_percent_unavailable_reasons"] == [reason]
 
 
 def test_finish_reads_original_quota_day_after_rollover(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- gate seeded dry wells on two-run novelty, a real roster transition, bounded concurrency, and classification of every current-run structured-output rejection
- make `qa_shift.py finish` emit an exact `rejection_ledger.json` with repair-tax totals, seat subtotals, and the `skald_writer` tripwire
- expand the probe/report templates and runbook with stable rate comparisons and qualified, restore-tested seed progression

## Why

Two consecutive dry runs hid a worsening structured-output repair tax. The latest run spent 94,495 of 313,800 tokens (30.11%) on rejected attempts even though every public turn eventually succeeded. The old charter also allowed recent dry families to converge and treated seed progression informally.

## Validation

- `poetry run pytest` — 2,122 passed, 482 skipped
- `poetry run pytest tests/test_qa_shift.py -q` — 14 passed
- `poetry run black --check scripts/qa_shift/qa_shift.py tests/test_qa_shift.py`
- `poetry run flake8 scripts/qa_shift/qa_shift.py tests/test_qa_shift.py`
- `poetry run mypy scripts/qa_shift/qa_shift.py`
- replayed the summarizer against both real QA archives: 65,721 rejected tokens (19.47%) and 94,495 (30.11%)

## Data and configuration impact

No database schema or tracked configuration changes. `finish` adds one structured evidence artifact to future ignored run archives. The newly qualified local seed is ignored and is not part of this PR.

Codex — GPT-5