### PR TITLE
Normalize Already-Active Extend-Expiry Re-Asserts at the Validated Boundary

### DIFF
--- a/nexus/agents/logon/orrery_tag_validation.py
+++ b/nexus/agents/logon/orrery_tag_validation.py
@@ -530,6 +530,172 @@ def _row_value(row: Any, key: str, index: int) -> Any:
     return row[index]
 
 
+@dataclass(frozen=True)
+class _ExtendExpiryCandidate:
+    """One wire-list entry eligible for active-state normalization."""
+
+    ordinal: int
+    entity_kind: str
+    update: Any
+    tags_add: List[str]
+    tag_index: int
+    wire_id: Optional[int]
+    wire_name: str
+    tag: str
+
+
+def normalize_extend_expiry_reasserts(
+    response: Any,
+    cur: Any,
+    *,
+    vocabulary: StorytellerVocabulary,
+) -> int:
+    """Remove already-active ``extend_expiry`` tags from wire update deltas."""
+
+    updates = getattr(response, "updates", None)
+    if updates is None:
+        return 0
+
+    candidates: List[_ExtendExpiryCandidate] = []
+    for array_name, entity_kind in (
+        ("characters", "character"),
+        ("places", "place"),
+        ("factions", "faction"),
+    ):
+        policies = vocabulary.tag_reapplication_policies_by_kind.get(entity_kind, {})
+        for update in getattr(updates, array_name, []) or []:
+            tags_add = getattr(update, "tags_add", None)
+            if not tags_add:
+                continue
+            for tag_index, tag in enumerate(tags_add):
+                if policies.get(tag) != "extend_expiry":
+                    continue
+                candidates.append(
+                    _ExtendExpiryCandidate(
+                        ordinal=len(candidates),
+                        entity_kind=entity_kind,
+                        update=update,
+                        tags_add=tags_add,
+                        tag_index=tag_index,
+                        wire_id=getattr(update, "id", None),
+                        wire_name=str(getattr(update, "name", "")),
+                        tag=tag,
+                    )
+                )
+
+    if not candidates:
+        return 0
+
+    cur.execute(
+        """
+        WITH candidates AS (
+            SELECT *
+            FROM UNNEST(
+                %s::integer[],
+                %s::text[],
+                %s::bigint[],
+                %s::text[],
+                %s::text[]
+            ) AS candidate(ordinal, entity_kind, wire_id, wire_name, tag)
+        ),
+        canonical_entities AS (
+            SELECT
+                'character'::text AS entity_kind,
+                id AS wire_id,
+                entity_id,
+                name::text AS canonical_name
+            FROM characters
+            UNION ALL
+            SELECT
+                'place'::text AS entity_kind,
+                id AS wire_id,
+                entity_id,
+                name::text AS canonical_name
+            FROM places
+            UNION ALL
+            SELECT
+                'faction'::text AS entity_kind,
+                id AS wire_id,
+                entity_id,
+                name::text AS canonical_name
+            FROM factions
+        )
+        SELECT
+            candidate.ordinal,
+            canonical.canonical_name,
+            (current_tag.entity_id IS NOT NULL) AS is_active
+        FROM candidates candidate
+        JOIN canonical_entities canonical
+          ON canonical.entity_kind = candidate.entity_kind
+         AND (
+             (
+                 candidate.wire_id IS NOT NULL
+                 AND canonical.wire_id = candidate.wire_id
+             )
+             OR (
+                 candidate.wire_id IS NULL
+                 AND canonical.canonical_name = candidate.wire_name
+             )
+         )
+        JOIN entities entity
+          ON entity.id = canonical.entity_id
+         AND entity.kind::text = candidate.entity_kind
+        LEFT JOIN entity_tags_current current_tag
+          ON current_tag.entity_id = entity.id
+         AND current_tag.tag = candidate.tag
+        ORDER BY candidate.ordinal
+        """,
+        (
+            [candidate.ordinal for candidate in candidates],
+            [candidate.entity_kind for candidate in candidates],
+            [candidate.wire_id for candidate in candidates],
+            [candidate.wire_name for candidate in candidates],
+            [candidate.tag for candidate in candidates],
+        ),
+    )
+    matches_by_ordinal: dict[int, List[Tuple[str, bool]]] = {}
+    for row in cur.fetchall():
+        ordinal = int(_row_value(row, "ordinal", 0))
+        matches_by_ordinal.setdefault(ordinal, []).append(
+            (
+                str(_row_value(row, "canonical_name", 1)),
+                bool(_row_value(row, "is_active", 2)),
+            )
+        )
+
+    removals_by_update: dict[int, Tuple[Any, List[str], set[int]]] = {}
+    normalized = 0
+    for candidate in candidates:
+        matches = matches_by_ordinal.get(candidate.ordinal, [])
+        if len(matches) != 1 or not matches[0][1]:
+            continue
+        canonical_name = matches[0][0]
+        update_key = id(candidate.update)
+        if update_key not in removals_by_update:
+            removals_by_update[update_key] = (
+                candidate.update,
+                candidate.tags_add,
+                set(),
+            )
+        removals_by_update[update_key][2].add(candidate.tag_index)
+        logger.warning(
+            "extend-expiry re-assert normalized " "entity_kind=%s entity=%s tag=%s",
+            candidate.entity_kind,
+            canonical_name,
+            candidate.tag,
+        )
+        normalized += 1
+
+    for update, tags_add, removal_indexes in removals_by_update.values():
+        tags_add[:] = [
+            tag for index, tag in enumerate(tags_add) if index not in removal_indexes
+        ]
+        if not tags_add:
+            update.tags_add = None
+
+    return normalized
+
+
 def _annotate_declaration_issues(
     issues: List[str],
     declarations: Any,
@@ -723,6 +889,11 @@ def build_storyteller_tag_validator(
         vocabulary = read_storyteller_vocabulary(dbname)
         with get_connection(dbname) as conn:
             with conn.cursor() as cur:
+                normalize_extend_expiry_reasserts(
+                    output,
+                    cur,
+                    vocabulary=vocabulary,
+                )
                 issues = collect_orrery_tag_issues(
                     output,
                     cur,

--- a/nexus/agents/logon/orrery_tag_validation.py
+++ b/nexus/agents/logon/orrery_tag_validation.py
@@ -544,6 +544,42 @@ class _ExtendExpiryCandidate:
     tag: str
 
 
+_SUBSTANTIVE_UPDATE_PREDICATES: Mapping[str, Callable[[Any], bool]] = {
+    "character": lambda update: any(
+        (
+            update.activity,
+            update.location is not None,
+            update.emotional_state,
+            update.observations,
+            update.tags_add,
+            update.tags_clear,
+        )
+    ),
+    "place": lambda update: any(
+        (
+            update.condition,
+            update.notable_change,
+            update.tags_add,
+            update.tags_clear,
+        )
+    ),
+    "faction": lambda update: any(
+        (
+            update.action,
+            update.stance_toward and update.stance,
+            update.tags_add,
+            update.tags_clear,
+        )
+    ),
+}
+
+
+def _has_substantive_update(entity_kind: str, update: Any) -> bool:
+    """Mirror the per-kind wire validator's substantive-update predicate."""
+
+    return _SUBSTANTIVE_UPDATE_PREDICATES[entity_kind](update)
+
+
 def normalize_extend_expiry_reasserts(
     response: Any,
     cur: Any,
@@ -557,13 +593,18 @@ def normalize_extend_expiry_reasserts(
         return 0
 
     candidates: List[_ExtendExpiryCandidate] = []
+    update_lists_by_kind: dict[str, List[Any]] = {}
     for array_name, entity_kind in (
         ("characters", "character"),
         ("places", "place"),
         ("factions", "faction"),
     ):
+        update_list = getattr(updates, array_name, None)
+        if update_list is None:
+            continue
+        update_lists_by_kind[entity_kind] = update_list
         policies = vocabulary.tag_reapplication_policies_by_kind.get(entity_kind, {})
-        for update in getattr(updates, array_name, []) or []:
+        for update in update_list:
             tags_add = getattr(update, "tags_add", None)
             if not tags_add:
                 continue
@@ -663,7 +704,10 @@ def normalize_extend_expiry_reasserts(
             )
         )
 
-    removals_by_update: dict[int, Tuple[Any, List[str], set[int]]] = {}
+    removals_by_update: dict[
+        int,
+        Tuple[str, Any, List[str], set[int], str],
+    ] = {}
     normalized = 0
     for candidate in candidates:
         matches = matches_by_ordinal.get(candidate.ordinal, [])
@@ -673,11 +717,13 @@ def normalize_extend_expiry_reasserts(
         update_key = id(candidate.update)
         if update_key not in removals_by_update:
             removals_by_update[update_key] = (
+                candidate.entity_kind,
                 candidate.update,
                 candidate.tags_add,
                 set(),
+                canonical_name,
             )
-        removals_by_update[update_key][2].add(candidate.tag_index)
+        removals_by_update[update_key][3].add(candidate.tag_index)
         logger.warning(
             "extend-expiry re-assert normalized " "entity_kind=%s entity=%s tag=%s",
             candidate.entity_kind,
@@ -686,12 +732,34 @@ def normalize_extend_expiry_reasserts(
         )
         normalized += 1
 
-    for update, tags_add, removal_indexes in removals_by_update.values():
+    removed_update_ids_by_kind: dict[str, set[int]] = {}
+    for (
+        entity_kind,
+        update,
+        tags_add,
+        removal_indexes,
+        canonical_name,
+    ) in removals_by_update.values():
         tags_add[:] = [
             tag for index, tag in enumerate(tags_add) if index not in removal_indexes
         ]
         if not tags_add:
             update.tags_add = None
+            if not _has_substantive_update(entity_kind, update):
+                removed_update_ids_by_kind.setdefault(entity_kind, set()).add(
+                    id(update)
+                )
+                logger.warning(
+                    "extend-expiry no-op update removed entity_kind=%s entity=%s",
+                    entity_kind,
+                    canonical_name,
+                )
+
+    for entity_kind, removed_update_ids in removed_update_ids_by_kind.items():
+        update_list = update_lists_by_kind[entity_kind]
+        update_list[:] = [
+            update for update in update_list if id(update) not in removed_update_ids
+        ]
 
     return normalized
 

--- a/nexus/agents/logon/orrery_tag_validation.py
+++ b/nexus/agents/logon/orrery_tag_validation.py
@@ -544,40 +544,35 @@ class _ExtendExpiryCandidate:
     tag: str
 
 
-_SUBSTANTIVE_UPDATE_PREDICATES: Mapping[str, Callable[[Any], bool]] = {
-    "character": lambda update: any(
-        (
-            update.activity,
-            update.location is not None,
-            update.emotional_state,
-            update.observations,
-            update.tags_add,
-            update.tags_clear,
-        )
-    ),
-    "place": lambda update: any(
-        (
-            update.condition,
-            update.notable_change,
-            update.tags_add,
-            update.tags_clear,
-        )
-    ),
-    "faction": lambda update: any(
-        (
-            update.action,
-            update.stance_toward and update.stance,
-            update.tags_add,
-            update.tags_clear,
-        )
-    ),
+_SUBSTANTIVE_UPDATE_PREDICATES: Mapping[str, Mapping[str, Callable[[Any], bool]]] = {
+    "character": {
+        "activity": lambda update: bool(update.activity),
+        "location": lambda update: update.location is not None,
+        "emotional_state": lambda update: bool(update.emotional_state),
+        "observations": lambda update: bool(update.observations),
+        "tags_clear": lambda update: bool(update.tags_clear),
+    },
+    "place": {
+        "condition": lambda update: bool(update.condition),
+        "notable_change": lambda update: bool(update.notable_change),
+        "tags_clear": lambda update: bool(update.tags_clear),
+    },
+    "faction": {
+        "action": lambda update: bool(update.action),
+        "stance_toward": lambda update: bool(update.stance_toward and update.stance),
+        "stance": lambda update: bool(update.stance_toward and update.stance),
+        "tags_clear": lambda update: bool(update.tags_clear),
+    },
 }
 
 
 def _has_substantive_update(entity_kind: str, update: Any) -> bool:
-    """Mirror the per-kind wire validator's substantive-update predicate."""
+    """Mirror the wire predicate after normalization strips ``tags_add``."""
 
-    return _SUBSTANTIVE_UPDATE_PREDICATES[entity_kind](update)
+    return any(
+        predicate(update)
+        for predicate in _SUBSTANTIVE_UPDATE_PREDICATES[entity_kind].values()
+    )
 
 
 def normalize_extend_expiry_reasserts(

--- a/tests/test_orrery_tag_validation.py
+++ b/tests/test_orrery_tag_validation.py
@@ -101,7 +101,10 @@ class FakeRegistryCursor:
         return False
 
     def execute(self, sql: str, params: Tuple[Any, ...] = ()) -> None:
-        if "FROM entities" in sql and "kind::text" in sql:
+        if "WITH candidates AS" in sql and "entity_tags_current" in sql:
+            self._result = []
+            self._one = None
+        elif "FROM entities" in sql and "kind::text" in sql:
             entity_ids = params[0]
             self._result = [
                 (entity_id, self.entity_kinds_by_id[entity_id])

--- a/tests/test_orrery_tag_validation_pg.py
+++ b/tests/test_orrery_tag_validation_pg.py
@@ -1,0 +1,424 @@
+"""Real-PostgreSQL regressions for extend-expiry normalization (issue #649)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import os
+from types import SimpleNamespace
+from typing import Any, Iterator, List, Optional
+import uuid
+
+import psycopg2
+from psycopg2 import sql
+import pytest
+
+from nexus.agents.logon.orrery_tag_validation import (
+    build_storyteller_tag_validator,
+    collect_orrery_tag_issues,
+    normalize_extend_expiry_reasserts,
+    read_storyteller_vocabulary,
+)
+from nexus.agents.logon.skald_wire import SkaldTurnWire
+from nexus.api.db_pool import close_all_pools
+from nexus.api.slot_utils import VALID_DBNAMES
+
+
+pytestmark = pytest.mark.requires_postgres
+
+CHARACTER_TAG = "recently_protective"
+FACTION_TAG = "schismatic_internal_threat"
+PLACE_TAG = "qa649_place_watch"
+CHARACTER_REJECTION = (
+    "updates.characters[0]: applied_tags: Tag 'recently_protective' uses "
+    "reapplication_policy='extend_expiry', which requires duration_override; "
+    "storyteller tags_add cannot express duration_override. If the tag is already "
+    "active, leave it unchanged; otherwise omit it."
+)
+
+
+@dataclass(frozen=True)
+class _EntityRef:
+    """Subtype and canonical identifiers for one seeded test entity."""
+
+    wire_id: int
+    entity_id: int
+    name: str
+
+
+@dataclass(frozen=True)
+class _Qa649Database:
+    """Disposable database plus the entity rows seeded into it."""
+
+    dbname: str
+    active_character: _EntityRef
+    inactive_character: _EntityRef
+    place: _EntityRef
+    faction: _EntityRef
+
+
+def _connect(dbname: str) -> Any:
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+def _insert_entity(cur: Any, kind: str, name: str) -> _EntityRef:
+    cur.execute(
+        "INSERT INTO entities (kind) VALUES (%s::entity_kind) RETURNING id",
+        (kind,),
+    )
+    entity_id = int(cur.fetchone()[0])
+    if kind == "character":
+        cur.execute(
+            "INSERT INTO characters (name, entity_id) VALUES (%s, %s) RETURNING id",
+            (name, entity_id),
+        )
+    elif kind == "place":
+        cur.execute(
+            """
+            INSERT INTO places (name, type, entity_id)
+            VALUES (%s, 'fixed_location', %s)
+            RETURNING id
+            """,
+            (name, entity_id),
+        )
+    elif kind == "faction":
+        cur.execute("SELECT COALESCE(MAX(id), 0) + 649 FROM factions")
+        faction_id = int(cur.fetchone()[0])
+        cur.execute(
+            """
+            INSERT INTO factions (id, name, entity_id)
+            VALUES (%s, %s, %s)
+            RETURNING id
+            """,
+            (faction_id, name, entity_id),
+        )
+    else:
+        raise AssertionError(f"Unsupported test entity kind: {kind}")
+    return _EntityRef(
+        wire_id=int(cur.fetchone()[0]),
+        entity_id=entity_id,
+        name=name,
+    )
+
+
+def _activate_tag(cur: Any, entity_id: int, tag: str) -> None:
+    cur.execute(
+        """
+        INSERT INTO entity_tags (entity_id, tag_id, source_kind)
+        SELECT %s, id, 'llm_generated'
+        FROM tags
+        WHERE tag = %s
+        """,
+        (entity_id, tag),
+    )
+    assert cur.rowcount == 1
+
+
+@pytest.fixture(scope="module")
+def qa649_db() -> Iterator[_Qa649Database]:
+    """Yield a populated current-template clone and drop it after the module."""
+
+    dbname = f"qa649_{uuid.uuid4().hex[:12]}"
+    admin = _connect("postgres")
+    admin.autocommit = True
+    try:
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier("NEXUS_template"),
+                )
+            )
+        VALID_DBNAMES.add(dbname)
+        with _connect(dbname) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO global_variables (id, new_story, base_timestamp)
+                    VALUES (true, true, '2026-07-31T12:00:00+00:00')
+                    ON CONFLICT (id) DO UPDATE
+                    SET base_timestamp = EXCLUDED.base_timestamp
+                    """
+                )
+                cur.execute("INSERT INTO entities (kind) VALUES ('place')")
+                active_character = _insert_entity(
+                    cur, "character", "QA649 Active Character"
+                )
+                inactive_character = _insert_entity(
+                    cur, "character", "QA649 Inactive Character"
+                )
+                place = _insert_entity(cur, "place", "QA649 Place")
+                faction = _insert_entity(cur, "faction", "QA649 Faction")
+                cur.execute(
+                    """
+                    INSERT INTO tags (
+                        tag,
+                        category,
+                        is_ephemeral,
+                        clearance_kind,
+                        reapplication_policy,
+                        description
+                    ) VALUES (
+                        %s,
+                        'place_threat',
+                        true,
+                        'semantic',
+                        'extend_expiry',
+                        'Issue 649 disposable place tag.'
+                    )
+                    """,
+                    (PLACE_TAG,),
+                )
+                _activate_tag(cur, active_character.entity_id, CHARACTER_TAG)
+                _activate_tag(cur, place.entity_id, PLACE_TAG)
+                _activate_tag(cur, faction.entity_id, FACTION_TAG)
+        yield _Qa649Database(
+            dbname=dbname,
+            active_character=active_character,
+            inactive_character=inactive_character,
+            place=place,
+            faction=faction,
+        )
+    finally:
+        close_all_pools()
+        VALID_DBNAMES.discard(dbname)
+        with admin.cursor() as cur:
+            cur.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (dbname,),
+            )
+            cur.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+            )
+        admin.close()
+
+
+def _response(
+    *,
+    characters: Optional[List[dict[str, Any]]] = None,
+    places: Optional[List[dict[str, Any]]] = None,
+    factions: Optional[List[dict[str, Any]]] = None,
+    orrery_adjudications: Optional[List[dict[str, Any]]] = None,
+) -> SkaldTurnWire:
+    payload: dict[str, Any] = {
+        "narrative": "The QA649 state changes without a model retry.",
+        "choices": ["Continue.", "Observe."],
+        "letter": "Preserve the deterministic boundary behavior.",
+        "new_entities": [],
+        "orrery_adjudications": orrery_adjudications or [],
+        "updates": {
+            "characters": characters or [],
+            "places": places or [],
+            "factions": factions or [],
+            "relationships": [],
+        },
+    }
+    return SkaldTurnWire.model_validate(payload)
+
+
+def _normalize_and_collect(
+    response: SkaldTurnWire,
+    database: _Qa649Database,
+    *,
+    proposal_bindings: Optional[dict[str, dict[str, int]]] = None,
+) -> tuple[int, List[str]]:
+    vocabulary = read_storyteller_vocabulary(database.dbname)
+    with _connect(database.dbname) as conn:
+        with conn.cursor() as cur:
+            normalized = normalize_extend_expiry_reasserts(
+                response,
+                cur,
+                vocabulary=vocabulary,
+            )
+            issues = collect_orrery_tag_issues(
+                response,
+                cur,
+                vocabulary=vocabulary,
+                proposal_bindings=proposal_bindings,
+            )
+    return normalized, issues
+
+
+@pytest.mark.asyncio
+async def test_active_character_reassert_is_removed_from_original_wire(
+    qa649_db: _Qa649Database,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    response = _response(
+        characters=[
+            {
+                "name": qa649_db.active_character.name,
+                "tags_add": [CHARACTER_TAG],
+            }
+        ]
+    )
+    assert response.updates is not None
+    update = response.updates.characters[0]
+    original_tags_add = update.tags_add
+    assert original_tags_add == [CHARACTER_TAG]
+    validator = build_storyteller_tag_validator(qa649_db.dbname)
+    assert validator is not None
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="nexus.logon.orrery_tag_validation",
+    ):
+        validated = await validator(SimpleNamespace(retry=0), response)
+
+    assert validated is response
+    assert original_tags_add == []
+    assert update.tags_add is None
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("extend-expiry re-assert normalized")
+    ] == [
+        "extend-expiry re-assert normalized entity_kind=character "
+        f"entity={qa649_db.active_character.name} tag={CHARACTER_TAG}"
+    ]
+    vocabulary = read_storyteller_vocabulary(qa649_db.dbname)
+    with _connect(qa649_db.dbname) as conn:
+        with conn.cursor() as cur:
+            assert (
+                collect_orrery_tag_issues(
+                    response,
+                    cur,
+                    vocabulary=vocabulary,
+                )
+                == []
+            )
+
+
+def test_inactive_extend_expiry_rejection_text_is_unchanged(
+    qa649_db: _Qa649Database,
+) -> None:
+    response = _response(
+        characters=[
+            {
+                "name": qa649_db.inactive_character.name,
+                "tags_add": [CHARACTER_TAG],
+            }
+        ]
+    )
+
+    normalized, issues = _normalize_and_collect(response, qa649_db)
+
+    assert normalized == 0
+    assert response.updates is not None
+    assert response.updates.characters[0].tags_add == [CHARACTER_TAG]
+    assert issues == [CHARACTER_REJECTION]
+
+
+def test_replacement_state_delta_extend_expiry_remains_rejected(
+    qa649_db: _Qa649Database,
+) -> None:
+    response = _response(
+        orrery_adjudications=[
+            {
+                "proposal_id": "qa649-proposal",
+                "action": "replace",
+                "replacement_state_delta": {
+                    "entity_tags_add": [CHARACTER_TAG],
+                },
+            }
+        ]
+    )
+
+    normalized, issues = _normalize_and_collect(
+        response,
+        qa649_db,
+        proposal_bindings={
+            "qa649-proposal": {
+                "actor": qa649_db.active_character.entity_id,
+            }
+        },
+    )
+
+    assert normalized == 0
+    assert issues == [
+        "orrery_adjudications[0].replacement_state_delta.entity_tags_add: "
+        "applied_tags: Tag 'recently_protective' uses "
+        "reapplication_policy='extend_expiry', which requires duration_override; "
+        "storyteller tags_add cannot express duration_override. If the tag is "
+        "already active, leave it unchanged; otherwise omit it."
+    ]
+
+
+def test_non_extend_expiry_tags_survive_active_normalization(
+    qa649_db: _Qa649Database,
+) -> None:
+    response = _response(
+        characters=[
+            {
+                "name": qa649_db.active_character.name,
+                "tags_add": [CHARACTER_TAG, "human"],
+            }
+        ]
+    )
+
+    normalized, issues = _normalize_and_collect(response, qa649_db)
+
+    assert normalized == 1
+    assert response.updates is not None
+    assert response.updates.characters[0].tags_add == ["human"]
+    assert issues == []
+
+
+def test_unknown_name_preserves_extend_expiry_rejection(
+    qa649_db: _Qa649Database,
+) -> None:
+    response = _response(
+        characters=[
+            {
+                "name": "QA649 Missing Character",
+                "tags_add": [CHARACTER_TAG],
+            }
+        ]
+    )
+
+    normalized, issues = _normalize_and_collect(response, qa649_db)
+
+    assert normalized == 0
+    assert response.updates is not None
+    assert response.updates.characters[0].tags_add == [CHARACTER_TAG]
+    assert issues == [CHARACTER_REJECTION]
+
+
+@pytest.mark.parametrize(
+    ("array_name", "entity_attribute", "tag"),
+    [
+        ("places", "place", PLACE_TAG),
+        ("factions", "faction", FACTION_TAG),
+    ],
+)
+def test_active_place_and_faction_reasserts_are_normalized_by_id(
+    qa649_db: _Qa649Database,
+    array_name: str,
+    entity_attribute: str,
+    tag: str,
+) -> None:
+    entity = getattr(qa649_db, entity_attribute)
+    response = _response(
+        **{
+            array_name: [
+                {
+                    "id": entity.wire_id,
+                    "name": entity.name,
+                    "tags_add": [tag],
+                }
+            ]
+        }
+    )
+
+    normalized, issues = _normalize_and_collect(response, qa649_db)
+
+    assert normalized == 1
+    assert response.updates is not None
+    assert getattr(response.updates, array_name)[0].tags_add is None
+    assert issues == []

--- a/tests/test_orrery_tag_validation_pg.py
+++ b/tests/test_orrery_tag_validation_pg.py
@@ -19,6 +19,7 @@ from nexus.agents.logon.gaia_registry_schema import (
     load_gaia_registry_wire_spec,
 )
 from nexus.agents.logon.orrery_tag_validation import (
+    _SUBSTANTIVE_UPDATE_PREDICATES,
     _has_substantive_update,
     build_storyteller_tag_validator,
     collect_orrery_tag_issues,
@@ -394,6 +395,23 @@ def test_normalization_predicate_matches_identity_only_wire_rejection(
     assert not _has_substantive_update(entity_kind, identity_only)
     with pytest.raises(ValidationError, match=error):
         model.model_validate(identity_only.model_dump(mode="python"))
+
+
+@pytest.mark.parametrize(
+    ("entity_kind", "model"),
+    [
+        ("character", CharacterUpdateDelta),
+        ("place", PlaceUpdateDelta),
+        ("faction", FactionUpdateDelta),
+    ],
+)
+def test_normalization_predicate_fields_match_wire_model(
+    entity_kind: str,
+    model: Any,
+) -> None:
+    assert set(_SUBSTANTIVE_UPDATE_PREDICATES[entity_kind]) == set(
+        model.model_fields
+    ) - {"name", "id", "tags_add"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_orrery_tag_validation_pg.py
+++ b/tests/test_orrery_tag_validation_pg.py
@@ -11,15 +11,27 @@ import uuid
 
 import psycopg2
 from psycopg2 import sql
+from pydantic import ValidationError
 import pytest
 
+from nexus.agents.logon.gaia_registry_schema import (
+    coerce_gaia_registry_wire,
+    load_gaia_registry_wire_spec,
+)
 from nexus.agents.logon.orrery_tag_validation import (
+    _has_substantive_update,
     build_storyteller_tag_validator,
     collect_orrery_tag_issues,
     normalize_extend_expiry_reasserts,
     read_storyteller_vocabulary,
 )
-from nexus.agents.logon.skald_wire import SkaldTurnWire
+from nexus.agents.logon.skald_wire import (
+    CharacterUpdateDelta,
+    FactionUpdateDelta,
+    PlaceUpdateDelta,
+    SkaldGaiaWire,
+    SkaldTurnWire,
+)
 from nexus.api.db_pool import close_all_pools
 from nexus.api.slot_utils import VALID_DBNAMES
 
@@ -222,6 +234,38 @@ def _response(
     return SkaldTurnWire.model_validate(payload)
 
 
+def _gaia_registry_response(
+    database: _Qa649Database,
+    *,
+    characters: Optional[List[dict[str, Any]]] = None,
+) -> SkaldGaiaWire:
+    schema_model = load_gaia_registry_wire_spec(database.dbname).model
+    return schema_model.model_validate(
+        {
+            "letter": "Preserve the deterministic boundary behavior.",
+            "new_entities": [],
+            "orrery_adjudications": [],
+            "updates": {
+                "characters": characters or [],
+                "places": [],
+                "factions": [],
+                "relationships": [],
+            },
+        }
+    )
+
+
+def _normalize(response: Any, database: _Qa649Database) -> int:
+    vocabulary = read_storyteller_vocabulary(database.dbname)
+    with _connect(database.dbname) as conn:
+        with conn.cursor() as cur:
+            return normalize_extend_expiry_reasserts(
+                response,
+                cur,
+                vocabulary=vocabulary,
+            )
+
+
 def _normalize_and_collect(
     response: SkaldTurnWire,
     database: _Qa649Database,
@@ -245,8 +289,115 @@ def _normalize_and_collect(
     return normalized, issues
 
 
+def test_identity_only_active_character_update_is_removed_before_registry_coercion(
+    qa649_db: _Qa649Database,
+) -> None:
+    response = _gaia_registry_response(
+        qa649_db,
+        characters=[
+            {
+                "name": qa649_db.active_character.name,
+                "tags_add": [CHARACTER_TAG],
+            }
+        ],
+    )
+    assert response.__class__ is not SkaldGaiaWire
+    assert response.updates is not None
+    original_updates = response.updates.characters
+
+    normalized = _normalize(response, qa649_db)
+    coerced = coerce_gaia_registry_wire(response)
+
+    assert normalized == 1
+    assert response.updates.characters is original_updates
+    assert original_updates == []
+    assert coerced.updates is not None
+    assert coerced.updates.characters == []
+
+
+def test_active_character_update_with_activity_survives_registry_coercion(
+    qa649_db: _Qa649Database,
+) -> None:
+    response = _gaia_registry_response(
+        qa649_db,
+        characters=[
+            {
+                "name": qa649_db.active_character.name,
+                "activity": "Keeps watch over the QA boundary.",
+                "tags_add": [CHARACTER_TAG],
+            }
+        ],
+    )
+
+    normalized = _normalize(response, qa649_db)
+    coerced = coerce_gaia_registry_wire(response)
+
+    assert normalized == 1
+    assert response.updates is not None
+    assert len(response.updates.characters) == 1
+    assert response.updates.characters[0].tags_add is None
+    assert coerced.updates is not None
+    assert coerced.updates.characters[0].activity == "Keeps watch over the QA boundary."
+    assert coerced.updates.characters[0].tags_add is None
+
+
+def test_active_character_update_with_tags_clear_survives_registry_coercion(
+    qa649_db: _Qa649Database,
+) -> None:
+    response = _gaia_registry_response(
+        qa649_db,
+        characters=[
+            {
+                "name": qa649_db.active_character.name,
+                "tags_add": [CHARACTER_TAG],
+                "tags_clear": [CHARACTER_TAG],
+            }
+        ],
+    )
+
+    normalized = _normalize(response, qa649_db)
+    coerced = coerce_gaia_registry_wire(response)
+
+    assert normalized == 1
+    assert response.updates is not None
+    assert len(response.updates.characters) == 1
+    assert response.updates.characters[0].tags_add is None
+    assert response.updates.characters[0].tags_clear == [CHARACTER_TAG]
+    assert coerced.updates is not None
+    assert coerced.updates.characters[0].tags_add is None
+    assert coerced.updates.characters[0].tags_clear == [CHARACTER_TAG]
+
+
+@pytest.mark.parametrize(
+    ("entity_kind", "model", "error"),
+    [
+        (
+            "character",
+            CharacterUpdateDelta,
+            "character update requires a substantive field",
+        ),
+        ("place", PlaceUpdateDelta, "place update requires a substantive field"),
+        (
+            "faction",
+            FactionUpdateDelta,
+            "faction update requires a substantive field",
+        ),
+    ],
+)
+def test_normalization_predicate_matches_identity_only_wire_rejection(
+    entity_kind: str,
+    model: Any,
+    error: str,
+) -> None:
+    identity_only = model.model_construct(name=f"QA649 {entity_kind}")
+
+    assert not _has_substantive_update(entity_kind, identity_only)
+    with pytest.raises(ValidationError, match=error):
+        model.model_validate(identity_only.model_dump(mode="python"))
+
+
 @pytest.mark.asyncio
-async def test_active_character_reassert_is_removed_from_original_wire(
+async def test_active_character_identity_only_reassert_arm_is_removed(
     qa649_db: _Qa649Database,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -274,6 +425,7 @@ async def test_active_character_reassert_is_removed_from_original_wire(
     assert validated is response
     assert original_tags_add == []
     assert update.tags_add is None
+    assert response.updates.characters == []
     assert [
         record.getMessage()
         for record in caplog.records
@@ -281,6 +433,14 @@ async def test_active_character_reassert_is_removed_from_original_wire(
     ] == [
         "extend-expiry re-assert normalized entity_kind=character "
         f"entity={qa649_db.active_character.name} tag={CHARACTER_TAG}"
+    ]
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("extend-expiry no-op update removed")
+    ] == [
+        "extend-expiry no-op update removed entity_kind=character "
+        f"entity={qa649_db.active_character.name}"
     ]
     vocabulary = read_storyteller_vocabulary(qa649_db.dbname)
     with _connect(qa649_db.dbname) as conn:
@@ -397,7 +557,7 @@ def test_unknown_name_preserves_extend_expiry_rejection(
         ("factions", "faction", FACTION_TAG),
     ],
 )
-def test_active_place_and_faction_reasserts_are_normalized_by_id(
+def test_active_place_and_faction_identity_only_reassert_arms_are_removed_by_id(
     qa649_db: _Qa649Database,
     array_name: str,
     entity_attribute: str,
@@ -420,5 +580,5 @@ def test_active_place_and_faction_reasserts_are_normalized_by_id(
 
     assert normalized == 1
     assert response.updates is not None
-    assert getattr(response.updates, array_name)[0].tags_add is None
+    assert getattr(response.updates, array_name) == []
     assert issues == []


### PR DESCRIPTION
Closes #649.

## What This Does

The dominant surviving Gaia rejection class (3 of 4 deep turns in the 2026-07-31 QA run, ~29k tokens per retry) is the storyteller re-asserting an already-active `extend_expiry`-policy tag via `tags_add`. The validator's own retry instruction — "If the tag is already active, leave it unchanged" — is deterministic, so this executes it mechanically at the validated boundary instead of paying a model retry.

`normalize_extend_expiry_reasserts()` runs inside `build_storyteller_tag_validator._validate` before issue collection, using the already-open cursor:

- Walks the ORIGINAL `updates.{characters,places,factions}` wire deltas (not the synthesized `_bestowal_sites` copies — the mutation must reach the object that flows to commit).
- One batched UNNEST query resolves each candidate entity (wire `id` first, else exact canonical name) through `characters`/`places`/`factions` → `entities`, and checks activity against `entity_tags_current`.
- Exactly-one-match + active → the entry is removed in place (`tags_add[:]` slice assignment; empty list becomes `None`) with a grep-able warning: `extend-expiry re-assert normalized entity_kind=… entity=… tag=…`.
- Not active, resolution failure, or ambiguity → the existing rejection stands verbatim (fail toward status quo). `updates.relationships`, `state_updates.*`, and replacement-state-delta sites are deliberately out of scope and keep rejecting.

No config knob: this is deterministic execution of the validator's documented instruction, not tunable behavior.

## Tests

Real-PostgreSQL regressions in `tests/test_orrery_tag_validation_pg.py` (disposable `qa649_*` clones from `NEXUS_template`, dropped after): active re-assert normalized on the original wire object (aliasing regression), not-active rejection verbatim, replacement-delta site still rejects, empty-list→None, resolution-failure passthrough, and places/factions arms. Full suite: 2,123 passed, 490 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gEoexyFZe1M6tQDqBsK5p