### PR TITLE
Split PresenceRef by Kind in the Skald Wire Grammar

### DIFF
--- a/nexus/agents/logon/skald_wire.py
+++ b/nexus/agents/logon/skald_wire.py
@@ -7,7 +7,7 @@ per-chunk mentions, never members of the carried scene roster.
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Sequence, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -81,24 +81,26 @@ class PresenceRef(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
 
+class CharacterRef(PresenceRef):
+    """Character-only provider-facing entity reference."""
+
+    kind: Literal["character"] = Field(description="Referenced entity kind.")
+
+
+class PlaceRef(PresenceRef):
+    """Place-only provider-facing entity reference."""
+
+    kind: Literal["place"] = Field(description="Referenced entity kind.")
+
+
 class SceneReset(BaseModel):
     """Fresh character roster and setting after a scene cut."""
 
-    place: PresenceRef = Field(description="New setting place.")
-    present: List[PresenceRef] = Field(
+    place: PlaceRef = Field(description="New setting place.")
+    present: List[CharacterRef] = Field(
         default_factory=list,
         description="Complete present-character roster.",
     )
-
-    @model_validator(mode="after")
-    def validate_presence_kinds(self) -> "SceneReset":
-        """Reject ontology-invalid reset references."""
-
-        if self.place.kind != "place":
-            raise ValueError("scene_reset.place must be a place")
-        if any(reference.kind != "character" for reference in self.present):
-            raise ValueError("scene_reset.present accepts characters only")
-        return self
 
     model_config = ConfigDict(extra="forbid")
 
@@ -106,11 +108,11 @@ class SceneReset(BaseModel):
 class PresenceDelta(BaseModel):
     """Sparse changes to scene presence and references."""
 
-    enter: List[PresenceRef] = Field(
+    enter: List[CharacterRef] = Field(
         default_factory=list,
         description="Characters entering the scene.",
     )
-    exit: List[PresenceRef] = Field(
+    exit: List[CharacterRef] = Field(
         default_factory=list,
         description="Characters leaving the scene.",
     )
@@ -118,7 +120,7 @@ class PresenceDelta(BaseModel):
         default_factory=list,
         description="Absent entities referenced this chunk.",
     )
-    transit: List[PresenceRef] = Field(
+    transit: List[PlaceRef] = Field(
         default_factory=list,
         description="Places passed through this chunk.",
     )
@@ -128,15 +130,9 @@ class PresenceDelta(BaseModel):
     )
 
     @model_validator(mode="after")
-    def validate_presence_kinds(self) -> "PresenceDelta":
-        """Reject ontology-invalid presence references."""
+    def validate_presence_consistency(self) -> "PresenceDelta":
+        """Reject contradictory roster changes."""
 
-        if any(reference.kind != "character" for reference in self.enter):
-            raise ValueError("presence.enter accepts characters only")
-        if any(reference.kind != "character" for reference in self.exit):
-            raise ValueError("presence.exit accepts characters only")
-        if any(reference.kind != "place" for reference in self.transit):
-            raise ValueError("presence.transit accepts places only")
         if self.scene_reset is not None and (self.enter or self.exit):
             raise ValueError("scene_reset cannot be combined with enter or exit")
         enter_names = {reference.name.casefold() for reference in self.enter}
@@ -155,24 +151,14 @@ class PresenceDelta(BaseModel):
 class PresenceBaseline(BaseModel):
     """Parent chunk's present characters and setting place."""
 
-    present: List[PresenceRef] = Field(
+    present: List[CharacterRef] = Field(
         default_factory=list,
         description="Parent present-character roster.",
     )
-    setting: Optional[PresenceRef] = Field(
+    setting: Optional[PlaceRef] = Field(
         default=None,
         description="Parent setting place.",
     )
-
-    @model_validator(mode="after")
-    def validate_presence_kinds(self) -> "PresenceBaseline":
-        """Reject ontology-invalid baseline references."""
-
-        if any(reference.kind != "character" for reference in self.present):
-            raise ValueError("presence baseline accepts characters only")
-        if self.setting is not None and self.setting.kind != "place":
-            raise ValueError("presence baseline setting must be a place")
-        return self
 
     model_config = ConfigDict(extra="forbid")
 
@@ -547,13 +533,16 @@ def _presence_key(reference: PresenceRef) -> tuple[str, str]:
     return reference.kind, reference.name.casefold()
 
 
+PresenceRefT = TypeVar("PresenceRefT", bound=PresenceRef)
+
+
 def _deduplicate_presence(
-    references: List[PresenceRef],
-) -> List[PresenceRef]:
+    references: Sequence[PresenceRefT],
+) -> List[PresenceRefT]:
     """Keep the first occurrence of each semantic entity reference."""
 
     seen: set[tuple[str, str]] = set()
-    result: List[PresenceRef] = []
+    result: List[PresenceRefT] = []
     for reference in references:
         key = _presence_key(reference)
         if key not in seen:
@@ -574,7 +563,7 @@ def _hydrate_references(
         return ReferencedEntities()
 
     assert baseline is not None
-    setting: Optional[PresenceRef]
+    setting: Optional[PlaceRef]
     if presence is not None and presence.scene_reset is not None:
         roster = _deduplicate_presence(presence.scene_reset.present)
         setting = presence.scene_reset.place

--- a/nexus/agents/logon/skald_wire.py
+++ b/nexus/agents/logon/skald_wire.py
@@ -96,7 +96,7 @@ class PlaceRef(PresenceRef):
 class SceneReset(BaseModel):
     """Fresh character roster and setting after a scene cut."""
 
-    place: PlaceRef = Field(description="New setting place.")
+    place: PlaceRef
     present: List[CharacterRef] = Field(
         default_factory=list,
         description="Complete present-character roster.",
@@ -155,10 +155,7 @@ class PresenceBaseline(BaseModel):
         default_factory=list,
         description="Parent present-character roster.",
     )
-    setting: Optional[PlaceRef] = Field(
-        default=None,
-        description="Parent setting place.",
-    )
+    setting: Optional[PlaceRef] = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -880,6 +877,8 @@ def _prompt_guide_enum(
         if not isinstance(enum_values, list):
             raise ValueError("Skald wire enum schema must contain a list")
         return enum_values
+    if "const" in schema_node:
+        return [schema_node["const"]]
     items = schema_node.get("items")
     if isinstance(items, dict):
         return _prompt_guide_enum(items, definitions)

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -31,8 +31,9 @@ from nexus.agents.logon.gaia_registry_schema import (  # noqa: E402
     load_gaia_registry_wire_spec,
 )
 from nexus.agents.logon.skald_wire import (  # noqa: E402
+    CharacterRef,
+    PlaceRef,
     PresenceBaseline,
-    PresenceRef,
     SkaldGaiaWire,
     SkaldTurnWire,
     SkaldWriterWire,
@@ -187,7 +188,7 @@ def read_presence_baseline(
                 (parent_chunk_id,),
             )
             present = [
-                PresenceRef(kind="character", id=row[0], name=row[1])
+                CharacterRef(kind="character", id=row[0], name=row[1])
                 for row in cur.fetchall()
             ]
             cur.execute(
@@ -208,7 +209,7 @@ def read_presence_baseline(
     if len(setting_rows) > 1:
         raise ValueError(f"Parent chunk {parent_chunk_id} has multiple setting places")
     setting = (
-        PresenceRef(
+        PlaceRef(
             kind="place",
             id=setting_rows[0][0],
             name=setting_rows[0][1],

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 import pytest
 
 from nexus.agents.lore.logon_utility import LogonUtility
-from nexus.agents.logon.skald_wire import PresenceBaseline, PresenceRef
+from nexus.agents.logon.skald_wire import CharacterRef, PlaceRef, PresenceBaseline
 
 
 PROMPTS_DIR = Path(__file__).parents[2] / "prompts"
@@ -461,8 +461,8 @@ def test_context_prompt_includes_contextual_tag_library(monkeypatch) -> None:
         lambda _dbname: 99,
     )
     baseline = PresenceBaseline(
-        present=[PresenceRef(kind="character", id=7, name="Mara")],
-        setting=PresenceRef(kind="place", id=12, name="The Sluice"),
+        present=[CharacterRef(kind="character", id=7, name="Mara")],
+        setting=PlaceRef(kind="place", id=12, name="The Sluice"),
     )
 
     prompt = LogonUtility({}, dbname="save_05")._format_context_prompt(

--- a/tests/test_lore/test_two_pass_pipeline.py
+++ b/tests/test_lore/test_two_pass_pipeline.py
@@ -24,8 +24,9 @@ from nexus.agents.logon.orrery_tag_validation import (
     build_storyteller_tag_validator,
 )
 from nexus.agents.logon.skald_wire import (
+    CharacterRef,
+    PlaceRef,
     PresenceBaseline,
-    PresenceRef,
     SkaldGaiaWire,
     SkaldTurnWire,
     SkaldWriterWire,
@@ -141,8 +142,8 @@ SINGLE_PASS_PAYLOAD: dict[str, Any] = {
     "letter": "Keep the bell's ringer unresolved while the Choir advances.",
 }
 BASELINE = PresenceBaseline(
-    present=[PresenceRef(kind="character", name="Iona Vale", id=4)],
-    setting=PresenceRef(kind="place", name="The Lower Sluice", id=9),
+    present=[CharacterRef(kind="character", name="Iona Vale", id=4)],
+    setting=PlaceRef(kind="place", name="The Lower Sluice", id=9),
 )
 
 

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -179,7 +179,7 @@ def _identity_only_updates(namespace: str) -> dict[str, list[dict[str, str]]]:
 def _wire_validator_sentinel_cases() -> (
     list[tuple[type[BaseModel], str, dict[str, Any]]]
 ):
-    """Cover every prose-adjacent wire validator family."""
+    """Cover every prose-adjacent wire validation-error family."""
 
     cases: list[tuple[type[BaseModel], str, dict[str, Any]]] = []
 
@@ -251,7 +251,15 @@ def test_structured_output_error_text_omits_wire_payload_prose(
     with pytest.raises(ValidationError) as exc_info:
         wire_model.model_validate(payload)
 
-    assert _WIRE_PROSE_SENTINEL in str(exc_info.value), validator_family
+    raw_error = str(exc_info.value)
+    if validator_family in {"presence_ontology", "scene_ontology"}:
+        # #639 moves kind enforcement from model-level validators to Literal
+        # fields. Pydantic now reports only the bad kind at its exact path, so
+        # unrelated prose is absent even before diagnostic sanitization.
+        assert _WIRE_PROSE_SENTINEL not in raw_error, validator_family
+        assert ".kind" in raw_error, validator_family
+    else:
+        assert _WIRE_PROSE_SENTINEL in raw_error, validator_family
     assert _WIRE_PROSE_SENTINEL not in structured_output_error_text(
         exc_info.value
     ), validator_family
@@ -1285,7 +1293,7 @@ def test_anthropic_provider_uses_native_output_format() -> None:
         "json_decode_error",
     ],
 )
-async def test_anthropic_rejection_logs_cover_every_transport_branch_without_input_leaks(
+async def test_anthropic_rejection_logs_cover_branches_without_input_leaks(
     caplog: pytest.LogCaptureFixture,
     transport: Literal["native", "prompted", "tool_envelope"],
     call_style: Literal["sync", "async"],

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -526,8 +526,12 @@ def test_writer_schema_encodes_presence_kind_partitions() -> None:
     assert presence["transit"]["items"]["$ref"] == "#/$defs/PlaceRef"
 
     reset = definitions["SceneReset"]["properties"]
-    assert reset["place"]["properties"]["kind"]["const"] == "place"
+    assert reset["place"] == {"$ref": "#/$defs/PlaceRef"}
     assert reset["present"]["items"]["$ref"] == "#/$defs/CharacterRef"
+
+    baseline_setting = PresenceBaseline.model_json_schema()["properties"]["setting"]
+    assert baseline_setting["anyOf"][0]["$ref"] == "#/$defs/PlaceRef"
+    assert "description" not in baseline_setting
 
 
 def _assert_canonical_fields_equal(
@@ -894,12 +898,27 @@ def test_presence_without_baseline_raises_loudly() -> None:
     "presence",
     [
         {"enter": [{"kind": "place", "name": "Archive"}]},
+        {"enter": [{"kind": "faction", "name": "Guild"}]},
         {"exit": [{"kind": "place", "name": "Archive"}]},
+        {"exit": [{"kind": "faction", "name": "Guild"}]},
         {"transit": [{"kind": "character", "name": "Brena"}]},
+        {"transit": [{"kind": "faction", "name": "Guild"}]},
         {
             "scene_reset": {
                 "place": {"kind": "character", "name": "Brena"},
                 "present": [],
+            }
+        },
+        {
+            "scene_reset": {
+                "place": {"kind": "faction", "name": "Guild"},
+                "present": [],
+            }
+        },
+        {
+            "scene_reset": {
+                "place": {"kind": "place", "name": "Archive"},
+                "present": [{"kind": "place", "name": "Annex"}],
             }
         },
         {
@@ -920,7 +939,9 @@ def test_presence_kind_partitions_reject_invalid_json(
 @pytest.mark.parametrize(
     "baseline",
     [
+        {"present": [{"kind": "place", "name": "Archive"}]},
         {"present": [{"kind": "faction", "name": "Guild"}]},
+        {"setting": {"kind": "character", "name": "Brena"}},
         {"setting": {"kind": "faction", "name": "Guild"}},
     ],
 )
@@ -1383,6 +1404,17 @@ def test_skald_wire_prompt_guide_preserves_enum_values_verbatim() -> None:
         'declared_entity_role?:string|enum=["subject","object"]|'
         '"Whether the declared entity is subject or object of the pair tag."' in guide
     )
+
+
+def test_skald_wire_prompt_guide_pins_presence_ref_kinds() -> None:
+    guide = skald_wire_prompt_guide()
+
+    for ref_name, kind in (("CharacterRef", "character"), ("PlaceRef", "place")):
+        block = guide.split(f"{ref_name}{{\n", 1)[1].split("\n}", 1)[0]
+        assert (
+            f'kind!:string|enum=["{kind}"]|"Referenced entity kind."'
+            in block.splitlines()
+        )
 
 
 def test_skald_wire_prompt_guide_stays_within_token_budget() -> None:

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import Counter
 import json
 import os
+import tomllib
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast, get_args
@@ -49,6 +50,8 @@ from nexus.agents.logon.gaia_registry_schema import (
     load_gaia_registry_wire_spec,
 )
 from nexus.agents.logon.skald_wire import (
+    CharacterRef,
+    PlaceRef,
     PresenceBaseline,
     PresenceRef,
     SkaldGaiaWire,
@@ -70,13 +73,19 @@ from nexus.agents.lore import logon_utility
 from nexus.agents.lore.logon_utility import LogonUtility, read_presence_baseline
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
 from nexus.api.native_structured_output import anthropic_output_config
+from nexus.config import resolve_model_ref
 from scripts.api_openai import OpenAIProvider
 
 
 # Filled from the deterministic compact serializations, with modest drift room.
-SKALD_WIRE_STRICT_MAX_BYTES = 19_600
+SKALD_WIRE_STRICT_MAX_BYTES = 21_000
 SKALD_WIRE_LENIENT_MAX_BYTES = 18_950
 SKALD_WIRE_DESCRIPTION_MAX_CHARS = 70
+SKALD_WIRE_PROMPT_MAX_TOKENS = 1_500
+# #639 measurement: 5,583 bytes / 1,248 o200k tokens before the split;
+# 6,533 bytes / 1,458 o200k tokens after it. These ceilings retain ~10% headroom.
+SKALD_WRITER_STRICT_MAX_BYTES = 7_200
+SKALD_WRITER_STRICT_MAX_TOKENS = 1_610
 
 # Post-#577 unification: the replacement vocabulary's guidance lives in the
 # contextual tag library (Event-Type Names) and the imminent-activity prompt
@@ -103,10 +112,10 @@ SPARSE_WIRE_PAYLOAD = {
 
 BASELINE = PresenceBaseline(
     present=[
-        PresenceRef(kind="character", name="Brena Tideloft", id=7),
-        PresenceRef(kind="character", name="Odile", id=8),
+        CharacterRef(kind="character", name="Brena Tideloft", id=7),
+        CharacterRef(kind="character", name="Odile", id=8),
     ],
-    setting=PresenceRef(kind="place", name="The Lower Sluice", id=41),
+    setting=PlaceRef(kind="place", name="The Lower Sluice", id=41),
 )
 
 
@@ -497,6 +506,30 @@ def test_two_pass_strict_and_lenient_schema_shapes() -> None:
     assert "anyOf" not in gaia_lenient["properties"]["updates"]
 
 
+def test_writer_schema_encodes_presence_kind_partitions() -> None:
+    schema = skald_writer_strict_text_format()["schema"]
+    definitions = schema["$defs"]
+
+    assert issubclass(CharacterRef, PresenceRef)
+    assert issubclass(PlaceRef, PresenceRef)
+    assert CharacterRef.model_fields["kind"].is_required()
+    assert PlaceRef.model_fields["kind"].is_required()
+    assert definitions["CharacterRef"]["properties"]["kind"]["const"] == "character"
+    assert definitions["PlaceRef"]["properties"]["kind"]["const"] == "place"
+    assert definitions["CharacterRef"]["required"] == ["kind", "name", "id"]
+    assert definitions["PlaceRef"]["required"] == ["kind", "name", "id"]
+
+    presence = definitions["PresenceDelta"]["properties"]
+    assert presence["enter"]["items"]["$ref"] == "#/$defs/CharacterRef"
+    assert presence["exit"]["items"]["$ref"] == "#/$defs/CharacterRef"
+    assert presence["mentions"]["items"]["$ref"] == "#/$defs/PresenceRef"
+    assert presence["transit"]["items"]["$ref"] == "#/$defs/PlaceRef"
+
+    reset = definitions["SceneReset"]["properties"]
+    assert reset["place"]["properties"]["kind"]["const"] == "place"
+    assert reset["present"]["items"]["$ref"] == "#/$defs/CharacterRef"
+
+
 def _assert_canonical_fields_equal(
     actual: StorytellerResponseExtended,
     expected: StorytellerResponseExtended,
@@ -860,8 +893,8 @@ def test_presence_without_baseline_raises_loudly() -> None:
 @pytest.mark.parametrize(
     "presence",
     [
-        {"enter": [{"kind": "faction", "name": "Guild"}]},
-        {"exit": [{"kind": "faction", "name": "Guild"}]},
+        {"enter": [{"kind": "place", "name": "Archive"}]},
+        {"exit": [{"kind": "place", "name": "Archive"}]},
         {"transit": [{"kind": "character", "name": "Brena"}]},
         {
             "scene_reset": {
@@ -877,11 +910,40 @@ def test_presence_without_baseline_raises_loudly() -> None:
         },
     ],
 )
-def test_presence_rejects_ontology_invalid_kinds(
+def test_presence_kind_partitions_reject_invalid_json(
     presence: dict[str, Any],
 ) -> None:
     with pytest.raises(ValidationError):
-        SkaldTurnWire.model_validate({**SPARSE_WIRE_PAYLOAD, "presence": presence})
+        SkaldWriterWire.model_validate({**SPARSE_WIRE_PAYLOAD, "presence": presence})
+
+
+@pytest.mark.parametrize(
+    "baseline",
+    [
+        {"present": [{"kind": "faction", "name": "Guild"}]},
+        {"setting": {"kind": "faction", "name": "Guild"}},
+    ],
+)
+def test_presence_baseline_kind_partitions_reject_invalid_json(
+    baseline: dict[str, Any],
+) -> None:
+    with pytest.raises(ValidationError):
+        PresenceBaseline.model_validate(baseline)
+
+
+def test_faction_mention_remains_valid() -> None:
+    writer = SkaldWriterWire.model_validate(
+        {
+            **SPARSE_WIRE_PAYLOAD,
+            "presence": {"mentions": [{"kind": "faction", "name": "The Sluice Guild"}]},
+        }
+    )
+
+    assert writer.presence is not None
+    assert len(writer.presence.mentions) == 1
+    mention = writer.presence.mentions[0]
+    assert type(mention) is PresenceRef
+    assert mention.kind == "faction"
 
 
 @pytest.mark.parametrize("roster_operation", ["enter", "exit"])
@@ -1327,7 +1389,9 @@ def test_skald_wire_prompt_guide_stays_within_token_budget() -> None:
     tiktoken = pytest.importorskip("tiktoken")
     encoding = tiktoken.get_encoding("o200k_base")
 
-    assert len(encoding.encode(skald_wire_prompt_guide())) <= 1_400
+    assert (
+        len(encoding.encode(skald_wire_prompt_guide())) <= SKALD_WIRE_PROMPT_MAX_TOKENS
+    )
 
 
 def test_skald_gaia_prompt_guide_stays_within_token_budget() -> None:
@@ -1722,7 +1786,9 @@ def test_presence_baseline_reads_real_slot_parent_rows() -> None:
         pytest.skip("Slot has no parent chunk with presence junction rows")
     baseline = read_presence_baseline(dbname, parent_chunk_id)
     assert baseline.present or baseline.setting is not None
+    assert all(isinstance(reference, CharacterRef) for reference in baseline.present)
     assert all(reference.kind == "character" for reference in baseline.present)
+    assert baseline.setting is None or isinstance(baseline.setting, PlaceRef)
     assert baseline.setting is None or baseline.setting.kind == "place"
 
 
@@ -1733,6 +1799,75 @@ def test_schema_token_measurement_uses_o200k() -> None:
     lenient_wire = _compact_schema_json(skald_wire_lenient_schema())
     assert len(encoding.encode(strict_wire)) > 0
     assert len(encoding.encode(lenient_wire)) > 0
+
+
+def test_writer_schema_size_stays_within_measured_budget() -> None:
+    tiktoken = pytest.importorskip("tiktoken")
+    encoding = tiktoken.get_encoding("o200k_base")
+    writer_wire = _compact_schema_json(skald_writer_strict_text_format()["schema"])
+    writer_bytes = len(writer_wire.encode("utf-8"))
+    writer_tokens = len(encoding.encode(writer_wire))
+
+    print(
+        "Skald writer strict schema measurement: "
+        f"{writer_bytes} bytes/{writer_tokens} tokens"
+    )
+    assert writer_bytes <= SKALD_WRITER_STRICT_MAX_BYTES
+    assert writer_tokens <= SKALD_WRITER_STRICT_MAX_TOKENS
+
+
+@pytest.mark.live
+@pytest.mark.live_llm
+@pytest.mark.skipif(
+    os.environ.get("NEXUS_639_PRESENCE_E2E") != "1",
+    reason="Set NEXUS_639_PRESENCE_E2E=1 for the live writer presence gate.",
+)
+def test_live_openai_decodes_writer_presence_kind_partitions() -> None:
+    config_path = Path(__file__).parents[1] / "nexus.toml"
+    with config_path.open("rb") as config_file:
+        model_ref = tomllib.load(config_file)["apex"]["model"]
+    if not isinstance(model_ref, str) or not model_ref.startswith("@openai."):
+        pytest.fail("The configured writer model must be an @openai.<role> reference")
+    model = resolve_model_ref(model_ref, config_path)
+
+    provider = OpenAIProvider(
+        model=model,
+        max_output_tokens=1_000,
+        reasoning_effort="low",
+        structured_output_retries=0,
+        usage_seat="writer_presence_schema_e2e",
+    )
+    parsed, _response = provider.get_structured_completion(
+        (
+            "Write one concise story beat in which Arin Vale and Bela Sorn enter "
+            "the Copper Observatory at a hard scene cut to that new place. This "
+            "beat combines character arrivals with a setting transition, so encode "
+            "presence using scene_reset only: scene_reset.place is the exact place "
+            "'Copper Observatory', and scene_reset.present is the complete roster "
+            "with exactly the characters 'Arin Vale' and 'Bela Sorn'. Do not use "
+            "presence.enter or presence.exit alongside the reset. Use no mentions "
+            "or transit places, provide exactly two short choices, no operation, "
+            "and a short non-null private letter."
+        ),
+        SkaldWriterWire,
+        text_format=skald_writer_strict_text_format(),
+    )
+
+    assert isinstance(parsed, SkaldWriterWire)
+    assert parsed.presence is not None
+    assert parsed.presence.enter == []
+    assert parsed.presence.exit == []
+    reset = parsed.presence.scene_reset
+    assert reset is not None
+    assert isinstance(reset.place, PlaceRef)
+    assert reset.place.kind == "place"
+    assert reset.place.name == "Copper Observatory"
+    assert {reference.name for reference in reset.present} == {
+        "Arin Vale",
+        "Bela Sorn",
+    }
+    assert all(isinstance(reference, CharacterRef) for reference in reset.present)
+    assert all(reference.kind == "character" for reference in reset.present)
 
 
 def test_replacement_event_type_requires_replacement_delta() -> None:

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -895,61 +895,115 @@ def test_presence_without_baseline_raises_loudly() -> None:
 
 
 @pytest.mark.parametrize(
-    "presence",
+    ("presence", "expected_loc"),
     [
-        {"enter": [{"kind": "place", "name": "Archive"}]},
-        {"enter": [{"kind": "faction", "name": "Guild"}]},
-        {"exit": [{"kind": "place", "name": "Archive"}]},
-        {"exit": [{"kind": "faction", "name": "Guild"}]},
-        {"transit": [{"kind": "character", "name": "Brena"}]},
-        {"transit": [{"kind": "faction", "name": "Guild"}]},
-        {
-            "scene_reset": {
-                "place": {"kind": "character", "name": "Brena"},
-                "present": [],
-            }
-        },
-        {
-            "scene_reset": {
-                "place": {"kind": "faction", "name": "Guild"},
-                "present": [],
-            }
-        },
-        {
-            "scene_reset": {
-                "place": {"kind": "place", "name": "Archive"},
-                "present": [{"kind": "place", "name": "Annex"}],
-            }
-        },
-        {
-            "scene_reset": {
-                "place": {"kind": "place", "name": "Archive"},
-                "present": [{"kind": "faction", "name": "Guild"}],
-            }
-        },
+        (
+            {"enter": [{"kind": "place", "name": "Archive"}]},
+            ("presence", "enter", 0, "kind"),
+        ),
+        (
+            {"enter": [{"kind": "faction", "name": "Guild"}]},
+            ("presence", "enter", 0, "kind"),
+        ),
+        (
+            {"exit": [{"kind": "place", "name": "Archive"}]},
+            ("presence", "exit", 0, "kind"),
+        ),
+        (
+            {"exit": [{"kind": "faction", "name": "Guild"}]},
+            ("presence", "exit", 0, "kind"),
+        ),
+        (
+            {"transit": [{"kind": "character", "name": "Brena"}]},
+            ("presence", "transit", 0, "kind"),
+        ),
+        (
+            {"transit": [{"kind": "faction", "name": "Guild"}]},
+            ("presence", "transit", 0, "kind"),
+        ),
+        (
+            {
+                "scene_reset": {
+                    "place": {"kind": "character", "name": "Brena"},
+                    "present": [],
+                }
+            },
+            ("presence", "scene_reset", "place", "kind"),
+        ),
+        (
+            {
+                "scene_reset": {
+                    "place": {"kind": "faction", "name": "Guild"},
+                    "present": [],
+                }
+            },
+            ("presence", "scene_reset", "place", "kind"),
+        ),
+        (
+            {
+                "scene_reset": {
+                    "place": {"kind": "place", "name": "Archive"},
+                    "present": [{"kind": "place", "name": "Annex"}],
+                }
+            },
+            ("presence", "scene_reset", "present", 0, "kind"),
+        ),
+        (
+            {
+                "scene_reset": {
+                    "place": {"kind": "place", "name": "Archive"},
+                    "present": [{"kind": "faction", "name": "Guild"}],
+                }
+            },
+            ("presence", "scene_reset", "present", 0, "kind"),
+        ),
     ],
 )
 def test_presence_kind_partitions_reject_invalid_json(
     presence: dict[str, Any],
+    expected_loc: tuple[str | int, ...],
 ) -> None:
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         SkaldWriterWire.model_validate({**SPARSE_WIRE_PAYLOAD, "presence": presence})
+    error_pairs = {
+        (error["type"], error["loc"][-len(expected_loc) :])
+        for error in exc_info.value.errors()
+    }
+    assert ("literal_error", expected_loc) in error_pairs
 
 
 @pytest.mark.parametrize(
-    "baseline",
+    ("baseline", "expected_loc"),
     [
-        {"present": [{"kind": "place", "name": "Archive"}]},
-        {"present": [{"kind": "faction", "name": "Guild"}]},
-        {"setting": {"kind": "character", "name": "Brena"}},
-        {"setting": {"kind": "faction", "name": "Guild"}},
+        (
+            {"present": [{"kind": "place", "name": "Archive"}]},
+            ("present", 0, "kind"),
+        ),
+        (
+            {"present": [{"kind": "faction", "name": "Guild"}]},
+            ("present", 0, "kind"),
+        ),
+        (
+            {"setting": {"kind": "character", "name": "Brena"}},
+            ("setting", "kind"),
+        ),
+        (
+            {"setting": {"kind": "faction", "name": "Guild"}},
+            ("setting", "kind"),
+        ),
     ],
 )
 def test_presence_baseline_kind_partitions_reject_invalid_json(
     baseline: dict[str, Any],
+    expected_loc: tuple[str | int, ...],
 ) -> None:
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         PresenceBaseline.model_validate(baseline)
+    error_pairs = {
+        (error["type"], error["loc"][-len(expected_loc) :])
+        for error in exc_info.value.errors()
+    }
+    assert ("literal_error", expected_loc) in error_pairs
 
 
 def test_faction_mention_remains_valid() -> None:


### PR DESCRIPTION
Closes #639.

## What This Does

Every presence slot in the Skald wire shared one `PresenceRef` with `kind: Literal["character","place","faction"]`, policing kind correctness with three cross-field `model_validator`s — so a wrong-kind reference cost a full ~22k-token model retry. This moves the constraint into the grammar, where OpenAI strict decoding makes wrong-kind references unemittable:

- `CharacterRef`/`PlaceRef` subclass `PresenceRef` with single-value `kind` Literals (required, no default — the decoder must emit the pinned value; `isinstance` and shared helpers keep working).
- `enter`/`exit`/`scene_reset.present`/`baseline.present` are now `CharacterRef`; `transit`/`scene_reset.place`/`baseline.setting` are `PlaceRef`; `mentions` keeps the three-kind base type (faction mentions are legitimate).
- All three kind-checking validators are deleted. Two rules the grammar cannot express survive app-side: scene_reset-vs-enter/exit exclusivity and the enter/exit same-name overlap check.
- Frozen non-changes per the issue: choices keep `minItems 2 / maxItems 4` client-side (authorial latitude for 2–3-choice moments), letter nullable-then-reject and `max_letter_tokens = 300` untouched.

Writer schema cost: 5,583 bytes / 1,248 tokens → 6,533 bytes / 1,458 tokens (+210 tokens/turn) from the added `$defs`. Against the measured writer-rejection class (~22k tokens per retry, 3 of 27 turns in the original audit ≈ 2,400 tokens/turn expected), the trade is strongly net-positive.

## Tests

Partition-equivalence coverage (every shape the deleted validators rejected now fails at parse from JSON input), retained-rule coverage, faction-mention latitude, schema `const` rendering, size budget, and a live OpenAI writer decode on a roster/setting-transition beat — the exact family where the original #639 rejections clustered — via the `@openai` registry role, zero retries. Full suite: 2,128 passed, 484 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gEoexyFZe1M6tQDqBsK5p