### PR TITLE
Card Intertitle and LocalModelRows; fix grid overflow on 65 cards

### DIFF
--- a/ui/.design-sync/NOTES.md
+++ b/ui/.design-sync/NOTES.md
@@ -191,9 +191,15 @@ state diversity into one rich stub scenario instead.
   `[aria-expanded="false"]` so it is idempotent and never toggles an open family shut.
   Same principle as the ContextMenu preview: drive the real trigger, never hand-write
   the open state.
-- It renders bare `<li>`s — wrap in `<ul className="model-list">`, as `SettingsPane` does.
-  `.lm-*` and `.intertitle` rules are unscoped, so no `.nexus-shell` wrapper is needed
-  (unlike `SettingsPane`'s footer buttons).
+- It renders bare `<li>`s — wrap in `<ul className="model-list">` inside a
+  **`.nexus-shell` ancestor**, as `SettingsPane` does. Checking that the `.lm-*` rules
+  are unscoped is NOT sufficient: the component also emits `.caption`, `.btn-soft`, and
+  `.btn-primary`, and nexus-layout.css defines all three ONLY under `.nexus-shell`, so a
+  bare `<ul>` renders the quant labels and the EJECT / APPLY buttons as browser defaults
+  (caught in Codex review of PR #656). Override the shell's `100vh` and its `52px 1fr`
+  row grid locally. **When auditing a preview's wrapper, grep every class the component
+  emits — not just its own namespace.** `Intertitle` was checked the same way and is
+  genuinely clean (only unscoped `.intertitle*` rules).
 
 ## Component-type recipes (folded from wave-2 authoring)
 

--- a/ui/.design-sync/NOTES.md
+++ b/ui/.design-sync/NOTES.md
@@ -61,11 +61,41 @@ around it:
 - Review sheet renders each cell as a populated top band + an empty band below —
   the empty band is sheet layout, NOT a missing render.
 
+## OPEN GAP: every `.d.ts` is a permissive stub
+
+**All 97 components ship `interface <Name>Props { [key: string]: unknown }`** — no real
+prop contract. The `.d.ts` is what the claude.ai/design agent codes against, so today it
+learns each component's API only from the `.prompt.md` and the preview card, never from
+types. Pre-existing (it predates the 2026-07-30 sync; not a regression).
+
+Cause: the driver logs **`[DTS] parsed 0 .d.ts files`**. The phantom `--entry` points at
+the Vite lib build, which emits only `index.js` + `style.css` — there is no declaration
+tree for ts-morph to read, so extraction falls back to the permissive stub. `@types/react`
+IS installed, so this is not the `[DTS_REACT]` case.
+
+Candidate fixes, cheapest first:
+1. Emit declarations from the lib build — add `vite-plugin-dts` to
+   `vite.lib.config.mts`, or a `tsc --emitDeclarationOnly --outDir .cache/lib-dist`
+   pass in `build.mjs` after the Vite step. Then the converter parses a real tree and
+   all 97 contracts improve at once. Expect to spend time on `tsc` config: the app has
+   never been type-built as a library.
+2. Per-component `cfg.dtsPropsFor.<Name>` with a hand-written props body. Exact, but 97
+   entries that rot as the app evolves — reserve for stragglers after (1).
+
+The props interfaces themselves are well-formed in source (e.g. `IntertitleProps`,
+`LocalModelRowsProps`), so (1) should be mostly mechanical once the build emits.
+
+## Known render warns
+
+**As of 2026-07-30 the final driver run emits ZERO warn lines** — no `[GRID_OVERFLOW]`,
+no `[RENDER_*]`, no `[FONT_*]`, no `[DOCS_*]`. Treat any warn on a future run as new:
+look at it, then fix it or record it here.
+
 ## Known cosmetic issues (polish before final upload)
 
-- 51 shadcn primitives land in group `general` (the converter skips `ui` as a
-  generic container). Acceptable, but a tidier grouping (e.g. "Components") would
-  improve the pane. Regroup via docsMap category stubs if desired.
+- The shadcn primitives land in group `general` (the converter treats `ui` as a generic
+  container). Acceptable, but a tidier grouping (e.g. "Components") would improve the
+  pane. Regroup via docsMap category stubs if desired.
 - Each card cell reserves a tall viewport (content top, empty below). Cosmetic.
 
 ## Re-sync risks (watch-list)
@@ -76,14 +106,94 @@ around it:
   null for a nonexistent path — verify if the converter is upgraded.
 - `build.mjs`'s font-url rewrite (`/fonts/` → `../../../client/public/fonts/`) is
   path-depth-specific to `.cache/lib-dist/`.
-- Playwright/Chromium installed under `.ds-sync/node_modules` + `~/.cache/ms-playwright`.
+- Playwright lives in `.ds-sync/node_modules` (1.61.0, which pins chromium rev 1228).
+  The browser cache on macOS is **`~/Library/Caches/ms-playwright`** — not
+  `~/.cache/ms-playwright`, which is the Linux path this file used to name.
 - **`pages/dev-orrery/` is excluded from the bundle** (`gen-entry.mjs` `find` filter).
   It's the internal `/dev/orrery` audit dashboard (#430, a separate "design-package
   port"), not IRIS's customer design system — its viz deps must not bloat the synced
-  bundle. If a genuinely new IRIS component appears (e.g. `Intertitle`, #456), it rides
-  the bundle uncarded until deliberately added to `config.json`'s `componentSrcMap` with
-  an authored preview. Never blind-merge `.cache/componentSrcMap.json`: discovery drifts
-  (it renamed the `Form` card's primary export to `FormItem`).
+  bundle. A genuinely new IRIS component rides the bundle uncarded until deliberately
+  added to `config.json`'s `componentSrcMap` with an authored preview — `Intertitle`
+  (#456) and `LocalModelRows` (#465 Phase 1b) were both carded on 2026-07-30, so the
+  standing deferral list is currently empty. Never blind-merge
+  `.cache/componentSrcMap.json`: discovery drifts (it still renames the `Form` card's
+  primary export to `FormItem` — keep the committed `Form` pin, drop `FormItem`).
+- **The cached anchor is always one generation stale.** `.design-sync/.cache/remote-sync.json`
+  is fetched at the START of a run, and that run then uploads a NEW `_ds_sync.json`. So
+  the file left on disk describes the run *before* last. Re-fetch it from the project, or
+  `cp ds-bundle/_ds_sync.json .design-sync/.cache/remote-sync.json` after confirming that
+  file's `auxSha`/`bundleSha12` match the live project's.
+
+## Running the sync from a git worktree
+
+The owner often has backend work in the main checkout, so this sync is normally run
+from a `git worktree` to keep the durable-set edits (`config.json`, `ds-provider.tsx`,
+`previews/*.tsx`) out of their `git status`. Everything the sync needs that is
+gitignored must be re-provisioned there:
+
+- **`ui/node_modules` — hardlink-copy it, NEVER symlink it.** `cp -Rl ../../../ui/node_modules
+  ./node_modules` (~14 s, near-zero disk, shared inodes). esbuild inlines each resolved
+  module's path as a comment inside `_preview/<Name>.js`, and a symlinked `node_modules`
+  resolves to its realpath — emitting `../../../../ui/node_modules/lucide-react/…`
+  instead of `node_modules/lucide-react/…`. That silently churns `renderHashes` for
+  every component whose preview imports a **bundled** dep (lucide-react, recharts,
+  cmdk): 10 components, phantom `changed` entries, a spurious `[SPOT_CHECK]` canary, and
+  an upload set of 12 instead of 2. Previews importing only the externalized `nexus-ui`
+  (Button, Badge, Card, Input, Dialog) are unaffected, which is the tell-tale signature.
+  Uploaded bytes must not depend on which directory the sync ran from.
+- `.ds-sync/`: `cp -r` the scripts from the skill dir, copy `package.json` +
+  `package-lock.json`, then symlinking `.ds-sync/node_modules` at the main checkout IS
+  safe — converter deps never reach the emitted artifacts.
+- `.design-sync/.cache/remote-sync.json` (the anchor) and, optionally,
+  `.design-sync/.cache/review/` to carry grade state. Neither is in git.
+- `.design-sync/previews/` needs nothing — it is tracked, so it arrives with the worktree.
+
+## Card layout: `cfg.overrides` cardMode (triaged 2026-07-30)
+
+Validate's `[GRID_OVERFLOW]` check flags stories that crop or escape their cell in the
+product's grid view. 65 of 97 components were flagged and had been shipping untriaged
+since the first sync (`config.json` had no `overrides` key at all). All 65 now carry an
+override: **51 `{"cardMode":"column"}"`** (wide — keeps every story, one per full-width
+row) and **14 `{"cardMode":"single", "primaryStory": …}`** for the portal/fixed-position
+overlays, where a single open overlay is the honest card anyway. Primary picks favour the
+open state showing real content over a trivial one (`Select`→`ModelPicker` not `Closed`,
+`WaitScreen`→`Generating`, `AlertDialog`→`WipeSlot`, `HoverCard`→`CharacterCard`).
+
+- **These overrides do NOT invalidate grades.** `configSlicesFor` deliberately strips
+  `cardMode`/`primaryStory` from the graded component slice ("they arrange the default
+  card view, not any solo-captured story"), so a layout flip carries grades forward. It
+  does change each `.html`, so the 65 land in `upload.components` and trigger a
+  `render_churn` `[SPOT_CHECK]` canary — that canary is expected, not a defect.
+- Review sheets capture each story **solo** (`?story=`), so they show every export
+  regardless of `cardMode`. To eyeball the actual card arrangement use `.review.html`.
+- Judge grid overflow from `.render-check.json`'s `gridOverflow` field, never from a
+  contact sheet — the sheet tiles full-card screenshots at fixed width, so it clips
+  cards (e.g. `Intertitle`) that the product's grid presents fine.
+
+## Data-bound cards share ONE query cache
+
+A card renders all of its cells in a single page load against the one `queryClient`
+singleton, so every cell necessarily sees the same payload — **per-cell mock scenarios
+are impossible**. Vary cells by real props and by driving real interactions; put the
+state diversity into one rich stub scenario instead.
+
+- **`LocalModelRows`** (`/api/local-models/status` + `/download` in `ds-provider.tsx`).
+  The stub is required, not a nicety: the component does
+  `if (statusQuery.error && !status) throw statusQuery.error`, so an unmocked status
+  endpoint throws and blanks every pane mounting it — `SettingsPane` embeds it since
+  #482. The single scenario is tuned so one render shows the maximum number of row
+  states (`system_ram_gb: 48` puts two 70B quants over the memory ceiling; one quant
+  serving, one on disk, one downloadable, one mid-download). Catalog mirrors
+  `nexus.toml [local_models]` so the cards name the real Hermes families.
+- Its accordion `open` map is internal `useState` with no prop to seed it, and the
+  families do not exist in the DOM until the query resolves. The `Quantizations` cell
+  therefore polls briefly and clicks the component's own chevron, selecting on
+  `[aria-expanded="false"]` so it is idempotent and never toggles an open family shut.
+  Same principle as the ContextMenu preview: drive the real trigger, never hand-write
+  the open state.
+- It renders bare `<li>`s — wrap in `<ul className="model-list">`, as `SettingsPane` does.
+  `.lm-*` and `.intertitle` rules are unscoped, so no `.nexus-shell` wrapper is needed
+  (unlike `SettingsPane`'s footer buttons).
 
 ## Component-type recipes (folded from wave-2 authoring)
 

--- a/ui/.design-sync/config.json
+++ b/ui/.design-sync/config.json
@@ -7,8 +7,221 @@
   "srcDir": "client/src",
   "cssEntry": ".design-sync/.cache/lib-dist/style.css",
   "buildCmd": "node .design-sync/build.mjs",
-  "provider": { "component": "DesignThemeRoot" },
+  "provider": {
+    "component": "DesignThemeRoot"
+  },
   "readmeHeader": ".design-sync/conventions.md",
+  "overrides": {
+    "Accordion": {
+      "cardMode": "column"
+    },
+    "Alert": {
+      "cardMode": "column"
+    },
+    "AlertDialog": {
+      "cardMode": "single",
+      "primaryStory": "WipeSlot"
+    },
+    "AnimatedBeam": {
+      "cardMode": "column"
+    },
+    "ArtifactSidePanel": {
+      "cardMode": "column"
+    },
+    "AspectRatio": {
+      "cardMode": "column"
+    },
+    "Button": {
+      "cardMode": "column"
+    },
+    "CharacterPhase": {
+      "cardMode": "column"
+    },
+    "CharactersPane": {
+      "cardMode": "column"
+    },
+    "ChartContainer": {
+      "cardMode": "column"
+    },
+    "Checkbox": {
+      "cardMode": "column"
+    },
+    "Collapsible": {
+      "cardMode": "column"
+    },
+    "ContextMenu": {
+      "cardMode": "single",
+      "primaryStory": "ChapterActions"
+    },
+    "Conversation": {
+      "cardMode": "column"
+    },
+    "DecoRays": {
+      "cardMode": "column"
+    },
+    "DevMarkdownPreview": {
+      "cardMode": "column"
+    },
+    "DropdownMenu": {
+      "cardMode": "single",
+      "primaryStory": "SlotActions"
+    },
+    "GildedSplash": {
+      "cardMode": "column"
+    },
+    "HoverCard": {
+      "cardMode": "single",
+      "primaryStory": "CharacterCard"
+    },
+    "InteractiveWizard": {
+      "cardMode": "column"
+    },
+    "LocalModelRows": {
+      "cardMode": "column"
+    },
+    "LocationPhase": {
+      "cardMode": "column"
+    },
+    "MapPane": {
+      "cardMode": "column"
+    },
+    "MapPlaceDialog": {
+      "cardMode": "single",
+      "primaryStory": "Open"
+    },
+    "Menubar": {
+      "cardMode": "single",
+      "primaryStory": "StoryMenu"
+    },
+    "Message": {
+      "cardMode": "column"
+    },
+    "ModeSelector": {
+      "cardMode": "column"
+    },
+    "NarrativePane": {
+      "cardMode": "column"
+    },
+    "NewStoryPage": {
+      "cardMode": "column"
+    },
+    "NewStoryWizard": {
+      "cardMode": "column"
+    },
+    "NexusLayout": {
+      "cardMode": "column"
+    },
+    "NotFound": {
+      "cardMode": "column"
+    },
+    "Pagination": {
+      "cardMode": "column"
+    },
+    "Popover": {
+      "cardMode": "single",
+      "primaryStory": "ContextSettings"
+    },
+    "PromptInput": {
+      "cardMode": "single",
+      "primaryStory": "Ready"
+    },
+    "ResizablePanelGroup": {
+      "cardMode": "column"
+    },
+    "Response": {
+      "cardMode": "column"
+    },
+    "RightLedger": {
+      "cardMode": "column"
+    },
+    "ScrollArea": {
+      "cardMode": "column"
+    },
+    "SeedPhase": {
+      "cardMode": "column"
+    },
+    "Select": {
+      "cardMode": "single",
+      "primaryStory": "ModelPicker"
+    },
+    "Separator": {
+      "cardMode": "column"
+    },
+    "SettingPhase": {
+      "cardMode": "column"
+    },
+    "SettingsPane": {
+      "cardMode": "column"
+    },
+    "Skeleton": {
+      "cardMode": "column"
+    },
+    "Slider": {
+      "cardMode": "column"
+    },
+    "SlotSelector": {
+      "cardMode": "column"
+    },
+    "SplashPage": {
+      "cardMode": "column"
+    },
+    "SplashThemeMenu": {
+      "cardMode": "column"
+    },
+    "StoryChoices": {
+      "cardMode": "column"
+    },
+    "Switch": {
+      "cardMode": "column"
+    },
+    "Table": {
+      "cardMode": "column"
+    },
+    "Tabs": {
+      "cardMode": "column"
+    },
+    "Textarea": {
+      "cardMode": "column"
+    },
+    "ThemeMenu": {
+      "cardMode": "single",
+      "primaryStory": "Open"
+    },
+    "Toast": {
+      "cardMode": "single",
+      "primaryStory": "ChapterSaved"
+    },
+    "Toaster": {
+      "cardMode": "single",
+      "primaryStory": "NotificationStack"
+    },
+    "Tooltip": {
+      "cardMode": "single",
+      "primaryStory": "IronmanHint"
+    },
+    "TopBar": {
+      "cardMode": "column"
+    },
+    "TraitSelector": {
+      "cardMode": "column"
+    },
+    "TraitSelectorGrid": {
+      "cardMode": "column"
+    },
+    "VectorSplash": {
+      "cardMode": "column"
+    },
+    "VeilSplash": {
+      "cardMode": "column"
+    },
+    "WaitScreen": {
+      "cardMode": "single",
+      "primaryStory": "Generating"
+    },
+    "WizardChoices": {
+      "cardMode": "column"
+    }
+  },
   "componentSrcMap": {
     "ErrorBoundary": "client/src/components/ErrorBoundary.tsx",
     "ArtifactSidePanel": "client/src/components/NewStoryWizard/ArtifactSidePanel.tsx",
@@ -36,7 +249,9 @@
     "DecoFrame": "client/src/components/deco/DecoFrame.tsx",
     "DecoSunburst": "client/src/components/deco/DecoSunburst.tsx",
     "CharactersPane": "client/src/components/nexus/CharactersPane.tsx",
+    "Intertitle": "client/src/components/nexus/Intertitle.tsx",
     "LeftRail": "client/src/components/nexus/LeftRail.tsx",
+    "LocalModelRows": "client/src/components/nexus/LocalModelRows.tsx",
     "MapPane": "client/src/components/nexus/MapPane.tsx",
     "MapPlaceDialog": "client/src/components/nexus/MapPlaceDialog.tsx",
     "NarrativePane": "client/src/components/nexus/NarrativePane.tsx",

--- a/ui/.design-sync/ds-provider.tsx
+++ b/ui/.design-sync/ds-provider.tsx
@@ -69,6 +69,54 @@ if (typeof window !== "undefined" && !(window as any).__dsFetchStubbed) {
       typewriter: { min: 0, max: 60 },
     },
   });
+  // Local-model manager (/api/local-models). LocalModelRows does
+  // `if (statusQuery.error && !status) throw statusQuery.error`, so an unmocked
+  // status endpoint doesn't degrade the card — it throws and blanks every pane
+  // that mounts it (SettingsPane embeds it). The catalog mirrors nexus.toml's
+  // [local_models] so the cards show the real Hermes families.
+  //
+  // ONE scenario, deliberately: a card renders all its cells in a single page
+  // load sharing one React Query cache, so every cell necessarily sees the same
+  // payload — per-cell scenarios are impossible. This one is therefore tuned to
+  // exercise the maximum number of row states at once. With system_ram_gb = 48:
+  //   36b q4_k_m  installed + verified + active  -> active dot, EJECT row
+  //   36b q6_k    installed + verified           -> ready, armed-delete trash
+  //   36b q8_0    absent (min_ram 48, fits)      -> download arrow
+  //   70b q4_k_m  download in flight             -> 37% + progress bar + cancel
+  //   70b q6_k    min_ram 64 > 48                -> exceeds (RAM-ceiling tooltip)
+  //   70b q8_0    min_ram 96 > 48                -> exceeds
+  const LM_DIR = "~/.lmstudio/models/lmstudio-community";
+  const LM_36B = `${LM_DIR}/Hermes-4.3-36B-GGUF`;
+  const LM_70B = `${LM_DIR}/Hermes-4-70B-GGUF`;
+  const LOCAL_STATUS = {
+    models_dir: LM_DIR,
+    system_ram_gb: 48,
+    catalog: [
+      { family: "hermes-4-70b", label: "Hermes 4 70B Q4_K_M", hf_repo: "lmstudio-community/Hermes-4-70B-GGUF", subdir: "Hermes-4-70B-GGUF", filename: "Hermes-4-70B-Q4_K_M.gguf", quant: "Q4_K_M", size_gb: 42.5, min_ram_gb: 48 },
+      { family: "hermes-4-70b", label: "Hermes 4 70B Q6_K", hf_repo: "lmstudio-community/Hermes-4-70B-GGUF", subdir: "Hermes-4-70B-GGUF", filename: "Hermes-4-70B-Q6_K-00001-of-00002.gguf", quant: "Q6_K", size_gb: 57.9, min_ram_gb: 64 },
+      { family: "hermes-4-70b", label: "Hermes 4 70B Q8_0", hf_repo: "lmstudio-community/Hermes-4-70B-GGUF", subdir: "Hermes-4-70B-GGUF", filename: "Hermes-4-70B-Q8_0-00001-of-00002.gguf", quant: "Q8_0", size_gb: 75.0, min_ram_gb: 96 },
+      { family: "hermes-4.3-36b", label: "Hermes 4.3 36B Q4_K_M", hf_repo: "bartowski/NousResearch_Hermes-4.3-36B-GGUF", subdir: "Hermes-4.3-36B-GGUF", filename: "NousResearch_Hermes-4.3-36B-Q4_K_M.gguf", quant: "Q4_K_M", size_gb: 21.8, min_ram_gb: 32 },
+      { family: "hermes-4.3-36b", label: "Hermes 4.3 36B Q6_K", hf_repo: "bartowski/NousResearch_Hermes-4.3-36B-GGUF", subdir: "Hermes-4.3-36B-GGUF", filename: "NousResearch_Hermes-4.3-36B-Q6_K.gguf", quant: "Q6_K", size_gb: 29.7, min_ram_gb: 40 },
+      { family: "hermes-4.3-36b", label: "Hermes 4.3 36B Q8_0", hf_repo: "bartowski/NousResearch_Hermes-4.3-36B-GGUF", subdir: "Hermes-4.3-36B-GGUF", filename: "NousResearch_Hermes-4.3-36B-Q8_0.gguf", quant: "Q8_0", size_gb: 38.4, min_ram_gb: 48 },
+    ],
+    // Installed iff models_dir/subdir/filename matches a row's path exactly;
+    // `ready` is verified, not merely present.
+    installed: [
+      { path: `${LM_36B}/NousResearch_Hermes-4.3-36B-Q4_K_M.gguf`, filename: "NousResearch_Hermes-4.3-36B-Q4_K_M.gguf", arch: "seed_oss", quant: "Q4_K_M", size_bytes: 21_800_000_000, verified: true, active: true },
+      { path: `${LM_36B}/NousResearch_Hermes-4.3-36B-Q6_K.gguf`, filename: "NousResearch_Hermes-4.3-36B-Q6_K.gguf", arch: "seed_oss", quant: "Q6_K", size_bytes: 29_700_000_000, verified: true, active: false },
+    ],
+    active: { gguf_path: `${LM_36B}/NousResearch_Hermes-4.3-36B-Q4_K_M.gguf`, ready: true, failed: false },
+  };
+  const LOCAL_DOWNLOAD = {
+    state: "downloading",
+    family: "hermes-4-70b",
+    quant: "Q4_K_M",
+    downloaded_bytes: 15_725_000_000,
+    total_bytes: 42_500_000_000,
+    progress: 0.37,
+    files: ["Hermes-4-70B-Q4_K_M.gguf"],
+    local_dir: LM_70B,
+  };
   // GET-only: mutations (POST/PATCH/DELETE) fall through to the real fetch so a
   // preview that wires an interactive write fails visibly instead of silently
   // succeeding with mock data (Claude review).
@@ -81,6 +129,8 @@ if (typeof window !== "undefined" && !(window as any).__dsFetchStubbed) {
         const theme = window.localStorage.getItem("nexus-theme") || "veil";
         return Promise.resolve(json(SETTINGS(theme)));
       }
+      if (url.includes("/api/local-models/download")) return Promise.resolve(json(LOCAL_DOWNLOAD));
+      if (url.includes("/api/local-models/status")) return Promise.resolve(json(LOCAL_STATUS));
       if (url.includes("/api/story/new/slots")) return Promise.resolve(json(SLOTS));
       if (/\/api\/characters\/[^/]+\/images(\?|$)/.test(url)) return Promise.resolve(json([]));
       if (url.includes("/api/characters")) return Promise.resolve(json(CAST));

--- a/ui/.design-sync/previews/Intertitle.tsx
+++ b/ui/.design-sync/previews/Intertitle.tsx
@@ -1,0 +1,56 @@
+import { Intertitle } from "nexus-ui";
+
+// Quiet scene grounding. NarrativePane emits one only at a committed scene
+// boundary — the first chunk, or wherever the season/episode/scene key changes.
+// Pure props, no data binding, so every cell is the real component at a real
+// boundary.
+//
+// Two fields carry the variation: `worldTime` is the calculated in-world
+// timestamp (nullable — chunks before the first base_timestamp have none), and
+// the layer suffix appears only for a non-"primary" world_layer. The schema
+// admits exactly two layers, 'primary' and 'retrograde'.
+
+const READER = { maxWidth: 560 };
+
+// Canonical boundary: primary layer, world clock resolved. The timestamp
+// formats as "14 Mar 2073 · 21:40".
+export const SceneBoundary = () => (
+  <div style={READER}>
+    <Intertitle
+      season={1}
+      episode={2}
+      scene={3}
+      worldLayer="primary"
+      worldTime="2073-03-14T21:40"
+    />
+  </div>
+);
+
+// No world clock: the slug line stands alone, and the divider still carries the
+// boundary. This is the state every chunk shows before a base_timestamp is set.
+export const WithoutWorldTime = () => (
+  <div style={READER}>
+    <Intertitle
+      season={1}
+      episode={1}
+      scene={1}
+      worldLayer="primary"
+      worldTime={null}
+    />
+  </div>
+);
+
+// Retrograde layer: summaries held out of narrative continuity are stamped with
+// a non-primary world_layer, and the slug picks up the layer suffix so the
+// boundary reads as off-spine.
+export const RetrogradeLayer = () => (
+  <div style={READER}>
+    <Intertitle
+      season={2}
+      episode={7}
+      scene={12}
+      worldLayer="retrograde"
+      worldTime="2071-11-02T04:15"
+    />
+  </div>
+);

--- a/ui/.design-sync/previews/LocalModelRows.tsx
+++ b/ui/.design-sync/previews/LocalModelRows.tsx
@@ -47,10 +47,22 @@ function Rows({ expand }: { expand: boolean }) {
     };
   }, [expand]);
 
+  // The `nexus-shell` ancestor is required, not decoration: alongside its own
+  // unscoped `.lm-*` rules the component emits `.caption`, `.btn-soft`, and
+  // `.btn-primary`, and nexus-layout.css defines all three ONLY under
+  // `.nexus-shell`. A bare <ul> renders the quant labels and the EJECT / APPLY
+  // buttons as browser defaults. Same trap the SettingsPane preview documents.
+  // The shell's 100vh height and 52px TopBar grid row are overridden locally so
+  // the lone list fills the cell.
   return (
-    <ul className="model-list" ref={ref} style={{ width: 440 }}>
-      <LocalModelRows selected onPickLocal={() => {}} knobs={STILL_KNOBS} />
-    </ul>
+    <div
+      className="nexus-shell"
+      style={{ width: 480, height: "auto", gridTemplateRows: "auto", padding: 16 }}
+    >
+      <ul className="model-list" ref={ref}>
+        <LocalModelRows selected onPickLocal={() => {}} knobs={STILL_KNOBS} />
+      </ul>
+    </div>
   );
 }
 

--- a/ui/.design-sync/previews/LocalModelRows.tsx
+++ b/ui/.design-sync/previews/LocalModelRows.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from "react";
+import { LocalModelRows } from "nexus-ui";
+
+// Per-quant local-model manager — the "local" provider's rows inside the MODEL
+// card. Data-bound: the fetch stub in ds-provider.tsx serves GET
+// /api/local-models/status and /download from the real nexus.toml Hermes
+// catalog. The component returns bare <li>s, so a <ul className="model-list">
+// wrapper is required; that is exactly how SettingsPane mounts it.
+//
+// Both cells of a card render in ONE page load against ONE React Query cache,
+// so they necessarily read the same payload — per-cell scenarios are not
+// possible here. The stub's single scenario is therefore tuned to show every
+// row state at once: 36b q4_k_m serving, q6_k on disk, q8_0 downloadable, 70b
+// q4_k_m mid-download, and the two 70b quants above the 48 gb memory ceiling.
+
+// Cadence is dialled back from the nexus.toml knobs: a still card has no use for
+// a 1 s download poll, and a quiet page lets the capture settle.
+const STILL_KNOBS = {
+  poll_busy_ms: 60_000,
+  poll_idle_ms: 60_000,
+  download_poll_ms: 60_000,
+  delete_arm_ms: 2_800,
+};
+
+function Rows({ expand }: { expand: boolean }) {
+  const ref = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    if (!expand) return;
+    // The accordion's `open` map is internal useState with no prop to seed it,
+    // and the families do not exist in the DOM until the status query resolves —
+    // so poll briefly and drive the component's own chevron, the same way the
+    // ContextMenu preview dispatches a real event rather than faking the open
+    // state. Selecting on aria-expanded="false" makes this idempotent: a family
+    // that is already open is never toggled shut.
+    const openCollapsed = () =>
+      ref.current
+        ?.querySelectorAll<HTMLButtonElement>(
+          '[data-testid^="lm-toggle-"][aria-expanded="false"]',
+        )
+        .forEach((chevron) => chevron.click());
+    const poll = setInterval(openCollapsed, 60);
+    const stop = setTimeout(() => clearInterval(poll), 2500);
+    return () => {
+      clearInterval(poll);
+      clearTimeout(stop);
+    };
+  }, [expand]);
+
+  return (
+    <ul className="model-list" ref={ref} style={{ width: 440 }}>
+      <LocalModelRows selected onPickLocal={() => {}} knobs={STILL_KNOBS} />
+    </ul>
+  );
+}
+
+// Rest state: one row per family, collapsed. The serving family carries its
+// quant summary and a filled radio; the idle one shows neither. The EJECT
+// action appears because a model is loaded.
+export const Families = () => <Rows expand={false} />;
+
+// Expanded: the per-quant manager. Reading down, the states are the active dot,
+// an on-disk quant with its armed-delete trash, a downloadable quant, the
+// in-flight download with percentage and progress bar, and the two quants the
+// machine has too little memory to load.
+export const Quantizations = () => <Rows expand />;


### PR DESCRIPTION
Design-sync of the `ui/` component library to the NEXUS Iris project on claude.ai/design. **95 → 97 components.** Already uploaded and verified; this PR lands the sync *inputs* so future runs reuse them.

## New cards

`Intertitle` (#456) and `LocalModelRows` (#465 Phase 1b) were both riding the bundle uncarded — importable by the design agent but with no preview, no prop doc, no card. Both are now pinned in `componentSrcMap` with authored previews, which clears the standing deferral NOTES.md was tracking.

`ds-provider.tsx` gains a GET stub for `/api/local-models/status` and `/download`, built from the real `nexus.toml` Hermes catalog. This is **required, not cosmetic**: `LocalModelRows` does `if (statusQuery.error && !status) throw statusQuery.error`, so an unmocked endpoint throws and blanks every pane that mounts it — and `SettingsPane` has embedded it since #482, i.e. since the last sync.

One constraint shaped the preview: a card renders all its cells in a single page load against one React Query cache, so every cell necessarily sees the same payload — per-cell mock scenarios are impossible. The stub therefore uses one scenario tuned to show the maximum number of row states at once (`system_ram_gb: 48` puts two 70B quants over the memory ceiling; one quant serving, one on disk, one downloadable, one mid-download at 37%).

## Card layout — 65 cards were cropping

Validate flags `[GRID_OVERFLOW]` when stories crop or escape their cell in the design pane's grid view. **65 of 97 were flagged and had never been triaged** — `config.json` carried no `overrides` key at all, so this has been shipping since the first sync. All 65 now carry the remedy validate names: 51 `cardMode: column` (keeps every story, one per full-width row) and 14 `cardMode: single` for the portal/overlay components, with a primary chosen to favour the open state showing real content (`Select`→`ModelPicker` over `Closed`, `WaitScreen`→`Generating`, `AlertDialog`→`WipeSlot`).

No grades were invalidated: `configSlicesFor` deliberately strips `cardMode`/`primaryStory` from the graded component slice, since they arrange the default card view rather than any solo-captured story.

## NOTES.md

Four things a future sync needs:

- **Never symlink `node_modules` when syncing from a worktree.** esbuild inlines each resolved module's path as a comment inside `_preview/<Name>.js`; a symlink resolves to its realpath and emits `../../../../ui/node_modules/lucide-react/…`, churning render hashes for every preview that imports a bundled dep. That made 10 components look `changed` purely because of *where* the sync ran, and inflated the upload set from 2 to 12. Hardlink-copy (`cp -Rl`) instead.
- The cached `remote-sync.json` anchor is always one generation stale — it's fetched before the run that then uploads a new one.
- The cardMode triage above, with the reasoning behind each `single` pick.
- **Open gap:** all 97 `.d.ts` files are permissive stubs (`{ [key: string]: unknown }`) because the phantom `--entry` points at a Vite lib build with no declaration tree (`[DTS] parsed 0 .d.ts files`). Filed separately.

## Verification

- Render check clean: 97 components, `bad 0`, `thin 0`, `variantsIdentical 0`, zero floor cards
- **Zero warn lines** on the final driver run (was 65 `[GRID_OVERFLOW]`)
- Both new cards graded `good` against the absolute rubric from their review sheets
- Conventions header re-validated against the fresh build — every token family, font utility, theme class and component name it names still resolves
- 514 files uploaded, 0 deletes, anchor written last

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019697mhq4W45PA4Srr1AFib