### PR TITLE
Reuse Orrery Configuration Within Resolver and Commit Operations

### DIFF
--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -10,7 +10,7 @@ and transaction management.
 import json
 import logging
 from datetime import datetime
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional, cast
 import asyncpg  # type: ignore[import-untyped]
 
 from nexus.agents.logon.apex_schema import (
@@ -705,6 +705,7 @@ async def commit_incubator_to_database(
                 await apply_state_updates(conn, state_updates, source_chunk_id=chunk_id)
 
             # Step 9.5: Commit Orrery proposal inside the accepted-chunk transaction
+            orrery_settings = _load_orrery_settings()
             orrery_result = await commit_orrery_tick_async(
                 conn,
                 incubator.get("orrery_proposal"),
@@ -713,19 +714,19 @@ async def commit_incubator_to_database(
                 world_layer=world_layer,
                 adjudications=incubator.get("orrery_adjudications"),
                 storyteller_state_updates=incubator.get("entity_updates"),
-                prompt_settings=_orrery_prompt_settings(),
-                ecology_settings=_orrery_ecology_settings(),
-                project_settings=_orrery_project_settings(),
-                mood_settings=_orrery_mood_settings(),
+                prompt_settings=orrery_settings.get("prompt"),
+                ecology_settings=orrery_settings.get("ecology"),
+                project_settings=orrery_settings.get("projects"),
+                mood_settings=orrery_settings.get("mood"),
                 epistemics_settings=(
-                    _orrery_epistemics_settings()
+                    orrery_settings.get("epistemics")
                     if incubator.get("orrery_proposal") is None
                     else None
                 ),
-                contagion_settings=_orrery_contagion_settings(),
-                distortion_settings=_orrery_distortion_settings(),
-                drift_settings=_orrery_drift_settings(),
-                reveal_settings=_orrery_reveal_settings(),
+                contagion_settings=orrery_settings.get("contagion"),
+                distortion_settings=orrery_settings.get("distortion"),
+                drift_settings=orrery_settings.get("drift"),
+                reveal_settings=orrery_settings.get("reveal"),
             )
             if (
                 orrery_result.resolution_count
@@ -760,7 +761,7 @@ async def commit_incubator_to_database(
                 )
 
             # Step 9.55: interval state checkpoint (reconstruction bar 7c)
-            checkpoint_interval = _orrery_checkpoint_interval()
+            checkpoint_interval = _orrery_checkpoint_interval(orrery_settings)
             if checkpoint_interval:
                 playable_ordinal = await playable_narrative_ordinal_async(conn)
                 if interval_checkpoint_due(
@@ -815,84 +816,16 @@ async def commit_incubator_to_database(
     return chunk_id
 
 
-def _orrery_ecology_settings() -> Any:
-    """[orrery.ecology] signal-detection policy for branch signal emissions."""
+def _load_orrery_settings() -> Mapping[str, Any]:
+    """Load the Orrery configuration once for one accepted-chunk operation."""
 
     from nexus.config import load_settings_as_dict
 
-    return (load_settings_as_dict().get("orrery") or {}).get("ecology")
+    return cast(Mapping[str, Any], load_settings_as_dict().get("orrery") or {})
 
 
-def _orrery_prompt_settings() -> Any:
-    """[orrery.prompt] render caps, so the prompt-exposure log matches what
-    logon_utility actually rendered for this tick."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("prompt")
-
-
-def _orrery_project_settings() -> Any:
-    """[orrery.projects] cadence and abandonment policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("projects")
-
-
-def _orrery_mood_settings() -> Any:
-    """[orrery.mood] mechanical affect write policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("mood")
-
-
-def _orrery_contagion_settings() -> Any:
-    """[orrery.contagion] frontier and communication policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("contagion")
-
-
-def _orrery_distortion_settings() -> Any:
-    """[orrery.distortion] authored hop-depth account selection policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("distortion")
-
-
-def _orrery_epistemics_settings() -> Any:
-    """[orrery.epistemics] claim-minting and awareness policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("epistemics")
-
-
-def _orrery_drift_settings() -> Any:
-    """[orrery.drift] continuous relationship-valence policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("drift")
-
-
-def _orrery_reveal_settings() -> Any:
-    """[orrery.reveal] template-authored backstory reveal policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("reveal")
-
-
-def _orrery_checkpoint_interval() -> int:
+def _orrery_checkpoint_interval(orrery_settings: Mapping[str, Any]) -> int:
     """[orrery.reconstruction] checkpoint cadence; 0 disables."""
 
-    from nexus.config import load_settings_as_dict
-
-    orrery = load_settings_as_dict().get("orrery") or {}
-    reconstruction = orrery.get("reconstruction") or {}
+    reconstruction = orrery_settings.get("reconstruction") or {}
     return int(reconstruction.get("checkpoint_interval_chunks", 0))

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -9,7 +9,7 @@ with the existing narrative API.
 import json
 import logging
 from datetime import datetime
-from typing import Optional, Any, Dict, List
+from typing import Any, Dict, List, Mapping, Optional, cast
 from psycopg2.extras import RealDictCursor
 
 from nexus.agents.logon.apex_schema import (
@@ -573,6 +573,7 @@ def commit_incubator_to_database_sync(
                 apply_state_updates_sync(conn, state_updates, source_chunk_id=chunk_id)
 
             # Step 9.5: Commit Orrery proposal inside the accepted-chunk transaction
+            orrery_settings = _load_orrery_settings()
             orrery_result = commit_orrery_tick_sync(
                 conn,
                 incubator.get("orrery_proposal"),
@@ -581,19 +582,19 @@ def commit_incubator_to_database_sync(
                 world_layer=world_layer,
                 adjudications=incubator.get("orrery_adjudications"),
                 storyteller_state_updates=incubator.get("entity_updates"),
-                prompt_settings=_orrery_prompt_settings(),
-                ecology_settings=_orrery_ecology_settings(),
-                project_settings=_orrery_project_settings(),
-                mood_settings=_orrery_mood_settings(),
+                prompt_settings=orrery_settings.get("prompt"),
+                ecology_settings=orrery_settings.get("ecology"),
+                project_settings=orrery_settings.get("projects"),
+                mood_settings=orrery_settings.get("mood"),
                 epistemics_settings=(
-                    _orrery_epistemics_settings()
+                    orrery_settings.get("epistemics")
                     if incubator.get("orrery_proposal") is None
                     else None
                 ),
-                contagion_settings=_orrery_contagion_settings(),
-                distortion_settings=_orrery_distortion_settings(),
-                drift_settings=_orrery_drift_settings(),
-                reveal_settings=_orrery_reveal_settings(),
+                contagion_settings=orrery_settings.get("contagion"),
+                distortion_settings=orrery_settings.get("distortion"),
+                drift_settings=orrery_settings.get("drift"),
+                reveal_settings=orrery_settings.get("reveal"),
             )
             if (
                 orrery_result.resolution_count
@@ -630,7 +631,7 @@ def commit_incubator_to_database_sync(
             # Step 9.55: interval state checkpoint (reconstruction bar 7c).
             # Fresh cursor: the earlier `with conn.cursor()` blocks have
             # closed theirs by this point (review finding on #428).
-            checkpoint_interval = _orrery_checkpoint_interval()
+            checkpoint_interval = _orrery_checkpoint_interval(orrery_settings)
             if checkpoint_interval:
                 with conn.cursor() as checkpoint_cur:
                     playable_ordinal = playable_narrative_ordinal_sync(checkpoint_cur)
@@ -988,84 +989,16 @@ def _apply_state_tags(
         logger.info(f"Tag bestowal {kind}/{subtype_id}: {counters}")
 
 
-def _orrery_ecology_settings() -> Any:
-    """[orrery.ecology] signal-detection policy for branch signal emissions."""
+def _load_orrery_settings() -> Mapping[str, Any]:
+    """Load the Orrery configuration once for one accepted-chunk operation."""
 
     from nexus.config import load_settings_as_dict
 
-    return (load_settings_as_dict().get("orrery") or {}).get("ecology")
+    return cast(Mapping[str, Any], load_settings_as_dict().get("orrery") or {})
 
 
-def _orrery_prompt_settings() -> Any:
-    """[orrery.prompt] render caps, so the prompt-exposure log matches what
-    logon_utility actually rendered for this tick."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("prompt")
-
-
-def _orrery_project_settings() -> Any:
-    """[orrery.projects] cadence and abandonment policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("projects")
-
-
-def _orrery_mood_settings() -> Any:
-    """[orrery.mood] mechanical affect write policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("mood")
-
-
-def _orrery_contagion_settings() -> Any:
-    """[orrery.contagion] frontier and communication policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("contagion")
-
-
-def _orrery_distortion_settings() -> Any:
-    """[orrery.distortion] authored hop-depth account selection policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("distortion")
-
-
-def _orrery_epistemics_settings() -> Any:
-    """[orrery.epistemics] claim-minting and awareness policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("epistemics")
-
-
-def _orrery_drift_settings() -> Any:
-    """[orrery.drift] continuous relationship-valence policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("drift")
-
-
-def _orrery_reveal_settings() -> Any:
-    """[orrery.reveal] template-authored backstory reveal policy."""
-
-    from nexus.config import load_settings_as_dict
-
-    return (load_settings_as_dict().get("orrery") or {}).get("reveal")
-
-
-def _orrery_checkpoint_interval() -> int:
+def _orrery_checkpoint_interval(orrery_settings: Mapping[str, Any]) -> int:
     """[orrery.reconstruction] checkpoint cadence; 0 disables."""
 
-    from nexus.config import load_settings_as_dict
-
-    orrery = load_settings_as_dict().get("orrery") or {}
-    reconstruction = orrery.get("reconstruction") or {}
+    reconstruction = orrery_settings.get("reconstruction") or {}
     return int(reconstruction.get("checkpoint_interval_chunks", 0))

--- a/tests/test_api/test_correspondence_pg.py
+++ b/tests/test_api/test_correspondence_pg.py
@@ -132,7 +132,7 @@ def test_parallel_approvals_claim_incubator_row_once(
     monkeypatch.setattr(
         commit_handler_sync,
         "_orrery_checkpoint_interval",
-        lambda: 0,
+        lambda _settings: 0,
     )
     monkeypatch.setattr(
         "nexus.api.presence_audit.presence_audit_enabled",
@@ -262,7 +262,7 @@ def test_accept_reject_hysteresis_and_digest_undo(
     monkeypatch.setattr(
         commit_handler_sync,
         "_orrery_checkpoint_interval",
-        lambda: 0,
+        lambda _settings: 0,
     )
     compaction_calls: list[dict[str, Any]] = []
 

--- a/tests/test_api/test_orrery_config_reuse_pg.py
+++ b/tests/test_api/test_orrery_config_reuse_pg.py
@@ -1,0 +1,261 @@
+"""PostgreSQL regressions for accepted-chunk Orrery configuration reuse."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from typing import Any, Iterator
+
+import asyncpg  # type: ignore[import-untyped]
+import psycopg2
+import pytest
+from psycopg2 import sql
+
+import nexus.config as config_module
+from nexus.api import commit_handler, commit_handler_sync
+
+
+pytestmark = pytest.mark.requires_postgres
+
+
+def _connect(dbname: str) -> Any:
+    """Open a direct psycopg2 connection to a disposable database."""
+
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+@pytest.fixture()
+def qa654_db() -> Iterator[str]:
+    """Clone NEXUS_template into a qa654 database and drop it after the test."""
+
+    dbname = f"qa654_{uuid.uuid4().hex[:12]}"
+    admin = _connect("postgres")
+    admin.autocommit = True
+    try:
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier("NEXUS_template"),
+                )
+            )
+        yield dbname
+    finally:
+        with admin.cursor() as cur:
+            cur.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (dbname,),
+            )
+            cur.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+            )
+        admin.close()
+
+
+def _seed_commit(dbname: str, session_id: str) -> int:
+    """Seed one parent and proposal-free incubator turn; return the parent id."""
+
+    with _connect(dbname) as conn:
+        with conn.cursor() as cur:
+            cur.execute("TRUNCATE incubator, narrative_chunks RESTART IDENTITY CASCADE")
+            cur.execute(
+                """
+                INSERT INTO narrative_chunks (raw_text, storyteller_text, state)
+                VALUES ('Parent scene.', 'Parent scene.', 'finalized')
+                RETURNING id
+                """
+            )
+            parent_chunk_id = int(cur.fetchone()[0])
+            cur.execute(
+                """
+                INSERT INTO chunk_metadata (
+                    chunk_id, season, episode, scene, world_layer, slug
+                ) VALUES (%s, 1, 1, 1, 'primary', 'S01E01_001')
+                """,
+                (parent_chunk_id,),
+            )
+            cur.execute(
+                """
+                INSERT INTO incubator (
+                    id, chunk_id, parent_chunk_id, user_text, storyteller_text,
+                    generation_model, metadata_updates, entity_updates,
+                    reference_updates, orrery_proposal, orrery_adjudications,
+                    new_entities, session_id, llm_response_id, status
+                ) VALUES (
+                    TRUE, 2, %s, 'continue', 'Accepted scene.', 'TEST',
+                    '{}'::jsonb, NULL, '{}'::jsonb, NULL, '[]'::jsonb,
+                    '[]'::jsonb, %s, 'qa654-response', 'provisional'
+                )
+                """,
+                (parent_chunk_id, session_id),
+            )
+    return parent_chunk_id
+
+
+def _disable_presence_audit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the regression scoped to the accepted-chunk transaction."""
+
+    monkeypatch.setattr(
+        "nexus.api.presence_audit.presence_audit_enabled",
+        lambda: False,
+    )
+
+
+def test_sync_commit_loads_application_config_once(
+    qa654_db: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The genuine sync commit reuses one Orrery settings mapping."""
+
+    session_id = "00000000-0000-0000-0000-000000000654"
+    parent_chunk_id = _seed_commit(qa654_db, session_id)
+    _disable_presence_audit(monkeypatch)
+
+    original_loader = config_module.load_settings_as_dict
+    original_tick = commit_handler_sync.commit_orrery_tick_sync
+    original_checkpoint = commit_handler_sync._orrery_checkpoint_interval
+    loaded_settings: list[dict[str, Any]] = []
+    tick_kwargs: list[dict[str, Any]] = []
+    checkpoint_settings: list[Any] = []
+
+    def counted_loader() -> dict[str, Any]:
+        settings = original_loader()
+        loaded_settings.append(settings)
+        return settings
+
+    def recording_tick(conn: Any, proposal: Any, **kwargs: Any) -> Any:
+        tick_kwargs.append(kwargs)
+        return original_tick(conn, proposal, **kwargs)
+
+    def recording_checkpoint(settings: Any) -> int:
+        checkpoint_settings.append(settings)
+        return original_checkpoint(settings)
+
+    monkeypatch.setattr(config_module, "load_settings_as_dict", counted_loader)
+    monkeypatch.setattr(commit_handler_sync, "commit_orrery_tick_sync", recording_tick)
+    monkeypatch.setattr(
+        commit_handler_sync,
+        "_orrery_checkpoint_interval",
+        recording_checkpoint,
+    )
+
+    conn = _connect(qa654_db)
+    try:
+        committed_chunk_id = commit_handler_sync.commit_incubator_to_database_sync(
+            conn, session_id
+        )
+    finally:
+        conn.close()
+
+    assert committed_chunk_id > parent_chunk_id
+    assert len(loaded_settings) == 1
+    orrery = loaded_settings[0]["orrery"]
+    assert checkpoint_settings == [orrery]
+    assert tick_kwargs == [
+        {
+            "tick_chunk_id": committed_chunk_id,
+            "slot": None,
+            "world_layer": "primary",
+            "adjudications": [],
+            "storyteller_state_updates": None,
+            "prompt_settings": orrery.get("prompt"),
+            "ecology_settings": orrery.get("ecology"),
+            "project_settings": orrery.get("projects"),
+            "mood_settings": orrery.get("mood"),
+            "epistemics_settings": orrery.get("epistemics"),
+            "contagion_settings": orrery.get("contagion"),
+            "distortion_settings": orrery.get("distortion"),
+            "drift_settings": orrery.get("drift"),
+            "reveal_settings": orrery.get("reveal"),
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_commit_loads_application_config_once(
+    qa654_db: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The genuine async commit reuses one Orrery settings mapping."""
+
+    session_id = "00000000-0000-0000-0000-000000006540"
+    parent_chunk_id = _seed_commit(qa654_db, session_id)
+    _disable_presence_audit(monkeypatch)
+
+    original_loader = config_module.load_settings_as_dict
+    original_tick = commit_handler.commit_orrery_tick_async
+    original_checkpoint = commit_handler._orrery_checkpoint_interval
+    loaded_settings: list[dict[str, Any]] = []
+    tick_kwargs: list[dict[str, Any]] = []
+    checkpoint_settings: list[Any] = []
+
+    def counted_loader() -> dict[str, Any]:
+        settings = original_loader()
+        loaded_settings.append(settings)
+        return settings
+
+    async def recording_tick(conn: Any, proposal: Any, **kwargs: Any) -> Any:
+        tick_kwargs.append(kwargs)
+        return await original_tick(conn, proposal, **kwargs)
+
+    def recording_checkpoint(settings: Any) -> int:
+        checkpoint_settings.append(settings)
+        return original_checkpoint(settings)
+
+    monkeypatch.setattr(config_module, "load_settings_as_dict", counted_loader)
+    monkeypatch.setattr(commit_handler, "commit_orrery_tick_async", recording_tick)
+    monkeypatch.setattr(
+        commit_handler,
+        "_orrery_checkpoint_interval",
+        recording_checkpoint,
+    )
+
+    conn = await asyncpg.connect(
+        database=qa654_db,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+    for type_name in ("json", "jsonb"):
+        await conn.set_type_codec(
+            type_name,
+            schema="pg_catalog",
+            encoder=json.dumps,
+            decoder=json.loads,
+        )
+    try:
+        committed_chunk_id = await commit_handler.commit_incubator_to_database(
+            conn, session_id
+        )
+    finally:
+        await conn.close()
+
+    assert committed_chunk_id > parent_chunk_id
+    assert len(loaded_settings) == 1
+    orrery = loaded_settings[0]["orrery"]
+    assert checkpoint_settings == [orrery]
+    assert tick_kwargs == [
+        {
+            "tick_chunk_id": committed_chunk_id,
+            "slot": None,
+            "world_layer": "primary",
+            "adjudications": [],
+            "storyteller_state_updates": None,
+            "prompt_settings": orrery.get("prompt"),
+            "ecology_settings": orrery.get("ecology"),
+            "project_settings": orrery.get("projects"),
+            "mood_settings": orrery.get("mood"),
+            "epistemics_settings": orrery.get("epistemics"),
+            "contagion_settings": orrery.get("contagion"),
+            "distortion_settings": orrery.get("distortion"),
+            "drift_settings": orrery.get("drift"),
+            "reveal_settings": orrery.get("reveal"),
+        }
+    ]

--- a/tests/test_commit_handler.py
+++ b/tests/test_commit_handler.py
@@ -209,7 +209,9 @@ async def test_async_commit_links_same_turn_character_declaration(monkeypatch):
         commit_handler, "set_commit_chunk_attribution_async", no_op_attribution
     )
     monkeypatch.setattr(commit_handler, "commit_orrery_tick_async", empty_orrery_tick)
-    monkeypatch.setattr(commit_handler, "_orrery_checkpoint_interval", lambda: 0)
+    monkeypatch.setattr(
+        commit_handler, "_orrery_checkpoint_interval", lambda _settings: 0
+    )
 
     chunk_id = await commit_incubator_to_database(conn, "session-2", slot=5)
 
@@ -279,7 +281,9 @@ async def test_async_commit_resolves_all_name_addressed_state_updates(monkeypatc
     monkeypatch.setattr(commit_handler, "log_state_delta_async", no_op)
     monkeypatch.setattr(commit_handler, "apply_tag_bestowal_async", record_tag_write)
     monkeypatch.setattr(commit_handler, "commit_orrery_tick_async", empty_orrery_tick)
-    monkeypatch.setattr(commit_handler, "_orrery_checkpoint_interval", lambda: 0)
+    monkeypatch.setattr(
+        commit_handler, "_orrery_checkpoint_interval", lambda _settings: 0
+    )
 
     await commit_incubator_to_database(conn, "state-session", slot=5)
 

--- a/tests/test_commit_handler_sync.py
+++ b/tests/test_commit_handler_sync.py
@@ -250,7 +250,9 @@ def test_sync_commit_links_same_turn_character_declaration(monkeypatch):
     monkeypatch.setattr(
         commit_handler_sync, "set_commit_chunk_attribution_sync", lambda *_args: None
     )
-    monkeypatch.setattr(commit_handler_sync, "_orrery_checkpoint_interval", lambda: 0)
+    monkeypatch.setattr(
+        commit_handler_sync, "_orrery_checkpoint_interval", lambda _settings: 0
+    )
 
     chunk_id = commit_incubator_to_database_sync(conn, "session-1", slot=5)
 
@@ -288,7 +290,9 @@ def _patch_sync_commit_runtime(monkeypatch) -> None:
     monkeypatch.setattr(
         commit_handler_sync, "log_state_delta_sync", lambda *_a, **_k: None
     )
-    monkeypatch.setattr(commit_handler_sync, "_orrery_checkpoint_interval", lambda: 0)
+    monkeypatch.setattr(
+        commit_handler_sync, "_orrery_checkpoint_interval", lambda _settings: 0
+    )
 
 
 def test_sync_commit_resolves_all_name_addressed_state_updates(monkeypatch):

--- a/tests/test_orrery/test_resolver.py
+++ b/tests/test_orrery/test_resolver.py
@@ -1,9 +1,11 @@
 """Tests for Orrery dry-run resolver integration."""
 
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 
+import nexus.agents.orrery.resolver as resolver_module
 from nexus.agents.orrery.audit import explain_dry_run
 from nexus.agents.lore.utils.turn_context import TurnContext
 from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
@@ -47,6 +49,57 @@ from nexus.config.settings_models import OrreryWeatherSettings
 
 
 _DEFAULT_WORLD_TIME = object()
+
+
+def test_resolve_dry_run_with_supplied_epistemics_skips_config_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller-supplied epistemics policy avoids application config I/O."""
+
+    load_count = 0
+    original_loader = resolver_module.load_epistemics_policy
+
+    def counted_loader() -> Any:
+        nonlocal load_count
+        load_count += 1
+        return original_loader()
+
+    monkeypatch.setattr(resolver_module, "load_epistemics_policy", counted_loader)
+
+    resolve_dry_run(
+        FakeSession(),
+        [],
+        anchor_chunk_id=100,
+        window_chunks=30,
+        epistemics_settings={},
+    )
+
+    assert load_count == 0
+
+
+def test_resolve_dry_run_fallback_loads_config_at_most_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The standalone resolver fallback reads application config only once."""
+
+    load_count = 0
+    original_loader = resolver_module.load_epistemics_policy
+
+    def counted_loader() -> Any:
+        nonlocal load_count
+        load_count += 1
+        return original_loader()
+
+    monkeypatch.setattr(resolver_module, "load_epistemics_policy", counted_loader)
+
+    resolve_dry_run(
+        FakeSession(),
+        [],
+        anchor_chunk_id=100,
+        window_chunks=30,
+    )
+
+    assert load_count <= 1
 
 
 class FakeResult:
@@ -3531,15 +3584,15 @@ def test_habituation_dampens_repeat_winner_and_respects_exemptions() -> None:
     bindings = {Slot.ACTOR: 1}
 
     fresh = WorldState()
-    assert evaluate_stack((low, high), fresh, bindings, None, policy).template_id == (
-        "surveil"
-    )
+    fresh_winner = evaluate_stack((low, high), fresh, bindings, None, policy)
+    assert fresh_winner is not None
+    assert fresh_winner.template_id == "surveil"
 
     # Three committed wins drop surveil's effective priority to 39 < 40.
     worn = WorldState(win_history={(1, "surveil"): 3})
-    assert evaluate_stack((low, high), worn, bindings, None, policy).template_id == (
-        "reach_out"
-    )
+    worn_winner = evaluate_stack((low, high), worn, bindings, None, policy)
+    assert worn_winner is not None
+    assert worn_winner.template_id == "reach_out"
     # The cap bounds the debit: ten wins is still only -10.
     capped = WorldState(win_history={(1, "surveil"): 10})
     ordered = stack_order((low, high), capped, bindings, policy)
@@ -3551,9 +3604,9 @@ def test_habituation_dampens_repeat_winner_and_respects_exemptions() -> None:
     assert [t.id for t in ordered] == ["evade_pursuers", "reach_out"]
 
     # Disabled policy is inert.
-    assert evaluate_stack((low, high), worn, bindings, None, None).template_id == (
-        "surveil"
-    )
+    disabled_winner = evaluate_stack((low, high), worn, bindings, None, None)
+    assert disabled_winner is not None
+    assert disabled_winner.template_id == "surveil"
 
 
 def test_explain_stack_orders_like_evaluate_under_habituation() -> None:


### PR DESCRIPTION
Closes #654.

## What

One accepted-chunk commit previously triggered ~10 independent `load_settings_as_dict()` calls (nine per-subsection helpers plus the checkpoint-cadence read, ~2.7 ms each) in each of the sync and async commit handlers. Both handlers now load the Orrery configuration once per operation (`_load_orrery_settings()`) and index its subsections; `_orrery_checkpoint_interval` takes the loaded mapping instead of re-loading.

The resolver needed no change: `resolve_dry_run()` already accepted `epistemics_settings`, and the commit path already supplied it conditionally — the same conditional now indexes the operation-local mapping. Reuse is strictly operation-local: no process-global cache, no memoization; configuration reload behavior across separate operations is unchanged.

## Tests

- `tests/test_api/test_orrery_config_reuse_pg.py` (new, `requires_postgres`): drives the **genuine** `commit_incubator_to_database_sync` / `commit_incubator_to_database` entry points against disposable `NEXUS_template` clones, with a counting wrapper on `load_settings_as_dict` asserting exactly one load per operation, plus identity assertions that the tick and checkpoint consumers receive subsections of that single mapping. Wrappers delegate to the real implementations (recording, not stubbing).
- `tests/test_orrery/test_resolver.py`: supplied `epistemics_settings` ⇒ zero config loads; standalone fallback ⇒ at most one.
- Existing commit-handler test doubles updated for the new `_orrery_checkpoint_interval(settings)` signature (pure signature parity).

## Benchmarks (Local, Before → After)

| Measurement | Before | After |
|---|---:|---:|
| `load_settings_as_dict()` median / p95 (50 samples, ms) | 3.341 / 3.577 | 3.228 / 3.406 |
| One commit's config-load shape (ms) | 27.919 (8 loads) | 3.331 (1 load) |
| Dense resolver dry run, default policy, median (ms) | 12.776 | 12.550 |
| Dense resolver dry run, preloaded policy, median (ms) | 9.294 | 9.196 |

Post-change resolver p95s showed local timing spikes and are reported unsmoothed in the build log; medians are the stable signal.

## Gates

Black / flake8 / mypy clean on touched files; resolver suite 103 passed; PostgreSQL API suite 232 passed, 2 skipped; full suite **2138 passed, 502 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwQAcSeuSfJAcjUvxVzadv