### PR TITLE
Fail-Closed QA Guard While Detached Maturation Is In Flight

### DIFF
--- a/nexus/agents/orrery/retrograde_maturation.py
+++ b/nexus/agents/orrery/retrograde_maturation.py
@@ -1142,20 +1142,60 @@ def namespace_expansion_event_refs(
     return payload
 
 
-def load_maturation_status_sync(cur: Any) -> dict[str, int]:
-    """Return compact maturation queue counts for status snapshots."""
+def load_maturation_status_sync(cur: Any) -> dict[str, Any]:
+    """Return maturation queue counts and diagnosable non-terminal jobs."""
 
     cur.execute(
         """
-        SELECT state::text AS state, count(*) AS count
+        SELECT
+            jsonb_build_object(
+                'queued', count(*) FILTER (WHERE state = 'queued'),
+                'leased', count(*) FILTER (WHERE state = 'leased'),
+                'succeeded', count(*) FILTER (WHERE state = 'succeeded'),
+                'failed', count(*) FILTER (WHERE state = 'failed')
+            ) AS counts,
+            COALESCE(
+                jsonb_agg(
+                    jsonb_build_object(
+                        'id', id,
+                        'state', state::text,
+                        'entity_kind', entity_kind,
+                        'entity_name', entity_name,
+                        'requesting_chunk_id', requesting_chunk_id,
+                        'attempts', attempts,
+                        'available_at', available_at,
+                        'lease_until', lease_until
+                    ) ORDER BY id
+                ) FILTER (WHERE state IN ('queued', 'leased')),
+                '[]'::jsonb
+            ) AS non_terminal_jobs
         FROM orrery_maturation_jobs
-        GROUP BY state
         """
     )
-    counts = {"queued": 0, "leased": 0, "succeeded": 0, "failed": 0}
-    for row in cur.fetchall():
-        counts[str(_row_value(row, "state", 0))] = int(_row_value(row, "count", 1))
-    return counts
+    row = cur.fetchone()
+    if row is None:
+        raise RuntimeError("Maturation status query returned no row")
+    raw_counts = _row_value(row, "counts", 0)
+    raw_jobs = _row_value(row, "non_terminal_jobs", 1)
+    if not isinstance(raw_counts, Mapping) or not isinstance(raw_jobs, list):
+        raise RuntimeError("Maturation status query returned an invalid shape")
+    counts = {
+        state: int(raw_counts.get(state, 0))
+        for state in ("queued", "leased", "succeeded", "failed")
+    }
+    return {"counts": counts, "non_terminal_jobs": raw_jobs}
+
+
+def load_maturation_status_for_slot_sync(slot: int) -> dict[str, Any]:
+    """Return the durable maturation queue snapshot for one save slot."""
+
+    conn = _connect_for_slot(slot)
+    try:
+        with conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                return load_maturation_status_sync(cur)
+    finally:
+        conn.close()
 
 
 # ============================================================================

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -326,10 +326,10 @@ def load_orrery_status_sync(
             with conn.cursor(cursor_factory=RealDictCursor) as cur:
                 maturation_counts = load_maturation_status_sync(cur)
                 return OrreryStatus(
-                    queued_maturation_jobs=maturation_counts["queued"],
-                    leased_maturation_jobs=maturation_counts["leased"],
-                    succeeded_maturation_jobs=maturation_counts["succeeded"],
-                    failed_maturation_jobs=maturation_counts["failed"],
+                    queued_maturation_jobs=maturation_counts["counts"]["queued"],
+                    leased_maturation_jobs=maturation_counts["counts"]["leased"],
+                    succeeded_maturation_jobs=maturation_counts["counts"]["succeeded"],
+                    failed_maturation_jobs=maturation_counts["counts"]["failed"],
                     pending_promotions=_count_sync(
                         cur,
                         """
@@ -614,7 +614,8 @@ def _generate_narration(provider: Any, row: Mapping[str, Any]) -> str:
         f"Template: {row['template_id']}\n"
         f"Actor: {row.get('actor_name') or row.get('actor_entity_id')}\n"
         f"Brief: {row.get('brief')}\n"
-        f"Promotion verdict: {json.dumps(row.get('promotion_verdict') or {}, sort_keys=True)}\n"
+        "Promotion verdict: "
+        f"{json.dumps(row.get('promotion_verdict') or {}, sort_keys=True)}\n"
         f"State delta: {json.dumps(row.get('state_delta') or {}, sort_keys=True)}\n\n"
         "Length: 80-180 words. Do not address the player."
     )

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -7,6 +7,7 @@ Commands:
     nexus undo --slot N         Revert the last action
     nexus regenerate --slot N   Regenerate the last storyteller turn
     nexus model --slot N        Get or set the model for a slot
+    nexus jobs --slot N         Show durable Retrograde maturation jobs
     nexus trait-audit --slot N  Dry-run new-story trait compiler audit
     nexus retrograde-packet --slot N  Build dry-run Retrograde seed packet
     nexus retrograde-seed-candidates  Call Skald for non-mutating seed candidates
@@ -41,7 +42,7 @@ import time
 from typing import Any, Callable, Dict, List, Mapping, Optional
 import uuid
 
-import requests
+import requests  # type: ignore[import-untyped]
 
 from nexus.config import load_settings
 from nexus.config.settings_models import Settings
@@ -1601,6 +1602,11 @@ def run_continue(args: argparse.Namespace) -> Dict[str, Any]:
                 no_session_result["retrograde"] = retrograde_info
             return no_session_result
 
+        return {
+            "success": False,
+            "error": "Slot state was neither wizard nor narrative mode",
+        }
+
     except requests.exceptions.ConnectionError:
         return {
             "success": False,
@@ -3031,6 +3037,20 @@ def run_usage(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
+def run_jobs(args: argparse.Namespace) -> Dict[str, Any]:
+    """Return the durable Retrograde maturation queue for one slot."""
+
+    from nexus.agents.orrery.retrograde_maturation import (
+        load_maturation_status_for_slot_sync,
+    )
+
+    return {
+        "success": True,
+        "slot": args.slot,
+        **load_maturation_status_for_slot_sync(args.slot),
+    }
+
+
 def _run_with_cli_usage(
     args: argparse.Namespace,
     command: Callable[[argparse.Namespace], Dict[str, Any]],
@@ -3110,6 +3130,7 @@ Examples:
   nexus up --foreground         Stay attached; Ctrl+C tears down
   nexus status                  Runtime health, processes, slot, version
   nexus usage --day 2026-07-29 Show exact API-reported UTC-day token usage
+  nexus jobs --slot 4           Show durable Retrograde maturation jobs
   nexus logs gateway -f         Follow the gateway log
   nexus down                    Stop the runtime
   nexus load --slot 5           Show current state of slot 5
@@ -3230,6 +3251,26 @@ Examples:
         help="UTC quota day in YYYY-MM-DD format (default: current UTC day)",
     )
     usage_parser.add_argument("--run", help="Filter events by correlation run id")
+
+    jobs_parser = subparsers.add_parser(
+        "jobs",
+        help="Show durable Retrograde maturation job state for one slot",
+    )
+    jobs_parser.add_argument(
+        "--json",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Emit JSON output",
+    )
+    jobs_parser.add_argument(
+        "--truncate",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Truncate long text fields (accepted for global CLI consistency)",
+    )
+    jobs_parser.add_argument(
+        "--slot", type=int, required=True, help="Slot number (1-5)"
+    )
 
     # load command
     load_parser = subparsers.add_parser("load", help="Display current slot state")
@@ -3777,6 +3818,7 @@ def main() -> int:
         "place-manifest",
         "place-apply",
         "backfill-review-packet",
+        "jobs",
         "lock",
         "unlock",
     ):
@@ -3815,6 +3857,8 @@ def main() -> int:
         result = run_logs(args)
     elif args.command == "usage":
         result = run_usage(args)
+    elif args.command == "jobs":
+        result = run_jobs(args)
     elif args.command == "load":
         result = run_load(args)
     elif args.command == "continue":

--- a/scripts/qa_shift/mission_prompt.md
+++ b/scripts/qa_shift/mission_prompt.md
@@ -135,6 +135,17 @@ not an organization-wide Platform meter. Count any known non-NEXUS API usage
 against the configured limit before starting. Read-only commands that cannot
 call a model do not need an `--expect-call` check.
 
+A check may also return `status=pending` (exit code 3). This means the QA slot
+still has non-terminal Retrograde maturation jobs (queued or leased), so
+provider-capable work caused by an earlier command has not settled. A pending
+check does not advance the usage watermark and does not authorize any remote
+request. When you see pending: wait roughly ten seconds, then re-run the same
+check with the same flags. Repeat until it returns continue or stop. The late
+maturation usage then lands in the same command delta as the command that
+caused it. If pending persists for more than twenty minutes with no state
+change in the reported jobs, stop probing, run the finish step, and record the
+stalled job ids in the mission report.
+
 Never detach a request or restart/kill the gateway while a provider response is
 unaccounted for. Gateway-restart interruption probes may run only between
 settled operations until the provider ledger can prove usage across process

--- a/scripts/qa_shift/mission_prompt.md
+++ b/scripts/qa_shift/mission_prompt.md
@@ -145,6 +145,10 @@ maturation usage then lands in the same command delta as the command that
 caused it. If pending persists for more than twenty minutes with no state
 change in the reported jobs, stop probing, run the finish step, and record the
 stalled job ids in the mission report.
+A check instead returns stop with reason `maturation_job_failed` when any
+maturation job newly reaches the failed state during the shift: usage
+accounting can no longer be proven complete, so end the shift and record the
+job's last_error from the archive in the mission report.
 
 Never detach a request or restart/kill the gateway while a provider response is
 unaccounted for. Gateway-restart interruption probes may run only between

--- a/scripts/qa_shift/qa_shift.py
+++ b/scripts/qa_shift/qa_shift.py
@@ -579,6 +579,7 @@ def begin_shift(
         "baseline_event_count": len(usage["events"]),
         "last_event_count": len(usage["events"]),
         "last_unknown_usage_events": usage["unknown"],
+        "baseline_failed_jobs": jobs["counts"]["failed"],
         "checks": 0,
         "max_command_delta": 0,
         "config": _config_payload(config),
@@ -681,6 +682,8 @@ def evaluate_check(
     started_at = _parse_utc(str(state["started_at"]))
     elapsed_minutes = (now.astimezone(timezone.utc) - started_at).total_seconds() / 60
     jobs = _jobs_snapshot(jobs_payload, slot=slot)
+    baseline_failed_jobs = int(state["baseline_failed_jobs"])
+    current_failed_jobs = int(jobs["counts"]["failed"])
     if jobs["non_terminal_jobs"]:
         return (
             {
@@ -716,6 +719,8 @@ def evaluate_check(
                 "expect_call": expect_call,
                 "jobs": jobs,
                 "non_terminal_jobs": jobs["non_terminal_jobs"],
+                "baseline_failed_jobs": baseline_failed_jobs,
+                "current_failed_jobs": current_failed_jobs,
             },
             dict(state),
         )
@@ -727,6 +732,8 @@ def evaluate_check(
         reasons.append("daily_total_decreased")
     if same_quota_day and len(usage["events"]) < previous_events:
         reasons.append("event_count_decreased")
+    if current_failed_jobs > baseline_failed_jobs:
+        reasons.append("maturation_job_failed")
     if unexpected_routes:
         reasons.append("unexpected_qa_model_route")
     if expect_call and not expected_events:
@@ -795,6 +802,8 @@ def evaluate_check(
         "expect_call": expect_call,
         "jobs": jobs,
         "non_terminal_jobs": jobs["non_terminal_jobs"],
+        "baseline_failed_jobs": baseline_failed_jobs,
+        "current_failed_jobs": current_failed_jobs,
     }
     return result, updated
 
@@ -851,7 +860,11 @@ def finish_shift(
     quota_day = str(state["quota_day"])
     slot = int(state["config"]["slot"])
     jobs = _jobs_snapshot(jobs_reader(repo_root, slot), slot=slot)
-    usage_settled = not jobs["non_terminal_jobs"]
+    baseline_failed_jobs = int(state["baseline_failed_jobs"])
+    current_failed_jobs = int(jobs["counts"]["failed"])
+    usage_settled = (
+        not jobs["non_terminal_jobs"] and current_failed_jobs <= baseline_failed_jobs
+    )
     usage_payload = usage_reader(repo_root, quota_day)
     usage = _usage_snapshot(usage_payload)
     if usage["day"] != quota_day:
@@ -892,6 +905,8 @@ def finish_shift(
             "skald_writer_tripwire": rejection_ledger["skald_writer_tripwire"],
             "jobs": jobs,
             "usage_settled": usage_settled,
+            "baseline_failed_jobs": baseline_failed_jobs,
+            "current_failed_jobs": current_failed_jobs,
         }
     )
     _atomic_write_json(archive / STATE_FILE, final_state)
@@ -914,6 +929,8 @@ def finish_shift(
         "archive": str(archive),
         "jobs": jobs,
         "usage_settled": usage_settled,
+        "baseline_failed_jobs": baseline_failed_jobs,
+        "current_failed_jobs": current_failed_jobs,
     }
     _append_jsonl(
         archive / CHECKS_FILE,

--- a/scripts/qa_shift/qa_shift.py
+++ b/scripts/qa_shift/qa_shift.py
@@ -27,6 +27,7 @@ DEFAULT_CONFIG_PATH = Path(__file__).with_name("qa_shift.toml")
 STATE_FILE = "shift_state.json"
 CHECKS_FILE = "usage_checks.jsonl"
 STOP_EXIT_CODE = 2
+PENDING_EXIT_CODE = 3
 
 
 class ShiftError(RuntimeError):
@@ -56,6 +57,7 @@ class ShiftConfig:
 
 
 UsageReader = Callable[[Path, str | None], dict[str, Any]]
+JobsReader = Callable[[Path, int], dict[str, Any]]
 
 
 def _required_int(table: Mapping[str, Any], key: str) -> int:
@@ -157,6 +159,39 @@ def _read_usage(repo_root: Path, day: str | None = None) -> dict[str, Any]:
     return payload
 
 
+def _read_jobs(repo_root: Path, slot: int) -> dict[str, Any]:
+    """Read durable maturation jobs through the public NEXUS CLI."""
+
+    command = ["nexus", "jobs", "--slot", str(slot), "--json"]
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise ShiftError(
+            "The nexus executable is unavailable; run this utility with "
+            "`poetry run python`."
+        ) from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise ShiftError(f"`nexus jobs --slot {slot} --json` failed: {detail}")
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise ShiftError(
+            f"`nexus jobs --slot {slot} --json` returned invalid JSON"
+        ) from exc
+    if payload.get("success") is not True:
+        raise ShiftError(
+            f"`nexus jobs --slot {slot} --json` reported failure: {payload}"
+        )
+    return payload
+
+
 def _usage_snapshot(payload: Mapping[str, Any]) -> dict[str, Any]:
     usage = payload.get("usage")
     if not isinstance(usage, dict):
@@ -183,6 +218,59 @@ def _usage_snapshot(payload: Mapping[str, Any]) -> dict[str, Any]:
         "unknown": unknown,
         "events": events,
     }
+
+
+def _jobs_snapshot(payload: Mapping[str, Any], *, slot: int) -> dict[str, Any]:
+    """Validate one public maturation-jobs payload for the configured slot."""
+
+    payload_slot = payload.get("slot")
+    if isinstance(payload_slot, bool) or not isinstance(payload_slot, int):
+        raise ShiftError("Jobs payload has no integer at .slot")
+    if payload_slot != slot:
+        raise ShiftError(
+            f"Jobs payload returned the wrong slot ({payload_slot} != {slot})"
+        )
+    raw_counts = payload.get("counts")
+    raw_jobs = payload.get("non_terminal_jobs")
+    if not isinstance(raw_counts, dict):
+        raise ShiftError("Jobs payload has no object at .counts")
+    if not isinstance(raw_jobs, list):
+        raise ShiftError("Jobs payload has no list at .non_terminal_jobs")
+
+    counts: dict[str, int] = {}
+    for state in ("queued", "leased", "succeeded", "failed"):
+        value = raw_counts.get(state)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ShiftError(f"Jobs payload count for {state!r} is invalid")
+        counts[state] = value
+
+    jobs: list[dict[str, Any]] = []
+    required_fields = (
+        "id",
+        "state",
+        "entity_kind",
+        "entity_name",
+        "requesting_chunk_id",
+        "attempts",
+        "available_at",
+        "lease_until",
+    )
+    for index, raw_job in enumerate(raw_jobs):
+        if not isinstance(raw_job, dict):
+            raise ShiftError(f"Jobs payload row {index} is not an object")
+        missing = [field for field in required_fields if field not in raw_job]
+        if missing:
+            raise ShiftError(f"Jobs payload row {index} is missing fields: {missing}")
+        if raw_job["state"] not in ("queued", "leased"):
+            raise ShiftError(
+                f"Jobs payload row {index} has terminal state " f"{raw_job['state']!r}"
+            )
+        jobs.append({field: raw_job[field] for field in required_fields})
+    if counts["queued"] + counts["leased"] != len(jobs):
+        raise ShiftError(
+            "Jobs payload non-terminal counts do not match its diagnostic list"
+        )
+    return {"slot": slot, "counts": counts, "non_terminal_jobs": jobs}
 
 
 def _rejection_ledger(
@@ -431,11 +519,18 @@ def begin_shift(
     config: ShiftConfig,
     repo_root: Path = REPO_ROOT,
     usage_reader: UsageReader = _read_usage,
+    jobs_reader: JobsReader = _read_jobs,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     """Create a shift archive, isolated config, and usage baseline."""
 
     current_time = now or datetime.now(timezone.utc)
+    jobs = _jobs_snapshot(jobs_reader(repo_root, config.slot), slot=config.slot)
+    if jobs["non_terminal_jobs"]:
+        raise ShiftError(
+            "QA shift cannot begin with non-terminal maturation jobs: "
+            + json.dumps(jobs["non_terminal_jobs"], sort_keys=True)
+        )
     usage_payload = usage_reader(repo_root, None)
     usage = _usage_snapshot(usage_payload)
     if usage["unknown"]:
@@ -498,6 +593,7 @@ def begin_shift(
         "daily_limit": config.daily_token_limit,
         "token_fence": config.token_fence,
         "tokens_before_fence": config.token_fence - usage["total"],
+        "jobs": jobs,
     }
     _append_jsonl(
         archive / CHECKS_FILE,
@@ -523,6 +619,7 @@ def evaluate_check(
     *,
     state: Mapping[str, Any],
     usage_payload: Mapping[str, Any],
+    jobs_payload: Mapping[str, Any],
     expect_call: bool,
     now: datetime,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -530,19 +627,13 @@ def evaluate_check(
 
     usage = _usage_snapshot(usage_payload)
     config = state["config"]
-    reasons: list[str] = []
     previous_total = int(state["last_total"])
     previous_events = int(state["last_event_count"])
     same_quota_day = usage["day"] == state["quota_day"]
     raw_delta = usage["total"] - previous_total if same_quota_day else None
     delta = max(0, raw_delta) if raw_delta is not None else None
 
-    if not same_quota_day:
-        reasons.append("quota_day_changed")
-    if raw_delta is not None and raw_delta < 0:
-        reasons.append("daily_total_decreased")
     if same_quota_day and len(usage["events"]) < previous_events:
-        reasons.append("event_count_decreased")
         new_events: list[Any] = []
     elif same_quota_day:
         new_events = usage["events"][previous_events:]
@@ -586,6 +677,56 @@ def evaluate_check(
             if event.get("provider") != "openai" or event.get("model") != target_model
         }
     )
+    token_fence = int(config["token_fence"])
+    started_at = _parse_utc(str(state["started_at"]))
+    elapsed_minutes = (now.astimezone(timezone.utc) - started_at).total_seconds() / 60
+    jobs = _jobs_snapshot(jobs_payload, slot=slot)
+    if jobs["non_terminal_jobs"]:
+        return (
+            {
+                "status": "pending",
+                "reasons": [],
+                "quota_day": usage["day"],
+                "daily_total": usage["total"],
+                "daily_limit": int(config["daily_token_limit"]),
+                "daily_headroom": max(
+                    0, int(config["daily_token_limit"]) - usage["total"]
+                ),
+                "token_fence": token_fence,
+                "tokens_before_fence": max(0, token_fence - usage["total"]),
+                "openai_delta_since_last_check": delta,
+                "shift_openai_total": (
+                    max(0, usage["total"] - int(state["baseline_total"]))
+                    if same_quota_day
+                    else None
+                ),
+                "max_command_delta": int(state["max_command_delta"]),
+                "elapsed_minutes": round(elapsed_minutes, 2),
+                "new_usage_events": len(new_events),
+                "qa_usage_events": len(qa_events),
+                "qa_api_calls": qa_api_calls,
+                "qa_models_seen": sorted(
+                    {
+                        str(event.get("model"))
+                        for event in qa_events
+                        if event.get("model") is not None
+                    }
+                ),
+                "unexpected_routes": unexpected_routes,
+                "expect_call": expect_call,
+                "jobs": jobs,
+                "non_terminal_jobs": jobs["non_terminal_jobs"],
+            },
+            dict(state),
+        )
+
+    reasons: list[str] = []
+    if not same_quota_day:
+        reasons.append("quota_day_changed")
+    if raw_delta is not None and raw_delta < 0:
+        reasons.append("daily_total_decreased")
+    if same_quota_day and len(usage["events"]) < previous_events:
+        reasons.append("event_count_decreased")
     if unexpected_routes:
         reasons.append("unexpected_qa_model_route")
     if expect_call and not expected_events:
@@ -593,12 +734,9 @@ def evaluate_check(
     if usage["unknown"] > 0:
         reasons.append("unknown_openai_usage")
 
-    token_fence = int(config["token_fence"])
     if usage["total"] >= token_fence:
         reasons.append("token_fence_reached")
 
-    started_at = _parse_utc(str(state["started_at"]))
-    elapsed_minutes = (now.astimezone(timezone.utc) - started_at).total_seconds() / 60
     if elapsed_minutes >= int(config["wall_clock_minutes"]):
         reasons.append("wall_clock_reached")
 
@@ -655,6 +793,8 @@ def evaluate_check(
         ),
         "unexpected_routes": unexpected_routes,
         "expect_call": expect_call,
+        "jobs": jobs,
+        "non_terminal_jobs": jobs["non_terminal_jobs"],
     }
     return result, updated
 
@@ -665,6 +805,7 @@ def check_shift(
     expect_call: bool,
     repo_root: Path = REPO_ROOT,
     usage_reader: UsageReader = _read_usage,
+    jobs_reader: JobsReader = _read_jobs,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     """Run and persist one fail-closed usage check."""
@@ -672,10 +813,12 @@ def check_shift(
     archive = archive.resolve()
     state = _load_state(archive)
     current_time = now or datetime.now(timezone.utc)
+    jobs_payload = jobs_reader(repo_root, int(state["config"]["slot"]))
     usage_payload = usage_reader(repo_root, None)
     result, updated = evaluate_check(
         state=state,
         usage_payload=usage_payload,
+        jobs_payload=jobs_payload,
         expect_call=expect_call,
         now=current_time,
     )
@@ -697,6 +840,7 @@ def finish_shift(
     exit_condition: str,
     repo_root: Path = REPO_ROOT,
     usage_reader: UsageReader = _read_usage,
+    jobs_reader: JobsReader = _read_jobs,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     """Capture final usage and close the shift state."""
@@ -705,6 +849,9 @@ def finish_shift(
     state = _load_state(archive)
     current_time = now or datetime.now(timezone.utc)
     quota_day = str(state["quota_day"])
+    slot = int(state["config"]["slot"])
+    jobs = _jobs_snapshot(jobs_reader(repo_root, slot), slot=slot)
+    usage_settled = not jobs["non_terminal_jobs"]
     usage_payload = usage_reader(repo_root, quota_day)
     usage = _usage_snapshot(usage_payload)
     if usage["day"] != quota_day:
@@ -743,6 +890,8 @@ def finish_shift(
                 "repair_tax_percent_unavailable_reasons"
             ],
             "skald_writer_tripwire": rejection_ledger["skald_writer_tripwire"],
+            "jobs": jobs,
+            "usage_settled": usage_settled,
         }
     )
     _atomic_write_json(archive / STATE_FILE, final_state)
@@ -763,6 +912,8 @@ def finish_shift(
         "skald_writer_tripwire": rejection_ledger["skald_writer_tripwire"],
         "rejection_ledger": str(archive / "rejection_ledger.json"),
         "archive": str(archive),
+        "jobs": jobs,
+        "usage_settled": usage_settled,
     }
     _append_jsonl(
         archive / CHECKS_FILE,
@@ -846,6 +997,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(json.dumps(result, indent=2, sort_keys=True))
     if args.command == "check" and result["status"] == "stop":
         return STOP_EXIT_CODE
+    if args.command == "check" and result["status"] == "pending":
+        return PENDING_EXIT_CODE
     return 0
 
 

--- a/tests/test_jobs_cli_pg.py
+++ b/tests/test_jobs_cli_pg.py
@@ -1,0 +1,170 @@
+"""PostgreSQL coverage for the public maturation-jobs CLI readout."""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+import os
+from typing import Any, Iterator
+import uuid
+
+import psycopg2
+from psycopg2 import sql
+import pytest
+
+from nexus import cli
+from nexus.api import slot_utils
+
+
+pytestmark = pytest.mark.requires_postgres
+
+
+def _connect(dbname: str) -> Any:
+    """Open a direct PostgreSQL connection to a disposable database."""
+
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+        connect_timeout=2,
+    )
+
+
+@contextmanager
+def _disposable_jobs_db() -> Iterator[str]:
+    """Yield a unique NEXUS_template clone and always drop it afterward."""
+
+    dbname = f"qa653_{uuid.uuid4().hex[:12]}"
+    admin: Any = None
+    try:
+        try:
+            admin = _connect("postgres")
+        except psycopg2.Error as exc:
+            pytest.skip(f"PostgreSQL admin connection unavailable: {exc}")
+        admin.autocommit = True
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier("NEXUS_template"),
+                )
+            )
+        yield dbname
+    finally:
+        if admin is not None:
+            with admin.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = %s AND pid <> pg_backend_pid()",
+                    (dbname,),
+                )
+                cur.execute(
+                    sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+                )
+            admin.close()
+
+
+def test_jobs_cli_reports_counts_and_non_terminal_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CLI reads all four states while diagnosing only queued and leased."""
+
+    with _disposable_jobs_db() as dbname:
+        conn = _connect(dbname)
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "INSERT INTO narrative_chunks (raw_text) VALUES (%s) "
+                        "RETURNING id",
+                        ("Issue 653 disposable chunk",),
+                    )
+                    chunk_id = int(cur.fetchone()[0])
+                    cur.execute(
+                        "INSERT INTO entities (kind) "
+                        "SELECT 'character'::entity_kind "
+                        "FROM generate_series(1, 4) RETURNING id"
+                    )
+                    entity_ids = [int(row[0]) for row in cur.fetchall()]
+                    for index, (entity_id, state) in enumerate(
+                        zip(
+                            entity_ids,
+                            ("queued", "leased", "succeeded", "failed"),
+                            strict=True,
+                        ),
+                        start=1,
+                    ):
+                        cur.execute(
+                            """
+                            INSERT INTO orrery_maturation_jobs (
+                                entity_id,
+                                entity_kind,
+                                entity_subtype_id,
+                                entity_name,
+                                slot,
+                                requesting_chunk_id,
+                                declaration,
+                                state,
+                                attempts,
+                                available_at,
+                                lease_until
+                            ) VALUES (
+                                %s, 'character', %s, %s, '4', %s,
+                                '{}'::jsonb, %s::orrery_job_state, %s,
+                                '2026-08-03T04:30:00+00:00'::timestamptz,
+                                CASE WHEN %s = 'leased'
+                                    THEN '2026-08-03T04:35:00+00:00'::timestamptz
+                                    ELSE NULL
+                                END
+                            )
+                            """,
+                            (
+                                entity_id,
+                                index,
+                                f"Entity {index}",
+                                chunk_id,
+                                state,
+                                index - 1,
+                                state,
+                            ),
+                        )
+        finally:
+            conn.close()
+
+        monkeypatch.setattr(
+            slot_utils,
+            "require_slot_dbname",
+            lambda *, slot: dbname,
+        )
+        parsed = cli.build_parser().parse_args(["jobs", "--slot", "4", "--json"])
+        payload = cli.run_jobs(argparse.Namespace(slot=parsed.slot))
+
+        assert payload["success"] is True
+        assert payload["slot"] == 4
+        assert payload["counts"] == {
+            "queued": 1,
+            "leased": 1,
+            "succeeded": 1,
+            "failed": 1,
+        }
+        assert [row["state"] for row in payload["non_terminal_jobs"]] == [
+            "queued",
+            "leased",
+        ]
+        assert [row["entity_name"] for row in payload["non_terminal_jobs"]] == [
+            "Entity 1",
+            "Entity 2",
+        ]
+        assert set(payload["non_terminal_jobs"][0]) == {
+            "id",
+            "state",
+            "entity_kind",
+            "entity_name",
+            "requesting_chunk_id",
+            "attempts",
+            "available_at",
+            "lease_until",
+        }
+        assert payload["non_terminal_jobs"][0]["lease_until"] is None
+        assert payload["non_terminal_jobs"][1]["lease_until"] is not None

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -43,7 +43,17 @@ class WorkerCursor:
         self._fetchall = []
         self._fetchone = None
         normalized = " ".join(str(sql).split())
-        if "SELECT count(*) AS count" in normalized:
+        if "AS non_terminal_jobs" in normalized:
+            self._fetchone = {
+                "counts": {
+                    "queued": 0,
+                    "leased": 0,
+                    "succeeded": 0,
+                    "failed": 0,
+                },
+                "non_terminal_jobs": [],
+            }
+        elif "SELECT count(*) AS count" in normalized:
             self._fetchone = {"count": self.count_rows.pop(0)}
         elif "FROM orrery_resolutions r" in normalized:
             self._fetchall = self.promotion_rows
@@ -480,6 +490,10 @@ def test_load_orrery_status_sync_counts_background_work() -> None:
 
     status = load_orrery_status_sync(conn=WorkerConn(cursor))
 
+    assert status.queued_maturation_jobs == 0
+    assert status.leased_maturation_jobs == 0
+    assert status.succeeded_maturation_jobs == 0
+    assert status.failed_maturation_jobs == 0
     assert status.pending_promotions == 1
     assert status.queued_narration_jobs == 2
     assert status.leased_narration_jobs == 3

--- a/tests/test_qa_shift.py
+++ b/tests/test_qa_shift.py
@@ -91,11 +91,17 @@ def _jobs(
     *,
     state: str | None = None,
     attempts: int = 1,
+    failed_jobs: int = 0,
 ) -> dict[str, object]:
-    counts = {"queued": 0, "leased": 0, "succeeded": 0, "failed": 0}
+    counts = {
+        "queued": 0,
+        "leased": 0,
+        "succeeded": 0,
+        "failed": failed_jobs,
+    }
     non_terminal_jobs: list[dict[str, object]] = []
     if state is not None:
-        counts[state] = 1
+        counts[state] += 1
         if state in ("queued", "leased"):
             non_terminal_jobs.append(_job(state, attempts=attempts))
     return {
@@ -121,6 +127,7 @@ def _state(config: qa_shift.ShiftConfig) -> dict[str, object]:
         "baseline_event_count": 0,
         "last_event_count": 0,
         "last_unknown_usage_events": 0,
+        "baseline_failed_jobs": 0,
         "checks": 0,
         "max_command_delta": 0,
         "config": qa_shift._config_payload(config),
@@ -494,6 +501,66 @@ def test_pending_post_check_retains_late_usage_in_causal_command_delta(
     assert checks[2]["non_terminal_jobs"] == [_job("leased")]
 
 
+def test_failure_during_pending_stops_after_settlement_with_full_delta(
+    tmp_path: Path,
+) -> None:
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+    begin = qa_shift.begin_shift(
+        config=config,
+        usage_reader=lambda _root, _day: _usage(total=100),
+        jobs_reader=_settled_jobs_reader,
+        now=NOW,
+    )
+    archive = Path(begin["archive"])
+    synchronous_event = {
+        **_event(total=200),
+        "seat": "skald_writer",
+        "request_id": "writer-before-failure",
+    }
+    late_event = {
+        **_event(total=50),
+        "seat": "retrograde_expansion",
+        "request_id": "late-before-failure",
+    }
+
+    pending = qa_shift.check_shift(
+        archive=archive,
+        expect_call=True,
+        usage_reader=lambda _root, _day: _usage(
+            total=300,
+            events=[synchronous_event],
+        ),
+        jobs_reader=lambda _root, _slot: _jobs(
+            state="leased",
+            failed_jobs=1,
+        ),
+        now=NOW + timedelta(seconds=2),
+    )
+    pending_state = json.loads((archive / "shift_state.json").read_text())
+    settled = qa_shift.check_shift(
+        archive=archive,
+        expect_call=True,
+        usage_reader=lambda _root, _day: _usage(
+            total=350,
+            events=[synchronous_event, late_event],
+        ),
+        jobs_reader=lambda _root, _slot: _jobs(failed_jobs=1),
+        now=NOW + timedelta(seconds=12),
+    )
+
+    assert pending["status"] == "pending"
+    assert pending["reasons"] == []
+    assert pending["current_failed_jobs"] == 1
+    assert pending_state["last_total"] == 100
+    assert pending_state["last_event_count"] == 0
+    assert pending_state["max_command_delta"] == 0
+    assert settled["status"] == "stop"
+    assert "maturation_job_failed" in settled["reasons"]
+    assert settled["openai_delta_since_last_check"] == 250
+    assert settled["new_usage_events"] == 2
+    assert settled["max_command_delta"] == 250
+
+
 def test_check_reads_queue_before_usage_to_close_settlement_race(
     tmp_path: Path,
 ) -> None:
@@ -541,8 +608,11 @@ def test_only_non_terminal_maturation_states_block_checks(
     attempts: int,
     expected_status: str,
 ) -> None:
+    shift_state = _state(qa_shift.load_shift_config())
+    if state == "failed":
+        shift_state["baseline_failed_jobs"] = 1
     result, _ = qa_shift.evaluate_check(
-        state=_state(qa_shift.load_shift_config()),
+        state=shift_state,
         usage_payload=_usage(total=100),
         jobs_payload=_jobs(state=state, attempts=attempts),
         expect_call=False,
@@ -550,6 +620,47 @@ def test_only_non_terminal_maturation_states_block_checks(
     )
 
     assert result["status"] == expected_status
+
+
+def test_new_terminal_maturation_failure_stops_settled_check() -> None:
+    result, _ = qa_shift.evaluate_check(
+        state=_state(qa_shift.load_shift_config()),
+        usage_payload=_usage(total=100),
+        jobs_payload=_jobs(failed_jobs=1),
+        expect_call=False,
+        now=NOW + timedelta(minutes=1),
+    )
+
+    assert result["status"] == "stop"
+    assert "maturation_job_failed" in result["reasons"]
+    assert result["baseline_failed_jobs"] == 0
+    assert result["current_failed_jobs"] == 1
+
+
+def test_preexisting_failed_jobs_become_shift_baseline(tmp_path: Path) -> None:
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+    begin = qa_shift.begin_shift(
+        config=config,
+        usage_reader=lambda _root, _day: _usage(total=100),
+        jobs_reader=lambda _root, _slot: _jobs(failed_jobs=2),
+        now=NOW,
+    )
+    archive = Path(begin["archive"])
+    state = json.loads((archive / "shift_state.json").read_text())
+
+    check = qa_shift.check_shift(
+        archive=archive,
+        expect_call=False,
+        usage_reader=lambda _root, _day: _usage(total=100),
+        jobs_reader=lambda _root, _slot: _jobs(failed_jobs=2),
+        now=NOW + timedelta(minutes=1),
+    )
+
+    assert state["baseline_failed_jobs"] == 2
+    assert check["status"] == "continue"
+    assert "maturation_job_failed" not in check["reasons"]
+    assert check["baseline_failed_jobs"] == 2
+    assert check["current_failed_jobs"] == 2
 
 
 def test_begin_refuses_dirty_maturation_queue(tmp_path: Path) -> None:
@@ -865,6 +976,30 @@ def test_finish_reports_maturation_settlement_without_refusal(
         [] if job_state is None else [_job("leased")]
     )
     assert final_state["usage_settled"] is usage_settled
+
+
+def test_finish_marks_new_maturation_failure_unsettled(tmp_path: Path) -> None:
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+    begin = qa_shift.begin_shift(
+        config=config,
+        usage_reader=lambda _root, _day: _usage(total=100),
+        jobs_reader=lambda _root, _slot: _jobs(failed_jobs=1),
+        now=NOW,
+    )
+    archive = Path(begin["archive"])
+
+    finish = qa_shift.finish_shift(
+        archive=archive,
+        exit_condition="blocked",
+        usage_reader=lambda _root, _day: _usage(total=125),
+        jobs_reader=lambda _root, _slot: _jobs(failed_jobs=2),
+        now=NOW + timedelta(minutes=1),
+    )
+
+    assert finish["status"] == "finished"
+    assert finish["usage_settled"] is False
+    assert finish["baseline_failed_jobs"] == 1
+    assert finish["current_failed_jobs"] == 2
 
 
 def test_pending_check_exit_code_contract(

--- a/tests/test_qa_shift.py
+++ b/tests/test_qa_shift.py
@@ -8,7 +8,7 @@ import json
 from pathlib import Path
 import shlex
 import tomllib
-from typing import Any, Mapping
+from typing import Any, Mapping, cast
 
 import pytest
 import tomlkit
@@ -74,6 +74,42 @@ def _usage(
     }
 
 
+def _job(state: str, *, attempts: int = 1) -> dict[str, object]:
+    return {
+        "id": 17,
+        "state": state,
+        "entity_kind": "character",
+        "entity_name": "Nika Rel",
+        "requesting_chunk_id": 47,
+        "attempts": attempts,
+        "available_at": "2026-07-30T04:31:00+00:00",
+        "lease_until": ("2026-07-30T04:36:00+00:00" if state == "leased" else None),
+    }
+
+
+def _jobs(
+    *,
+    state: str | None = None,
+    attempts: int = 1,
+) -> dict[str, object]:
+    counts = {"queued": 0, "leased": 0, "succeeded": 0, "failed": 0}
+    non_terminal_jobs: list[dict[str, object]] = []
+    if state is not None:
+        counts[state] = 1
+        if state in ("queued", "leased"):
+            non_terminal_jobs.append(_job(state, attempts=attempts))
+    return {
+        "success": True,
+        "slot": 4,
+        "counts": counts,
+        "non_terminal_jobs": non_terminal_jobs,
+    }
+
+
+def _settled_jobs_reader(_root: Path, _slot: int) -> dict[str, object]:
+    return _jobs()
+
+
 def _state(config: qa_shift.ShiftConfig) -> dict[str, object]:
     return {
         "schema_version": 1,
@@ -113,12 +149,13 @@ def test_begin_creates_archive_and_pins_every_openai_role(
     result = qa_shift.begin_shift(
         config=config,
         usage_reader=lambda _root, _day: _usage(total=123),
+        jobs_reader=_settled_jobs_reader,
         now=NOW,
     )
 
     archive = Path(result["archive"])
     state = json.loads((archive / "shift_state.json").read_text())
-    document = tomlkit.parse((archive / "nexus.qa.toml").read_text())
+    document = cast(Any, tomlkit.parse((archive / "nexus.qa.toml").read_text()))
     model = document["global"]["model"]
     roles = model["api_models"]["openai"]["roles"]
 
@@ -153,6 +190,7 @@ def test_generated_runtime_environment_selects_qa_config(
     result = qa_shift.begin_shift(
         config=config,
         usage_reader=lambda _root, _day: _usage(total=123),
+        jobs_reader=_settled_jobs_reader,
         now=NOW,
     )
     archive = Path(result["archive"])
@@ -180,7 +218,10 @@ def test_runtime_config_shape_errors_are_clean_shift_errors(
     archive = tmp_path / "archive"
     repo.mkdir()
     archive.mkdir()
-    document = tomlkit.parse((qa_shift.REPO_ROOT / "nexus.toml").read_text())
+    document = cast(
+        Any,
+        tomlkit.parse((qa_shift.REPO_ROOT / "nexus.toml").read_text()),
+    )
     if missing_table == "roles":
         del document["global"]["model"]["api_models"]["openai"]["roles"]
     elif missing_table == "narration":
@@ -278,7 +319,11 @@ def test_begin_refuses_untrustworthy_or_exhausted_usage(tmp_path: Path) -> None:
         with pytest.raises(qa_shift.ShiftError):
             qa_shift.begin_shift(
                 config=config,
-                usage_reader=lambda _root, _day, value=payload: value,
+                usage_reader=cast(
+                    qa_shift.UsageReader,
+                    lambda _root, _day, value=payload: value,
+                ),
+                jobs_reader=_settled_jobs_reader,
                 now=NOW,
             )
 
@@ -292,6 +337,7 @@ def test_post_call_check_reports_exact_delta_and_route() -> None:
     result, updated = qa_shift.evaluate_check(
         state=_state(config),
         usage_payload=_usage(total=421, events=[event]),
+        jobs_payload=_jobs(),
         expect_call=True,
         now=NOW + timedelta(minutes=1),
     )
@@ -325,6 +371,7 @@ def test_post_call_check_fails_closed_on_missing_or_wrong_route() -> None:
     missing, _ = qa_shift.evaluate_check(
         state=_state(config),
         usage_payload=_usage(total=100),
+        jobs_payload=_jobs(),
         expect_call=True,
         now=NOW + timedelta(minutes=1),
     )
@@ -334,6 +381,7 @@ def test_post_call_check_fails_closed_on_missing_or_wrong_route() -> None:
             total=200,
             events=[_event(model="gpt-5.6-sol")],
         ),
+        jobs_payload=_jobs(),
         expect_call=True,
         now=NOW + timedelta(minutes=1),
     )
@@ -344,6 +392,190 @@ def test_post_call_check_fails_closed_on_missing_or_wrong_route() -> None:
     assert "unexpected_qa_model_route" in wrong["reasons"]
 
 
+def test_post_call_with_leased_job_is_pending_without_advancing_state() -> None:
+    config = qa_shift.load_shift_config()
+    state = _state(config)
+    state["max_command_delta"] = 77
+
+    result, updated = qa_shift.evaluate_check(
+        state=state,
+        usage_payload=_usage(total=100),
+        jobs_payload=_jobs(state="leased"),
+        expect_call=True,
+        now=NOW + timedelta(minutes=1),
+    )
+
+    assert result["status"] == "pending"
+    assert result["reasons"] == []
+    assert "expected_usage_event_missing" not in result["reasons"]
+    assert result["non_terminal_jobs"] == [_job("leased")]
+    assert result["max_command_delta"] == 77
+    assert updated == state
+    assert updated["last_total"] == 100
+    assert updated["last_event_count"] == 0
+    assert updated["max_command_delta"] == 77
+
+
+def test_pending_post_check_retains_late_usage_in_causal_command_delta(
+    tmp_path: Path,
+) -> None:
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+    begin = qa_shift.begin_shift(
+        config=config,
+        usage_reader=lambda _root, _day: _usage(total=100),
+        jobs_reader=_settled_jobs_reader,
+        now=NOW,
+    )
+    archive = Path(begin["archive"])
+    sync_events = [
+        {**_event(total=200), "seat": "skald_writer", "request_id": "writer"},
+        {
+            **_event(total=100),
+            "seat": "retrograde_seed_selection",
+            "request_id": "seed-selection",
+        },
+    ]
+    late_event = {
+        **_event(total=50),
+        "seat": "retrograde_expansion",
+        "request_id": "late-expansion",
+    }
+
+    pre = qa_shift.check_shift(
+        archive=archive,
+        expect_call=False,
+        usage_reader=lambda _root, _day: _usage(total=100),
+        jobs_reader=_settled_jobs_reader,
+        now=NOW + timedelta(seconds=1),
+    )
+    pending = qa_shift.check_shift(
+        archive=archive,
+        expect_call=True,
+        usage_reader=lambda _root, _day: _usage(total=400, events=sync_events),
+        jobs_reader=lambda _root, _slot: _jobs(state="leased"),
+        now=NOW + timedelta(seconds=2),
+    )
+    pending_state = json.loads((archive / "shift_state.json").read_text())
+    settled = qa_shift.check_shift(
+        archive=archive,
+        expect_call=True,
+        usage_reader=lambda _root, _day: _usage(
+            total=450,
+            events=[*sync_events, late_event],
+        ),
+        jobs_reader=_settled_jobs_reader,
+        now=NOW + timedelta(seconds=12),
+    )
+    final_state = json.loads((archive / "shift_state.json").read_text())
+
+    assert pre["status"] == "continue"
+    assert pending["status"] == "pending"
+    assert pending["openai_delta_since_last_check"] == 300
+    assert pending_state["last_total"] == 100
+    assert pending_state["last_event_count"] == 0
+    assert pending_state["max_command_delta"] == 0
+    assert settled["status"] == "continue"
+    assert settled["openai_delta_since_last_check"] == 350
+    assert settled["new_usage_events"] == 3
+    assert settled["max_command_delta"] == 350
+    assert {call["seat"] for call in settled["qa_api_calls"]} == {
+        "skald_writer",
+        "retrograde_seed_selection",
+        "retrograde_expansion",
+    }
+    assert final_state["last_total"] == 450
+    assert final_state["last_event_count"] == 3
+    assert final_state["max_command_delta"] == 350
+    checks = [
+        json.loads(line)
+        for line in (archive / "usage_checks.jsonl").read_text().splitlines()
+    ]
+    assert checks[2]["status"] == "pending"
+    assert checks[2]["non_terminal_jobs"] == [_job("leased")]
+
+
+def test_check_reads_queue_before_usage_to_close_settlement_race(
+    tmp_path: Path,
+) -> None:
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+    begin = qa_shift.begin_shift(
+        config=config,
+        usage_reader=lambda _root, _day: _usage(total=100),
+        jobs_reader=_settled_jobs_reader,
+        now=NOW,
+    )
+    archive = Path(begin["archive"])
+    calls: list[str] = []
+
+    def read_jobs(_root: Path, _slot: int) -> dict[str, object]:
+        calls.append("jobs")
+        return _jobs()
+
+    def read_usage(_root: Path, _day: str | None) -> dict[str, object]:
+        calls.append("usage")
+        return _usage(total=100)
+
+    result = qa_shift.check_shift(
+        archive=archive,
+        expect_call=False,
+        jobs_reader=read_jobs,
+        usage_reader=read_usage,
+        now=NOW + timedelta(minutes=1),
+    )
+
+    assert result["status"] == "continue"
+    assert calls == ["jobs", "usage"]
+
+
+@pytest.mark.parametrize(
+    ("state", "attempts", "expected_status"),
+    (
+        ("queued", 2, "pending"),
+        ("leased", 1, "pending"),
+        ("succeeded", 1, "continue"),
+        ("failed", 3, "continue"),
+    ),
+)
+def test_only_non_terminal_maturation_states_block_checks(
+    state: str,
+    attempts: int,
+    expected_status: str,
+) -> None:
+    result, _ = qa_shift.evaluate_check(
+        state=_state(qa_shift.load_shift_config()),
+        usage_payload=_usage(total=100),
+        jobs_payload=_jobs(state=state, attempts=attempts),
+        expect_call=False,
+        now=NOW + timedelta(minutes=1),
+    )
+
+    assert result["status"] == expected_status
+
+
+def test_begin_refuses_dirty_maturation_queue(tmp_path: Path) -> None:
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+    usage_read = False
+
+    def read_usage(_root: Path, _day: str | None) -> dict[str, object]:
+        nonlocal usage_read
+        usage_read = True
+        return _usage(total=100)
+
+    with pytest.raises(
+        qa_shift.ShiftError,
+        match=r"cannot begin.*Nika Rel",
+    ):
+        qa_shift.begin_shift(
+            config=config,
+            usage_reader=read_usage,
+            jobs_reader=lambda _root, _slot: _jobs(state="queued", attempts=2),
+            now=NOW,
+        )
+
+    assert usage_read is False
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_check_fails_closed_at_token_time_day_and_unknown_boundaries() -> None:
     config = qa_shift.load_shift_config()
     state = _state(config)
@@ -351,24 +583,28 @@ def test_check_fails_closed_at_token_time_day_and_unknown_boundaries() -> None:
     fenced, _ = qa_shift.evaluate_check(
         state=state,
         usage_payload=_usage(total=9_000_000),
+        jobs_payload=_jobs(),
         expect_call=False,
         now=NOW + timedelta(minutes=1),
     )
     timed, _ = qa_shift.evaluate_check(
         state=state,
         usage_payload=_usage(total=100),
+        jobs_payload=_jobs(),
         expect_call=False,
         now=NOW + timedelta(minutes=60),
     )
     rolled, rolled_state = qa_shift.evaluate_check(
         state=state,
         usage_payload=_usage(total=100, day="2026-07-31"),
+        jobs_payload=_jobs(),
         expect_call=False,
         now=NOW + timedelta(minutes=1),
     )
     unknown, _ = qa_shift.evaluate_check(
         state=state,
         usage_payload=_usage(total=100, unknown=1),
+        jobs_payload=_jobs(),
         expect_call=False,
         now=NOW + timedelta(minutes=1),
     )
@@ -388,6 +624,7 @@ def test_check_and_finish_persist_end_to_end_tally(tmp_path: Path) -> None:
     begin = qa_shift.begin_shift(
         config=config,
         usage_reader=lambda _root, _day: _usage(total=100),
+        jobs_reader=_settled_jobs_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -397,12 +634,14 @@ def test_check_and_finish_persist_end_to_end_tally(tmp_path: Path) -> None:
         archive=archive,
         expect_call=True,
         usage_reader=lambda _root, _day: _usage(total=300, events=[first_event]),
+        jobs_reader=_settled_jobs_reader,
         now=NOW + timedelta(minutes=1),
     )
     finish = qa_shift.finish_shift(
         archive=archive,
         exit_condition="dry_well",
         usage_reader=lambda _root, _day: _usage(total=350, events=[first_event]),
+        jobs_reader=_settled_jobs_reader,
         now=NOW + timedelta(minutes=2),
     )
 
@@ -446,6 +685,7 @@ def test_finish_persists_exact_repair_tax_and_writer_tripwire(
             total=100,
             events=[historical_rejection],
         ),
+        jobs_reader=_settled_jobs_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -469,6 +709,7 @@ def test_finish_persists_exact_repair_tax_and_writer_tripwire(
             total=400,
             events=[historical_rejection, writer_rejection, accepted_retry],
         ),
+        jobs_reader=_settled_jobs_reader,
         now=NOW + timedelta(minutes=2),
     )
     ledger = json.loads((archive / "rejection_ledger.json").read_text())
@@ -518,6 +759,7 @@ def test_finish_withholds_repair_tax_percent_for_untrusted_denominator(
     begin = qa_shift.begin_shift(
         config=config,
         usage_reader=lambda _root, _day: _usage(total=100),
+        jobs_reader=_settled_jobs_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -534,6 +776,7 @@ def test_finish_withholds_repair_tax_percent_for_untrusted_denominator(
             unknown=unknown_usage,
             events=[rejection],
         ),
+        jobs_reader=_settled_jobs_reader,
         now=NOW + timedelta(minutes=2),
     )
     ledger = json.loads((archive / "rejection_ledger.json").read_text())
@@ -550,6 +793,7 @@ def test_finish_reads_original_quota_day_after_rollover(tmp_path: Path) -> None:
     begin = qa_shift.begin_shift(
         config=config,
         usage_reader=lambda _root, _day: _usage(total=100),
+        jobs_reader=_settled_jobs_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -561,6 +805,7 @@ def test_finish_reads_original_quota_day_after_rollover(tmp_path: Path) -> None:
             total=40,
             day="2026-07-31",
         ),
+        jobs_reader=_settled_jobs_reader,
         now=datetime(2026, 7, 31, 0, 1, tzinfo=timezone.utc),
     )
     requested_days: list[str | None] = []
@@ -573,6 +818,7 @@ def test_finish_reads_original_quota_day_after_rollover(tmp_path: Path) -> None:
         archive=archive,
         exit_condition="token_fence",
         usage_reader=read_original_day,
+        jobs_reader=_settled_jobs_reader,
         now=datetime(2026, 7, 31, 0, 2, tzinfo=timezone.utc),
     )
     state = json.loads((archive / "shift_state.json").read_text())
@@ -584,3 +830,53 @@ def test_finish_reads_original_quota_day_after_rollover(tmp_path: Path) -> None:
     assert finish["shift_openai_total"] == 250
     assert state["final_usage_day"] == "2026-07-30"
     assert state["finished_after_quota_rollover"] is True
+
+
+@pytest.mark.parametrize(
+    ("job_state", "usage_settled"),
+    ((None, True), ("leased", False)),
+)
+def test_finish_reports_maturation_settlement_without_refusal(
+    tmp_path: Path,
+    job_state: str | None,
+    usage_settled: bool,
+) -> None:
+    config = replace(qa_shift.load_shift_config(), archive_root=tmp_path)
+    begin = qa_shift.begin_shift(
+        config=config,
+        usage_reader=lambda _root, _day: _usage(total=100),
+        jobs_reader=_settled_jobs_reader,
+        now=NOW,
+    )
+    archive = Path(begin["archive"])
+
+    finish = qa_shift.finish_shift(
+        archive=archive,
+        exit_condition="blocked",
+        usage_reader=lambda _root, _day: _usage(total=125),
+        jobs_reader=lambda _root, _slot: _jobs(state=job_state),
+        now=NOW + timedelta(minutes=1),
+    )
+    final_state = json.loads((archive / "shift_state.json").read_text())
+
+    assert finish["status"] == "finished"
+    assert finish["usage_settled"] is usage_settled
+    assert finish["jobs"]["non_terminal_jobs"] == (
+        [] if job_state is None else [_job("leased")]
+    )
+    assert final_state["usage_settled"] is usage_settled
+
+
+def test_pending_check_exit_code_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        qa_shift,
+        "check_shift",
+        lambda **_kwargs: {"status": "pending"},
+    )
+
+    assert qa_shift.main(["check", str(tmp_path)]) == qa_shift.PENDING_EXIT_CODE == 3
+    assert json.loads(capsys.readouterr().out) == {"status": "pending"}


### PR DESCRIPTION
Closes #653.

## What

The Night QA usage guard could return `continue` from a post-command check while a detached Retrograde maturation call caused by that command was still in flight; the late usage event then poisoned the next pre-check's delta (observed twice: 14,532 and 13,566 late tokens, understating `max_command_delta` by ~15%).

The durable in-flight signal already existed — `orrery_maturation_jobs` with non-terminal states `queued`/`leased` in the per-slot database — the guard just never consulted it. Now it does, via a new public CLI readout, preserving the script's deliberate subprocess-only posture:

- **`nexus jobs --slot N --json`**: per-state counts plus a diagnosable non-terminal job list, built on the extended `load_maturation_status_sync` (one atomic query; the Orrery status consumer updated for the richer shape).
- **`JobsReader` seam** in `qa_shift.py`, mirroring `UsageReader`.
- **Third check status `pending` (exit code 3)**: any non-terminal job → the check reports the jobs and does NOT advance the usage watermark, does not update `max_command_delta`, and authorizes nothing. Re-running after settlement computes the delta from the original watermark, so late maturation usage lands in the causal command's delta — attribution is fixed by *refusing to move the goalposts*, not by event correlation.
- **Read ordering closes the race**: the queue is read *before* the usage snapshot. A job reaches a terminal state only after its usage event is durably recorded, so "settled queue, then usage" cannot miss a late event (regression-tested).
- **`begin` fails closed** on a dirty queue; **`finish` never blocks** but reports the jobs snapshot and `usage_settled: false` when unsettled.
- **Mission prompt** gains the pending protocol block (retry cadence and the twenty-minute plateau live there as operator guidance, not code constants).

Detached maturation itself is untouched — gameplay stays non-blocking (spec decision 10).

## Called-Out Drive-Bys (Mypy on Touched Files)

- `run_continue` in `nexus/cli.py` had an implicit-`None` fall-through when slot state was neither wizard nor narrative mode; now returns a loud structured error.
- `requests` import annotated `# type: ignore[import-untyped]`.

## Tests

- `tests/test_qa_shift.py` (+13 unit tests through the reader seams): pending without watermark advance; the issue's full timing scenario end-to-end (pre-check → leased job → `pending` → settle + late `retrograde_expansion` event → `continue` with the true 350-token command delta); queue-before-usage race ordering; only non-terminal states block; dirty-queue begin refusal; `usage_settled` both ways; exit-code contract.
- `tests/test_jobs_cli_pg.py` (new, `requires_postgres`): disposable `qa653_*` template clone, job rows across all four states, counts + non-terminal list shape.

## Gates

Black / flake8 / mypy clean on touched files; guard suite 27 passed; pg test passed; full suite **2147 passed, 501 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwQAcSeuSfJAcjUvxVzadv