### PR TITLE
Normalize Same-Character Enter/Exit to Net End-of-Turn State

### DIFF
--- a/nexus/agents/logon/skald_wire.py
+++ b/nexus/agents/logon/skald_wire.py
@@ -167,28 +167,41 @@ class PresenceDelta(BaseModel):
         if not overlap:
             return data
 
+        removed = [*enter, *exit_references]
+        matching_by_name = {
+            name_key: [
+                reference
+                for reference in removed
+                if reference.name.casefold() == name_key
+            ]
+            for name_key in overlap
+        }
+        normalizable_overlap = {
+            name_key
+            for name_key, matching in matching_by_name.items()
+            if len({reference.id for reference in matching if reference.id is not None})
+            <= 1
+        }
+        if not normalizable_overlap:
+            return data
+
         normalized = dict(data)
         normalized["enter"] = [
             reference
             for reference, parsed in zip(enter_data, enter)
-            if parsed.name.casefold() not in overlap
+            if parsed.name.casefold() not in normalizable_overlap
         ]
         normalized["exit"] = [
             reference
             for reference, parsed in zip(exit_data, exit_references)
-            if parsed.name.casefold() not in overlap
+            if parsed.name.casefold() not in normalizable_overlap
         ]
         normalized_mentions = list(mentions_data)
         mention_keys = {
             (reference.kind, reference.name.casefold()) for reference in mentions
         }
-        removed = [*enter, *exit_references]
-        for name_key in sorted(overlap):
-            matching = [
-                reference
-                for reference in removed
-                if reference.name.casefold() == name_key
-            ]
+        for name_key in sorted(normalizable_overlap):
+            matching = matching_by_name[name_key]
             name = matching[0].name
             reference_id = next(
                 (reference.id for reference in matching if reference.id is not None),
@@ -220,6 +233,45 @@ class PresenceDelta(BaseModel):
         exit_names = {reference.name.casefold() for reference in self.exit}
         overlap = enter_names & exit_names
         if overlap:
+            conflicts: List[str] = []
+            for name in sorted(overlap):
+                enter_ids = sorted(
+                    {
+                        reference.id
+                        for reference in self.enter
+                        if reference.name.casefold() == name
+                        and reference.id is not None
+                    }
+                )
+                exit_ids = sorted(
+                    {
+                        reference.id
+                        for reference in self.exit
+                        if reference.name.casefold() == name
+                        and reference.id is not None
+                    }
+                )
+                if len(set(enter_ids) | set(exit_ids)) < 2:
+                    continue
+                id_details: List[str] = []
+                if enter_ids:
+                    enter_label = "id" if len(enter_ids) == 1 else "ids"
+                    id_details.append(
+                        f"enter {enter_label}="
+                        + ", ".join(str(reference_id) for reference_id in enter_ids)
+                    )
+                if exit_ids:
+                    exit_label = "id" if len(exit_ids) == 1 else "ids"
+                    id_details.append(
+                        f"exit {exit_label}="
+                        + ", ".join(str(reference_id) for reference_id in exit_ids)
+                    )
+                conflicts.append(f"{name} ({', '.join(id_details)})")
+            if conflicts:
+                raise ValueError(
+                    "presence cannot enter and exit the same character: "
+                    + "; ".join(conflicts)
+                )
             raise ValueError(
                 "presence cannot enter and exit the same character: "
                 + ", ".join(sorted(overlap))

--- a/nexus/agents/logon/skald_wire.py
+++ b/nexus/agents/logon/skald_wire.py
@@ -7,9 +7,10 @@ per-chunk mentions, never members of the carried scene roster.
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, Dict, List, Literal, Optional, Sequence, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from nexus.agents.logon.apex_enums import (
     EmotionalValence,
@@ -43,6 +44,9 @@ from nexus.api.native_structured_output import (
     openai_response_text_format,
     strict_json_schema,
 )
+
+
+logger = logging.getLogger("nexus.logon.skald_wire")
 
 
 class SceneDelta(BaseModel):
@@ -128,6 +132,83 @@ class PresenceDelta(BaseModel):
         default=None,
         description="Fresh roster and setting after relocation.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_out_and_back(cls, data: Any) -> Any:
+        """Collapse same-turn character crossings to one mention."""
+
+        if not isinstance(data, dict) or data.get("scene_reset") is not None:
+            return data
+
+        enter_data = data.get("enter", [])
+        exit_data = data.get("exit", [])
+        mentions_data = data.get("mentions", [])
+        if not all(
+            isinstance(references, list)
+            for references in (enter_data, exit_data, mentions_data)
+        ):
+            return data
+
+        try:
+            enter = [CharacterRef.model_validate(reference) for reference in enter_data]
+            exit_references = [
+                CharacterRef.model_validate(reference) for reference in exit_data
+            ]
+            mentions = [
+                PresenceRef.model_validate(reference) for reference in mentions_data
+            ]
+        except ValidationError:
+            return data
+
+        overlap = {reference.name.casefold() for reference in enter} & {
+            reference.name.casefold() for reference in exit_references
+        }
+        if not overlap:
+            return data
+
+        normalized = dict(data)
+        normalized["enter"] = [
+            reference
+            for reference, parsed in zip(enter_data, enter)
+            if parsed.name.casefold() not in overlap
+        ]
+        normalized["exit"] = [
+            reference
+            for reference, parsed in zip(exit_data, exit_references)
+            if parsed.name.casefold() not in overlap
+        ]
+        normalized_mentions = list(mentions_data)
+        mention_keys = {
+            (reference.kind, reference.name.casefold()) for reference in mentions
+        }
+        removed = [*enter, *exit_references]
+        for name_key in sorted(overlap):
+            matching = [
+                reference
+                for reference in removed
+                if reference.name.casefold() == name_key
+            ]
+            name = matching[0].name
+            reference_id = next(
+                (reference.id for reference in matching if reference.id is not None),
+                None,
+            )
+            mention_key: tuple[Literal["character", "place", "faction"], str] = (
+                "character",
+                name_key,
+            )
+            if mention_key not in mention_keys:
+                normalized_mentions.append(
+                    {"kind": "character", "name": name, "id": reference_id}
+                )
+                mention_keys.add(mention_key)
+            logger.warning(
+                "presence out-and-back normalized to mention: %s",
+                name,
+            )
+        normalized["mentions"] = normalized_mentions
+        return normalized
 
     @model_validator(mode="after")
     def validate_presence_consistency(self) -> "PresenceDelta":

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -34,6 +34,7 @@ from nexus.agents.logon.apex_schema import (
     NamedObservation,
     NewEntityPairTagHint,
     OrreryAdjudication,
+    OrreryReplacementStateDelta,
     PlaceReference,
     ReferencedEntities,
     RelationshipUpdate,
@@ -53,6 +54,7 @@ from nexus.agents.logon.skald_wire import (
     CharacterRef,
     PlaceRef,
     PresenceBaseline,
+    PresenceDelta,
     PresenceRef,
     SkaldGaiaWire,
     SkaldTurnWire,
@@ -1041,20 +1043,148 @@ def test_scene_reset_rejects_roster_operations(roster_operation: str) -> None:
         )
 
 
-def test_presence_rejects_same_name_in_enter_and_exit_casefolded() -> None:
-    with pytest.raises(
-        ValidationError,
-        match="presence cannot enter and exit the same character",
-    ):
-        SkaldTurnWire.model_validate(
-            {
-                **SPARSE_WIRE_PAYLOAD,
-                "presence": {
-                    "enter": [{"kind": "character", "name": "Brena Tideloft"}],
-                    "exit": [{"kind": "character", "name": "BRENA TIDELOFT"}],
-                },
-            }
+def test_presence_normalizes_same_name_in_enter_and_exit_casefolded(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    presence = PresenceDelta(
+        enter=[CharacterRef(kind="character", name="nika rel")],
+        exit=[CharacterRef(kind="character", name="Nika Rel", id=31)],
+    )
+
+    assert presence.enter == []
+    assert presence.exit == []
+    assert presence.mentions == [PresenceRef(kind="character", name="nika rel", id=31)]
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if "presence out-and-back normalized to mention:" in record.getMessage()
+    ] == ["presence out-and-back normalized to mention: nika rel"]
+
+
+def test_presence_out_and_back_normalization_is_idempotent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    normalized = PresenceDelta.model_validate(
+        {
+            "enter": [{"kind": "character", "name": "Nika Rel", "id": 31}],
+            "exit": [{"kind": "character", "name": "nika rel"}],
+        }
+    )
+
+    caplog.clear()
+    revalidated = PresenceDelta.model_validate(normalized.model_dump())
+
+    assert revalidated == normalized
+    assert len(revalidated.mentions) == 1
+    assert "presence out-and-back normalized to mention:" not in caplog.text
+
+
+def test_presence_out_and_back_deduplicates_existing_character_mention() -> None:
+    existing_mention = PresenceRef(kind="character", name="NIKA REL", id=31)
+
+    presence = PresenceDelta(
+        enter=[CharacterRef(kind="character", name="Nika Rel")],
+        exit=[CharacterRef(kind="character", name="nika rel", id=32)],
+        mentions=[existing_mention],
+    )
+
+    assert presence.enter == []
+    assert presence.exit == []
+    assert presence.mentions == [existing_mention]
+
+
+def test_non_overlapping_presence_payload_passes_through_byte_identical(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    payload = {
+        "enter": [{"kind": "character", "name": "Nika Rel", "id": 31}],
+        "exit": [{"kind": "character", "name": "Brena Tideloft", "id": 7}],
+        "mentions": [{"kind": "faction", "name": "Sluice Guild", "id": 12}],
+        "transit": [{"kind": "place", "name": "East Lock", "id": 43}],
+        "scene_reset": None,
+    }
+    expected = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+    presence = PresenceDelta.model_validate(payload)
+    actual = json.dumps(
+        presence.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+    assert actual == expected
+    assert "presence out-and-back normalized to mention:" not in caplog.text
+
+
+def test_writer_raw_json_presence_out_and_back_decodes_normalized() -> None:
+    writer = SkaldWriterWire.model_validate(
+        {
+            **SPARSE_WIRE_PAYLOAD,
+            "presence": {
+                "enter": [{"kind": "character", "name": "nika rel"}],
+                "exit": [{"kind": "character", "name": "Nika Rel", "id": 31}],
+            },
+        }
+    )
+
+    assert writer.presence is not None
+    assert writer.presence.enter == []
+    assert writer.presence.exit == []
+    assert writer.presence.mentions == [
+        PresenceRef(kind="character", name="nika rel", id=31)
+    ]
+
+
+def test_hydration_out_and_back_absent_from_baseline_is_mentioned() -> None:
+    wire = SkaldTurnWire.model_validate(
+        {
+            **SPARSE_WIRE_PAYLOAD,
+            "presence": {
+                "enter": [{"kind": "character", "name": "Nika Rel", "id": 31}],
+                "exit": [{"kind": "character", "name": "nika rel"}],
+            },
+        }
+    )
+
+    hydrated = hydrate_skald_turn(wire, presence_baseline=PresenceBaseline())
+
+    assert hydrated.referenced_entities.characters == [
+        CharacterReference(
+            character_id=31,
+            character_name="Nika Rel",
+            reference_type=ReferenceType.MENTIONED,
         )
+    ]
+
+
+def test_hydration_out_and_back_prior_present_yields_both_references() -> None:
+    wire = SkaldTurnWire.model_validate(
+        {
+            **SPARSE_WIRE_PAYLOAD,
+            "presence": {
+                "enter": [{"kind": "character", "name": "Nika Rel", "id": 31}],
+                "exit": [{"kind": "character", "name": "nika rel"}],
+            },
+        }
+    )
+    baseline = PresenceBaseline(
+        present=[CharacterRef(kind="character", name="Nika Rel", id=31)]
+    )
+
+    hydrated = hydrate_skald_turn(wire, presence_baseline=baseline)
+
+    assert hydrated.referenced_entities.characters == [
+        CharacterReference(
+            character_id=31,
+            character_name="Nika Rel",
+            reference_type=ReferenceType.PRESENT,
+        ),
+        CharacterReference(
+            character_id=31,
+            character_name="Nika Rel",
+            reference_type=ReferenceType.MENTIONED,
+        ),
+    ]
 
 
 @pytest.mark.parametrize(
@@ -1970,7 +2100,9 @@ def test_replacement_event_type_requires_replacement_delta() -> None:
     adjudication = OrreryAdjudication(
         proposal_id="drink:aaa",
         action="replace",
-        replacement_state_delta={"character_current_activity": "resting"},
+        replacement_state_delta=OrreryReplacementStateDelta(
+            character_current_activity="resting"
+        ),
         replacement_event_type="mock_replacement",
     )
     assert adjudication.replacement_event_type == "mock_replacement"

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -1061,6 +1061,75 @@ def test_presence_normalizes_same_name_in_enter_and_exit_casefolded(
     ] == ["presence out-and-back normalized to mention: nika rel"]
 
 
+def test_presence_rejects_casefold_name_with_conflicting_ids(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    baseline = PresenceBaseline(
+        present=[CharacterRef(kind="character", name="NIKA REL", id=32)]
+    )
+    presence_payload = {
+        "enter": [{"kind": "character", "name": "Nika Rel", "id": 31}],
+        "exit": [{"kind": "character", "name": "NIKA REL", "id": 32}],
+    }
+    payload_before_validation = json.dumps(presence_payload, sort_keys=True)
+
+    with pytest.raises(ValidationError) as exc_info:
+        wire = SkaldTurnWire.model_validate(
+            {**SPARSE_WIRE_PAYLOAD, "presence": presence_payload}
+        )
+        hydrate_skald_turn(wire, presence_baseline=baseline)
+
+    assert (
+        "presence cannot enter and exit the same character: "
+        "nika rel (enter id=31, exit id=32)" in str(exc_info.value)
+    )
+    assert json.dumps(presence_payload, sort_keys=True) == payload_before_validation
+    assert "presence out-and-back normalized to mention:" not in caplog.text
+
+
+def test_presence_normalizes_casefold_name_with_same_id() -> None:
+    presence = PresenceDelta.model_validate(
+        {
+            "enter": [{"kind": "character", "name": "Nika Rel", "id": 31}],
+            "exit": [{"kind": "character", "name": "NIKA REL", "id": 31}],
+        }
+    )
+
+    assert presence.enter == []
+    assert presence.exit == []
+    assert presence.mentions == [PresenceRef(kind="character", name="Nika Rel", id=31)]
+
+
+def test_presence_mixed_compatible_and_conflicting_names_rejects_conflict(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    presence_payload = {
+        "enter": [
+            {"kind": "character", "name": "Nika Rel", "id": 31},
+            {"kind": "character", "name": "Mara Venn", "id": 41},
+        ],
+        "exit": [
+            {"kind": "character", "name": "NIKA REL", "id": 31},
+            {"kind": "character", "name": "MARA VENN", "id": 42},
+        ],
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        PresenceDelta.model_validate(presence_payload)
+
+    error_message = exc_info.value.errors()[0]["msg"]
+    assert (
+        "presence cannot enter and exit the same character: "
+        "mara venn (enter id=41, exit id=42)" in error_message
+    )
+    assert "nika rel" not in error_message
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if "presence out-and-back normalized to mention:" in record.getMessage()
+    ] == ["presence out-and-back normalized to mention: Nika Rel"]
+
+
 def test_presence_out_and_back_normalization_is_idempotent(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
Closes #639 (the reopened same-character enter/exit branch).

## What

PR #652 deliberately retained the app-side enter/exit overlap rejection because a strict JSON grammar cannot express cross-array disjointness. The first post-#652 roster-transition probe hit exactly that branch: a grammar-valid out-and-back move (new character enters the scene, then exits through the doors) was rejected with `presence cannot enter and exit the same character: nika rel` at a cost of 23,465 tokens for the writer retry.

A `mode="before"` model validator on `PresenceDelta` now normalizes the payload before the after-validator runs: every character in the casefolded enter∩exit intersection is removed from both lists and collapsed to one `kind="character"` mention (id carried from whichever side had one; de-duplicated against existing mentions). Each normalization logs the grep-stable marker `presence out-and-back normalized to mention: <name>` for QA-night rejection mining.

## Why This Is Correct Without Consulting the Prior Roster

The hydration algebra is roster = dedupe(baseline.present + enter) − exit. Working all four prior-state × intent combinations:

- **Absent + out-and-back** (the observed case): dropping both nets to absent-at-end; the mention preserves the junction row.
- **Present + leave-and-return**: dropping both leaves the baseline roster intact — net present; the extra mention collapses into the present row via the commit handlers' present-wins `ON CONFLICT` clause. (Raw hydration of the un-normalized payload would have gotten this case *wrong* — exit subtracts after enter adds, marking a still-present character absent.)

Loud rejections are preserved where the contradiction is genuine: `scene_reset` alongside enter/exit still raises, and the after-validator's overlap check stays as a defense-in-depth tripwire behind the normalizer.

No schema change (before-validators don't alter the emitted JSON schema — the writer schema budget test passes untouched) and no prompt change (normalization makes the encoding free; per-turn prompt tokens teaching avoidance would cost more than the thing they prevent).

## Tests

Seven new regressions in `tests/test_skald_wire.py`: casefolded normalization with id carry, idempotent re-validation (`model_validate(model_dump())` — the #651 boundary-coercion lesson), mention de-duplication, byte-identical passthrough of non-overlapping payloads, full raw-JSON wire decode, and both hydration end-states (absent-from-baseline → MENTIONED; present-on-baseline → PRESENT + mention pair). Warning-marker assertions via caplog. Also fixes the pre-existing mypy error at the old line 1973 (dict literal → constructed `OrreryReplacementStateDelta`; runtime-identical).

## Gates

Black / flake8 / mypy clean; focused suite 92 passed, 2 skipped; full suite **2142 passed, 500 skipped**.

Post-merge: the nightly QA lane's forced roster-transition family measures the class live; the reopen comment's acceptance metric (rejected attempts per writer attempt) comes from the shift's rejection ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwQAcSeuSfJAcjUvxVzadv