### PR TITLE
Reconcile Prose-Named Characters into Presence Mentions Before Commit

### DIFF
--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -60,6 +60,12 @@ from nexus.agents.orrery.tag_library import (  # noqa: E402
 from nexus.api.native_structured_output import (  # noqa: E402
     structured_output_error_text,
 )
+from nexus.api.presence_reconciliation import (  # noqa: E402
+    CharacterRosterRows,
+    read_character_roster,
+    read_character_roster_async,
+    reconcile_prose_mentions,
+)
 from nexus.config.loader import get_provider_for_model, resolve_model_ref  # noqa: E402
 from nexus.config.settings_models import (  # noqa: E402
     APEXTagLibrarySettings,
@@ -885,6 +891,7 @@ class LogonUtility:
             context_payload,
             schema_model,
         )
+        character_roster = self._read_character_roster_for_schema(schema_model)
         # Format the context into a prompt
         prompt = self._format_context_prompt(
             context_payload,
@@ -902,6 +909,7 @@ class LogonUtility:
                 response = self._generate_narrative_two_pass(
                     prompt,
                     presence_baseline=presence_baseline,
+                    character_roster=character_roster,
                     effective_context_window=effective_context_window,
                 )
             else:
@@ -921,6 +929,7 @@ class LogonUtility:
                     parsed_response,
                     schema_model,
                     presence_baseline=presence_baseline,
+                    character_roster=character_roster,
                 )
             logger.debug(
                 "Received structured response with narrative length: %s",
@@ -960,6 +969,9 @@ class LogonUtility:
             context_payload,
             schema_model,
         )
+        character_roster = await self._read_character_roster_for_schema_async(
+            schema_model
+        )
         prompt = self._format_context_prompt(
             context_payload,
             presence_baseline=presence_baseline,
@@ -974,6 +986,7 @@ class LogonUtility:
                 response = await self._generate_narrative_two_pass_async(
                     prompt,
                     presence_baseline=presence_baseline,
+                    character_roster=character_roster,
                     effective_context_window=effective_context_window,
                 )
             else:
@@ -993,6 +1006,7 @@ class LogonUtility:
                     parsed_response,
                     schema_model,
                     presence_baseline=presence_baseline,
+                    character_roster=character_roster,
                 )
             logger.debug(
                 "Received structured response with narrative length: %s",
@@ -1360,6 +1374,7 @@ class LogonUtility:
         turn_prompt: str,
         *,
         presence_baseline: Optional[PresenceBaseline],
+        character_roster: Optional[CharacterRosterRows],
         effective_context_window: Optional[int],
     ) -> StoryTurnResponse:
         """Run synchronous writer and gaia calls, then hydrate once."""
@@ -1443,6 +1458,7 @@ class LogonUtility:
             combine_two_pass(writer, gaia),
             SkaldTurnWire,
             presence_baseline=presence_baseline,
+            character_roster=character_roster,
         )
 
     async def _generate_narrative_two_pass_async(
@@ -1450,6 +1466,7 @@ class LogonUtility:
         turn_prompt: str,
         *,
         presence_baseline: Optional[PresenceBaseline],
+        character_roster: Optional[CharacterRosterRows],
         effective_context_window: Optional[int],
     ) -> StoryTurnResponse:
         """Run asynchronous writer and gaia calls, then hydrate once."""
@@ -1535,6 +1552,7 @@ class LogonUtility:
             combine_two_pass(writer, gaia),
             SkaldTurnWire,
             presence_baseline=presence_baseline,
+            character_roster=character_roster,
         )
 
     def _enforce_final_prompt_window(
@@ -1650,12 +1668,33 @@ class LogonUtility:
             )
         return await read_presence_baseline_async(self.dbname, parent_chunk_id)
 
+    def _read_character_roster_for_schema(
+        self,
+        schema_model: type[StorytellerResponseBootstrap] | type[SkaldTurnWire],
+    ) -> Optional[CharacterRosterRows]:
+        """Read known characters for a synchronous extended turn."""
+
+        if schema_model is not SkaldTurnWire or self.dbname is None:
+            return None
+        return read_character_roster(self.dbname)
+
+    async def _read_character_roster_for_schema_async(
+        self,
+        schema_model: type[StorytellerResponseBootstrap] | type[SkaldTurnWire],
+    ) -> Optional[CharacterRosterRows]:
+        """Read known characters for an asynchronous extended turn."""
+
+        if schema_model is not SkaldTurnWire or self.dbname is None:
+            return None
+        return await read_character_roster_async(self.dbname)
+
     @staticmethod
     def _hydrate_provider_response(
         parsed_response: Any,
         schema_model: type[StorytellerResponseBootstrap] | type[SkaldTurnWire],
         *,
         presence_baseline: Optional[PresenceBaseline] = None,
+        character_roster: Optional[CharacterRosterRows] = None,
     ) -> StoryTurnResponse:
         """Hydrate extended wire output while leaving bootstrap output unchanged."""
 
@@ -1663,6 +1702,12 @@ class LogonUtility:
             if not isinstance(parsed_response, SkaldTurnWire):
                 raise TypeError(
                     "Extended LOGON provider returned a non-SkaldTurnWire response"
+                )
+            if character_roster is not None:
+                reconcile_prose_mentions(
+                    parsed_response,
+                    presence_baseline=presence_baseline,
+                    roster_rows=character_roster,
                 )
             return hydrate_skald_turn(
                 parsed_response,

--- a/nexus/api/presence_reconciliation.py
+++ b/nexus/api/presence_reconciliation.py
@@ -21,6 +21,7 @@ from nexus.agents.logon.skald_wire import (
     _presence_key,
 )
 from nexus.api.presence_audit import _character_only_detector
+from nexus.memory.entity_detector import HighSpecificityEntityDetector
 
 
 logger = logging.getLogger("nexus.api.presence_reconciliation")
@@ -73,7 +74,48 @@ def _matches_character(character: Any, reference: PresenceRef) -> bool:
     character_id = character["id"]
     if character_id is not None and reference.id is not None:
         return character_id == reference.id
-    return str(character["name"]).casefold() == reference.name.casefold()
+    return str(character["name"]) == reference.name
+
+
+def _ambiguous_character_keys(
+    roster_rows: CharacterRosterRows,
+) -> dict[str, set[int]]:
+    """Return casefolded lookup keys that identify multiple characters."""
+
+    candidate_ids: dict[str, set[int]] = {}
+    known_character_ids: set[int] = set()
+    for character in roster_rows.characters:
+        character_id = int(character["id"])
+        known_character_ids.add(character_id)
+        key = str(character["name"]).casefold()
+        candidate_ids.setdefault(key, set()).add(character_id)
+    for alias in roster_rows.aliases:
+        character_id = int(alias["character_id"])
+        if character_id not in known_character_ids:
+            continue
+        key = str(alias["alias"]).casefold()
+        candidate_ids.setdefault(key, set()).add(character_id)
+    return {key: ids for key, ids in candidate_ids.items() if len(ids) > 1}
+
+
+def _reconciliation_detector(
+    roster_rows: CharacterRosterRows,
+) -> HighSpecificityEntityDetector:
+    """Build the shared detector with ambiguous character keys excluded."""
+
+    ambiguous = _ambiguous_character_keys(roster_rows)
+    for key in sorted(ambiguous):
+        logger.warning(
+            "presence prose mention ambiguous: %s candidate_ids=%s",
+            key,
+            sorted(ambiguous[key]),
+        )
+
+    detector = _character_only_detector(roster_rows.characters, roster_rows.aliases)
+    for lookup_key in list(detector.character_lookup):
+        if lookup_key.casefold() in ambiguous:
+            del detector.character_lookup[lookup_key]
+    return detector
 
 
 def _end_of_turn_roster(
@@ -122,8 +164,9 @@ def reconcile_prose_mentions(
     baseline by design and therefore require their own child mention.
     """
 
-    detector = _character_only_detector(roster_rows.characters, roster_rows.aliases)
-    detected = detector.detect_entities(wire.narrative).characters
+    detector = _reconciliation_detector(roster_rows)
+    public_text = "\n".join([wire.narrative, *wire.choices])
+    detected = detector.detect_entities(public_text).characters
     presence = wire.presence
     end_roster = _end_of_turn_roster(presence, presence_baseline)
     mentions = presence.mentions if presence is not None else []

--- a/nexus/api/presence_reconciliation.py
+++ b/nexus/api/presence_reconciliation.py
@@ -1,0 +1,149 @@
+"""Pre-hydration reconciliation for prose-named character mentions."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import logging
+import os
+from typing import Any, List, Optional, Sequence
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+from nexus.agents.logon.skald_wire import (
+    CharacterRef,
+    PresenceBaseline,
+    PresenceDelta,
+    PresenceRef,
+    SkaldTurnWire,
+    _deduplicate_presence,
+    _presence_key,
+)
+from nexus.api.presence_audit import _character_only_detector
+
+
+logger = logging.getLogger("nexus.api.presence_reconciliation")
+
+
+@dataclass(frozen=True)
+class CharacterRosterRows:
+    """Prefetched character and alias rows for one turn."""
+
+    characters: List[Any]
+    aliases: List[Any]
+
+
+def read_character_roster(dbname: str) -> CharacterRosterRows:
+    """Read the known-character roster and aliases for one turn."""
+
+    conn = psycopg2.connect(
+        host=os.environ.get("PGHOST", "localhost"),
+        database=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+    try:
+        conn.set_session(readonly=True, autocommit=True)
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                "SELECT id, name, summary FROM characters WHERE name IS NOT NULL"
+            )
+            character_rows = cur.fetchall()
+            cur.execute("SELECT character_id, alias FROM character_aliases")
+            alias_rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    return CharacterRosterRows(
+        characters=list(character_rows),
+        aliases=list(alias_rows),
+    )
+
+
+async def read_character_roster_async(dbname: str) -> CharacterRosterRows:
+    """Read the known-character roster without blocking the async turn loop."""
+
+    return await asyncio.to_thread(read_character_roster, dbname)
+
+
+def _matches_character(character: Any, reference: PresenceRef) -> bool:
+    """Match canonical identity by id when possible, otherwise by name."""
+
+    character_id = character["id"]
+    if character_id is not None and reference.id is not None:
+        return character_id == reference.id
+    return str(character["name"]).casefold() == reference.name.casefold()
+
+
+def _end_of_turn_roster(
+    presence: Optional[PresenceDelta],
+    baseline: Optional[PresenceBaseline],
+) -> List[CharacterRef]:
+    """Apply the same end-roster algebra used by Skald hydration."""
+
+    if presence is not None and presence.scene_reset is not None:
+        return _deduplicate_presence(presence.scene_reset.present)
+    if baseline is None:
+        return []
+
+    enter = presence.enter if presence is not None else []
+    exit_references = presence.exit if presence is not None else []
+    roster = _deduplicate_presence([*baseline.present, *enter])
+    exit_keys = {_presence_key(reference) for reference in exit_references}
+    return [
+        reference for reference in roster if _presence_key(reference) not in exit_keys
+    ]
+
+
+def _is_accounted(
+    character: Any,
+    references: Sequence[PresenceRef],
+) -> bool:
+    """Return whether any character reference accounts for the detection."""
+
+    return any(
+        reference.kind == "character" and _matches_character(character, reference)
+        for reference in references
+    )
+
+
+def reconcile_prose_mentions(
+    wire: SkaldTurnWire,
+    *,
+    presence_baseline: Optional[PresenceBaseline],
+    roster_rows: CharacterRosterRows,
+) -> SkaldTurnWire:
+    """Append missing known-character mentions detected in final wire prose.
+
+    Accounting mirrors the post-commit audit contract: the end-of-turn roster,
+    explicit current mentions, and parent-present characters each exempt a
+    detected identity. Parent-mentioned characters are absent from the
+    baseline by design and therefore require their own child mention.
+    """
+
+    detector = _character_only_detector(roster_rows.characters, roster_rows.aliases)
+    detected = detector.detect_entities(wire.narrative).characters
+    presence = wire.presence
+    end_roster = _end_of_turn_roster(presence, presence_baseline)
+    mentions = presence.mentions if presence is not None else []
+    parent_present = presence_baseline.present if presence_baseline is not None else []
+
+    for character in detected:
+        if any(
+            _is_accounted(character, references)
+            for references in (end_roster, mentions, parent_present)
+        ):
+            continue
+        if wire.presence is None:
+            wire.presence = PresenceDelta()
+            mentions = wire.presence.mentions
+        canonical = PresenceRef(
+            kind="character",
+            name=character["name"],
+            id=character["id"],
+        )
+        wire.presence.mentions.append(canonical)
+        logger.warning("presence prose mention normalized: %s", canonical.name)
+
+    return wire

--- a/tests/test_commit_handler.py
+++ b/tests/test_commit_handler.py
@@ -5,12 +5,16 @@ from types import SimpleNamespace
 import pytest
 
 from nexus.agents.logon.apex_schema import FactionStateUpdate, StateUpdates
+from nexus.agents.logon.skald_wire import PresenceBaseline, SkaldTurnWire
+from nexus.agents.lore.logon_utility import LogonUtility
 from nexus.api.commit_handler import (
     apply_state_updates,
     commit_incubator_to_database,
     insert_chunk_metadata,
 )
 import nexus.api.commit_handler as commit_handler
+from nexus.api.lore_adapter import response_to_incubator
+from nexus.api.presence_reconciliation import CharacterRosterRows
 
 
 class RecordingAsyncConnection:
@@ -217,6 +221,79 @@ async def test_async_commit_links_same_turn_character_declaration(monkeypatch):
 
     assert chunk_id == conn.chunk_id
     assert conn.character_junctions == [(conn.chunk_id, 72, "present")]
+
+
+@pytest.mark.asyncio
+async def test_async_reconciled_mentions_flow_through_adapter_and_commit(monkeypatch):
+    """The validated wire boundary feeds normalized mentions to the real commit."""
+
+    conn = AsyncCommitConnection()
+    conn.characters.update({"Ressa Morn": 101, "Niko Rell": 102, "Ora Pell": 103})
+    wire = SkaldTurnWire(
+        narrative=(
+            "Ressa Morn remains due before dawn. "
+            "Niko Rell and Ora Pell have made no contact."
+        ),
+        choices=["Wait.", "Proceed."],
+        letter="Keep the three debts unresolved.",
+    )
+    response = LogonUtility._hydrate_provider_response(
+        wire,
+        SkaldTurnWire,
+        presence_baseline=PresenceBaseline(),
+        character_roster=CharacterRosterRows(
+            characters=[
+                {"id": 101, "name": "Ressa Morn", "summary": None},
+                {"id": 102, "name": "Niko Rell", "summary": None},
+                {"id": 103, "name": "Ora Pell", "summary": None},
+            ],
+            aliases=[],
+        ),
+    )
+    conn.incubator = response_to_incubator(
+        response,
+        parent_chunk_id=88,
+        user_text="Continue.",
+        session_id="async-655",
+    )
+
+    async def no_op(*_args, **_kwargs):
+        return None
+
+    async def empty_orrery_tick(*_args, **_kwargs):
+        return _empty_orrery_result()
+
+    monkeypatch.setattr(commit_handler, "set_commit_chunk_attribution_async", no_op)
+    monkeypatch.setattr(commit_handler, "commit_orrery_tick_async", empty_orrery_tick)
+    monkeypatch.setattr(
+        commit_handler, "_orrery_checkpoint_interval", lambda _settings: 0
+    )
+
+    assert conn.incubator["reference_updates"]["characters"] == [
+        {
+            "character_id": 101,
+            "character_name": "Ressa Morn",
+            "reference_type": "mentioned",
+        },
+        {
+            "character_id": 102,
+            "character_name": "Niko Rell",
+            "reference_type": "mentioned",
+        },
+        {
+            "character_id": 103,
+            "character_name": "Ora Pell",
+            "reference_type": "mentioned",
+        },
+    ]
+
+    chunk_id = await commit_incubator_to_database(conn, "async-655", slot=5)
+
+    assert conn.character_junctions == [
+        (chunk_id, 101, "mentioned"),
+        (chunk_id, 102, "mentioned"),
+        (chunk_id, 103, "mentioned"),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_commit_handler_sync.py
+++ b/tests/test_commit_handler_sync.py
@@ -10,14 +10,17 @@ from nexus.agents.logon.apex_schema import (
     ReferenceType,
     StateUpdates,
 )
+from nexus.agents.logon.skald_wire import PresenceBaseline, SkaldTurnWire
 from nexus.agents.lore import logon_utility
-from nexus.agents.lore.logon_utility import read_presence_baseline
+from nexus.agents.lore.logon_utility import LogonUtility, read_presence_baseline
 from nexus.api.commit_handler_sync import (
     apply_state_updates_sync,
     commit_incubator_to_database_sync,
     resolve_character_references_sync,
 )
 import nexus.api.commit_handler_sync as commit_handler_sync
+from nexus.api.lore_adapter import response_to_incubator
+from nexus.api.presence_reconciliation import CharacterRosterRows
 
 
 class MissingLookupCursor:
@@ -262,6 +265,67 @@ def test_sync_commit_links_same_turn_character_declaration(monkeypatch):
         "FROM incubator" in sql and "FOR UPDATE" in sql
         for sql, _params in conn.statements
     )
+
+
+def test_sync_reconciled_mentions_flow_through_adapter_and_commit(monkeypatch):
+    """The validated wire boundary feeds normalized mentions to the real commit."""
+
+    conn = CommitConnection()
+    conn.characters.update({"Ressa Morn": 101, "Niko Rell": 102, "Ora Pell": 103})
+    wire = SkaldTurnWire(
+        narrative=(
+            "Ressa Morn remains due before dawn. "
+            "Niko Rell and Ora Pell have made no contact."
+        ),
+        choices=["Wait.", "Proceed."],
+        letter="Keep the three debts unresolved.",
+    )
+    response = LogonUtility._hydrate_provider_response(
+        wire,
+        SkaldTurnWire,
+        presence_baseline=PresenceBaseline(),
+        character_roster=CharacterRosterRows(
+            characters=[
+                {"id": 101, "name": "Ressa Morn", "summary": None},
+                {"id": 102, "name": "Niko Rell", "summary": None},
+                {"id": 103, "name": "Ora Pell", "summary": None},
+            ],
+            aliases=[],
+        ),
+    )
+    conn.incubator = response_to_incubator(
+        response,
+        parent_chunk_id=44,
+        user_text="Continue.",
+        session_id="sync-655",
+    )
+    _patch_sync_commit_runtime(monkeypatch)
+
+    assert conn.incubator["reference_updates"]["characters"] == [
+        {
+            "character_id": 101,
+            "character_name": "Ressa Morn",
+            "reference_type": "mentioned",
+        },
+        {
+            "character_id": 102,
+            "character_name": "Niko Rell",
+            "reference_type": "mentioned",
+        },
+        {
+            "character_id": 103,
+            "character_name": "Ora Pell",
+            "reference_type": "mentioned",
+        },
+    ]
+
+    chunk_id = commit_incubator_to_database_sync(conn, "sync-655", slot=5)
+
+    assert conn.character_junctions == [
+        (chunk_id, 101, "mentioned"),
+        (chunk_id, 102, "mentioned"),
+        (chunk_id, 103, "mentioned"),
+    ]
 
 
 def _patch_sync_commit_runtime(monkeypatch) -> None:

--- a/tests/test_lore/test_two_pass_pipeline.py
+++ b/tests/test_lore/test_two_pass_pipeline.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 import pytest
 from pydantic_ai import ModelRetry
 
+from nexus.agents.logon.apex_enums import ReferenceType
 from nexus.agents.logon.apex_schema import (
     StorytellerResponseBootstrap,
     StorytellerResponseExtended,
@@ -46,6 +47,7 @@ from nexus.api.native_structured_output import (
     retry_prompt,
     run_output_validator,
 )
+from nexus.api.presence_reconciliation import CharacterRosterRows
 
 
 @pytest.fixture(autouse=True)
@@ -542,6 +544,88 @@ async def test_async_two_pass_pipeline_uses_provider_specific_transports(
     _assert_two_pass_calls(provider, provider_type, anthropic_transport)
     assert response.narrative == WRITER_PAYLOAD["narrative"]
     assert response.generation_model == provider.model
+
+
+def test_sync_two_pass_reconciles_writer_prose_before_hydration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The combined writer wire receives the prefetched roster exactly once."""
+
+    writer_payload = {
+        **WRITER_PAYLOAD,
+        "narrative": "Ressa Morn waits beyond the archive door.",
+    }
+    utility, _provider = _utility("openai", [writer_payload, GAIA_PAYLOAD])
+    monkeypatch.setattr(
+        utility,
+        "_read_presence_baseline_for_context",
+        lambda _context_payload, _schema_model: BASELINE,
+    )
+    roster = CharacterRosterRows(
+        characters=[{"id": 101, "name": "Ressa Morn", "summary": None}],
+        aliases=[],
+    )
+    monkeypatch.setattr(
+        utility,
+        "_read_character_roster_for_schema",
+        lambda _schema_model: roster,
+    )
+
+    response = utility.generate_narrative(
+        _context(),
+        effective_context_window=75_000,
+    )
+
+    assert [
+        (reference.character_id, reference.reference_type)
+        for reference in response.referenced_entities.characters
+    ][-1] == (101, ReferenceType.MENTIONED)
+
+
+@pytest.mark.asyncio
+async def test_async_two_pass_reconciles_writer_prose_before_hydration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The async combined writer wire receives the prefetched roster once."""
+
+    writer_payload = {
+        **WRITER_PAYLOAD,
+        "narrative": "Ressa Morn waits beyond the archive door.",
+    }
+    utility, _provider = _utility("openai", [writer_payload, GAIA_PAYLOAD])
+
+    async def read_baseline(
+        _context_payload: dict[str, Any],
+        _schema_model: type,
+    ) -> PresenceBaseline:
+        return BASELINE
+
+    async def read_roster(_schema_model: type) -> CharacterRosterRows:
+        return CharacterRosterRows(
+            characters=[{"id": 101, "name": "Ressa Morn", "summary": None}],
+            aliases=[],
+        )
+
+    monkeypatch.setattr(
+        utility,
+        "_read_presence_baseline_for_context_async",
+        read_baseline,
+    )
+    monkeypatch.setattr(
+        utility,
+        "_read_character_roster_for_schema_async",
+        read_roster,
+    )
+
+    response = await utility.generate_narrative_async(
+        _context(),
+        effective_context_window=75_000,
+    )
+
+    assert [
+        (reference.character_id, reference.reference_type)
+        for reference in response.referenced_entities.characters
+    ][-1] == (101, ReferenceType.MENTIONED)
 
 
 def test_sync_anthropic_two_pass_rejects_native_before_provider_call(

--- a/tests/test_presence_reconciliation.py
+++ b/tests/test_presence_reconciliation.py
@@ -1,0 +1,377 @@
+"""Pre-commit prose mention reconciliation tests (issue #655)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Iterator
+import uuid
+
+import psycopg2
+import pytest
+from psycopg2 import sql
+
+from nexus.agents.logon.apex_enums import ReferenceType
+from nexus.agents.logon.skald_wire import (
+    CharacterRef,
+    PresenceBaseline,
+    PresenceDelta,
+    PresenceRef,
+    SkaldTurnWire,
+    hydrate_skald_turn,
+)
+from nexus.api.presence_reconciliation import (
+    CharacterRosterRows,
+    read_character_roster,
+    reconcile_prose_mentions,
+)
+
+
+CHARACTERS = [
+    {"id": 7, "name": "Kosi Adebayo", "summary": "A river pilot."},
+    {"id": 9, "name": "Nneka Daramola", "summary": "A watch captain."},
+]
+ALIASES = [{"character_id": 7, "alias": "the Boatman"}]
+ROSTER_ROWS = CharacterRosterRows(characters=CHARACTERS, aliases=ALIASES)
+EMPTY_BASELINE = PresenceBaseline()
+
+
+def _wire(
+    narrative: str,
+    *,
+    presence: PresenceDelta | None = None,
+) -> SkaldTurnWire:
+    """Build a minimal valid extended wire response."""
+
+    return SkaldTurnWire(
+        narrative=narrative,
+        choices=["Wait.", "Proceed."],
+        presence=presence,
+        letter="Keep the river crossing unresolved.",
+    )
+
+
+@pytest.mark.parametrize(
+    "prose",
+    [
+        "Kosi Adebayo waits beside the launch.",
+        "The Boatman waits beside the launch.",
+    ],
+)
+def test_canonical_name_and_alias_resolve_to_canonical_identity(prose: str) -> None:
+    """Canonical names and aliases append the same canonical mention."""
+
+    wire = reconcile_prose_mentions(
+        _wire(prose),
+        presence_baseline=EMPTY_BASELINE,
+        roster_rows=ROSTER_ROWS,
+    )
+
+    assert wire.presence is not None
+    assert wire.presence.mentions == [
+        PresenceRef(kind="character", name="Kosi Adebayo", id=7)
+    ]
+
+
+def test_end_of_turn_roster_accounts_for_detected_character() -> None:
+    """A character entering this turn needs no additional mention."""
+
+    wire = _wire(
+        "Kosi Adebayo takes the wheel.",
+        presence=PresenceDelta(
+            enter=[CharacterRef(kind="character", name="Kosi Adebayo", id=7)]
+        ),
+    )
+
+    reconcile_prose_mentions(
+        wire,
+        presence_baseline=EMPTY_BASELINE,
+        roster_rows=ROSTER_ROWS,
+    )
+
+    assert wire.presence is not None
+    assert wire.presence.mentions == []
+
+
+def test_existing_mention_accounts_for_detected_character() -> None:
+    """An existing current-chunk mention prevents duplication."""
+
+    mention = PresenceRef(kind="character", name="Kosi Adebayo", id=7)
+    wire = _wire(
+        "The Boatman is expected before dawn.",
+        presence=PresenceDelta(mentions=[mention]),
+    )
+
+    reconcile_prose_mentions(
+        wire,
+        presence_baseline=EMPTY_BASELINE,
+        roster_rows=ROSTER_ROWS,
+    )
+
+    assert wire.presence is not None
+    assert wire.presence.mentions == [mention]
+
+
+def test_parent_present_accounts_for_authored_exit() -> None:
+    """A parent-present character remains exempt after an authored exit."""
+
+    baseline = PresenceBaseline(
+        present=[CharacterRef(kind="character", name="Kosi Adebayo", id=7)]
+    )
+    wire = _wire(
+        "Kosi Adebayo leaves the launch behind.",
+        presence=PresenceDelta(
+            exit=[CharacterRef(kind="character", name="Kosi Adebayo", id=7)]
+        ),
+    )
+
+    reconcile_prose_mentions(
+        wire,
+        presence_baseline=baseline,
+        roster_rows=ROSTER_ROWS,
+    )
+
+    assert wire.presence is not None
+    assert wire.presence.mentions == []
+
+
+def test_parent_mentioned_character_still_gets_child_mention() -> None:
+    """Parent mentions are deliberately absent from the parent-present baseline."""
+
+    wire = reconcile_prose_mentions(
+        _wire("Kosi Adebayo is still expected before dawn."),
+        presence_baseline=EMPTY_BASELINE,
+        roster_rows=ROSTER_ROWS,
+    )
+
+    assert wire.presence is not None
+    assert wire.presence.mentions == [
+        PresenceRef(kind="character", name="Kosi Adebayo", id=7)
+    ]
+
+
+@pytest.mark.parametrize(
+    "prose",
+    [
+        "She watches the dark water without speaking.",
+        "Unknown Mariner watches the dark water without speaking.",
+    ],
+)
+def test_pronouns_and_unknown_names_add_nothing(prose: str) -> None:
+    """Pronoun-only and unknown references stay outside the detector contract."""
+
+    wire = _wire(prose)
+
+    reconcile_prose_mentions(
+        wire,
+        presence_baseline=EMPTY_BASELINE,
+        roster_rows=ROSTER_ROWS,
+    )
+
+    assert wire.presence is None
+
+
+def test_presence_none_constructs_mentions_only_delta_and_preserves_roster() -> None:
+    """A mentions-only delta carries the baseline roster through hydration."""
+
+    baseline = PresenceBaseline(
+        present=[CharacterRef(kind="character", name="Nneka Daramola", id=9)]
+    )
+    wire = reconcile_prose_mentions(
+        _wire("Kosi Adebayo answers from the far bank."),
+        presence_baseline=baseline,
+        roster_rows=ROSTER_ROWS,
+    )
+
+    assert wire.presence == PresenceDelta(
+        mentions=[PresenceRef(kind="character", name="Kosi Adebayo", id=7)]
+    )
+    response = hydrate_skald_turn(wire, presence_baseline=baseline)
+    assert [
+        (reference.character_id, reference.reference_type)
+        for reference in response.referenced_entities.characters
+    ] == [
+        (9, ReferenceType.PRESENT),
+        (7, ReferenceType.MENTIONED),
+    ]
+
+
+def test_reconciliation_is_idempotent_and_round_trip_stable() -> None:
+    """A second pass is silent and Pydantic revalidation preserves the mutation."""
+
+    wire = reconcile_prose_mentions(
+        _wire("Kosi Adebayo answers from the far bank."),
+        presence_baseline=EMPTY_BASELINE,
+        roster_rows=ROSTER_ROWS,
+    )
+    first_dump = wire.model_dump()
+
+    reconcile_prose_mentions(
+        wire,
+        presence_baseline=EMPTY_BASELINE,
+        roster_rows=ROSTER_ROWS,
+    )
+    revalidated = SkaldTurnWire.model_validate(wire.model_dump())
+
+    assert wire.model_dump() == first_dump
+    assert revalidated.model_dump() == first_dump
+
+
+def test_warning_marker_emits_once_per_character_and_is_silent_when_clean(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Only actual additions emit the grep-stable normalization marker."""
+
+    wire = _wire("Kosi Adebayo speaks to Nneka Daramola about the crossing.")
+    with caplog.at_level(
+        logging.WARNING,
+        logger="nexus.api.presence_reconciliation",
+    ):
+        reconcile_prose_mentions(
+            wire,
+            presence_baseline=EMPTY_BASELINE,
+            roster_rows=ROSTER_ROWS,
+        )
+        reconcile_prose_mentions(
+            wire,
+            presence_baseline=EMPTY_BASELINE,
+            roster_rows=ROSTER_ROWS,
+        )
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "nexus.api.presence_reconciliation"
+    ]
+    assert messages == [
+        "presence prose mention normalized: Kosi Adebayo",
+        "presence prose mention normalized: Nneka Daramola",
+    ]
+
+
+def test_chunk_46_shape_adds_three_mentions_and_hydrates_reference_rows() -> None:
+    """The issue's three off-scene names all become MENTIONED references."""
+
+    characters = [
+        {"id": 101, "name": "Ressa Morn", "summary": None},
+        {"id": 102, "name": "Niko Rell", "summary": None},
+        {"id": 103, "name": "Ora Pell", "summary": None},
+        {"id": 104, "name": "Mara Vey", "summary": None},
+    ]
+    baseline = PresenceBaseline(
+        present=[CharacterRef(kind="character", name="Mara Vey", id=104)]
+    )
+    wire = _wire(
+        "Ivo Senn's account to Ressa Morn remains due before dawn. "
+        "Niko Rell and Ora Pell have made no contact with this hall."
+    )
+
+    reconcile_prose_mentions(
+        wire,
+        presence_baseline=baseline,
+        roster_rows=CharacterRosterRows(characters=characters, aliases=[]),
+    )
+
+    assert wire.presence is not None
+    assert [(mention.id, mention.name) for mention in wire.presence.mentions] == [
+        (101, "Ressa Morn"),
+        (102, "Niko Rell"),
+        (103, "Ora Pell"),
+    ]
+    response = hydrate_skald_turn(wire, presence_baseline=baseline)
+    mentioned = [
+        reference
+        for reference in response.referenced_entities.characters
+        if reference.reference_type == ReferenceType.MENTIONED
+    ]
+    assert [
+        (reference.character_id, reference.character_name) for reference in mentioned
+    ] == [
+        (101, "Ressa Morn"),
+        (102, "Niko Rell"),
+        (103, "Ora Pell"),
+    ]
+
+
+def _connect(dbname: str) -> Any:
+    """Open a direct psycopg2 connection to a disposable database."""
+
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+@pytest.fixture()
+def qa655_db() -> Iterator[str]:
+    """Clone NEXUS_template into a qa655 database and always drop it."""
+
+    dbname = f"qa655_{uuid.uuid4().hex[:12]}"
+    admin = _connect("postgres")
+    admin.autocommit = True
+    try:
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier("NEXUS_template"),
+                )
+            )
+        yield dbname
+    finally:
+        with admin.cursor() as cur:
+            cur.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (dbname,),
+            )
+            cur.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+            )
+        admin.close()
+
+
+@pytest.mark.requires_postgres
+def test_roster_fetch_reads_characters_and_aliases_from_disposable_clone(
+    qa655_db: str,
+) -> None:
+    """The read-only helper executes both roster queries against PostgreSQL."""
+
+    with _connect(qa655_db) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SET LOCAL session_replication_role = replica")
+            cur.execute(
+                "INSERT INTO entities (kind) VALUES ('character'::entity_kind) "
+                "RETURNING id"
+            )
+            entity_id = int(cur.fetchone()[0])
+            cur.execute(
+                "INSERT INTO characters (name, summary, entity_id) "
+                "VALUES (%s, %s, %s) RETURNING id",
+                (
+                    "QA655 Canonical Mariner",
+                    "Disposable roster-fetch fixture.",
+                    entity_id,
+                ),
+            )
+            character_id = int(cur.fetchone()[0])
+            character_name = "QA655 Canonical Mariner"
+            alias = f"QA655 Boatman {uuid.uuid4().hex}"
+            cur.execute(
+                "INSERT INTO character_aliases (character_id, alias) VALUES (%s, %s)",
+                (character_id, alias),
+            )
+            cur.execute("SET LOCAL session_replication_role = origin")
+
+    roster = read_character_roster(qa655_db)
+
+    assert any(
+        row["id"] == character_id and row["name"] == character_name
+        for row in roster.characters
+    )
+    assert any(
+        row["character_id"] == character_id and row["alias"] == alias
+        for row in roster.aliases
+    )

--- a/tests/test_presence_reconciliation.py
+++ b/tests/test_presence_reconciliation.py
@@ -20,6 +20,7 @@ from nexus.agents.logon.skald_wire import (
     SkaldTurnWire,
     hydrate_skald_turn,
 )
+from nexus.api.lore_adapter import compute_raw_text
 from nexus.api.presence_reconciliation import (
     CharacterRosterRows,
     read_character_roster,
@@ -39,15 +40,17 @@ EMPTY_BASELINE = PresenceBaseline()
 def _wire(
     narrative: str,
     *,
+    choices: list[str] | None = None,
+    letter: str = "Keep the river crossing unresolved.",
     presence: PresenceDelta | None = None,
 ) -> SkaldTurnWire:
     """Build a minimal valid extended wire response."""
 
     return SkaldTurnWire(
         narrative=narrative,
-        choices=["Wait.", "Proceed."],
+        choices=choices or ["Wait.", "Proceed."],
         presence=presence,
-        letter="Keep the river crossing unresolved.",
+        letter=letter,
     )
 
 
@@ -73,6 +76,47 @@ def test_canonical_name_and_alias_resolve_to_canonical_identity(prose: str) -> N
     ]
 
 
+def test_choice_only_name_reconciles_for_every_possible_enacted_choice() -> None:
+    """Offered-choice scanning is a safe superset of committed raw_text."""
+
+    choices = ["Ask Kosi Adebayo about the launch.", "Wait by the river."]
+    wire = reconcile_prose_mentions(
+        _wire("The launch rocks against its mooring.", choices=choices),
+        presence_baseline=EMPTY_BASELINE,
+        roster_rows=ROSTER_ROWS,
+    )
+    enacted_raw_text = compute_raw_text(
+        wire.narrative,
+        {"presented": choices, "selected": 1},
+        choices[0],
+    )
+
+    assert enacted_raw_text == (
+        "The launch rocks against its mooring.\n\n" "Ask Kosi Adebayo about the launch."
+    )
+    assert wire.presence is not None
+    assert wire.presence.mentions == [
+        PresenceRef(kind="character", name="Kosi Adebayo", id=7)
+    ]
+
+
+def test_private_letter_is_not_scanned_for_presence_mentions() -> None:
+    """Private correspondence never enters public detection or raw_text."""
+
+    wire = _wire(
+        "The launch rocks against its mooring.",
+        letter="Have Kosi Adebayo arrive after the next crossing.",
+    )
+
+    reconcile_prose_mentions(
+        wire,
+        presence_baseline=EMPTY_BASELINE,
+        roster_rows=ROSTER_ROWS,
+    )
+
+    assert wire.presence is None
+
+
 def test_end_of_turn_roster_accounts_for_detected_character() -> None:
     """A character entering this turn needs no additional mention."""
 
@@ -80,6 +124,47 @@ def test_end_of_turn_roster_accounts_for_detected_character() -> None:
         "Kosi Adebayo takes the wheel.",
         presence=PresenceDelta(
             enter=[CharacterRef(kind="character", name="Kosi Adebayo", id=7)]
+        ),
+    )
+
+    reconcile_prose_mentions(
+        wire,
+        presence_baseline=EMPTY_BASELINE,
+        roster_rows=ROSTER_ROWS,
+    )
+
+    assert wire.presence is not None
+    assert wire.presence.mentions == []
+
+
+@pytest.mark.parametrize("wire_name", ["kosi adebayo", "the Boatman"])
+def test_idless_noncanonical_roster_ref_does_not_account(wire_name: str) -> None:
+    """Sloppy-cased and alias names cannot suppress a resolvable mention."""
+
+    wire = _wire(
+        "Kosi Adebayo takes the wheel.",
+        presence=PresenceDelta(enter=[CharacterRef(kind="character", name=wire_name)]),
+    )
+
+    reconcile_prose_mentions(
+        wire,
+        presence_baseline=EMPTY_BASELINE,
+        roster_rows=ROSTER_ROWS,
+    )
+
+    assert wire.presence is not None
+    assert wire.presence.mentions == [
+        PresenceRef(kind="character", name="Kosi Adebayo", id=7)
+    ]
+
+
+def test_exact_canonical_idless_roster_ref_accounts() -> None:
+    """An exact canonical name remains resolvable by commit-time SQL."""
+
+    wire = _wire(
+        "Kosi Adebayo takes the wheel.",
+        presence=PresenceDelta(
+            enter=[CharacterRef(kind="character", name="Kosi Adebayo")]
         ),
     )
 
@@ -247,6 +332,77 @@ def test_warning_marker_emits_once_per_character_and_is_silent_when_clean(
         "presence prose mention normalized: Kosi Adebayo",
         "presence prose mention normalized: Nneka Daramola",
     ]
+
+
+def test_ambiguous_identity_is_not_reconciled_but_clean_identity_is(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Casefold collisions warn and fail open without choosing the wrong id."""
+
+    roster = CharacterRosterRows(
+        characters=[
+            {"id": 21, "name": "Mara", "summary": None},
+            {"id": 22, "name": "MARA", "summary": None},
+            {"id": 23, "name": "Nneka Daramola", "summary": None},
+        ],
+        aliases=[],
+    )
+    wire = _wire("Mara speaks with Nneka Daramola beside the river.")
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="nexus.api.presence_reconciliation",
+    ):
+        reconcile_prose_mentions(
+            wire,
+            presence_baseline=EMPTY_BASELINE,
+            roster_rows=roster,
+        )
+
+    assert wire.presence is not None
+    assert wire.presence.mentions == [
+        PresenceRef(kind="character", name="Nneka Daramola", id=23)
+    ]
+    ambiguous_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "presence prose mention ambiguous:" in record.getMessage()
+    ]
+    assert ambiguous_messages == [
+        "presence prose mention ambiguous: mara candidate_ids=[21, 22]"
+    ]
+
+
+def test_alias_collision_participates_in_ambiguity_filter(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Aliases and canonical names share one collision namespace."""
+
+    roster = CharacterRosterRows(
+        characters=[
+            {"id": 31, "name": "Kosi Adebayo", "summary": None},
+            {"id": 32, "name": "Harbor Master", "summary": None},
+        ],
+        aliases=[{"character_id": 31, "alias": "harbor master"}],
+    )
+    wire = _wire("The Harbor Master waits beside the launch.")
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="nexus.api.presence_reconciliation",
+    ):
+        reconcile_prose_mentions(
+            wire,
+            presence_baseline=EMPTY_BASELINE,
+            roster_rows=roster,
+        )
+
+    assert wire.presence is None
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if "presence prose mention ambiguous:" in record.getMessage()
+    ] == ["presence prose mention ambiguous: harbor master candidate_ids=[31, 32]"]
 
 
 def test_chunk_46_shape_adds_three_mentions_and_hydrates_reference_rows() -> None:

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -75,6 +75,7 @@ from nexus.agents.lore import logon_utility
 from nexus.agents.lore.logon_utility import LogonUtility, read_presence_baseline
 from nexus.agents.orrery.tag_schemas import OrreryTagBestowal
 from nexus.api.native_structured_output import anthropic_output_config
+from nexus.api.presence_reconciliation import CharacterRosterRows
 from nexus.config import resolve_model_ref
 from scripts.api_openai import OpenAIProvider
 
@@ -1940,15 +1941,33 @@ def test_sync_logon_reads_and_supplies_parent_baseline(
             _schema_model: type,
             **_kwargs: Any,
         ) -> tuple[SkaldTurnWire, object]:
-            return SkaldTurnWire.model_validate(SPARSE_WIRE_PAYLOAD), object()
+            return (
+                SkaldTurnWire.model_validate(
+                    {
+                        **SPARSE_WIRE_PAYLOAD,
+                        "narrative": "Ressa Morn waits beyond the archive door.",
+                    }
+                ),
+                object(),
+            )
 
     calls: list[tuple[str, int]] = []
+    roster_calls: list[str] = []
 
     def fake_read(dbname: str, parent_chunk_id: int) -> PresenceBaseline:
         calls.append((dbname, parent_chunk_id))
         return BASELINE
 
     monkeypatch.setattr(logon_utility, "read_presence_baseline", fake_read)
+
+    def fake_read_roster(dbname: str) -> CharacterRosterRows:
+        roster_calls.append(dbname)
+        return CharacterRosterRows(
+            characters=[{"id": 101, "name": "Ressa Morn", "summary": None}],
+            aliases=[],
+        )
+
+    monkeypatch.setattr(logon_utility, "read_character_roster", fake_read_roster)
     monkeypatch.setattr(logon_utility, "read_user_character_id", lambda _dbname: 1)
     monkeypatch.setattr(
         logon_utility,
@@ -1975,8 +1994,16 @@ def test_sync_logon_reads_and_supplies_parent_baseline(
         effective_context_window=75_000,
     )
     assert calls == [("save_05", 77)]
+    assert roster_calls == ["save_05"]
     assert isinstance(response, StorytellerResponseExtended)
-    assert len(response.referenced_entities.characters) == 2
+    assert [
+        (reference.character_id, reference.reference_type)
+        for reference in response.referenced_entities.characters
+    ] == [
+        (7, ReferenceType.PRESENT),
+        (8, ReferenceType.PRESENT),
+        (101, ReferenceType.MENTIONED),
+    ]
     assert response.generation_model == "wire-test-model"
 
 
@@ -1993,15 +2020,37 @@ async def test_async_logon_reads_and_supplies_parent_baseline(
             _schema_model: type,
             **_kwargs: Any,
         ) -> tuple[SkaldTurnWire, object]:
-            return SkaldTurnWire.model_validate(SPARSE_WIRE_PAYLOAD), object()
+            return (
+                SkaldTurnWire.model_validate(
+                    {
+                        **SPARSE_WIRE_PAYLOAD,
+                        "narrative": "Ressa Morn waits beyond the archive door.",
+                    }
+                ),
+                object(),
+            )
 
     calls: list[tuple[str, int]] = []
+    roster_calls: list[str] = []
 
     async def fake_read(dbname: str, parent_chunk_id: int) -> PresenceBaseline:
         calls.append((dbname, parent_chunk_id))
         return BASELINE
 
     monkeypatch.setattr(logon_utility, "read_presence_baseline_async", fake_read)
+
+    async def fake_read_roster(dbname: str) -> CharacterRosterRows:
+        roster_calls.append(dbname)
+        return CharacterRosterRows(
+            characters=[{"id": 101, "name": "Ressa Morn", "summary": None}],
+            aliases=[],
+        )
+
+    monkeypatch.setattr(
+        logon_utility,
+        "read_character_roster_async",
+        fake_read_roster,
+    )
     monkeypatch.setattr(logon_utility, "read_user_character_id", lambda _dbname: 1)
     monkeypatch.setattr(
         logon_utility,
@@ -2028,8 +2077,16 @@ async def test_async_logon_reads_and_supplies_parent_baseline(
         effective_context_window=75_000,
     )
     assert calls == [("save_05", 77)]
+    assert roster_calls == ["save_05"]
     assert isinstance(response, StorytellerResponseExtended)
-    assert len(response.referenced_entities.characters) == 2
+    assert [
+        (reference.character_id, reference.reference_type)
+        for reference in response.referenced_entities.characters
+    ] == [
+        (7, ReferenceType.PRESENT),
+        (8, ReferenceType.PRESENT),
+        (101, ReferenceType.MENTIONED),
+    ]
     assert response.generation_model == "wire-test-model"
 
 


### PR DESCRIPTION
Closes #655.

## What

The writer could name known off-scene characters in committed prose without emitting them in `presence.mentions`; the commit then persisted no junction row, and the #567 presence audit could only warn after the incomplete state was durable (deterministic on the Night QA seed: Ressa Morn, Niko Rell, Ora Pell on chunk 46).

A mechanical reconciliation now runs at the validated boundary, in `LogonUtility._hydrate_provider_response` immediately before `hydrate_skald_turn`: the final wire prose is scanned with the audit's own DB-less detector (word-boundary, case-insensitive, alias-aware, pronoun-blind by construction) over a once-per-turn read-only roster fetch, and every detected-but-unaccounted known character is appended to `presence.mentions` with its canonical name and id, logged with the grep-stable marker `presence prose mention normalized:`.

The accounted set mirrors the audit contract exactly: the end-of-turn roster (same algebra as hydration, reusing `_presence_key`/`_deduplicate_presence`), existing mentions, and the parent baseline's `present` list (the authored-exit exemption). Parent-*mentioned* characters deliberately re-mention on the child, per the issue's acceptance criterion.

Because both commit handlers consume `incubator["reference_updates"]` — whose sole producer is the hydration of this wire — one mutation point covers the sync and async commit paths automatically. The post-commit audit is untouched and becomes a true tripwire that should now stay silent. `normalize_out_and_back` (#661), the presence validators, commit handlers, schemas, and prompts are all untouched.

## Tests

- `tests/test_presence_reconciliation.py` (new, 377 lines): pure-core coverage with injected detector rows — alias resolution, all three exemption legs, parent-mentioned re-mention, pronoun blindness, unknown names, the `presence is None` construction case, idempotency, `model_validate(model_dump())` round-trip stability, warning-marker discipline, and the chunk-46 three-name regression through hydration; plus a `requires_postgres` roster-fetch test against a disposable `qa655_*` template clone.
- Genuine-pipeline coverage: single-pass sync/async (`test_skald_wire.py`), two-pass sync/async through the real `_generate_narrative_two_pass` harness (`test_two_pass_pipeline.py`), and junction-insert proofs through the real commit handlers (both suites).

## Gates

Black / flake8 / mypy clean; focused suites 159 passed; full suite **2178 passed, 504 skipped**. No `qa655_*` databases remain.

## Post-Merge

The seeded live reproduction (Vesper Station 42-chunk seed → accept pending chunk 46 → zero presence-audit warnings, `mentioned` rows for all three names) runs on the isolated QA lane as the closing proof before the issue closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwQAcSeuSfJAcjUvxVzadv