### PR TITLE
Emit Structured JSON Errors for Invalid Usage Days

### DIFF
--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -3844,6 +3844,15 @@ def main() -> int:
             emit_error("Slot must be between 1 and 5", args.json)
             return 1
 
+    if args.command == "usage" and args.day is not None:
+        from nexus.telemetry.usage import validate_usage_day
+
+        try:
+            validate_usage_day(args.day)
+        except ValueError as exc:
+            emit_error(str(exc), args.json)
+            return 1
+
     # Execute command
     if args.command == "up":
         result = run_up(args)

--- a/nexus/telemetry/usage.py
+++ b/nexus/telemetry/usage.py
@@ -302,9 +302,14 @@ def validate_usage_day(day: str) -> None:
     """Validate that a usage day is a real calendar date in YYYY-MM-DD form."""
 
     try:
-        datetime.strptime(day, "%Y-%m-%d")
+        parsed = datetime.strptime(day, "%Y-%m-%d")
     except ValueError as exc:
         raise ValueError(f"Usage day must be YYYY-MM-DD, got {day!r}") from exc
+    # strptime tolerates non-zero-padded fields, but ledger filenames are
+    # keyed by date.isoformat() — a variant spelling would silently read a
+    # file that never exists.
+    if parsed.date().isoformat() != day:
+        raise ValueError(f"Usage day must be YYYY-MM-DD, got {day!r}")
 
 
 def summarize_usage(

--- a/nexus/telemetry/usage.py
+++ b/nexus/telemetry/usage.py
@@ -298,6 +298,15 @@ def _add_event(totals: Dict[str, int], event: UsageEvent) -> None:
             totals[output_key] += value
 
 
+def validate_usage_day(day: str) -> None:
+    """Validate that a usage day is a real calendar date in YYYY-MM-DD form."""
+
+    try:
+        datetime.strptime(day, "%Y-%m-%d")
+    except ValueError as exc:
+        raise ValueError(f"Usage day must be YYYY-MM-DD, got {day!r}") from exc
+
+
 def summarize_usage(
     day: Optional[str] = None,
     run_id: Optional[str] = None,
@@ -306,10 +315,7 @@ def summarize_usage(
     """Read one UTC day exactly and aggregate provider and seat totals."""
 
     selected_day = day or datetime.now(timezone.utc).date().isoformat()
-    try:
-        datetime.strptime(selected_day, "%Y-%m-%d")
-    except ValueError as exc:
-        raise ValueError(f"Usage day must be YYYY-MM-DD, got {selected_day!r}") from exc
+    validate_usage_day(selected_day)
 
     config = _get_recorder_config()
     directory = Path(usage_dir) if usage_dir is not None else config.usage_dir

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,7 +48,7 @@ def test_terminal_generation_statuses_include_api_and_incubator_values() -> None
     assert not _is_terminal_generation_status("error")
 
 
-@pytest.mark.parametrize("day", ["02-30-2026", "2026-02-30"])
+@pytest.mark.parametrize("day", ["02-30-2026", "2026-02-30", "2026-2-3"])
 @pytest.mark.parametrize("as_json", [False, True])
 def test_usage_invalid_day_exits_with_one_concise_error(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,6 +48,90 @@ def test_terminal_generation_statuses_include_api_and_incubator_values() -> None
     assert not _is_terminal_generation_status("error")
 
 
+@pytest.mark.parametrize("day", ["02-30-2026", "2026-02-30"])
+@pytest.mark.parametrize("as_json", [False, True])
+def test_usage_invalid_day_exits_with_one_concise_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    day: str,
+    as_json: bool,
+) -> None:
+    """Invalid usage days must not leak a traceback through the public CLI."""
+
+    argv = ["nexus"]
+    if as_json:
+        argv.append("--json")
+    argv.extend(["usage", "--day", day])
+    monkeypatch.setattr(sys, "argv", argv)
+
+    assert cli.main() == 1
+
+    captured = capsys.readouterr()
+    message = f"Usage day must be YYYY-MM-DD, got {day!r}"
+    assert captured.out == ""
+    if as_json:
+        assert captured.err == json.dumps({"error": message}) + "\n"
+    else:
+        assert captured.err == f"Error: {message}\n"
+    assert "Traceback" not in captured.out + captured.err
+
+
+@pytest.mark.parametrize("as_json", [False, True])
+@pytest.mark.parametrize("run_args", [[], ["--run", "isolated-run"]])
+def test_usage_valid_empty_day_keeps_success_output(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    as_json: bool,
+    run_args: list[str],
+) -> None:
+    """Valid usage queries read only the test-isolated empty ledger."""
+
+    argv = ["nexus"]
+    if as_json:
+        argv.append("--json")
+    argv.extend(["usage", "--day", "2026-02-28", *run_args])
+    monkeypatch.setattr(sys, "argv", argv)
+
+    assert cli.main() == 0
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    if as_json:
+        assert json.loads(captured.out) == {
+            "success": True,
+            "usage": {
+                "allowance": {
+                    "openai": {
+                        "allowance": 2_500_000,
+                        "remaining": 2_500_000,
+                        "unknown_usage_events": 0,
+                        "used": 0,
+                    }
+                },
+                "day": "2026-02-28",
+                "events": [],
+                "openai_day_total": {
+                    "total_tokens": 0,
+                    "unknown_usage_events": 0,
+                },
+                "providers": {},
+                "seats": {},
+            },
+        }
+    else:
+        assert captured.out == (
+            "OpenAI API-reported tokens (UTC day 2026-02-28): 0\n"
+            "openai allowance: 0 / 2,500,000 (remaining 2,500,000; "
+            "unknown events 0)\n"
+            "\n"
+            "Providers:\n"
+            "  (none)\n"
+            "\n"
+            "Seats:\n"
+            "  (none)\n"
+        )
+
+
 def test_generation_poll_window_covers_live_reasoning_models() -> None:
     """The configured elapsed-time budget covers slow reasoning models."""
 


### PR DESCRIPTION
Closes #664.

## Root Cause (Verified)
`summarize_usage` raises `ValueError` for malformed or impossible `--day` values, and neither `run_usage` nor the dispatcher had an exception boundary — so `nexus usage --json --day 2026-02-30` printed a full Python traceback on stderr with empty stdout, breaking the machine-readable contract that adjacent commands (`nexus jobs --json --slot 99`) honor.

## Fix
- New public `validate_usage_day()` in `nexus/telemetry/usage.py` — the single source of date-format truth, reused by `summarize_usage` (no duplicated strptime knowledge).
- Pre-dispatch validation in `main()` mirroring the slot-check precedent exactly: `emit_error(str(exc), args.json)` + exit 1, catching only `ValueError`. Unexpected errors still crash loudly per repo doctrine.

Proven byte-consistent with the `jobs` precedent:
```
$ nexus jobs --json --slot 99      → {"error": "Slot must be between 1 and 5"}            exit 1
$ nexus usage --json --day 2026-02-30 → {"error": "Usage day must be YYYY-MM-DD, got '2026-02-30'"} exit 1
```

## Tests
Public-CLI coverage (`tests/test_cli.py`) for malformed shape (`02-30-2026`), shape-valid impossible date (`2026-02-30`), and valid empty days with and without `--run` — both `--json` and human modes, asserting exact stdout/stderr bytes, exit codes, and no `Traceback` anywhere. Usage telemetry is isolated by the existing autouse conftest fixture (tmp usage dir + pinned test allowance); no real ledger touched.

Focused suite: 35 passed. mypy on touched files reports only `tests/test_cli.py:9` missing `requests` stubs — verified pre-existing on unmodified origin/main, not introduced here. black/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyugzKYfkonxthNs1EHRZD
