### PR TITLE
Reject Non-Positive Log Tail Counts Before Reading Logs

### DIFF
--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -3853,6 +3853,10 @@ def main() -> int:
             emit_error(str(exc), args.json)
             return 1
 
+    if args.command == "logs" and args.lines is not None and args.lines < 1:
+        emit_error("Log line count must be a positive integer", args.json)
+        return 1
+
     # Execute command
     if args.command == "up":
         result = run_up(args)

--- a/nexus/runtime/supervisor.py
+++ b/nexus/runtime/supervisor.py
@@ -138,6 +138,8 @@ def _describe_port_occupant(port: int) -> Optional[str]:
 
 
 def _tail_lines(path: Path, count: int) -> List[str]:
+    if count < 1:
+        raise ValueError("Log line count must be a positive integer")
     if not path.exists():
         return []
     with open(path, "rb") as handle:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,15 +1,37 @@
 """Tests for the NEXUS CLI helpers."""
 
 import json
+from pathlib import Path
 import sys
 from argparse import Namespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import requests
+import tomlkit
 
 from nexus import cli
 from nexus.cli import _is_terminal_generation_status
+
+
+REPO_CONFIG = Path(__file__).resolve().parents[1] / "nexus.toml"
+LOG_LINE_COUNT_ERROR = "Log line count must be a positive integer"
+
+
+def _write_runtime_log_config(tmp_path: Path, lines: list[str]) -> Path:
+    """Write an isolated runtime config and its captured gateway log."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "gateway.log").write_text(
+        "".join(f"{line}\n" for line in lines), encoding="utf-8"
+    )
+
+    document = tomlkit.parse(REPO_CONFIG.read_text(encoding="utf-8"))
+    runtime = cast(Any, document["runtime"])
+    runtime["state_dir"] = str(state_dir)
+    config_path = tmp_path / "nexus.toml"
+    config_path.write_text(tomlkit.dumps(document), encoding="utf-8")
+    return config_path
 
 
 class DummyResponse:
@@ -136,6 +158,78 @@ def test_generation_poll_window_covers_live_reasoning_models() -> None:
     """The configured elapsed-time budget covers slow reasoning models."""
 
     assert cli._generation_timeout_seconds() >= 180
+
+
+@pytest.mark.parametrize("count", (-2, -1, 0))
+@pytest.mark.parametrize("as_json", (False, True), ids=("human", "json"))
+def test_logs_rejects_non_positive_line_counts_before_reading_logs(
+    count: int,
+    as_json: bool,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Invalid public counts fail before supervisor construction or log reads."""
+    config_path = _write_runtime_log_config(tmp_path, ["must-not-be-emitted"])
+    argv = ["nexus"]
+    if as_json:
+        argv.append("--json")
+    argv.extend(
+        ["logs", "gateway", "--config", str(config_path), "--lines", str(count)]
+    )
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(
+        cli,
+        "_runtime_supervisor",
+        lambda _args: pytest.fail("invalid count constructed the supervisor"),
+    )
+
+    assert cli.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "must-not-be-emitted" not in captured.err
+    if as_json:
+        assert json.loads(captured.err) == {"error": LOG_LINE_COUNT_ERROR}
+    else:
+        assert captured.err == f"Error: {LOG_LINE_COUNT_ERROR}\n"
+
+
+@pytest.mark.parametrize("as_json", (False, True), ids=("human", "json"))
+@pytest.mark.parametrize(
+    "count,expected_count",
+    ((1, 1), (None, 100), (5_000, 4_096)),
+    ids=("one", "default", "larger-than-window"),
+)
+def test_logs_returns_requested_lines_within_retained_read_bound(
+    count: int | None,
+    expected_count: int,
+    as_json: bool,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Valid public counts retain exact tail and 256 KiB read-bound behavior."""
+    log_lines = [f"log-{index:04d}".ljust(63, ".") for index in range(5_000)]
+    config_path = _write_runtime_log_config(tmp_path, log_lines)
+    argv = ["nexus"]
+    if as_json:
+        argv.append("--json")
+    argv.extend(["logs", "gateway", "--config", str(config_path)])
+    if count is not None:
+        argv.extend(["--lines", str(count)])
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.delenv("NEXUS_GATEWAY_PORT", raising=False)
+
+    assert cli.main() == 0
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    if as_json:
+        output_lines = json.loads(captured.out)["lines"]
+    else:
+        output_lines = captured.out.splitlines()
+    assert output_lines == log_lines[-expected_count:]
 
 
 def test_continue_posts_choice_to_backend_without_preapproving(

--- a/tests/test_runtime/test_supervisor.py
+++ b/tests/test_runtime/test_supervisor.py
@@ -12,10 +12,12 @@ import tomlkit
 
 from nexus import cli
 from nexus.runtime import RUNTIME_CONFIG_ENV, Supervisor
+from nexus.runtime.supervisor import _tail_lines
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REPO_CONFIG = REPO_ROOT / "nexus.toml"
+LOG_LINE_COUNT_ERROR = "Log line count must be a positive integer"
 
 
 def _write_config(tmp_path: Path, name: str = "runtime.toml") -> Path:
@@ -26,6 +28,34 @@ def _write_config(tmp_path: Path, name: str = "runtime.toml") -> Path:
     path = tmp_path / name
     path.write_text(tomlkit.dumps(document), encoding="utf-8")
     return path
+
+
+@pytest.mark.parametrize("count", (-2, -1, 0))
+def test_tail_lines_rejects_non_positive_counts(tmp_path: Path, count: int) -> None:
+    """The low-level tail helper loudly rejects invalid counts."""
+    with pytest.raises(ValueError, match=f"^{LOG_LINE_COUNT_ERROR}$"):
+        _tail_lines(tmp_path / "missing.log", count)
+
+
+@pytest.mark.parametrize(
+    "count,expected",
+    (
+        (1, ["line-119"]),
+        (100, [f"line-{index}" for index in range(20, 120)]),
+        (500, [f"line-{index}" for index in range(120)]),
+    ),
+    ids=("one", "default-sized", "larger-than-window"),
+)
+def test_tail_lines_returns_requested_slice(
+    tmp_path: Path, count: int, expected: list[str]
+) -> None:
+    """Positive tail counts preserve normal slicing behavior."""
+    log_path = tmp_path / "gateway.log"
+    log_path.write_text(
+        "".join(f"line-{index}\n" for index in range(120)), encoding="utf-8"
+    )
+
+    assert _tail_lines(log_path, count) == expected
 
 
 def test_from_config_explicit_path_beats_runtime_environment(


### PR DESCRIPTION
Closes #666.

## Root Cause (Verified)
`--lines` parsed as an unrestricted `int` and `_tail_lines` returned `lines[-count:]` unvalidated — Python slice semantics turn `0` into the entire retained window (`lines[-0:]`) and `-N` into nearly all of it (`lines[N:]`). A zero/negative request amplified to ~300 KB of retained gateway history.

## Policy (Decided, Per Repo Loud-Error Doctrine)
Counts < 1 are invalid input and are rejected — never silently emptied:
- CLI: pre-dispatch structured error matching the slot-validation precedent — `{"error": "Log line count must be a positive integer"}` / `Error: ...`, exit 1, validated before any supervisor construction, log read, or `--follow` streaming.
- `_tail_lines` raises `ValueError` on `count < 1` as internal defense (its internal callers pass positive literals).
- Unchanged: the `runtime.logs.tail_lines` default, larger-than-window requests returning the whole window, the 256 KiB read bound, and the structured unknown-service error.

## Tests
- CLI-level (`tests/test_cli.py`): `-2/-1/0` rejected in both modes with zero log content leaked (a tripwire fails the test if the supervisor is even constructed); `1`, default, and larger-than-window against an isolated temp runtime config — including an exact 256 KiB boundary case (5,000 × 64-byte lines → precisely 4,096 returned).
- Unit (`tests/test_runtime/test_supervisor.py`): `_tail_lines` rejection and slice behavior across the same range.

Focused suites: 51 passed. mypy on touched files reports 11 errors — all verified pre-existing on unmodified origin/main (missing `requests` stubs, Windows-only attrs, optional-narrowing in untouched supervisor.py lines); none introduced here. black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyugzKYfkonxthNs1EHRZD
