### PR TITLE
Bind the Correct Summary ID for Every Retrograde Vector Upsert

### DIFF
--- a/nexus/agents/orrery/retrograde_embedding.py
+++ b/nexus/agents/orrery/retrograde_embedding.py
@@ -33,6 +33,19 @@ def _load_memnon_settings() -> dict[str, Any]:
     return settings
 
 
+def active_memnon_embedding_model_dimensions() -> dict[str, int]:
+    """Return configured active MEMNON model names and vector dimensions."""
+    configured_models = _load_memnon_settings().get("models", {})
+    active_models = {
+        str(name): int(config["dimensions"])
+        for name, config in configured_models.items()
+        if config.get("is_active", True)
+    }
+    if not active_models:
+        raise RuntimeError("No active MEMNON embedding models are configured")
+    return active_models
+
+
 def embed_retrograde_summaries(
     dbname: str,
     summary_ids: Sequence[int],
@@ -86,14 +99,7 @@ def embed_retrograde_summaries(
         raise RuntimeError(f"Retrograde summaries not found in {dbname}: {missing_ids}")
 
     memnon_settings = _load_memnon_settings()
-    configured_models = memnon_settings.get("models", {})
-    configured_active_models = [
-        name
-        for name, config in configured_models.items()
-        if config.get("is_active", True)
-    ]
-    if not configured_active_models:
-        raise RuntimeError("No active MEMNON embedding models are configured")
+    configured_active_models = list(active_memnon_embedding_model_dimensions())
 
     embedding_manager = EmbeddingManager(settings=memnon_settings)
     model_names = embedding_manager.get_available_models()
@@ -123,7 +129,7 @@ def embed_retrograde_summaries(
     with get_connection(dbname, dict_cursor=True) as conn:
         with conn.cursor() as cursor:
             ensured_tables: dict[int, str] = {}
-            for model_embeddings in generated.values():
+            for summary_id, model_embeddings in generated.items():
                 for model_name, embedding in model_embeddings:
                     dimensions = len(embedding)
                     table_name = ensured_tables.get(dimensions)

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -524,6 +524,7 @@ def _build_plan(
         "summaries_would_insert",
         "summaries_inserted",
         "summaries_already_present",
+        "summaries_stamped_missing_vectors",
         "summaries_blocked",
     ):
         counters.setdefault(key, 0)
@@ -1851,6 +1852,7 @@ def plan_retrograde_summaries(
         event_sources = _load_persisted_retrograde_event_sources(cur)
 
     rows: list[dict[str, Any]] = []
+    active_embedding_model_dimensions: Optional[dict[str, int]] = None
     for source in event_sources:
         source_status = str(source.get("source_status") or "persisted")
         world_event_id = _optional_int(source.get("world_event_id"))
@@ -1938,12 +1940,33 @@ def plan_retrograde_summaries(
                     f"Retrograde world event {world_event_id} already has "
                     "divergent summary fields: " + ", ".join(divergent_fields)
                 )
+            if active_embedding_model_dimensions is None:
+                from nexus.agents.orrery.retrograde_embedding import (
+                    active_memnon_embedding_model_dimensions,
+                )
+
+                active_embedding_model_dimensions = (
+                    active_memnon_embedding_model_dimensions()
+                )
+            missing_embedding_models = _missing_retrograde_summary_embedding_models(
+                cur,
+                summary_id=existing["summary_id"],
+                model_dimensions=active_embedding_model_dimensions,
+            )
+            embedding_stamp_present = existing["embedding_generated_at"] is not None
             rows.append(
                 {
                     **base,
-                    "status": "already_present",
+                    "status": (
+                        "stamped_missing_vectors"
+                        if embedding_stamp_present and missing_embedding_models
+                        else "already_present"
+                    ),
                     "summary_id": existing["summary_id"],
-                    "embedding_pending": existing["embedding_generated_at"] is None,
+                    "embedding_pending": (
+                        not embedding_stamp_present or bool(missing_embedding_models)
+                    ),
+                    "missing_embedding_models": missing_embedding_models,
                 }
             )
             continue
@@ -1983,6 +2006,64 @@ def plan_retrograde_summaries(
             }
         )
     return rows
+
+
+def _missing_retrograde_summary_embedding_models(
+    cur: Any,
+    *,
+    summary_id: int,
+    model_dimensions: Mapping[str, int],
+) -> list[dict[str, Any]]:
+    """Describe active MEMNON vectors absent for one persisted summary."""
+    from nexus.agents.memnon.utils.embedding_tables import (
+        retrograde_summary_table_name_for_dimensions,
+    )
+
+    models_by_table: dict[str, list[tuple[str, int]]] = {}
+    for model, dimensions in model_dimensions.items():
+        table_name = retrograde_summary_table_name_for_dimensions(dimensions)
+        models_by_table.setdefault(table_name, []).append((model, dimensions))
+
+    missing: list[dict[str, Any]] = []
+    for table_name, configured_models in models_by_table.items():
+        cur.execute(
+            """
+            /* orrery:retrograde:summary_embedding_table */
+            SELECT to_regclass(%s) AS table_name
+            """,
+            (f"public.{table_name}",),
+        )
+        table_row = cur.fetchone()
+        table_exists = (
+            table_row is not None and _row_value(table_row, "table_name", 0) is not None
+        )
+        present_models: set[str] = set()
+        if table_exists:
+            model_names = [model for model, _dimensions in configured_models]
+            cur.execute(
+                f"""
+                /* orrery:retrograde:summary_embedding_models */
+                SELECT model
+                FROM {table_name}
+                WHERE summary_id = %s
+                  AND model = ANY(%s)
+                """,
+                (summary_id, model_names),
+            )
+            present_models = {
+                str(_row_value(row, "model", 0)) for row in cur.fetchall()
+            }
+
+        missing.extend(
+            {
+                "model": model,
+                "dimensions": dimensions,
+                "table": table_name,
+            }
+            for model, dimensions in configured_models
+            if model not in present_models
+        )
+    return missing
 
 
 def _load_canonical_retrograde_event_source(

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -465,6 +465,7 @@ def _print_retrograde_persistence(payload: Dict[str, Any]) -> None:
         "summaries_would_insert",
         "summaries_inserted",
         "summaries_already_present",
+        "summaries_stamped_missing_vectors",
         "summaries_blocked",
     ):
         print(f"  {key}: {counters.get(key, 0)}")
@@ -2165,7 +2166,7 @@ def run_retrograde_embed_history(args: argparse.Namespace) -> Dict[str, Any]:
         if row["embedding_pending"] and row["summary_id"] is not None
     ]
     embedding_results: List[Dict[str, Any]] = []
-    if not dry_run and retrieval_settings.embed_after_apply and pending_summary_ids:
+    if not dry_run and pending_summary_ids:
         try:
             embedding_results = embed_retrograde_summaries(dbname, pending_summary_ids)
         except RuntimeError as exc:

--- a/nexus/cli.py
+++ b/nexus/cli.py
@@ -2157,7 +2157,7 @@ def run_retrograde_embed_history(args: argparse.Namespace) -> Dict[str, Any]:
                     cur,
                     dry_run=dry_run,
                 )
-    except ValueError as exc:
+    except (ValueError, RuntimeError) as exc:
         return {"success": False, "error": str(exc)}
 
     pending_summary_ids = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1270,6 +1270,32 @@ def test_retrograde_embed_history_dry_run_skips_embedding(monkeypatch) -> None:
     assert sync["embedding_results"] == []
 
 
+def test_retrograde_embed_history_reports_planner_runtime_error(monkeypatch) -> None:
+    """Planner RuntimeErrors surface as structured results, not tracebacks."""
+
+    from nexus.agents.orrery import retrograde_persistence
+    from nexus.api import db_pool
+
+    def fail_plan(cur: Any, *, dry_run: bool) -> Any:
+        raise RuntimeError("No active MEMNON embedding models are configured")
+
+    monkeypatch.setattr(
+        db_pool, "get_connection", lambda *args, **kwargs: FakeApplyConnection()
+    )
+    monkeypatch.setattr(
+        retrograde_persistence,
+        "plan_retrograde_summaries",
+        fail_plan,
+    )
+
+    result = cli.run_retrograde_embed_history(Namespace(slot=5, execute=False))
+
+    assert result == {
+        "success": False,
+        "error": "No active MEMNON embedding models are configured",
+    }
+
+
 def test_retrograde_persistence_formatter_uses_summary_identity(capsys) -> None:
     """The persistence formatter renders dedicated summary identities."""
 

--- a/tests/test_orrery/test_retrograde_embedding_pg.py
+++ b/tests/test_orrery/test_retrograde_embedding_pg.py
@@ -1,0 +1,400 @@
+"""PostgreSQL regressions for Retrograde summary embedding and repair.
+
+Every test uses real configured MEMNON embedding models against one disposable
+``NEXUS_template`` clone. No save-slot or template database is mutated.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Iterator
+import uuid
+
+import psycopg2
+from psycopg2 import sql
+import pytest
+
+from nexus import cli
+from nexus.agents.memnon.utils.db_access import (
+    _execute_retrograde_summary_vector_search,
+)
+from nexus.agents.memnon.utils.embedding_tables import (
+    retrograde_summary_table_name_for_dimensions,
+)
+from nexus.agents.orrery.retrograde_embedding import (
+    active_memnon_embedding_model_dimensions,
+    embed_retrograde_summaries,
+)
+from nexus.api import db_pool, slot_utils
+
+
+pytestmark = pytest.mark.requires_postgres
+
+
+def _connect(dbname: str) -> Any:
+    """Open a direct connection to the disposable issue-665 database."""
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+        connect_timeout=2,
+    )
+
+
+@pytest.fixture(scope="module")
+def disposable_db() -> Iterator[str]:
+    """Yield a unique template clone and drop it after all regressions."""
+    dbname = f"qa665_{uuid.uuid4().hex[:12]}"
+    admin: Any = None
+    try:
+        try:
+            admin = _connect("postgres")
+        except psycopg2.Error as exc:
+            pytest.skip(f"PostgreSQL admin connection unavailable: {exc}")
+        admin.autocommit = True
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier("NEXUS_template"),
+                )
+            )
+        yield dbname
+    finally:
+        pool = db_pool._pools.pop(dbname, None)
+        if pool is not None:
+            pool.closeall()
+        if admin is not None:
+            with admin.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = %s AND pid <> pg_backend_pid()",
+                    (dbname,),
+                )
+                cur.execute(
+                    sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+                )
+            admin.close()
+
+
+@pytest.fixture()
+def route_disposable_db(
+    disposable_db: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Route slot-only production entry points to the disposable clone."""
+
+    def require_disposable_db(
+        dbname: str | None = None,
+        slot: int | None = None,
+    ) -> str:
+        if dbname is not None and dbname != disposable_db:
+            raise AssertionError(f"unexpected database target: {dbname}")
+        if slot is not None and slot != 4:
+            raise AssertionError(f"unexpected slot target: {slot}")
+        return disposable_db
+
+    monkeypatch.setattr(db_pool, "require_slot_dbname", require_disposable_db)
+    monkeypatch.setattr(slot_utils, "slot_dbname", lambda slot: disposable_db)
+
+
+def _insert_retrograde_summaries(
+    dbname: str,
+    summary_texts: list[str],
+    *,
+    stamped: bool = False,
+) -> list[int]:
+    """Insert canonical events and dedicated summaries for a regression."""
+    conn = _connect(dbname)
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO narrative_chunks (raw_text) VALUES (%s) RETURNING id",
+                    ("Issue 665 disposable recording boundary",),
+                )
+                chunk_id = int(cur.fetchone()[0])
+                cur.execute(
+                    "SELECT type FROM event_types "
+                    "WHERE type::text NOT LIKE '%project_started%' "
+                    "ORDER BY type LIMIT 1"
+                )
+                event_type = cur.fetchone()[0]
+                summary_ids: list[int] = []
+                for index, summary_text in enumerate(summary_texts):
+                    event_ref = f"qa665_{uuid.uuid4().hex}_{index}"
+                    payload = {
+                        "retrograde_event_ref": event_ref,
+                        "summary": summary_text,
+                        "chronology": "deep_past",
+                    }
+                    cur.execute(
+                        """
+                        INSERT INTO world_events (
+                            event_type,
+                            tick_chunk_id,
+                            world_layer,
+                            source,
+                            changed_fields,
+                            payload
+                        ) VALUES (
+                            %s, %s, 'primary', 'retrograde', '{}', %s::jsonb
+                        )
+                        RETURNING id
+                        """,
+                        (event_type, chunk_id, json.dumps(payload)),
+                    )
+                    world_event_id = int(cur.fetchone()[0])
+                    cur.execute(
+                        """
+                        INSERT INTO retrograde_summaries (
+                            world_event_id,
+                            recorded_at_chunk_id,
+                            chronology,
+                            summary_text,
+                            embedding_generated_at
+                        ) VALUES (
+                            %s, %s, 'deep_past', %s,
+                            CASE WHEN %s
+                                THEN '2000-01-01T00:00:00+00:00'::timestamptz
+                                ELSE NULL
+                            END
+                        )
+                        RETURNING id
+                        """,
+                        (world_event_id, chunk_id, summary_text, stamped),
+                    )
+                    summary_ids.append(int(cur.fetchone()[0]))
+                return summary_ids
+    finally:
+        conn.close()
+
+
+def _drop_active_summary_embedding_tables(dbname: str) -> None:
+    """Remove lazily-created active-model tables inside the disposable DB."""
+    dimensions = set(active_memnon_embedding_model_dimensions().values())
+    conn = _connect(dbname)
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                for dimension in dimensions:
+                    table_name = retrograde_summary_table_name_for_dimensions(dimension)
+                    cur.execute(
+                        sql.SQL("DROP TABLE IF EXISTS {}").format(
+                            sql.Identifier(table_name)
+                        )
+                    )
+    finally:
+        conn.close()
+
+
+def _run_embed_history(slot: int, *, execute: bool) -> dict[str, Any]:
+    """Parse and invoke the genuine public CLI-level embed-history function."""
+    argv = ["--json", "retrograde-embed-history", "--slot", str(slot)]
+    if execute:
+        argv.append("--execute")
+    args = cli.build_parser().parse_args(argv)
+    return cli.run_retrograde_embed_history(args)
+
+
+def test_batch_embedding_writes_every_summary_model_pair(
+    disposable_db: str,
+    route_disposable_db: None,
+) -> None:
+    """A genuine batch stores every requested summary under every active model."""
+    summary_ids = _insert_retrograde_summaries(
+        disposable_db,
+        [
+            "The brass archive inherited a debt before the first crossing.",
+            "A winter courier hid the rival ledger beneath the empty observatory.",
+        ],
+    )
+    active_models = active_memnon_embedding_model_dimensions()
+
+    results = embed_retrograde_summaries(disposable_db, summary_ids)
+
+    assert [result["summary_id"] for result in results] == summary_ids
+    conn = _connect(disposable_db)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, embedding_generated_at FROM retrograde_summaries "
+                "WHERE id = ANY(%s) ORDER BY id",
+                (summary_ids,),
+            )
+            stamp_rows = cur.fetchall()
+            assert [row[0] for row in stamp_rows] == summary_ids
+            assert all(row[1] is not None for row in stamp_rows)
+
+            for model, dimensions in active_models.items():
+                table_name = retrograde_summary_table_name_for_dimensions(dimensions)
+                cur.execute(
+                    sql.SQL(
+                        "SELECT summary_id, model FROM {} "
+                        "WHERE summary_id = ANY(%s) AND model = %s "
+                        "ORDER BY summary_id"
+                    ).format(sql.Identifier(table_name)),
+                    (summary_ids, model),
+                )
+                assert cur.fetchall() == [
+                    (summary_id, model) for summary_id in summary_ids
+                ]
+    finally:
+        conn.close()
+
+
+def test_cli_repairs_stamped_summary_when_vector_table_is_missing(
+    disposable_db: str,
+    route_disposable_db: None,
+) -> None:
+    """Dry-run detects old damage and execute recreates every active vector."""
+    summary_id = _insert_retrograde_summaries(
+        disposable_db,
+        ["The stamped but vectorless treaty named the wrong surviving witness."],
+        stamped=True,
+    )[0]
+    active_models = active_memnon_embedding_model_dimensions()
+    _drop_active_summary_embedding_tables(disposable_db)
+    conn = _connect(disposable_db)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT embedding_generated_at FROM retrograde_summaries WHERE id = %s",
+                (summary_id,),
+            )
+            old_stamp = cur.fetchone()[0]
+    finally:
+        conn.close()
+
+    dry_run_payload = _run_embed_history(4, execute=False)
+
+    assert dry_run_payload["success"] is True
+    dry_run = dry_run_payload["retrograde_embed_history"]
+    damaged_row = next(
+        row for row in dry_run["summary_rows"] if row["summary_id"] == summary_id
+    )
+    assert damaged_row["status"] == "stamped_missing_vectors"
+    assert damaged_row["embedding_pending"] is True
+    assert damaged_row["missing_embedding_models"] == [
+        {
+            "model": model,
+            "dimensions": dimensions,
+            "table": retrograde_summary_table_name_for_dimensions(dimensions),
+        }
+        for model, dimensions in active_models.items()
+    ]
+    assert summary_id in dry_run["embedding_pending_summary_ids"]
+
+    conn = _connect(disposable_db)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT embedding_generated_at FROM retrograde_summaries WHERE id = %s",
+                (summary_id,),
+            )
+            assert cur.fetchone()[0] == old_stamp
+            for dimensions in set(active_models.values()):
+                table_name = retrograde_summary_table_name_for_dimensions(dimensions)
+                cur.execute("SELECT to_regclass(%s)", (f"public.{table_name}",))
+                assert cur.fetchone()[0] is None
+    finally:
+        conn.close()
+
+    execute_payload = _run_embed_history(4, execute=True)
+
+    assert execute_payload["success"] is True
+    execute = execute_payload["retrograde_embed_history"]
+    assert summary_id in execute["embedding_pending_summary_ids"]
+    assert summary_id in {
+        result["summary_id"] for result in execute["embedding_results"]
+    }
+    conn = _connect(disposable_db)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT embedding_generated_at FROM retrograde_summaries WHERE id = %s",
+                (summary_id,),
+            )
+            assert cur.fetchone()[0] > old_stamp
+            for model, dimensions in active_models.items():
+                table_name = retrograde_summary_table_name_for_dimensions(dimensions)
+                cur.execute(
+                    sql.SQL(
+                        "SELECT count(*) FROM {} WHERE summary_id = %s AND model = %s"
+                    ).format(sql.Identifier(table_name)),
+                    (summary_id, model),
+                )
+                assert cur.fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_repaired_summary_participates_in_dedicated_vector_join(
+    disposable_db: str,
+    route_disposable_db: None,
+) -> None:
+    """CLI-repaired vectors are visible through MEMNON's dedicated join."""
+    summary_text = (
+        "The repaired eclipse account binds the glass navigator to the hidden quay."
+    )
+    summary_id = _insert_retrograde_summaries(
+        disposable_db,
+        [summary_text],
+        stamped=True,
+    )[0]
+    active_models = active_memnon_embedding_model_dimensions()
+    conn = _connect(disposable_db)
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                for model, dimensions in active_models.items():
+                    table_name = retrograde_summary_table_name_for_dimensions(
+                        dimensions
+                    )
+                    cur.execute("SELECT to_regclass(%s)", (f"public.{table_name}",))
+                    if cur.fetchone()[0] is not None:
+                        cur.execute(
+                            sql.SQL(
+                                "DELETE FROM {} WHERE summary_id = %s AND model = %s"
+                            ).format(sql.Identifier(table_name)),
+                            (summary_id, model),
+                        )
+    finally:
+        conn.close()
+
+    execute_payload = _run_embed_history(4, execute=True)
+    assert execute_payload["success"] is True
+    assert (
+        summary_id
+        in execute_payload["retrograde_embed_history"]["embedding_pending_summary_ids"]
+    )
+
+    conn = _connect(disposable_db)
+    try:
+        with conn.cursor() as cur:
+            for model, dimensions in active_models.items():
+                table_name = retrograde_summary_table_name_for_dimensions(dimensions)
+                cur.execute(
+                    sql.SQL(
+                        "SELECT embedding::text FROM {} "
+                        "WHERE summary_id = %s AND model = %s"
+                    ).format(sql.Identifier(table_name)),
+                    (summary_id, model),
+                )
+                embedding_value = cur.fetchone()[0]
+                results = _execute_retrograde_summary_vector_search(
+                    cur,
+                    dimensions,
+                    embedding_value,
+                    model,
+                    10,
+                )
+                repaired = next(
+                    result for result in results if result["summary_id"] == summary_id
+                )
+                assert repaired["text"] == summary_text
+                assert repaired["source"] == "vector_search"
+    finally:
+        conn.close()

--- a/tests/test_orrery/test_retrograde_persistence.py
+++ b/tests/test_orrery/test_retrograde_persistence.py
@@ -703,6 +703,7 @@ class FakeRetrogradePersistenceCursor:
         persisted_retrograde_events: Optional[list[dict[str, Any]]] = None,
         canonical_world_events: Optional[list[dict[str, Any]]] = None,
         inactive_entity_ids: Optional[set[int]] = None,
+        missing_summary_embedding_models: Optional[set[str]] = None,
     ) -> None:
         self.vocabulary = vocabulary
         self.omit_place = omit_place
@@ -737,6 +738,9 @@ class FakeRetrogradePersistenceCursor:
             int(row["world_event_id"]): dict(row) for row in canonical_rows
         }
         self.inactive_entity_ids = set(inactive_entity_ids or set())
+        self.missing_summary_embedding_models = set(
+            missing_summary_embedding_models or set()
+        )
         self.deactivated_entity_ids: list[int] = []
         self.entity_activity_projections: list[dict[str, int]] = []
         self.inserted_character_stubs: list[str] = []
@@ -876,6 +880,16 @@ class FakeRetrogradePersistenceCursor:
             self._result = [row] if row is not None else []
         elif "orrery:retrograde:summary_lookup" in sql:
             self._result = list(self.existing_summaries)
+        elif "orrery:retrograde:summary_embedding_table" in sql:
+            assert params is not None
+            self._result = [{"table_name": str(params[0])}]
+        elif "orrery:retrograde:summary_embedding_models" in sql:
+            assert params is not None
+            self._result = [
+                {"model": model}
+                for model in params[1]
+                if model not in self.missing_summary_embedding_models
+            ]
         elif "orrery:retrograde:insert_summary" in sql:
             self._summary_seq += 1
             self._result = [{"id": self._summary_seq}]


### PR DESCRIPTION
Closes #665.

## Root Cause (Verified)
Classic leaked loop variable: the generation loop binds `summary_id` per summary, then the vector write loop iterated `generated.values()` and reused the name — frozen at the LAST requested id — so every INSERT upserted onto one row while ALL requested summaries were stamped `embedding_generated_at`. The stamp-trusting repair surface then reported every damaged row `already_present`, making the loss self-concealing. Live damage on slot 4: 16 of 24 summaries stamped with no vector row.

## Fix
- **Binding**: `for summary_id, model_embeddings in generated.items():` — the one-line correct change.
- **Detection**: `plan_retrograde_summaries` now checks each stamped summary for a vector row per configured active MEMNON model (per-dimension table via `to_regclass` — a lazily absent table counts as missing without being created during dry-run). Damaged rows report `status: "stamped_missing_vectors"` with an explicit `missing_embedding_models` list, join `embedding_pending_summary_ids`, and get a `summaries_stamped_missing_vectors` counter.
- **Repair**: `retrograde-embed-history --execute` re-embeds deficient summaries through the same genuine path (idempotent upsert) and refreshes stamps only after all rows exist. One deliberate semantics change, recorded: `--execute` no longer gates on `retrieval_settings.embed_after_apply` — that toggle governs *automatic* post-apply embedding, and gating the dedicated repair command on it would make repair silently impossible with the toggle off.
- This is the backfill path; the live backfill of slot 4's 16 damaged rows runs post-merge and will be reported on #665.

## Tests
New `tests/test_orrery/test_retrograde_embedding_pg.py` (requires_postgres, disposable `qa665_*` clone of NEXUS_template, dropped after; real configured MEMNON models — no mocks):
1. Genuine two-summary batch → one vector row per `(summary_id, model)` for every summary, stamps set.
2. Old-bug damage reconstruction → dry-run reports `stamped_missing_vectors` + stays strictly read-only (stamp unchanged, absent tables not created) → `--execute` repairs every active-model row and bumps the stamp.
3. Repaired summary visible through MEMNON's genuine dedicated vector-search join.

Existing fake-cursor coverage extended additively for the two new tagged read queries. Suites: 51 passed (unit) + 3 passed (pg, 5.5s). mypy/black/flake8 clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyugzKYfkonxthNs1EHRZD
