### PR TITLE
Delete Stamped Vectorless Project-Start Retrograde Summary Orphans

### DIFF
--- a/migrations/101_delete_project_start_summary_orphans.sql
+++ b/migrations/101_delete_project_start_summary_orphans.sql
@@ -1,0 +1,51 @@
+-- Remove stamped, vectorless summaries for excluded project-start provenance.
+
+DO $$
+DECLARE
+    embedding_table record;
+    deleted_count bigint := 0;
+BEGIN
+    CREATE TEMPORARY TABLE migration_101_summary_candidates (
+        summary_id bigint PRIMARY KEY
+    ) ON COMMIT DROP;
+
+    INSERT INTO migration_101_summary_candidates (summary_id)
+    SELECT rs.id
+    FROM retrograde_summaries AS rs
+    JOIN world_events AS we ON we.id = rs.world_event_id
+    WHERE we.event_type IN (
+        'relocation_plan_started',
+        'recruit_ally_started',
+        'build_venture_started',
+        'pursue_romance_started',
+        'court_patron_started',
+        'seek_redemption_started'
+    )
+      AND rs.embedding_generated_at IS NOT NULL;
+
+    FOR embedding_table IN
+        SELECT table_schema, table_name
+        FROM information_schema.tables
+        WHERE table_schema = current_schema()
+          AND table_type = 'BASE TABLE'
+          AND table_name ~ '^retrograde_summary_embeddings_[0-9]+d$'
+        ORDER BY table_name
+    LOOP
+        EXECUTE format(
+            'DELETE FROM migration_101_summary_candidates AS candidate '
+            'USING %I.%I AS embedding '
+            'WHERE embedding.summary_id = candidate.summary_id',
+            embedding_table.table_schema,
+            embedding_table.table_name
+        );
+    END LOOP;
+
+    DELETE FROM retrograde_summaries AS summary
+    USING migration_101_summary_candidates AS candidate
+    WHERE summary.id = candidate.summary_id;
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+    RAISE NOTICE
+        'migration 101 deleted % project-start Retrograde summary orphan(s)',
+        deleted_count;
+END $$;

--- a/nexus/agents/orrery/retrograde_persistence.py
+++ b/nexus/agents/orrery/retrograde_persistence.py
@@ -2140,6 +2140,7 @@ def _load_persisted_retrograde_event_sources(cur: Any) -> list[dict[str, Any]]:
           -- Project-start events are mechanical projection provenance, not
           -- generated history prose. Wizard and maturation starts share this
           -- exclusion; neither carries canonical summary/chronology fields.
+          -- Migration 101 removed legacy rows created before this exclusion.
           AND we.event_type <> ALL(%s)
         ORDER BY we.id
         """,

--- a/tests/test_orrery/test_project_start_summary_orphans_migration_pg.py
+++ b/tests/test_orrery/test_project_start_summary_orphans_migration_pg.py
@@ -1,0 +1,277 @@
+"""PostgreSQL regression for project-start Retrograde summary hygiene."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterator
+import uuid
+
+import psycopg2
+from psycopg2 import sql
+import pytest
+
+from nexus.agents.orrery.retrograde_persistence import PROJECT_STARTED_EVENT_TYPES
+from scripts import migrate
+
+
+pytestmark = pytest.mark.requires_postgres
+
+ROOT = Path(__file__).parents[2]
+MIGRATION_PATH = ROOT / "migrations" / "101_delete_project_start_summary_orphans.sql"
+
+
+def _connect(dbname: str) -> Any:
+    """Open a direct PostgreSQL connection to a disposable clone."""
+
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+        connect_timeout=2,
+    )
+
+
+@pytest.fixture()
+def disposable_retrograde_hygiene_db() -> Iterator[str]:
+    """Yield a unique template clone and remove it after the regression."""
+
+    dbname = f"qa672_{uuid.uuid4().hex[:12]}"
+    source_db = os.environ.get("NEXUS_TEST_TEMPLATE_DB", "NEXUS_template")
+    assert source_db == "NEXUS_template" or source_db.startswith("qa672_")
+    admin: Any = None
+    try:
+        try:
+            admin = _connect("postgres")
+        except psycopg2.Error as exc:
+            pytest.skip(f"PostgreSQL admin connection unavailable: {exc}")
+        admin.autocommit = True
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier(source_db),
+                )
+            )
+        yield dbname
+    finally:
+        if admin is not None:
+            with admin.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = %s AND pid <> pg_backend_pid()",
+                    (dbname,),
+                )
+                cur.execute(
+                    sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+                )
+            admin.close()
+
+
+def _insert_summary(
+    cur: Any,
+    chunk_id: int,
+    event_type: str,
+    *,
+    stamped: bool = True,
+) -> tuple[int, int]:
+    """Insert one Retrograde summary and return event and summary IDs."""
+
+    event_ref = f"qa672_{uuid.uuid4().hex}"
+    payload = {
+        "retrograde_event_ref": event_ref,
+        "summary": f"Legacy summary for {event_type}.",
+        "chronology": "deep_past",
+    }
+    cur.execute(
+        """
+        INSERT INTO world_events (
+            event_type,
+            tick_chunk_id,
+            world_layer,
+            source,
+            changed_fields,
+            payload
+        ) VALUES (%s, %s, 'primary', 'retrograde', '{}', %s::jsonb)
+        RETURNING id
+        """,
+        (event_type, chunk_id, json.dumps(payload)),
+    )
+    world_event_id = int(cur.fetchone()[0])
+    cur.execute(
+        """
+        INSERT INTO retrograde_summaries (
+            world_event_id,
+            recorded_at_chunk_id,
+            chronology,
+            summary_text,
+            embedding_generated_at
+        ) VALUES (
+            %s,
+            %s,
+            'deep_past',
+            %s,
+            CASE WHEN %s
+                THEN '2000-01-01T00:00:00+00:00'::timestamptz
+                ELSE NULL
+            END
+        )
+        RETURNING id
+        """,
+        (world_event_id, chunk_id, payload["summary"], stamped),
+    )
+    return world_event_id, int(cur.fetchone()[0])
+
+
+def _apply_migration_101(dbname: str) -> tuple[str, ...]:
+    """Apply migration 101 through the production migration entry point."""
+
+    assert (
+        "101",
+        "delete_project_start_summary_orphans",
+        MIGRATION_PATH,
+    ) in migrate.discover_migrations()
+    conn = _connect(dbname)
+    try:
+        assert migrate.apply_migration(
+            conn,
+            "101",
+            "delete_project_start_summary_orphans",
+            MIGRATION_PATH,
+        )
+        return tuple(conn.notices)
+    finally:
+        conn.close()
+
+
+def _rerun_migration_101(dbname: str) -> tuple[str, ...]:
+    """Re-run the SQL after migration tracking has recorded version 101."""
+
+    conn = _connect(dbname)
+    try:
+        conn.notices.clear()
+        with conn.cursor() as cur:
+            cur.execute(MIGRATION_PATH.read_text())
+        conn.commit()
+        return tuple(conn.notices)
+    finally:
+        conn.close()
+
+
+def test_migration_101_deletes_only_stamped_vectorless_project_starts(
+    disposable_retrograde_hygiene_db: str,
+) -> None:
+    """Delete every excluded orphan while preserving all protected controls."""
+
+    dbname = disposable_retrograde_hygiene_db
+    conn = _connect(dbname)
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO narrative_chunks (raw_text) VALUES (%s) RETURNING id",
+                    ("Issue 672 disposable recording boundary",),
+                )
+                chunk_id = int(cur.fetchone()[0])
+                project_rows = [
+                    _insert_summary(cur, chunk_id, event_type)
+                    for event_type in PROJECT_STARTED_EVENT_TYPES.values()
+                ]
+                vector_event_id, vector_summary_id = _insert_summary(
+                    cur,
+                    chunk_id,
+                    PROJECT_STARTED_EVENT_TYPES["plan_relocation"],
+                )
+                nonproject_event_id, nonproject_summary_id = _insert_summary(
+                    cur,
+                    chunk_id,
+                    "relocation_plan_progressed",
+                )
+                unstamped_event_id, unstamped_summary_id = _insert_summary(
+                    cur,
+                    chunk_id,
+                    PROJECT_STARTED_EVENT_TYPES["recruit_ally"],
+                    stamped=False,
+                )
+                cur.execute(
+                    """
+                    CREATE TABLE retrograde_summary_embeddings_0001d (
+                        summary_id bigint NOT NULL
+                            REFERENCES retrograde_summaries(id) ON DELETE CASCADE,
+                        model text NOT NULL,
+                        embedding vector(1) NOT NULL,
+                        created_at timestamptz NOT NULL DEFAULT now(),
+                        PRIMARY KEY (summary_id, model)
+                    )
+                    """
+                )
+                cur.execute(
+                    """
+                    INSERT INTO retrograde_summary_embeddings_0001d (
+                        summary_id,
+                        model,
+                        embedding
+                    ) VALUES (%s, 'migration-101-test', '[0]')
+                    """,
+                    (vector_summary_id,),
+                )
+    finally:
+        conn.close()
+
+    first_notices = _apply_migration_101(dbname)
+
+    assert (
+        "migration 101 deleted 6 project-start Retrograde summary orphan(s)"
+        in "".join(first_notices)
+    )
+    project_event_ids = [event_id for event_id, _summary_id in project_rows]
+    project_summary_ids = [summary_id for _event_id, summary_id in project_rows]
+    conn = _connect(dbname)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM retrograde_summaries WHERE id = ANY(%s) ORDER BY id",
+                (
+                    project_summary_ids
+                    + [vector_summary_id, nonproject_summary_id, unstamped_summary_id],
+                ),
+            )
+            assert [row[0] for row in cur.fetchall()] == sorted(
+                [vector_summary_id, nonproject_summary_id, unstamped_summary_id]
+            )
+            cur.execute(
+                "SELECT id FROM world_events WHERE id = ANY(%s) ORDER BY id",
+                (
+                    project_event_ids
+                    + [vector_event_id, nonproject_event_id, unstamped_event_id],
+                ),
+            )
+            assert [row[0] for row in cur.fetchall()] == sorted(
+                project_event_ids
+                + [vector_event_id, nonproject_event_id, unstamped_event_id]
+            )
+            cur.execute("SELECT summary_id FROM retrograde_summary_embeddings_0001d")
+            assert cur.fetchall() == [(vector_summary_id,)]
+    finally:
+        conn.close()
+
+    rerun_notices = _rerun_migration_101(dbname)
+
+    assert (
+        "migration 101 deleted 0 project-start Retrograde summary orphan(s)"
+        in "".join(rerun_notices)
+    )
+    conn = _connect(dbname)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM retrograde_summaries WHERE id = ANY(%s) ORDER BY id",
+                ([vector_summary_id, nonproject_summary_id, unstamped_summary_id],),
+            )
+            assert [row[0] for row in cur.fetchall()] == sorted(
+                [vector_summary_id, nonproject_summary_id, unstamped_summary_id]
+            )
+    finally:
+        conn.close()


### PR DESCRIPTION
Closes #672.

One-time hygiene migration (101) deleting `retrograde_summaries` rows that are (a) anchored to project-start provenance events, (b) ironman-stamped, and (c) vectorless in every `retrograde_summary_embeddings_*` dimension table — the legacy pre-exclusion rows found during #665's backfill (summary 9 → world_event 23 in save_04/save_05).

**Decision rationale** (recorded per the issue's "owner's call" framing, decided under delegated authority): deletion matches the exclusion's stated policy — and the rows are stamped-but-vectorless, so they were never reachable by retrieval; the "preserve retrieval value" argument is moot.

- Dynamic discovery of all current embedding dimension tables; idempotent rerun deletes zero.
- Planning-surface comment updated at the exclusion site.
- PG test covers deletion, protected controls (vector-backed / non-project-start / unstamped), and idempotency.

Fleet application via `scripts/migrate.py --all` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG