### PR TITLE
State the Configured Digest Token Bound in the Compaction Prompt

### DIFF
--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -762,15 +762,18 @@ def compact_accepted_correspondence_sync(
     dbname = getattr(getattr(conn, "info", None), "dbname", None)
     if not isinstance(dbname, str) or not dbname:
         raise RuntimeError("Correspondence compaction requires a slot DB connection")
+    max_digest_tokens = int(config["max_digest_tokens"])
     utility = LogonUtility(
         settings,
         dbname=dbname,
         model_override=model,
     )
     digest = utility.compact_correspondence(
-        system_prompt=load_compaction_system_prompt(),
+        system_prompt=load_compaction_system_prompt(
+            max_digest_tokens=max_digest_tokens
+        ),
         user_prompt=plan.render_user_prompt(),
-        max_digest_tokens=int(config["max_digest_tokens"]),
+        max_digest_tokens=max_digest_tokens,
     )
 
     # The model call intentionally owns no database transaction. Re-plan after

--- a/nexus/memory/correspondence.py
+++ b/nexus/memory/correspondence.py
@@ -351,7 +351,28 @@ def insert_digest_version(
     )
 
 
-def load_compaction_system_prompt() -> str:
+def _render_digest_budget(
+    text: str,
+    *,
+    max_digest_tokens: int,
+    source: str,
+) -> str:
+    """Render the configured correspondence-digest budget into a prompt."""
+
+    placeholder = "{{MAX_DIGEST_TOKENS}}"
+    if placeholder not in text:
+        raise ValueError(
+            f"Digest token budget placeholder {placeholder} is missing from {source}"
+        )
+    rendered = text.replace(placeholder, str(int(max_digest_tokens)))
+    if placeholder in rendered:
+        raise ValueError(
+            f"Digest token budget placeholder {placeholder} remains in {source}"
+        )
+    return rendered
+
+
+def load_compaction_system_prompt(*, max_digest_tokens: int) -> str:
     """Load the frozen compaction instructions without fallback prose."""
 
     path = (
@@ -360,7 +381,11 @@ def load_compaction_system_prompt() -> str:
     prompt = path.read_text()
     if not prompt.strip():
         raise ValueError(f"Correspondence compaction prompt is empty: {path}")
-    return prompt
+    return _render_digest_budget(
+        prompt,
+        max_digest_tokens=max_digest_tokens,
+        source=str(path),
+    )
 
 
 def _normalized_letter(value: Optional[str], seat: str) -> Optional[str]:

--- a/prompts/correspondence_compaction.md
+++ b/prompts/correspondence_compaction.md
@@ -19,3 +19,5 @@ The digest records authorial intent, never world canon: it asserts nothing about
 Nothing is invented: a plan absent from the letters and the old digest does not exist.
 
 The output is the complete new digest and nothing else, compact enough to be read every turn without regret.
+
+The complete digest must fit within {{MAX_DIGEST_TOKENS}} tokens.

--- a/tests/test_api/test_correspondence_pg.py
+++ b/tests/test_api/test_correspondence_pg.py
@@ -444,6 +444,11 @@ def test_accept_reject_hysteresis_and_digest_undo(
         assert compaction_calls[0]["thread"] != event_loop_thread
         assert "writer secret 5" in compaction_calls[0]["user_prompt"]
         assert "writer secret 11" in compaction_calls[0]["user_prompt"]
+        assert (
+            f'{compaction_calls[0]["max_digest_tokens"]} tokens'
+            in compaction_calls[0]["system_prompt"]
+        )
+        assert "{{MAX_DIGEST_TOKENS}}" not in compaction_calls[0]["system_prompt"]
 
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
             cur.execute(

--- a/tests/test_correspondence.py
+++ b/tests/test_correspondence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import copy
 from pathlib import Path
+import re
 import tomllib
 from typing import Any
 
@@ -26,6 +27,7 @@ from nexus.agents.logon.skald_wire import (
 )
 from nexus.agents.lore.logon_utility import LogonUtility
 from nexus.api.lore_adapter import compute_raw_text, response_to_incubator
+from nexus.config.loader import load_settings_as_dict
 from nexus.config.settings_models import Settings, StorytellerCorrespondenceSettings
 from nexus.memory import correspondence
 from nexus.memory.correspondence import (
@@ -33,10 +35,16 @@ from nexus.memory.correspondence import (
     CorrespondenceDigestWire,
     CorrespondenceExchange,
     GeneratedCorrespondence,
+    _render_digest_budget,
     build_digest_length_validator,
     build_letter_length_validator,
+    correspondence_settings,
+    load_compaction_system_prompt,
     plan_correspondence_compaction,
 )
+
+
+PROMPTS_DIR = Path(__file__).parents[1] / "prompts"
 
 
 def _exchange(chunk_id: int) -> CorrespondenceExchange:
@@ -47,6 +55,60 @@ def _exchange(chunk_id: int) -> CorrespondenceExchange:
             ("gaia", f"gaia reply {chunk_id}"),
         ),
     )
+
+
+def test_compaction_prompt_keeps_digest_budget_as_a_placeholder() -> None:
+    """The prompt source carries the token slot, never a copied numeric budget."""
+
+    prompt = (PROMPTS_DIR / "correspondence_compaction.md").read_text()
+
+    assert prompt.count("{{MAX_DIGEST_TOKENS}}") == 1
+    assert re.search(r"\b\d[\d_,]*[\s-]tokens?\b", prompt) is None
+    assert re.search(r"\btokens?\b[^.\n]{0,24}\b\d[\d_,]*\b", prompt) is None
+
+
+def test_compaction_prompt_loader_renders_configured_budget() -> None:
+    """The real loader replaces the digest token-budget placeholder."""
+
+    prompt = load_compaction_system_prompt(max_digest_tokens=12345)
+
+    assert "12345 tokens" in prompt
+    assert "{{MAX_DIGEST_TOKENS}}" not in prompt
+
+
+def test_digest_budget_render_fails_when_placeholder_is_missing() -> None:
+    """Removing the digest budget slot fails loudly with its source name."""
+
+    source = "correspondence_compaction.md"
+    with pytest.raises(ValueError, match=re.escape(source)):
+        _render_digest_budget(
+            "The complete digest has no configured bound.",
+            max_digest_tokens=12345,
+            source=source,
+        )
+
+
+def test_compaction_prompt_and_validator_share_real_digest_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real settings bind the same digest budget to prompt and validator."""
+
+    settings = load_settings_as_dict(PROMPTS_DIR.parent / "nexus.toml")
+    configured = correspondence_settings(settings)
+    expected = int(configured["max_digest_tokens"])
+    prompt = load_compaction_system_prompt(max_digest_tokens=expected)
+    validator = build_digest_length_validator(max_digest_tokens=expected)
+    output = CorrespondenceDigestWire(digest="Complete digest.")
+    monkeypatch.setattr(
+        correspondence,
+        "calculate_chunk_tokens",
+        lambda _text: expected + 1,
+    )
+
+    assert prompt.count(str(expected)) == 1
+    assert "{{MAX_DIGEST_TOKENS}}" not in prompt
+    with pytest.raises(ModelRetry, match=rf"limit {expected}\)"):
+        asyncio.run(validator(None, output))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #673.

Applies the proven #670 pre-generation-contract pattern to the compaction seat: the prompt now states the configured digest budget via a loud-fail `{{MAX_DIGEST_TOKENS}}` placeholder rendered from the same `correspondence_settings` mapping `build_digest_length_validator` binds. No second numeric source of truth; the validator stays as the fail-closed backstop.

Test suite mirrors #670's shape: raw-file guard, render, missing-placeholder loud-fail, config-consistency. Eliminates the observed ~8.5k-token wasted retry class (2026-08-06 live sample; 2026-07-30 audit residual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG