### PR TITLE
Retire the Observations Wire Arm

### DIFF
--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -59,15 +59,6 @@ class Coordinates(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class NamedObservation(BaseModel):
-    """Strict key/value observation entry for JSONB-style side notes."""
-
-    key: str = Field(min_length=1, description="Observation key or label")
-    value: str = Field(description="Observation value as concise prose")
-
-    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
-
-
 class FactionStanceChange(BaseModel):
     """Strict faction stance change entry."""
 
@@ -78,7 +69,7 @@ class FactionStanceChange(BaseModel):
 
 
 def _stringify_structured_value(value: Any) -> str:
-    """Render arbitrary legacy observation values into strict-schema prose."""
+    """Render arbitrary legacy structured values into strict-schema prose."""
 
     if value is None:
         return ""
@@ -392,28 +383,10 @@ class CharacterStateUpdate(BaseModel):
     emotional_state: Optional[str] = Field(
         default=None, description="Character's emotional state"
     )
-    extra_observations: List[NamedObservation] = Field(
-        default_factory=list,
-        description="Strict key/value observations for extra_data JSONB.",
-    )
     orrery_tags: Optional[OrreryTagBestowal] = Field(
         default=None,
         description="Registered tag deltas for this character.",
     )
-
-    @field_validator("extra_observations", mode="before")
-    @classmethod
-    def normalize_extra_observations(cls, value: Any) -> Any:
-        """Accept legacy dict observations while emitting strict list schema."""
-
-        if value is None or isinstance(value, list):
-            return value
-        if isinstance(value, dict):
-            return [
-                {"key": str(key), "value": _stringify_structured_value(item)}
-                for key, item in value.items()
-            ]
-        return value
 
     model_config = ConfigDict(extra="forbid")
 

--- a/nexus/agents/logon/orrery_tag_validation.py
+++ b/nexus/agents/logon/orrery_tag_validation.py
@@ -549,7 +549,6 @@ _SUBSTANTIVE_UPDATE_PREDICATES: Mapping[str, Mapping[str, Callable[[Any], bool]]
         "activity": lambda update: bool(update.activity),
         "location": lambda update: update.location is not None,
         "emotional_state": lambda update: bool(update.emotional_state),
-        "observations": lambda update: bool(update.observations),
         "tags_clear": lambda update: bool(update.tags_clear),
     },
     "place": {

--- a/nexus/agents/logon/skald_wire.py
+++ b/nexus/agents/logon/skald_wire.py
@@ -28,7 +28,6 @@ from nexus.agents.logon.apex_schema import (
     FactionStanceChange,
     FactionStateUpdate,
     LocationStateUpdate,
-    NamedObservation,
     NewEntityDeclaration,
     Operations,
     OrreryAdjudication,
@@ -304,10 +303,6 @@ class CharacterUpdateDelta(BaseModel):
         default=None,
         description="Current emotional state.",
     )
-    observations: Optional[List[NamedObservation]] = Field(
-        default=None,
-        description="New named observations.",
-    )
     tags_add: Optional[List[str]] = Field(
         default=None,
         description="Registered tags to add.",
@@ -326,7 +321,6 @@ class CharacterUpdateDelta(BaseModel):
                 self.activity,
                 self.location is not None,
                 self.emotional_state,
-                self.observations,
                 self.tags_add,
                 self.tags_clear,
             )
@@ -806,7 +800,6 @@ def _hydrate_updates(updates: Optional[UpdatesBlock]) -> StateUpdates:
                 current_location=character_update.location,
                 current_activity=character_update.activity,
                 emotional_state=character_update.emotional_state,
-                extra_observations=character_update.observations or [],
                 orrery_tags=_hydrate_tags(
                     character_update.tags_add,
                     character_update.tags_clear,

--- a/tests/test_api/test_lore_adapter.py
+++ b/tests/test_api/test_lore_adapter.py
@@ -166,9 +166,6 @@ def test_response_to_incubator_preserves_full_canonical_state_updates() -> None:
                         "current_location": 41,
                         "current_activity": "tracking the drowned clerk",
                         "emotional_state": "alert but composed",
-                        "extra_observations": [
-                            {"key": "clue", "value": "heard the drowned bell"}
-                        ],
                         "orrery_tags": {
                             "applied_tags": ["perceptive"],
                             "tags_to_clear": ["resting"],
@@ -225,9 +222,6 @@ def test_response_to_incubator_preserves_full_canonical_state_updates() -> None:
     payload = incubator["entity_updates"]
 
     character = payload["characters"][0]
-    assert character["extra_observations"] == [
-        {"key": "clue", "value": "heard the drowned bell"}
-    ]
     assert character["orrery_tags"]["applied_tags"] == ["perceptive"]
     place = payload["locations"][0]
     assert place["current_conditions"] == "Floodwater is rising."

--- a/tests/test_skald_wire.py
+++ b/tests/test_skald_wire.py
@@ -31,7 +31,6 @@ from nexus.agents.logon.apex_schema import (
     FactionStanceChange,
     FactionStateUpdate,
     LocationStateUpdate,
-    NamedObservation,
     NewEntityPairTagHint,
     OrreryAdjudication,
     OrreryReplacementStateDelta,
@@ -170,7 +169,6 @@ RICH_WIRE_PAYLOAD: dict[str, Any] = {
                 "activity": "tracking the drowned gaia",
                 "location": 41,
                 "emotional_state": "alert but composed",
-                "observations": [{"key": "clue", "value": "heard the drowned bell"}],
                 "tags_add": ["perceptive", "alert"],
                 "tags_clear": ["resting"],
             }
@@ -615,12 +613,6 @@ def _rich_canonical_expectation(wire: SkaldTurnWire) -> StorytellerResponseExten
                     current_location=41,
                     current_activity="tracking the drowned gaia",
                     emotional_state="alert but composed",
-                    extra_observations=[
-                        NamedObservation(
-                            key="clue",
-                            value="heard the drowned bell",
-                        )
-                    ],
                     orrery_tags=OrreryTagBestowal(
                         applied_tags=["perceptive", "alert"],
                         tags_to_clear=["resting"],
@@ -1423,6 +1415,47 @@ def test_openai_strict_wire_keeps_required_nullable_spelling() -> None:
         "factions",
         "relationships",
     ]
+
+
+def test_retired_observations_arm_is_absent_and_rejected() -> None:
+    """The dropped character-observations arm cannot re-enter either schema."""
+
+    schema = skald_wire_lenient_schema()
+    assert "observations" not in schema["$defs"]["CharacterUpdateDelta"]["properties"]
+    assert "NamedObservation" not in schema["$defs"]
+    assert (
+        "extra_observations"
+        not in CharacterStateUpdate.model_json_schema()["properties"]
+    )
+
+    with pytest.raises(ValidationError, match="observations"):
+        SkaldTurnWire.model_validate(
+            {
+                **SPARSE_WIRE_PAYLOAD,
+                "updates": _updates_payload(
+                    characters=[
+                        {
+                            "name": "Brena Tideloft",
+                            "activity": "keeping watch",
+                            "observations": [
+                                {"key": "clue", "value": "heard the drowned bell"}
+                            ],
+                        }
+                    ]
+                ),
+            }
+        )
+
+    with pytest.raises(ValidationError, match="extra_observations"):
+        CharacterStateUpdate.model_validate(
+            {
+                "character_name": "Brena Tideloft",
+                "current_activity": "keeping watch",
+                "extra_observations": [
+                    {"key": "clue", "value": "heard the drowned bell"}
+                ],
+            }
+        )
 
 
 def _compact_schema_json(schema: dict[str, Any]) -> str:


### PR DESCRIPTION
Closes #674.

Verified premise (independently by both reviews): `observations` → `extra_observations` was hydrated (`skald_wire.py:809`) and then ignored by **both** commit paths — a silent drop inviting false confidence that NPC observations became durable.

Resolution per the Arachne seq-24 ruling: with the full actor-experience layer (#677) approved as the proper home, the arm is **retired** rather than given persistence. Removal spans wire schema, `NamedObservation`, hydration, tag validation, and dead tests; `extra="forbid"` grammar kept strict throughout. No DB column existed, so no migration.

Wire-weight side effect: strict Gaia schema now 13,428 B / 3,050 tok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG