### PR TITLE
Render Recent Orrery Adjudication Outcomes into the Turn Prompt

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -454,6 +454,7 @@ checkpoint_interval_chunks = 25
 # prompt-exposure log records the same first-N slice, so these are also the
 # boundary between "ratified by omission" and "never shown".
 max_rendered_proposals = 5
+max_rendered_recent_rulings = 5
 max_rendered_pressures = 5
 
 [orrery.habituation]

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -1957,14 +1957,14 @@ class LogonUtility:
 
         lines = ["=== RECENT ORRERY RULINGS ==="]
         for ruling in rulings:
-            tick_chunk_id = ruling["tick_chunk_id"]
-            if isinstance(tick_chunk_id, bool) or not isinstance(tick_chunk_id, int):
-                raise TypeError("Recent Orrery ruling tick_chunk_id must be an integer")
-            turn_offset = anchor_chunk_id - tick_chunk_id + 1
-            if turn_offset <= 0:
+            turn_offset = ruling.get("turn_offset")
+            if (
+                isinstance(turn_offset, bool)
+                or not isinstance(turn_offset, int)
+                or turn_offset <= 0
+            ):
                 raise ValueError(
-                    "Recent Orrery ruling cannot occur after the prompt anchor: "
-                    f"ruling_tick={tick_chunk_id}, anchor_tick={anchor_chunk_id}"
+                    "Recent Orrery ruling requires a positive accepted-turn offset"
                 )
 
             outcome = ruling["outcome"]
@@ -2284,7 +2284,14 @@ class LogonUtility:
         max_rendered_proposals = prompt_settings.max_rendered_proposals
         max_rendered_pressures = prompt_settings.max_rendered_pressures
 
-        recent_rulings_section = context.get("orrery_recent_rulings_section") or []
+        recent_rulings_section = context.get("orrery_recent_rulings_section")
+        if recent_rulings_section is None:
+            recent_rulings_section = []
+        elif not isinstance(recent_rulings_section, list):
+            raise TypeError(
+                "orrery_recent_rulings_section must be None or a list, got "
+                f"{recent_rulings_section!r}"
+            )
         if not isinstance(recent_rulings_section, list) or not all(
             isinstance(line, str) and line for line in recent_rulings_section
         ):

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -1930,6 +1930,95 @@ class LogonUtility:
         )
         return bool(context_payload.get("is_bootstrap", False) or metadata_bootstrap)
 
+    @staticmethod
+    def build_recent_orrery_rulings_section(
+        session: Any,
+        *,
+        anchor_chunk_id: int,
+        limit: int,
+    ) -> list[str]:
+        """Build recent adjudication lines for the shared storyteller context."""
+
+        from nexus.agents.orrery.history import adjudication_history
+
+        if anchor_chunk_id <= 0:
+            raise ValueError("anchor_chunk_id must be positive")
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+
+        history = adjudication_history(
+            session,
+            through_tick=anchor_chunk_id,
+            recent_rulings_limit=limit,
+        )
+        rulings = history["recent_rulings"]
+        if not rulings:
+            return []
+
+        lines = ["=== RECENT ORRERY RULINGS ==="]
+        for ruling in rulings:
+            tick_chunk_id = ruling["tick_chunk_id"]
+            if isinstance(tick_chunk_id, bool) or not isinstance(tick_chunk_id, int):
+                raise TypeError("Recent Orrery ruling tick_chunk_id must be an integer")
+            turn_offset = anchor_chunk_id - tick_chunk_id + 1
+            if turn_offset <= 0:
+                raise ValueError(
+                    "Recent Orrery ruling cannot occur after the prompt anchor: "
+                    f"ruling_tick={tick_chunk_id}, anchor_tick={anchor_chunk_id}"
+                )
+
+            outcome = ruling["outcome"]
+            if outcome == "ratified":
+                summary = ruling.get("summary")
+                if not isinstance(summary, str) or not summary.strip():
+                    raise ValueError(
+                        "Ratified Orrery ruling requires its committed brief"
+                    )
+                summary = " ".join(summary.split())
+            elif outcome in {"deferred", "voided"}:
+                state_delta = ruling.get("state_delta")
+                if not isinstance(state_delta, Mapping):
+                    raise TypeError(
+                        f"{outcome.title()} Orrery ruling requires its state_delta"
+                    )
+                rendered_delta = json.dumps(
+                    state_delta,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                )
+                summary = f"{ruling['template_id']}: state_delta={rendered_delta}"
+            else:
+                raise ValueError(f"Unsupported recent Orrery outcome: {outcome!r}")
+
+            turn_label = f"(turn N-{turn_offset})"
+            if outcome == "ratified":
+                lines.append(f"[RATIFIED] {summary} {turn_label}")
+            elif outcome == "deferred":
+                count = ruling["consecutive_deferrals"]
+                if isinstance(count, bool) or not isinstance(count, int) or count <= 0:
+                    raise ValueError(
+                        "Deferred Orrery ruling requires a positive consecutive count"
+                    )
+                suffix = (
+                    "th"
+                    if 10 < count % 100 < 14
+                    else {1: "st", 2: "nd", 3: "rd"}.get(count % 10, "th")
+                )
+                lines.append(
+                    f"[DEFERRED] {summary} {turn_label} — "
+                    f"{count}{suffix} consecutive deferral"
+                )
+            elif outcome == "voided":
+                note = ruling.get("note")
+                rendered_note = " ".join(note.split()) if isinstance(note, str) else ""
+                lines.append(
+                    f"[VOIDED — {rendered_note or 'no note'}] "
+                    f"{summary} {turn_label}"
+                )
+        return lines
+
     def _format_context_prompt(
         self,
         context: Dict,
@@ -2190,18 +2279,21 @@ class LogonUtility:
         # the orrery section is absent.
         from nexus.config.settings_models import OrreryPromptSettings
 
-        _prompt_defaults = OrreryPromptSettings()
         _prompt_cfg = (self.settings.get("orrery") or {}).get("prompt") or {}
-        max_rendered_proposals = int(
-            _prompt_cfg.get(
-                "max_rendered_proposals", _prompt_defaults.max_rendered_proposals
+        prompt_settings = OrreryPromptSettings.model_validate(_prompt_cfg)
+        max_rendered_proposals = prompt_settings.max_rendered_proposals
+        max_rendered_pressures = prompt_settings.max_rendered_pressures
+
+        recent_rulings_section = context.get("orrery_recent_rulings_section") or []
+        if not isinstance(recent_rulings_section, list) or not all(
+            isinstance(line, str) and line for line in recent_rulings_section
+        ):
+            raise TypeError(
+                "orrery_recent_rulings_section must be a list of nonempty strings"
             )
-        )
-        max_rendered_pressures = int(
-            _prompt_cfg.get(
-                "max_rendered_pressures", _prompt_defaults.max_rendered_pressures
-            )
-        )
+        if recent_rulings_section:
+            sections.append("")
+            sections.extend(recent_rulings_section)
 
         imminent_activity = context.get("orrery_imminent_activity") or []
         if imminent_activity:

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -46,6 +46,7 @@ try:
         LORERetrievalSettings,
         OrreryBleedSettings,
         OrreryKnowledgeSettings,
+        OrreryPromptSettings,
     )
 except ImportError:
     # If relative import fails, try absolute
@@ -78,6 +79,7 @@ except ImportError:
         LORERetrievalSettings,
         OrreryBleedSettings,
         OrreryKnowledgeSettings,
+        OrreryPromptSettings,
     )
 
 try:
@@ -978,6 +980,7 @@ class TurnCycleManager:
 
         await self.select_orrery_bleed(turn_context)
         world_knowledge = self._build_world_knowledge(turn_context)
+        recent_rulings_section = self._build_recent_orrery_rulings_section(turn_context)
 
         # Build the context payload
         turn_context.context_payload = {
@@ -1056,6 +1059,11 @@ class TurnCycleManager:
                 getattr(world_knowledge, "truncated", False)
             )
 
+        if recent_rulings_section:
+            turn_context.context_payload["orrery_recent_rulings_section"] = (
+                recent_rulings_section
+            )
+
         if turn_context.target_chunk_id is not None:
             turn_context.context_payload["metadata"][
                 "target_chunk_id"
@@ -1083,6 +1091,40 @@ class TurnCycleManager:
         }
 
         logger.info(f"Context payload assembled: {utilization:.1f}% budget utilization")
+
+    def _build_recent_orrery_rulings_section(
+        self, turn_context: TurnContext
+    ) -> list[str]:
+        """Read and render recent rulings before payload-budget accounting."""
+
+        orrery_settings = self.settings.get("orrery", {})
+        if not orrery_settings.get("enabled", False):
+            return []
+        if not self.lore.memnon:
+            raise RuntimeError("Recent Orrery rulings require MEMNON database access")
+
+        prompt_settings = OrreryPromptSettings.model_validate(
+            orrery_settings.get("prompt", {})
+        )
+        with self.lore.memnon.Session() as session:
+            proposal = turn_context.orrery_proposal
+            anchor_chunk_id = (
+                proposal.anchor_chunk_id
+                if proposal is not None
+                else turn_context.target_chunk_id
+            )
+            if anchor_chunk_id is None:
+                anchor_chunk_id = self._orrery_anchor_chunk_id(session, turn_context)
+            if anchor_chunk_id is None:
+                return []
+
+            from nexus.agents.lore.logon_utility import LogonUtility
+
+            return LogonUtility.build_recent_orrery_rulings_section(
+                session,
+                anchor_chunk_id=anchor_chunk_id,
+                limit=prompt_settings.max_rendered_recent_rulings,
+            )
 
     def _enforce_context_payload_budget(
         self, turn_context: TurnContext

--- a/nexus/agents/orrery/history.py
+++ b/nexus/agents/orrery/history.py
@@ -85,14 +85,29 @@ def adjudication_history(
     session: Any,
     *,
     template_id: Optional[str] = None,
+    through_tick: Optional[int] = None,
+    recent_rulings_limit: Optional[int] = None,
 ) -> dict[str, Any]:
     """Return the adjudication-history payload for one slot.
 
-    Read-only. ``template_id`` narrows every block to one package.
+    Read-only. ``template_id`` narrows every block to one package;
+    ``through_tick`` excludes later outcomes during replay/regeneration.
     """
 
-    template_clause = "WHERE template_id = :template_id" if template_id else ""
-    params: dict[str, Any] = {"template_id": template_id} if template_id else {}
+    if through_tick is not None and through_tick <= 0:
+        raise ValueError("through_tick must be positive")
+    if recent_rulings_limit is not None and recent_rulings_limit <= 0:
+        raise ValueError("recent_rulings_limit must be positive")
+
+    filters: list[str] = []
+    params: dict[str, Any] = {}
+    if template_id:
+        filters.append("template_id = :template_id")
+        params["template_id"] = template_id
+    if through_tick is not None:
+        filters.append("tick_chunk_id <= :through_tick")
+        params["through_tick"] = through_tick
+    template_clause = f"WHERE {' AND '.join(filters)}" if filters else ""
 
     log_rows = [
         dict(row)
@@ -100,9 +115,10 @@ def adjudication_history(
             text(
                 f"""
                 /* orrery_history:adjudication_log */
-                SELECT tick_chunk_id, proposal_id, template_id, binding_hash,
+                SELECT id, tick_chunk_id, proposal_id, template_id, binding_hash,
                        action, adjudication_source, skald_note,
-                       applied_resolution_id, actor_entity_id, bindings
+                       original_state_delta, applied_resolution_id,
+                       actor_entity_id, bindings
                 FROM orrery_adjudication_log
                 {template_clause}
                 ORDER BY proposal_id, tick_chunk_id, id
@@ -118,8 +134,9 @@ def adjudication_history(
             text(
                 f"""
                 /* orrery_history:resolutions */
-                SELECT tick_chunk_id, template_id, binding_hash,
-                       actor_entity_id, promotion_status::text
+                SELECT id, tick_chunk_id, template_id, binding_hash,
+                       actor_entity_id, state_delta, brief,
+                       promotion_status::text
                            AS promotion_status,
                        narration_status::text AS narration_status
                 FROM orrery_resolutions
@@ -249,6 +266,79 @@ def adjudication_history(
         )
     defer_streaks.sort(key=lambda item: (-item["length"], item["proposal_id"]))
 
+    # --- Recent per-outcome rulings -----------------------------------------
+    # A replace that materialized a resolution is not ratification-by-omission.
+    replaced_resolution_ids = {
+        row["applied_resolution_id"]
+        for row in log_rows
+        if row["action"] == "replace" and row["applied_resolution_id"] is not None
+    }
+    ruling_timelines: dict[str, list[tuple[int, int, str, Optional[int]]]] = {}
+    for row in log_rows:
+        ruling_timelines.setdefault(row["proposal_id"], []).append(
+            (row["tick_chunk_id"], 0, row["action"], row["id"])
+        )
+    for row in resolution_rows:
+        proposal_id = f"{row['template_id']}:{row['binding_hash']}"
+        ruling_timelines.setdefault(proposal_id, []).append(
+            (row["tick_chunk_id"], 1, "committed", None)
+        )
+
+    deferral_counts: dict[int, int] = {}
+    for proposal_events in ruling_timelines.values():
+        consecutive = 0
+        for _tick, _order, action, log_id in sorted(proposal_events):
+            if action == "defer":
+                consecutive += 1
+                if log_id is None:
+                    raise RuntimeError("Deferred ruling is missing its ledger id")
+                deferral_counts[log_id] = consecutive
+            else:
+                consecutive = 0
+
+    recent_rulings: list[dict[str, Any]] = []
+    for row in resolution_rows:
+        if row["id"] in replaced_resolution_ids:
+            continue
+        recent_rulings.append(
+            {
+                "outcome": "ratified",
+                "tick_chunk_id": row["tick_chunk_id"],
+                "source_id": row["id"],
+                "proposal_id": f"{row['template_id']}:{row['binding_hash']}",
+                "template_id": row["template_id"],
+                "summary": row["brief"],
+                "state_delta": row["state_delta"],
+                "note": None,
+                "consecutive_deferrals": 0,
+            }
+        )
+    for row in log_rows:
+        if row["action"] not in {"defer", "void"}:
+            continue
+        recent_rulings.append(
+            {
+                "outcome": "deferred" if row["action"] == "defer" else "voided",
+                "tick_chunk_id": row["tick_chunk_id"],
+                "source_id": row["id"],
+                "proposal_id": row["proposal_id"],
+                "template_id": row["template_id"],
+                "summary": None,
+                "state_delta": row["original_state_delta"],
+                "note": row["skald_note"],
+                "consecutive_deferrals": deferral_counts.get(row["id"], 0),
+            }
+        )
+    recent_rulings.sort(
+        key=lambda row: (
+            -row["tick_chunk_id"],
+            0 if row["outcome"] == "ratified" else 1,
+            -row["source_id"],
+        )
+    )
+    if recent_rulings_limit is not None:
+        recent_rulings = recent_rulings[:recent_rulings_limit]
+
     # --- Names and epoch honesty --------------------------------------------
     entity_ids = {
         actor_id for actor_id in actor_by_proposal.values() if actor_id is not None
@@ -281,6 +371,7 @@ def adjudication_history(
         },
         "templates": templates,
         "defer_streaks": defer_streaks,
+        "recent_rulings": recent_rulings,
         "exposures": {
             "resolution": exposures.get(
                 "resolution", {"rows": 0, "earliest_tick": None}

--- a/nexus/agents/orrery/history.py
+++ b/nexus/agents/orrery/history.py
@@ -21,6 +21,7 @@ from typing import Any, List, Optional
 
 from sqlalchemy import text
 
+from nexus.agents.orrery.reconstruction import playable_narrative_predicate
 from nexus.agents.orrery.resolver import _entity_label, _load_entity_names
 
 _ACTIONS = ("defer", "replace", "void")
@@ -338,6 +339,36 @@ def adjudication_history(
     )
     if recent_rulings_limit is not None:
         recent_rulings = recent_rulings[:recent_rulings_limit]
+
+    if through_tick is not None and recent_rulings:
+        ruling_ticks = sorted({row["tick_chunk_id"] for row in recent_rulings})
+        ordinal_rows = session.execute(
+            text(
+                f"""
+                /* orrery_history:recent_ruling_ordinals */
+                WITH accepted_chunks AS (
+                    SELECT nc.id,
+                           row_number() OVER (ORDER BY nc.id DESC) AS turn_offset
+                    FROM narrative_chunks nc
+                    WHERE nc.id <= :through_tick
+                      AND {playable_narrative_predicate()}
+                )
+                SELECT id, turn_offset
+                FROM accepted_chunks
+                WHERE id = ANY(CAST(:ruling_ticks AS bigint[]))
+                """
+            ),
+            {"through_tick": through_tick, "ruling_ticks": ruling_ticks},
+        ).mappings()
+        turn_offsets = {int(row["id"]): int(row["turn_offset"]) for row in ordinal_rows}
+        missing_ticks = set(ruling_ticks) - set(turn_offsets)
+        if missing_ticks:
+            raise ValueError(
+                "Recent Orrery rulings reference non-playable narrative chunks: "
+                + ", ".join(str(tick) for tick in sorted(missing_ticks))
+            )
+        for ruling in recent_rulings:
+            ruling["turn_offset"] = turn_offsets[ruling["tick_chunk_id"]]
 
     # --- Names and epoch honesty --------------------------------------------
     entity_ids = {

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -751,6 +751,9 @@ def _load_win_history(
     if win_history_window <= 0 or anchor_chunk_id is None:
         return {}
     cutoff = anchor_chunk_id - win_history_window
+    # Habituation debits only committed wins. Ratified proposals reach
+    # orrery_resolutions and debit; voided proposals never reached the page,
+    # remain only in orrery_adjudication_log, and must never debit.
     rows = session.execute(
         text(
             """

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -2272,6 +2272,14 @@ class OrreryPromptSettings(BaseModel):
             "renders (ratify-by-omission applies only to rendered rows)."
         ),
     )
+    max_rendered_recent_rulings: int = Field(
+        default=5,
+        ge=1,
+        description=(
+            "How many recent Orrery adjudication outcomes the storyteller "
+            "prompt renders."
+        ),
+    )
     max_rendered_pressures: int = Field(
         default=5,
         ge=1,

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -372,6 +372,15 @@ def test_context_prompt_without_bootstrap_data_keeps_standard_shape() -> None:
     )
 
 
+def test_context_prompt_rejects_nonpositive_recent_rulings_cap() -> None:
+    """The recent-rulings cap is validated with its sibling prompt limits."""
+
+    utility = LogonUtility({"orrery": {"prompt": {"max_rendered_recent_rulings": 0}}})
+
+    with pytest.raises(ValueError, match="max_rendered_recent_rulings"):
+        utility._format_context_prompt({"user_input": "Continue."})
+
+
 def test_context_prompt_includes_orrery_scene_pressure_controls() -> None:
     """Prompt-only Orrery pressures are framed as Storyteller-controlled."""
 

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -381,6 +381,37 @@ def test_context_prompt_rejects_nonpositive_recent_rulings_cap() -> None:
         utility._format_context_prompt({"user_input": "Continue."})
 
 
+@pytest.mark.parametrize("invalid_section", ["", {}, ()])
+def test_context_prompt_rejects_falsy_nonlist_recent_rulings_section(
+    invalid_section: Any,
+) -> None:
+    """Falsy non-list payloads cannot masquerade as an absent section."""
+
+    with pytest.raises(TypeError, match=re.escape(repr(invalid_section))):
+        LogonUtility({})._format_context_prompt(
+            {
+                "user_input": "Continue.",
+                "orrery_recent_rulings_section": invalid_section,
+            }
+        )
+
+
+@pytest.mark.parametrize("empty_section", [None, []])
+def test_context_prompt_accepts_absent_or_empty_recent_rulings_section(
+    empty_section: Any,
+) -> None:
+    """None and an empty list both omit the optional rulings section."""
+
+    prompt = LogonUtility({})._format_context_prompt(
+        {
+            "user_input": "Continue.",
+            "orrery_recent_rulings_section": empty_section,
+        }
+    )
+
+    assert "=== RECENT ORRERY RULINGS ===" not in prompt
+
+
 def test_context_prompt_includes_orrery_scene_pressure_controls() -> None:
     """Prompt-only Orrery pressures are framed as Storyteller-controlled."""
 

--- a/tests/test_lore/test_recent_orrery_rulings_pg.py
+++ b/tests/test_lore/test_recent_orrery_rulings_pg.py
@@ -1,0 +1,269 @@
+"""Disposable-PostgreSQL prompt regressions for recent Orrery rulings."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import uuid
+from types import SimpleNamespace
+from typing import Any, Iterator
+
+import psycopg2
+import pytest
+from psycopg2 import sql
+from psycopg2.extras import Json
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from nexus.agents.lore.logon_utility import LogonUtility
+from nexus.agents.lore.utils.turn_context import TurnContext
+from nexus.agents.lore.utils.turn_cycle import (
+    TurnCycleManager,
+    _context_component_token_count,
+)
+from nexus.config import load_settings_as_dict
+from nexus.memory import ContextMemoryManager
+
+pytestmark = pytest.mark.requires_postgres
+
+
+def _connect(dbname: str) -> Any:
+    """Open a direct connection to the disposable Issue 685 database."""
+
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+@pytest.fixture()
+def recent_rulings_db() -> Iterator[dict[str, Any]]:
+    """Clone the template, seed genuine outcome ledgers, and always drop it."""
+
+    dbname = f"nexus_test_i685_{uuid.uuid4().hex[:12]}"
+    admin = _connect("postgres")
+    admin.autocommit = True
+    engine = None
+    try:
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier("NEXUS_template"),
+                )
+            )
+
+        with _connect(dbname) as conn:
+            with conn.cursor() as cur:
+                chunk_ids: list[int] = []
+                for index in range(1, 7):
+                    cur.execute(
+                        """
+                        INSERT INTO narrative_chunks (raw_text, storyteller_text)
+                        VALUES (%s, %s)
+                        RETURNING id
+                        """,
+                        (f"Issue 685 raw {index}", f"Issue 685 prose {index}"),
+                    )
+                    chunk_ids.append(int(cur.fetchone()[0]))
+
+                defer_delta = {"character.current_activity": "waiting in cover"}
+                for tick_chunk_id in chunk_ids[3:6]:
+                    cur.execute(
+                        """
+                        INSERT INTO orrery_adjudication_log (
+                            tick_chunk_id, proposal_id, template_id,
+                            binding_hash, action, adjudication_source,
+                            original_state_delta, bindings
+                        ) VALUES (
+                            %s, 'hide:defer-streak', 'hide', 'defer-streak',
+                            'defer', 'explicit', %s::jsonb, '{}'::jsonb
+                        )
+                        """,
+                        (tick_chunk_id, Json(defer_delta)),
+                    )
+
+                cur.execute(
+                    """
+                    INSERT INTO orrery_adjudication_log (
+                        tick_chunk_id, proposal_id, template_id, binding_hash,
+                        action, adjudication_source, original_state_delta, bindings
+                    ) VALUES (
+                        %s, 'sleep:voided-no-note', 'sleep', 'voided-no-note',
+                        'void', 'explicit',
+                        '{"character.current_activity":"dozing"}'::jsonb,
+                        '{}'::jsonb
+                    )
+                    """,
+                    (chunk_ids[4],),
+                )
+                cur.execute(
+                    """
+                    INSERT INTO orrery_adjudication_log (
+                        tick_chunk_id, proposal_id, template_id, binding_hash,
+                        action, adjudication_source, skald_note,
+                        original_state_delta, bindings
+                    ) VALUES (
+                        %s, 'sleep:voided', 'sleep', 'voided', 'void',
+                        'explicit', 'Contradicts the witnessed departure',
+                        '{"character.current_activity":"sleeping"}'::jsonb,
+                        '{}'::jsonb
+                    )
+                    """,
+                    (chunk_ids[5],),
+                )
+                cur.execute(
+                    """
+                    INSERT INTO orrery_resolutions (
+                        tick_chunk_id, template_id, binding_hash,
+                        priority, state_delta, brief, promotion_status
+                    ) VALUES (
+                        %s, 'surveil', 'ratified', 40,
+                        '{"character.current_activity":"watching the quay"}'::jsonb,
+                        'Mara watches the quay from a darkened window.', 'pending'
+                    )
+                    """,
+                    (chunk_ids[5],),
+                )
+
+        engine = create_engine(
+            f"postgresql://{os.environ.get('PGUSER', 'pythagor')}@"
+            f"{os.environ.get('PGHOST', 'localhost')}:"
+            f"{os.environ.get('PGPORT', '5432')}/{dbname}"
+        )
+        yield {
+            "dbname": dbname,
+            "Session": sessionmaker(bind=engine),
+            "empty_anchor": chunk_ids[0],
+            "outcome_anchor": chunk_ids[5],
+        }
+    finally:
+        if engine is not None:
+            engine.dispose()
+        with admin.cursor() as cur:
+            cur.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (dbname,),
+            )
+            cur.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+            )
+        admin.close()
+
+
+def _assemble_prompt(
+    seeded: dict[str, Any],
+    *,
+    anchor_chunk_id: int,
+    cap: int,
+) -> tuple[str, dict[str, Any]]:
+    settings = load_settings_as_dict()
+    settings["orrery"]["knowledge"]["enabled"] = False
+    settings["orrery"]["bleed"]["max_candidates"] = 0
+    settings["orrery"]["bleed"]["reserved_remote_slots"] = 0
+    settings["orrery"]["prompt"]["max_rendered_recent_rulings"] = cap
+
+    lore = SimpleNamespace(
+        settings=settings,
+        memnon=SimpleNamespace(Session=seeded["Session"]),
+        memory_manager=ContextMemoryManager(settings),
+        token_manager=None,
+        enable_logon=False,
+    )
+    manager = TurnCycleManager(lore)
+    context = TurnContext(
+        turn_id="issue-685",
+        user_input="Continue.",
+        start_time=time.time(),
+        target_chunk_id=anchor_chunk_id,
+        token_counts={"total_available": 75_000},
+    )
+
+    asyncio.run(manager.assemble_context_payload(context))
+    prompt = LogonUtility(settings)._format_context_prompt(context.context_payload)
+    return prompt, context.context_payload
+
+
+def test_recent_rulings_render_all_outcomes_for_both_seats_and_count_budget(
+    recent_rulings_db: dict[str, Any],
+) -> None:
+    """Real assembly renders every shape and carries it into Gaia's prompt."""
+
+    prompt, payload = _assemble_prompt(
+        recent_rulings_db,
+        anchor_chunk_id=recent_rulings_db["outcome_anchor"],
+        cap=5,
+    )
+
+    assert prompt.count("=== RECENT ORRERY RULINGS ===") == 1
+    assert (
+        "[RATIFIED] Mara watches the quay from a darkened window. (turn N-1)" in prompt
+    )
+    assert (
+        "[DEFERRED] hide: state_delta="
+        '{"character.current_activity":"waiting in cover"} '
+        "(turn N-1) — 3rd consecutive deferral" in prompt
+    )
+    assert (
+        "[VOIDED — Contradicts the witnessed departure] sleep: state_delta="
+        '{"character.current_activity":"sleeping"} (turn N-1)' in prompt
+    )
+    assert (
+        "[VOIDED — no note] sleep: state_delta="
+        '{"character.current_activity":"dozing"} (turn N-2)' in prompt
+    )
+
+    writer = SimpleNamespace(
+        narrative="The scene continues.",
+        choices=[],
+        scene=None,
+        presence=None,
+        operations=None,
+        letter="The outcome ledger informed the scene.",
+    )
+    gaia_prompt = LogonUtility._format_gaia_user_prompt(prompt, writer)
+    assert "=== RECENT ORRERY RULINGS ===" in gaia_prompt
+    assert "3rd consecutive deferral" in gaia_prompt
+
+    without_rulings = dict(payload)
+    without_rulings.pop("orrery_recent_rulings_section")
+    assert _context_component_token_count(payload) > _context_component_token_count(
+        without_rulings
+    )
+
+
+def test_recent_rulings_respect_configured_cap(
+    recent_rulings_db: dict[str, Any],
+) -> None:
+    """The configured cap bounds outcomes before prompt-budget measurement."""
+
+    prompt, payload = _assemble_prompt(
+        recent_rulings_db,
+        anchor_chunk_id=recent_rulings_db["outcome_anchor"],
+        cap=2,
+    )
+
+    section = payload["orrery_recent_rulings_section"]
+    assert len(section) == 3
+    assert prompt.count("[RATIFIED]") == 1
+    assert prompt.count("[VOIDED —") == 1
+    assert "[DEFERRED]" not in prompt
+
+
+def test_recent_rulings_omit_empty_section(
+    recent_rulings_db: dict[str, Any],
+) -> None:
+    """An anchor before every seeded outcome emits no header or payload key."""
+
+    prompt, payload = _assemble_prompt(
+        recent_rulings_db,
+        anchor_chunk_id=recent_rulings_db["empty_anchor"],
+        cap=5,
+    )
+
+    assert "orrery_recent_rulings_section" not in payload
+    assert "=== RECENT ORRERY RULINGS ===" not in prompt

--- a/tests/test_lore/test_recent_orrery_rulings_pg.py
+++ b/tests/test_lore/test_recent_orrery_rulings_pg.py
@@ -6,13 +6,13 @@ import asyncio
 import os
 import time
 import uuid
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, Iterator
 
 import psycopg2
 import pytest
 from psycopg2 import sql
-from psycopg2.extras import Json
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -22,6 +22,13 @@ from nexus.agents.lore.utils.turn_cycle import (
     TurnCycleManager,
     _context_component_token_count,
 )
+from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.agents.orrery.resolver import (
+    OrreryResolutionDraft,
+    OrreryTickProposal,
+    resolve_dry_run,
+)
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 from nexus.config import load_settings_as_dict
 from nexus.memory import ContextMemoryManager
 
@@ -39,9 +46,112 @@ def _connect(dbname: str) -> Any:
     )
 
 
+def _insert_accepted_chunk_after_rollback_gap(dbname: str, index: int) -> int:
+    """Consume one BIGSERIAL value, then insert the real accepted chunk."""
+
+    gap_conn = _connect(dbname)
+    try:
+        with gap_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO narrative_chunks (raw_text, storyteller_text)
+                VALUES (%s, %s)
+                RETURNING id
+                """,
+                (f"Rolled-back raw {index}", f"Rolled-back prose {index}"),
+            )
+            rolled_back_id = int(cur.fetchone()[0])
+        gap_conn.rollback()
+    finally:
+        gap_conn.close()
+
+    accepted_conn = _connect(dbname)
+    try:
+        with accepted_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO narrative_chunks (raw_text, storyteller_text)
+                VALUES (%s, %s)
+                RETURNING id
+                """,
+                (f"Issue 685 raw {index}", f"Issue 685 prose {index}"),
+            )
+            accepted_id = int(cur.fetchone()[0])
+        accepted_conn.commit()
+    finally:
+        accepted_conn.close()
+
+    assert accepted_id > rolled_back_id
+    return accepted_id
+
+
+def _draft(
+    *,
+    template_id: str,
+    binding_hash: str,
+    actor_entity_id: int,
+    narrative_stub: str,
+    state_delta: dict[str, Any],
+) -> OrreryResolutionDraft:
+    """Build one controlled draft for the real adjudication/commit boundary."""
+
+    return OrreryResolutionDraft(
+        template_id=template_id,
+        priority=40,
+        binding_hash=binding_hash,
+        bindings={"actor": actor_entity_id},
+        branch_label=f"Issue 685 {template_id}",
+        narrative_stub=narrative_stub,
+        state_delta=state_delta,
+        magnitude=0.2,
+        promotable=False,
+    )
+
+
+def _resolve_then_commit(
+    seeded: dict[str, Any],
+    *,
+    tick_chunk_id: int,
+    drafts: tuple[OrreryResolutionDraft, ...],
+    adjudications: list[dict[str, Any]],
+) -> Any:
+    """Exercise the live-cycle resolve then real adjudication/commit path."""
+
+    settings = seeded["settings"]
+    with seeded["Session"]() as session:
+        resolved = resolve_dry_run(
+            session,
+            BUILTIN_TEMPLATES,
+            anchor_chunk_id=tick_chunk_id,
+            window_chunks=int(settings["orrery"]["binding"]["window_chunks"]),
+            sunhelm_settings=settings["orrery"].get("sunhelm"),
+        )
+    assert resolved.anchor_chunk_id == tick_chunk_id
+
+    proposal = OrreryTickProposal(
+        anchor_chunk_id=tick_chunk_id,
+        actor_count=max(1, resolved.actor_count),
+        resolutions=drafts,
+    )
+    conn = _connect(seeded["dbname"])
+    try:
+        result = commit_orrery_tick_sync(
+            conn,
+            proposal,
+            tick_chunk_id=tick_chunk_id,
+            adjudications=adjudications,
+            prompt_settings=settings["orrery"]["prompt"],
+            sunhelm_settings=settings["orrery"].get("sunhelm"),
+        )
+        conn.commit()
+        return result
+    finally:
+        conn.close()
+
+
 @pytest.fixture()
 def recent_rulings_db() -> Iterator[dict[str, Any]]:
-    """Clone the template, seed genuine outcome ledgers, and always drop it."""
+    """Create real outcomes through resolve/adjudicate/commit, then drop the DB."""
 
     dbname = f"nexus_test_i685_{uuid.uuid4().hex[:12]}"
     admin = _connect("postgres")
@@ -56,89 +166,121 @@ def recent_rulings_db() -> Iterator[dict[str, Any]]:
                 )
             )
 
-        with _connect(dbname) as conn:
-            with conn.cursor() as cur:
-                chunk_ids: list[int] = []
-                for index in range(1, 7):
-                    cur.execute(
-                        """
-                        INSERT INTO narrative_chunks (raw_text, storyteller_text)
-                        VALUES (%s, %s)
-                        RETURNING id
-                        """,
-                        (f"Issue 685 raw {index}", f"Issue 685 prose {index}"),
-                    )
-                    chunk_ids.append(int(cur.fetchone()[0]))
-
-                defer_delta = {"character.current_activity": "waiting in cover"}
-                for tick_chunk_id in chunk_ids[3:6]:
-                    cur.execute(
-                        """
-                        INSERT INTO orrery_adjudication_log (
-                            tick_chunk_id, proposal_id, template_id,
-                            binding_hash, action, adjudication_source,
-                            original_state_delta, bindings
-                        ) VALUES (
-                            %s, 'hide:defer-streak', 'hide', 'defer-streak',
-                            'defer', 'explicit', %s::jsonb, '{}'::jsonb
-                        )
-                        """,
-                        (tick_chunk_id, Json(defer_delta)),
-                    )
-
-                cur.execute(
-                    """
-                    INSERT INTO orrery_adjudication_log (
-                        tick_chunk_id, proposal_id, template_id, binding_hash,
-                        action, adjudication_source, original_state_delta, bindings
-                    ) VALUES (
-                        %s, 'sleep:voided-no-note', 'sleep', 'voided-no-note',
-                        'void', 'explicit',
-                        '{"character.current_activity":"dozing"}'::jsonb,
-                        '{}'::jsonb
-                    )
-                    """,
-                    (chunk_ids[4],),
-                )
-                cur.execute(
-                    """
-                    INSERT INTO orrery_adjudication_log (
-                        tick_chunk_id, proposal_id, template_id, binding_hash,
-                        action, adjudication_source, skald_note,
-                        original_state_delta, bindings
-                    ) VALUES (
-                        %s, 'sleep:voided', 'sleep', 'voided', 'void',
-                        'explicit', 'Contradicts the witnessed departure',
-                        '{"character.current_activity":"sleeping"}'::jsonb,
-                        '{}'::jsonb
-                    )
-                    """,
-                    (chunk_ids[5],),
-                )
-                cur.execute(
-                    """
-                    INSERT INTO orrery_resolutions (
-                        tick_chunk_id, template_id, binding_hash,
-                        priority, state_delta, brief, promotion_status
-                    ) VALUES (
-                        %s, 'surveil', 'ratified', 40,
-                        '{"character.current_activity":"watching the quay"}'::jsonb,
-                        'Mara watches the quay from a darkened window.', 'pending'
-                    )
-                    """,
-                    (chunk_ids[5],),
-                )
-
         engine = create_engine(
             f"postgresql://{os.environ.get('PGUSER', 'pythagor')}@"
             f"{os.environ.get('PGHOST', 'localhost')}:"
             f"{os.environ.get('PGPORT', '5432')}/{dbname}"
         )
-        yield {
+        settings = load_settings_as_dict()
+        seeded = {
             "dbname": dbname,
             "Session": sessionmaker(bind=engine),
+            "settings": settings,
+        }
+        actor_conn = _connect(dbname)
+        try:
+            with actor_conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO global_variables (id, new_story, base_timestamp)
+                    VALUES (true, true, %s)
+                    ON CONFLICT (id) DO UPDATE
+                    SET base_timestamp = EXCLUDED.base_timestamp
+                    """,
+                    (datetime(2042, 8, 18, 8, 54, tzinfo=timezone.utc),),
+                )
+                cur.execute(
+                    "INSERT INTO entities (kind, is_active) "
+                    "VALUES ('character', true) RETURNING id"
+                )
+                actor_entity_id = int(cur.fetchone()[0])
+                cur.execute(
+                    "INSERT INTO characters (name, summary, entity_id) "
+                    "VALUES ('Mara', 'Issue 685 production-path actor.', %s)",
+                    (actor_entity_id,),
+                )
+            actor_conn.commit()
+        finally:
+            actor_conn.close()
+
+        chunk_ids = [
+            _insert_accepted_chunk_after_rollback_gap(dbname, index)
+            for index in range(1, 5)
+        ]
+        assert all(
+            later - earlier > 1 for earlier, later in zip(chunk_ids, chunk_ids[1:])
+        ), "fixture must prove sparse BIGSERIAL chronology"
+
+        defer_draft = _draft(
+            template_id="hide",
+            binding_hash="defer-streak",
+            actor_entity_id=actor_entity_id,
+            narrative_stub="The watcher remains hidden.",
+            state_delta={"character.current_activity": "waiting in cover"},
+        )
+        void_no_note = _draft(
+            template_id="sleep",
+            binding_hash="voided-no-note",
+            actor_entity_id=actor_entity_id,
+            narrative_stub="The watcher dozes.",
+            state_delta={"character.current_activity": "dozing"},
+        )
+        void_with_note = _draft(
+            template_id="sleep",
+            binding_hash="voided",
+            actor_entity_id=actor_entity_id,
+            narrative_stub="The watcher sleeps.",
+            state_delta={"character.current_activity": "sleeping"},
+        )
+        ratified = _draft(
+            template_id="surveil",
+            binding_hash="ratified",
+            actor_entity_id=actor_entity_id,
+            narrative_stub="Mara watches the quay from a darkened window.",
+            state_delta={},
+        )
+
+        first = _resolve_then_commit(
+            seeded,
+            tick_chunk_id=chunk_ids[1],
+            drafts=(defer_draft,),
+            adjudications=[{"proposal_id": defer_draft.proposal_id, "action": "defer"}],
+        )
+        assert first.deferred_count == 1
+
+        second = _resolve_then_commit(
+            seeded,
+            tick_chunk_id=chunk_ids[2],
+            drafts=(defer_draft, void_no_note),
+            adjudications=[
+                {"proposal_id": defer_draft.proposal_id, "action": "defer"},
+                {"proposal_id": void_no_note.proposal_id, "action": "void"},
+            ],
+        )
+        assert second.deferred_count == 1
+        assert second.voided_count == 1
+
+        third = _resolve_then_commit(
+            seeded,
+            tick_chunk_id=chunk_ids[3],
+            drafts=(defer_draft, void_with_note, ratified),
+            adjudications=[
+                {"proposal_id": defer_draft.proposal_id, "action": "defer"},
+                {
+                    "proposal_id": void_with_note.proposal_id,
+                    "action": "void",
+                    "note": "Contradicts the witnessed departure",
+                },
+            ],
+        )
+        assert third.deferred_count == 1
+        assert third.voided_count == 1
+        assert third.resolution_count == 1
+
+        yield {
+            **seeded,
             "empty_anchor": chunk_ids[0],
-            "outcome_anchor": chunk_ids[5],
+            "outcome_anchor": chunk_ids[3],
         }
     finally:
         if engine is not None:
@@ -188,10 +330,10 @@ def _assemble_prompt(
     return prompt, context.context_payload
 
 
-def test_recent_rulings_render_all_outcomes_for_both_seats_and_count_budget(
+def test_recent_rulings_render_real_outcomes_across_sparse_chunk_ids(
     recent_rulings_db: dict[str, Any],
 ) -> None:
-    """Real assembly renders every shape and carries it into Gaia's prompt."""
+    """Production writes render by accepted order, then reach both seats."""
 
     prompt, payload = _assemble_prompt(
         recent_rulings_db,
@@ -257,7 +399,7 @@ def test_recent_rulings_respect_configured_cap(
 def test_recent_rulings_omit_empty_section(
     recent_rulings_db: dict[str, Any],
 ) -> None:
-    """An anchor before every seeded outcome emits no header or payload key."""
+    """An anchor before every outcome emits no header or payload key."""
 
     prompt, payload = _assemble_prompt(
         recent_rulings_db,


### PR DESCRIPTION
Closes #685.

The outcome-vs-intent ledger asymmetry from the MGO review, resolved: Gaia and the writer now see what became of prior Orrery proposals. `=== RECENT ORRERY RULINGS ===` renders from the existing `adjudication_history()` payload builder — `[RATIFIED]`, `[DEFERRED] … — Nth consecutive deferral` (the "HIDE for 100 chunks" tell made visible), `[VOIDED — reason]`.

- Cap via `[orrery.prompt] max_rendered_recent_rulings` (default 5), Pydantic-validated.
- `through_tick` bound: replay/regeneration prompts can never read outcomes from their future.
- Replaced resolutions excluded from ratified outcomes; section omitted entirely when empty.
- Habituation invariant verified already-correct (committed wins only) and documented; no math changed.

122 live rulings in save_05 render on day one. 143 passed + new PG suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG