### PR TITLE
Harden Orrery Narration Jobs with Recoverable Leases and Idempotent Completion

### DIFF
--- a/migrations/102_narration_job_fencing.sql
+++ b/migrations/102_narration_job_fencing.sql
@@ -1,0 +1,57 @@
+-- migrations/102_narration_job_fencing.sql
+-- Owner-fenced, idempotent Orrery narration jobs.
+
+ALTER TYPE orrery_job_state
+    ADD VALUE IF NOT EXISTS 'stale_rejected';
+
+ALTER TABLE orrery_narration_jobs
+    ADD COLUMN IF NOT EXISTS lease_nonce uuid,
+    ADD COLUMN IF NOT EXISTS anchor_tick_chunk_id bigint,
+    ADD COLUMN IF NOT EXISTS anchor_world_layer world_layer_type,
+    ADD COLUMN IF NOT EXISTS superseded_at timestamptz;
+
+UPDATE orrery_narration_jobs AS jobs
+SET anchor_tick_chunk_id = resolutions.tick_chunk_id,
+    anchor_world_layer = COALESCE(metadata.world_layer, 'primary'::world_layer_type)
+FROM orrery_resolutions AS resolutions
+LEFT JOIN chunk_metadata AS metadata
+    ON metadata.chunk_id = resolutions.tick_chunk_id
+WHERE resolutions.id = jobs.resolution_id
+  AND (
+      jobs.anchor_tick_chunk_id IS NULL
+      OR jobs.anchor_world_layer IS NULL
+  );
+
+ALTER TABLE orrery_narration_jobs
+    ALTER COLUMN anchor_tick_chunk_id SET NOT NULL,
+    ALTER COLUMN anchor_world_layer SET NOT NULL;
+
+ALTER TABLE orrery_narration_jobs
+    DROP CONSTRAINT IF EXISTS orrery_narration_jobs_anchor_tick_chunk_id_fkey;
+
+ALTER TABLE orrery_narration_jobs
+    ADD CONSTRAINT orrery_narration_jobs_anchor_tick_chunk_id_fkey
+    FOREIGN KEY (anchor_tick_chunk_id)
+    REFERENCES narrative_chunks(id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_orrery_narration_jobs_effective_resolution
+    ON orrery_narration_jobs (resolution_id)
+    WHERE superseded_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_offscreen_narrations_resolution
+    ON offscreen_narrations (resolution_id);
+
+COMMENT ON COLUMN orrery_narration_jobs.lease_nonce IS
+    'Fresh UUID stamped for each lease acquisition; completion and failure writes must present the current nonce together with locked_by before lease expiry.';
+COMMENT ON COLUMN orrery_narration_jobs.anchor_tick_chunk_id IS
+    'Canonical resolution tick copied at enqueue and revalidated atomically before narration output is inserted.';
+COMMENT ON COLUMN orrery_narration_jobs.anchor_world_layer IS
+    'Canonical timeline layer copied from chunk_metadata at enqueue and revalidated atomically at completion.';
+COMMENT ON COLUMN orrery_narration_jobs.superseded_at IS
+    'Explicit retirement timestamp; only one row with NULL superseded_at may be effective for a resolution.';
+COMMENT ON COLUMN orrery_narration_jobs.locked_by IS
+    'Worker owner identifier stamped at lease acquisition and required with lease_nonce for fenced writes.';
+COMMENT ON INDEX ux_orrery_narration_jobs_effective_resolution IS
+    'Allows exactly one non-superseded narration job per Orrery resolution.';
+COMMENT ON INDEX ux_offscreen_narrations_resolution IS
+    'Makes narration completion idempotent at the database boundary: one output per Orrery resolution.';

--- a/nexus.toml
+++ b/nexus.toml
@@ -517,6 +517,8 @@ model_ref = "@anthropic.default"
 #   max_output_tokens  — narration output ceiling (default 1200)
 #   max_attempts       — narration job attempts before failure (default 3)
 #   retry_delay_seconds — backoff between attempts (default 300)
+lease_duration_seconds = 300
+max_jobs_per_drain = 5
 
 [orrery.bleed]
 density = 0.20

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 from typing import Any, Mapping, Optional
+from uuid import uuid4
 
 import psycopg2
 from psycopg2.extras import RealDictCursor
@@ -62,6 +63,18 @@ class OrreryWorkerResult(BaseModel):
     maturation_failed: int = 0
 
 
+class NarrationCompletionRejectedError(RuntimeError):
+    """Base error for a narration completion rejected by a durable fence."""
+
+
+class NarrationLeaseLostError(NarrationCompletionRejectedError):
+    """Raised when a worker no longer owns an unexpired narration lease."""
+
+
+class NarrationAnchorStaleError(NarrationCompletionRejectedError):
+    """Raised after a leased job is terminally rejected for a stale anchor."""
+
+
 class OrreryStatus(BaseModel):
     """Operational snapshot for Orrery outbox and tag-clearance state."""
 
@@ -69,6 +82,7 @@ class OrreryStatus(BaseModel):
     queued_narration_jobs: int = 0
     leased_narration_jobs: int = 0
     failed_narration_jobs: int = 0
+    stale_rejected_narration_jobs: int = 0
     pending_offscreen_embeddings: int = 0
     failed_offscreen_embeddings: int = 0
     active_semantic_tags: int = 0
@@ -84,7 +98,7 @@ def process_orrery_outbox_sync(
     slot: Optional[int] = None,
     *,
     promotion_limit: int = 20,
-    narration_limit: int = 5,
+    narration_limit: Optional[int] = None,
     semantic_clearance_limit: int = DEFAULT_SEMANTIC_CLEARANCE_LIMIT,
     semantic_clearance_recent_chunks: int = DEFAULT_SEMANTIC_CLEARANCE_RECENT_CHUNKS,
     semantic_clearance_evidence_chunks: int = (
@@ -196,17 +210,26 @@ def promote_pending_resolutions_sync(
 def drain_narration_outbox_sync(
     slot: Optional[int] = None,
     *,
-    limit: int = 5,
+    limit: Optional[int] = None,
     settings: Optional[Mapping[str, Any]] = None,
     narration_provider: Optional[Any] = None,
     conn: Optional[Any] = None,
 ) -> tuple[int, int]:
-    """Generate off-screen narrations for queued Orrery jobs."""
+    """Generate off-screen narrations for queued or expired Orrery jobs."""
 
+    settings_dict = dict(settings or load_settings_as_dict())
+    narration_settings = _narration_settings(settings_dict)
+    max_attempts, retry_delay_seconds = _narration_retry_settings(settings_dict)
+    job_limit = narration_settings.max_jobs_per_drain
+    if limit is not None:
+        if limit < 0:
+            raise ValueError("Narration job limit must be non-negative")
+        job_limit = min(limit, job_limit)
+    if job_limit == 0:
+        return (0, 0)
+    worker_owner = _narration_worker_owner(slot)
     owns_conn = conn is None
     conn = conn or _connect_for_slot(slot)
-    settings_dict = dict(settings or load_settings_as_dict())
-    max_attempts, retry_delay_seconds = _narration_retry_settings(settings_dict)
     try:
         with conn:
             with conn.cursor(cursor_factory=RealDictCursor) as cur:
@@ -217,6 +240,8 @@ def drain_narration_outbox_sync(
                         j.resolution_id,
                         j.slot,
                         j.attempts,
+                        j.anchor_tick_chunk_id,
+                        j.anchor_world_layer::text AS anchor_world_layer,
                         r.tick_chunk_id,
                         r.template_id,
                         r.actor_entity_id,
@@ -231,34 +256,62 @@ def drain_narration_outbox_sync(
                     JOIN orrery_resolutions r ON r.id = j.resolution_id
                     LEFT JOIN chunk_metadata cm ON cm.chunk_id = r.tick_chunk_id
                     LEFT JOIN entity_names_v n ON n.id = r.actor_entity_id
-                    WHERE j.state = 'queued'
-                      AND j.available_at <= now()
-                    ORDER BY j.available_at, j.id
+                    WHERE j.superseded_at IS NULL
+                      AND (
+                            (
+                                j.state = 'queued'
+                                AND j.available_at <= now()
+                            )
+                            OR (
+                                j.state = 'leased'
+                                AND j.lease_until IS NOT NULL
+                                AND j.lease_until < now()
+                            )
+                      )
+                    ORDER BY
+                        CASE
+                            WHEN j.state = 'leased' THEN j.lease_until
+                            ELSE j.available_at
+                        END,
+                        j.id
                     LIMIT %s
                     FOR UPDATE OF j SKIP LOCKED
                     """,
-                    (limit,),
+                    (job_limit,),
                 )
                 rows = cur.fetchall()
                 if not rows:
                     return (0, 0)
 
                 provider = narration_provider or _narration_provider(settings_dict)
-                for row in rows:
+                leased_rows = []
+                for selected_row in rows:
+                    row = dict(selected_row)
+                    lease_nonce = str(uuid4())
                     cur.execute(
                         """
                         UPDATE orrery_narration_jobs
                         SET state = 'leased',
-                            lease_until = now() + interval '5 minutes',
+                            lease_until = now() + (%s * interval '1 second'),
+                            locked_by = %s,
+                            lease_nonce = %s,
                             attempts = attempts + 1,
                             updated_at = now()
                         WHERE id = %s
                         """,
-                        (row["job_id"],),
+                        (
+                            narration_settings.lease_duration_seconds,
+                            worker_owner,
+                            lease_nonce,
+                            row["job_id"],
+                        ),
                     )
+                    row["locked_by"] = worker_owner
+                    row["lease_nonce"] = lease_nonce
+                    leased_rows.append(row)
         narrated = 0
         failed = 0
-        for row in rows:
+        for row in leased_rows:
             try:
                 with usage_context(
                     seat="orrery_narration",
@@ -267,26 +320,43 @@ def drain_narration_outbox_sync(
                 ):
                     narration_text = _generate_narration(provider, row)
                 descriptor = _perceptual_descriptor(row)
+                completion_error = None
                 with conn:
                     with conn.cursor(cursor_factory=RealDictCursor) as cur:
-                        _mark_narration_succeeded(
+                        completion_error = _mark_narration_succeeded(
                             cur,
                             row=row,
                             narration_text=narration_text,
                             descriptor=descriptor,
                         )
+                if completion_error is not None:
+                    raise completion_error
                 narrated += 1
+            except NarrationCompletionRejectedError as exc:
+                failed += 1
+                logger.error(
+                    "Rejected completion for Orrery narration job %s: %s",
+                    row["job_id"],
+                    exc,
+                )
             except Exception as exc:
                 failed += 1
-                with conn:
-                    with conn.cursor(cursor_factory=RealDictCursor) as cur:
-                        _mark_narration_failed(
-                            cur,
-                            row=row,
-                            error=str(exc),
-                            max_attempts=max_attempts,
-                            retry_delay_seconds=retry_delay_seconds,
-                        )
+                try:
+                    with conn:
+                        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                            _mark_narration_failed(
+                                cur,
+                                row=row,
+                                error=str(exc),
+                                max_attempts=max_attempts,
+                                retry_delay_seconds=retry_delay_seconds,
+                            )
+                except NarrationLeaseLostError as fence_exc:
+                    logger.error(
+                        "Rejected failure write for Orrery narration job %s: %s",
+                        row["job_id"],
+                        fence_exc,
+                    )
                 logger.exception("Failed to narrate Orrery job %s", row["job_id"])
         return (narrated, failed)
     finally:
@@ -344,6 +414,7 @@ def load_orrery_status_sync(
                         SELECT count(*) AS count
                         FROM orrery_narration_jobs
                         WHERE state = 'queued'
+                          AND superseded_at IS NULL
                         """,
                     ),
                     leased_narration_jobs=_count_sync(
@@ -352,6 +423,7 @@ def load_orrery_status_sync(
                         SELECT count(*) AS count
                         FROM orrery_narration_jobs
                         WHERE state = 'leased'
+                          AND superseded_at IS NULL
                         """,
                     ),
                     failed_narration_jobs=_count_sync(
@@ -360,6 +432,16 @@ def load_orrery_status_sync(
                         SELECT count(*) AS count
                         FROM orrery_narration_jobs
                         WHERE state = 'failed'
+                          AND superseded_at IS NULL
+                        """,
+                    ),
+                    stale_rejected_narration_jobs=_count_sync(
+                        cur,
+                        """
+                        SELECT count(*) AS count
+                        FROM orrery_narration_jobs
+                        WHERE state = 'stale_rejected'
+                          AND superseded_at IS NULL
                         """,
                     ),
                     pending_offscreen_embeddings=_count_sync(
@@ -418,7 +500,73 @@ def _mark_narration_succeeded(
     row: Mapping[str, Any],
     narration_text: str,
     descriptor: Mapping[str, Any],
-) -> None:
+) -> Optional[NarrationCompletionRejectedError]:
+    cur.execute(
+        """
+        /* orrery:narration:complete_fence */
+        SELECT
+            j.state::text AS state,
+            j.locked_by,
+            j.lease_nonce,
+            j.lease_until > now() AS lease_is_current,
+            j.anchor_tick_chunk_id,
+            j.anchor_world_layer::text AS anchor_world_layer,
+            r.tick_chunk_id AS current_tick_chunk_id,
+            COALESCE(cm.world_layer::text, 'primary') AS current_world_layer,
+            nc.id IS NOT NULL AS anchor_exists
+        FROM orrery_narration_jobs AS j
+        JOIN orrery_resolutions AS r ON r.id = j.resolution_id
+        LEFT JOIN narrative_chunks AS nc ON nc.id = j.anchor_tick_chunk_id
+        LEFT JOIN chunk_metadata AS cm ON cm.chunk_id = r.tick_chunk_id
+        WHERE j.id = %s
+        FOR UPDATE OF j, r
+        """,
+        (row["job_id"],),
+    )
+    current = cur.fetchone()
+    if not _lease_matches(current, row):
+        return NarrationLeaseLostError(
+            f"job {row['job_id']} is no longer owned by "
+            f"{row['locked_by']} with nonce {row['lease_nonce']}"
+        )
+
+    anchor_matches = (
+        bool(current.get("anchor_exists"))
+        and current.get("anchor_tick_chunk_id") == row.get("anchor_tick_chunk_id")
+        and current.get("current_tick_chunk_id") == row.get("anchor_tick_chunk_id")
+        and current.get("anchor_world_layer") == row.get("anchor_world_layer")
+        and current.get("current_world_layer") == row.get("anchor_world_layer")
+    )
+    if not anchor_matches:
+        error = (
+            f"job {row['job_id']} anchor changed: enqueued tick/layer "
+            f"{row.get('anchor_tick_chunk_id')}/{row.get('anchor_world_layer')}, "
+            f"current {current.get('current_tick_chunk_id')}/"
+            f"{current.get('current_world_layer')}"
+        )
+        cur.execute(
+            """
+            UPDATE orrery_narration_jobs
+            SET state = 'stale_rejected',
+                lease_until = NULL,
+                locked_by = NULL,
+                lease_nonce = NULL,
+                last_error = %s,
+                updated_at = now()
+            WHERE id = %s
+            """,
+            (error, row["job_id"]),
+        )
+        cur.execute(
+            """
+            UPDATE orrery_resolutions
+            SET narration_status = 'failed'
+            WHERE id = %s
+            """,
+            (row["resolution_id"],),
+        )
+        return NarrationAnchorStaleError(error)
+
     cur.execute(
         """
         INSERT INTO offscreen_narrations (
@@ -450,11 +598,22 @@ def _mark_narration_succeeded(
         UPDATE orrery_narration_jobs
         SET state = 'succeeded',
             lease_until = NULL,
+            locked_by = NULL,
+            lease_nonce = NULL,
             updated_at = now()
         WHERE id = %s
+          AND state = 'leased'
+          AND locked_by = %s
+          AND lease_nonce = %s
+          AND lease_until > now()
         """,
-        (row["job_id"],),
+        (row["job_id"], row["locked_by"], row["lease_nonce"]),
     )
+    if cur.rowcount != 1:
+        raise RuntimeError(
+            f"Narration job {row['job_id']} fence changed while row-locked"
+        )
+    return None
 
 
 def _mark_narration_failed(
@@ -473,12 +632,29 @@ def _mark_narration_failed(
             SET state = 'queued',
                 available_at = now() + (%s * interval '1 second'),
                 lease_until = NULL,
+                locked_by = NULL,
+                lease_nonce = NULL,
                 last_error = %s,
                 updated_at = now()
             WHERE id = %s
+              AND state = 'leased'
+              AND locked_by = %s
+              AND lease_nonce = %s
+              AND lease_until > now()
+            RETURNING id
             """,
-            (retry_delay_seconds, error, row["job_id"]),
+            (
+                retry_delay_seconds,
+                error,
+                row["job_id"],
+                row["locked_by"],
+                row["lease_nonce"],
+            ),
         )
+        if cur.fetchone() is None:
+            raise NarrationLeaseLostError(
+                f"job {row['job_id']} lost its lease before retry persistence"
+            )
         cur.execute(
             """
             UPDATE orrery_resolutions
@@ -494,12 +670,28 @@ def _mark_narration_failed(
         UPDATE orrery_narration_jobs
         SET state = 'failed',
             lease_until = NULL,
+            locked_by = NULL,
+            lease_nonce = NULL,
             last_error = %s,
             updated_at = now()
         WHERE id = %s
+          AND state = 'leased'
+          AND locked_by = %s
+          AND lease_nonce = %s
+          AND lease_until > now()
+        RETURNING id
         """,
-        (error, row["job_id"]),
+        (
+            error,
+            row["job_id"],
+            row["locked_by"],
+            row["lease_nonce"],
+        ),
     )
+    if cur.fetchone() is None:
+        raise NarrationLeaseLostError(
+            f"job {row['job_id']} lost its lease before failure persistence"
+        )
     cur.execute(
         """
         UPDATE orrery_resolutions
@@ -575,10 +767,18 @@ def _mark_promoted(
     cur.execute(
         """
         INSERT INTO orrery_narration_jobs (
-            resolution_id, slot, provider, model_ref
-        ) VALUES (%s, %s, %s, %s)
+            resolution_id, slot, provider, model_ref,
+            anchor_tick_chunk_id, anchor_world_layer
+        )
+        SELECT
+            r.id, %s, %s, %s, r.tick_chunk_id,
+            COALESCE(cm.world_layer, 'primary'::world_layer_type)
+        FROM orrery_resolutions AS r
+        LEFT JOIN chunk_metadata AS cm ON cm.chunk_id = r.tick_chunk_id
+        WHERE r.id = %s
+        ON CONFLICT (resolution_id) WHERE superseded_at IS NULL DO NOTHING
         """,
-        (row["id"], slot_label, provider, model_ref),
+        (slot_label, provider, model_ref, row["id"]),
     )
 
 
@@ -701,6 +901,26 @@ def _narration_retry_settings(settings: Mapping[str, Any]) -> tuple[int, int]:
     return max(1, narration.max_attempts), max(0, narration.retry_delay_seconds)
 
 
+def _lease_matches(
+    current: Optional[Mapping[str, Any]], leased_row: Mapping[str, Any]
+) -> bool:
+    """Return whether the durable job still matches this worker's live lease."""
+
+    return bool(
+        current
+        and current.get("state") == "leased"
+        and current.get("locked_by") == leased_row.get("locked_by")
+        and current.get("lease_nonce") == leased_row.get("lease_nonce")
+        and current.get("lease_is_current")
+    )
+
+
+def _narration_worker_owner(slot: Optional[int]) -> str:
+    """Build a unique owner label for one narration drain invocation."""
+
+    return f"{_slot_label(slot)}:{os.getpid()}:{uuid4()}"
+
+
 def _connect_for_slot(slot: Optional[int]) -> Any:
     from nexus.api.db_pool import get_connect_timeout_seconds
     from nexus.api.slot_utils import require_slot_dbname
@@ -745,8 +965,11 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument(
         "--narration-limit",
         type=int,
-        default=5,
-        help="Maximum queued narration jobs to drain in this run.",
+        default=None,
+        help=(
+            "Maximum narration jobs to drain, capped by "
+            "orrery.narration.max_jobs_per_drain."
+        ),
     )
     parser.add_argument(
         "--maturation-limit",

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -250,7 +250,7 @@ def drain_narration_outbox_sync(
                         r.brief,
                         r.promotion_verdict,
                         r.event_ids,
-                        cm.world_layer::text AS world_layer,
+                        COALESCE(cm.world_layer::text, 'primary') AS world_layer,
                         n.name AS actor_name
                     FROM orrery_narration_jobs j
                     JOIN orrery_resolutions r ON r.id = j.resolution_id
@@ -260,12 +260,12 @@ def drain_narration_outbox_sync(
                       AND (
                             (
                                 j.state = 'queued'
-                                AND j.available_at <= now()
+                                AND j.available_at <= clock_timestamp()
                             )
                             OR (
                                 j.state = 'leased'
                                 AND j.lease_until IS NOT NULL
-                                AND j.lease_until < now()
+                                AND j.lease_until < clock_timestamp()
                             )
                       )
                     ORDER BY
@@ -292,7 +292,8 @@ def drain_narration_outbox_sync(
                         """
                         UPDATE orrery_narration_jobs
                         SET state = 'leased',
-                            lease_until = now() + (%s * interval '1 second'),
+                            lease_until = clock_timestamp()
+                                + (%s * interval '1 second'),
                             locked_by = %s,
                             lease_nonce = %s,
                             attempts = attempts + 1,
@@ -508,22 +509,49 @@ def _mark_narration_succeeded(
             j.state::text AS state,
             j.locked_by,
             j.lease_nonce,
-            j.lease_until > now() AS lease_is_current,
+            j.lease_until,
             j.anchor_tick_chunk_id,
             j.anchor_world_layer::text AS anchor_world_layer,
             r.tick_chunk_id AS current_tick_chunk_id,
-            COALESCE(cm.world_layer::text, 'primary') AS current_world_layer,
             nc.id IS NOT NULL AS anchor_exists
         FROM orrery_narration_jobs AS j
         JOIN orrery_resolutions AS r ON r.id = j.resolution_id
         LEFT JOIN narrative_chunks AS nc ON nc.id = j.anchor_tick_chunk_id
-        LEFT JOIN chunk_metadata AS cm ON cm.chunk_id = r.tick_chunk_id
         WHERE j.id = %s
         FOR UPDATE OF j, r
         """,
         (row["job_id"],),
     )
     current = cur.fetchone()
+    if current is None:
+        return NarrationLeaseLostError(f"job {row['job_id']} no longer exists")
+
+    cur.execute(
+        """
+        /* orrery:narration:anchor_fence */
+        SELECT COALESCE(world_layer::text, 'primary') AS current_world_layer
+        FROM chunk_metadata
+        WHERE chunk_id = %s
+        FOR SHARE
+        """,
+        (current["current_tick_chunk_id"],),
+    )
+    metadata = cur.fetchone()
+    current["current_world_layer"] = (
+        metadata.get("current_world_layer") if metadata is not None else None
+    )
+    cur.execute(
+        """
+        SELECT lease_until > clock_timestamp() AS lease_is_current
+        FROM orrery_narration_jobs
+        WHERE id = %s
+        """,
+        (row["job_id"],),
+    )
+    lease_check = cur.fetchone()
+    current["lease_is_current"] = bool(
+        lease_check and lease_check.get("lease_is_current")
+    )
     if not _lease_matches(current, row):
         return NarrationLeaseLostError(
             f"job {row['job_id']} is no longer owned by "
@@ -605,7 +633,7 @@ def _mark_narration_succeeded(
           AND state = 'leased'
           AND locked_by = %s
           AND lease_nonce = %s
-          AND lease_until > now()
+          AND lease_until > clock_timestamp()
         """,
         (row["job_id"], row["locked_by"], row["lease_nonce"]),
     )
@@ -630,7 +658,8 @@ def _mark_narration_failed(
             """
             UPDATE orrery_narration_jobs
             SET state = 'queued',
-                available_at = now() + (%s * interval '1 second'),
+                available_at = clock_timestamp()
+                    + (%s * interval '1 second'),
                 lease_until = NULL,
                 locked_by = NULL,
                 lease_nonce = NULL,
@@ -640,7 +669,7 @@ def _mark_narration_failed(
               AND state = 'leased'
               AND locked_by = %s
               AND lease_nonce = %s
-              AND lease_until > now()
+              AND lease_until > clock_timestamp()
             RETURNING id
             """,
             (
@@ -678,7 +707,7 @@ def _mark_narration_failed(
           AND state = 'leased'
           AND locked_by = %s
           AND lease_nonce = %s
-          AND lease_until > now()
+          AND lease_until > clock_timestamp()
         RETURNING id
         """,
         (

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1269,6 +1269,18 @@ class OrreryNarrationSettings(BaseModel):
     retry_delay_seconds: int = Field(
         default=300, ge=0, description="Delay before a failed narration job retries"
     )
+    lease_duration_seconds: int = Field(
+        default=300,
+        ge=1,
+        description="Duration of one owner-fenced narration job lease",
+    )
+    max_jobs_per_drain: int = Field(
+        default=5,
+        ge=1,
+        description=(
+            "Maximum queued or expired narration jobs reclaimed per worker drain"
+        ),
+    )
 
 
 class OrreryBleedSettings(BaseModel):

--- a/tests/test_orrery/test_narration_job_fencing_pg.py
+++ b/tests/test_orrery/test_narration_job_fencing_pg.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from datetime import datetime, timezone
 import os
 from pathlib import Path
 from threading import Event
@@ -14,9 +15,13 @@ import psycopg2
 from psycopg2 import sql
 from psycopg2.errors import UniqueViolation
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.engine import URL
+from sqlalchemy.orm import Session
 
 from nexus.agents.orrery.events import commit_orrery_tick_sync
-from nexus.agents.orrery.resolver import OrreryResolutionDraft, OrreryTickProposal
+from nexus.agents.orrery.resolver import resolve_dry_run
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
 from nexus.agents.orrery.worker import (
     drain_narration_outbox_sync,
     promote_pending_resolutions_sync,
@@ -109,7 +114,7 @@ def _disposable_narration_db() -> Iterator[str]:
             admin.close()
 
 
-def _settings() -> dict[str, Any]:
+def _settings(*, lease_duration_seconds: int = 60) -> dict[str, Any]:
     """Return deterministic narration worker settings for database tests."""
 
     return {
@@ -119,7 +124,7 @@ def _settings() -> dict[str, Any]:
                 "model_ref": "test-narrator",
                 "max_attempts": 3,
                 "retry_delay_seconds": 0,
-                "lease_duration_seconds": 60,
+                "lease_duration_seconds": lease_duration_seconds,
                 "max_jobs_per_drain": 5,
             },
             "promote": {
@@ -144,11 +149,15 @@ def _insert_chunk(cur: Any, label: str, *, world_layer: str = "primary") -> int:
         "INSERT INTO chunk_metadata (chunk_id, world_layer) VALUES (%s, %s)",
         (chunk_id, world_layer),
     )
+    cur.execute(
+        "UPDATE chunk_metadata SET world_time = %s WHERE chunk_id = %s",
+        (datetime(2196, 7, 6, 23, 0, tzinfo=timezone.utc), chunk_id),
+    )
     return chunk_id
 
 
 def _materialize_pending_resolution(conn: Any, *, label: str) -> tuple[int, int]:
-    """Commit a real Orrery proposal at a narrative chunk anchor."""
+    """Resolve and commit a genuine Orrery proposal at a narrative anchor."""
 
     with conn.cursor() as cur:
         chunk_id = _insert_chunk(cur, f"Issue 676 anchor: {label}")
@@ -158,22 +167,65 @@ def _materialize_pending_resolution(conn: Any, *, label: str) -> tuple[int, int]
             "INSERT INTO characters (name, entity_id) VALUES (%s, %s)",
             (f"Courier {label}", actor_id),
         )
+        cur.execute(
+            """
+            UPDATE character_need_states
+            SET debt_score = 60,
+                last_evaluated_at = %s
+            WHERE character_entity_id = %s
+              AND need_type = 'sleep'
+            """,
+            (datetime(2196, 7, 6, 23, 0, tzinfo=timezone.utc), actor_id),
+        )
+        assert cur.rowcount == 1, "Character trigger did not initialize sleep debt"
+        cur.execute(
+            """
+            INSERT INTO world_events (
+                event_type, tick_chunk_id, actor_entity_id,
+                world_layer, source, changed_fields, payload
+            ) VALUES (
+                'slept', %s, %s, 'primary', 'resolver', '{}', '{}'::jsonb
+            )
+            """,
+            (chunk_id, actor_id),
+        )
+    conn.commit()
 
-    binding_hash = f"issue-676-{label}-{uuid4()}"
-    draft = OrreryResolutionDraft(
-        template_id="hide",
-        priority=80,
-        binding_hash=binding_hash,
-        bindings={"actor": actor_id},
-        binding_names={"actor": f"Courier {label}"},
-        branch_label="Issue 676 narration fencing probe",
-        narrative_stub="{actor} disappears below the viaduct.",
-        magnitude=0.72,
+    engine = create_engine(
+        URL.create(
+            "postgresql+psycopg2",
+            username=os.environ.get("PGUSER", "pythagor"),
+            host=os.environ.get("PGHOST", "localhost"),
+            port=int(os.environ.get("PGPORT", "5432")),
+            database=conn.info.dbname,
+        ),
+        future=True,
     )
-    proposal = OrreryTickProposal(
-        anchor_chunk_id=chunk_id,
-        actor_count=1,
-        resolutions=(draft,),
+    try:
+        with Session(engine) as session:
+            proposal = resolve_dry_run(
+                session,
+                BUILTIN_TEMPLATES,
+                anchor_chunk_id=chunk_id,
+                window_chunks=30,
+                epistemics_settings={"enabled": False},
+            )
+    finally:
+        engine.dispose()
+
+    assert proposal.resolutions, (
+        "Genuine Orrery resolver produced no draft for the seeded high sleep debt; "
+        f"actor={actor_id}, chunk={chunk_id}"
+    )
+    assert proposal.actor_count == 1
+    assert len(proposal.resolutions) == 1, (
+        "Issue 676 fixture must resolve exactly one deterministic draft; got "
+        f"{[draft.template_id for draft in proposal.resolutions]}"
+    )
+    draft = proposal.resolutions[0]
+    assert draft.template_id == "sleep", (
+        "Seeded high sleep debt must resolve through the real SLEEP package; got "
+        f"{draft.template_id}"
     )
     result = commit_orrery_tick_sync(
         conn,
@@ -185,7 +237,7 @@ def _materialize_pending_resolution(conn: Any, *, label: str) -> tuple[int, int]
     with conn.cursor() as cur:
         cur.execute(
             "SELECT id FROM orrery_resolutions WHERE binding_hash = %s",
-            (binding_hash,),
+            (draft.binding_hash,),
         )
         return int(cur.fetchone()[0]), chunk_id
 
@@ -207,14 +259,19 @@ def _enqueue(conn: Any, resolution_id: int) -> None:
         assert int(cur.fetchone()[0]) == 1
 
 
-def _drain(dbname: str, provider: Any) -> tuple[int, int]:
+def _drain(
+    dbname: str,
+    provider: Any,
+    *,
+    lease_duration_seconds: int = 60,
+) -> tuple[int, int]:
     """Run the public narration drain with its own worker connection."""
 
     conn = _connect(dbname)
     try:
         return drain_narration_outbox_sync(
             slot=676,
-            settings=_settings(),
+            settings=_settings(lease_duration_seconds=lease_duration_seconds),
             narration_provider=provider,
             conn=conn,
         )
@@ -347,6 +404,122 @@ def test_stale_anchor_completion_is_terminally_rejected() -> None:
                 assert state == "stale_rejected"
                 assert int(anchor_chunk) == original_chunk
                 assert "anchor changed" in error
+                cur.execute(
+                    "SELECT count(*) FROM offscreen_narrations "
+                    "WHERE resolution_id = %s",
+                    (resolution_id,),
+                )
+                assert int(cur.fetchone()[0]) == 0
+        finally:
+            conn.close()
+
+
+def test_completion_locks_world_layer_before_comparing_anchor() -> None:
+    """A concurrent layer update wins before completion and rejects stale prose."""
+
+    with _disposable_narration_db() as dbname:
+        conn = _connect(dbname)
+        try:
+            with conn:
+                resolution_id, anchor_chunk = _materialize_pending_resolution(
+                    conn, label="layer-lock"
+                )
+            _enqueue(conn, resolution_id)
+        finally:
+            conn.close()
+
+        provider = _BlockingProvider()
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            completion = executor.submit(_drain, dbname, provider)
+            assert provider.started.wait(timeout=10)
+
+            layer_writer = _connect(dbname)
+            try:
+                with layer_writer.cursor() as cur:
+                    cur.execute(
+                        "UPDATE chunk_metadata SET world_layer = 'flashback' "
+                        "WHERE chunk_id = %s",
+                        (anchor_chunk,),
+                    )
+                    assert cur.rowcount == 1
+                provider.release.set()
+                assert Event().wait(timeout=0.2) is False
+                assert not completion.done()
+                layer_writer.commit()
+            finally:
+                layer_writer.close()
+
+            assert completion.result(timeout=10) == (0, 1)
+
+        conn = _connect(dbname)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT j.state::text, cm.world_layer::text, count(n.id) "
+                    "FROM orrery_narration_jobs AS j "
+                    "JOIN orrery_resolutions AS r ON r.id = j.resolution_id "
+                    "JOIN chunk_metadata AS cm ON cm.chunk_id = r.tick_chunk_id "
+                    "LEFT JOIN offscreen_narrations AS n "
+                    "ON n.resolution_id = r.id "
+                    "WHERE r.id = %s "
+                    "GROUP BY j.state, cm.world_layer",
+                    (resolution_id,),
+                )
+                assert cur.fetchone() == ("stale_rejected", "flashback", 0)
+        finally:
+            conn.close()
+
+
+def test_completion_clock_counts_time_blocked_on_job_lock() -> None:
+    """A lease that expires during lock wait cannot complete with stale now()."""
+
+    with _disposable_narration_db() as dbname:
+        conn = _connect(dbname)
+        try:
+            with conn:
+                resolution_id, _ = _materialize_pending_resolution(
+                    conn, label="wall-clock-expiry"
+                )
+            _enqueue(conn, resolution_id)
+        finally:
+            conn.close()
+
+        provider = _BlockingProvider()
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            completion = executor.submit(
+                _drain,
+                dbname,
+                provider,
+                lease_duration_seconds=1,
+            )
+            assert provider.started.wait(timeout=10)
+
+            job_locker = _connect(dbname)
+            try:
+                with job_locker.cursor() as cur:
+                    cur.execute(
+                        "SELECT id FROM orrery_narration_jobs "
+                        "WHERE resolution_id = %s FOR UPDATE",
+                        (resolution_id,),
+                    )
+                    assert cur.fetchone() is not None
+                provider.release.set()
+                assert Event().wait(timeout=1.2) is False
+                job_locker.commit()
+            finally:
+                job_locker.close()
+
+            assert completion.result(timeout=10) == (0, 1)
+
+        conn = _connect(dbname)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT state::text, lease_until < clock_timestamp() "
+                    "FROM orrery_narration_jobs WHERE resolution_id = %s",
+                    (resolution_id,),
+                )
+                assert cur.fetchone() == ("leased", True)
                 cur.execute(
                     "SELECT count(*) FROM offscreen_narrations "
                     "WHERE resolution_id = %s",

--- a/tests/test_orrery/test_narration_job_fencing_pg.py
+++ b/tests/test_orrery/test_narration_job_fencing_pg.py
@@ -1,0 +1,405 @@
+"""Real-PostgreSQL narration job fencing regressions for issue #676."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+import os
+from pathlib import Path
+from threading import Event
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2
+from psycopg2 import sql
+from psycopg2.errors import UniqueViolation
+import pytest
+
+from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.agents.orrery.resolver import OrreryResolutionDraft, OrreryTickProposal
+from nexus.agents.orrery.worker import (
+    drain_narration_outbox_sync,
+    promote_pending_resolutions_sync,
+)
+
+
+pytestmark = pytest.mark.requires_postgres
+
+ROOT = Path(__file__).parents[2]
+MIGRATION_SQL = (ROOT / "migrations" / "102_narration_job_fencing.sql").read_text()
+
+
+class _ProviderResponse:
+    content = "The courier slips through the rain and disappears below the viaduct."
+
+
+class _ImmediateProvider:
+    """Deterministic provider double used after the genuine database lease."""
+
+    def get_completion(self, _prompt: str) -> _ProviderResponse:
+        return _ProviderResponse()
+
+
+class _BlockingProvider:
+    """Provider double that holds one worker outside its lease transaction."""
+
+    def __init__(self) -> None:
+        self.started = Event()
+        self.release = Event()
+
+    def get_completion(self, _prompt: str) -> _ProviderResponse:
+        self.started.set()
+        if not self.release.wait(timeout=10):
+            raise TimeoutError("test did not release the original narration worker")
+        return _ProviderResponse()
+
+
+def _connect(dbname: str) -> Any:
+    """Open a PostgreSQL connection to a disposable issue-676 clone."""
+
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+        connect_timeout=2,
+    )
+
+
+@contextmanager
+def _disposable_narration_db() -> Iterator[str]:
+    """Yield a migrated NEXUS_template clone and always drop it afterward."""
+
+    dbname = f"qa676_{uuid4().hex[:12]}"
+    source_db = os.environ.get("NEXUS_TEST_TEMPLATE_DB", "NEXUS_template")
+    assert source_db == "NEXUS_template" or source_db.startswith("qa676_")
+    admin: Any = None
+    try:
+        try:
+            admin = _connect("postgres")
+        except psycopg2.Error as exc:
+            pytest.skip(f"PostgreSQL admin connection unavailable: {exc}")
+        admin.autocommit = True
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier(source_db),
+                )
+            )
+        conn = _connect(dbname)
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(MIGRATION_SQL)
+        finally:
+            conn.close()
+        yield dbname
+    finally:
+        if admin is not None:
+            with admin.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = %s AND pid <> pg_backend_pid()",
+                    (dbname,),
+                )
+                cur.execute(
+                    sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+                )
+            admin.close()
+
+
+def _settings() -> dict[str, Any]:
+    """Return deterministic narration worker settings for database tests."""
+
+    return {
+        "orrery": {
+            "narration": {
+                "provider": "anthropic",
+                "model_ref": "test-narrator",
+                "max_attempts": 3,
+                "retry_delay_seconds": 0,
+                "lease_duration_seconds": 60,
+                "max_jobs_per_drain": 5,
+            },
+            "promote": {
+                "priority_threshold": 30.0,
+                "magnitude_threshold": 0.35,
+                "perceptual_summary_max_chars": 240,
+            },
+        }
+    }
+
+
+def _insert_chunk(cur: Any, label: str, *, world_layer: str = "primary") -> int:
+    """Insert one real narrative anchor and its timeline metadata."""
+
+    cur.execute(
+        "INSERT INTO narrative_chunks (raw_text, storyteller_text) "
+        "VALUES (%s, %s) RETURNING id",
+        (label, label),
+    )
+    chunk_id = int(cur.fetchone()[0])
+    cur.execute(
+        "INSERT INTO chunk_metadata (chunk_id, world_layer) VALUES (%s, %s)",
+        (chunk_id, world_layer),
+    )
+    return chunk_id
+
+
+def _materialize_pending_resolution(conn: Any, *, label: str) -> tuple[int, int]:
+    """Commit a real Orrery proposal at a narrative chunk anchor."""
+
+    with conn.cursor() as cur:
+        chunk_id = _insert_chunk(cur, f"Issue 676 anchor: {label}")
+        cur.execute("INSERT INTO entities (kind) VALUES ('character') RETURNING id")
+        actor_id = int(cur.fetchone()[0])
+        cur.execute(
+            "INSERT INTO characters (name, entity_id) VALUES (%s, %s)",
+            (f"Courier {label}", actor_id),
+        )
+
+    binding_hash = f"issue-676-{label}-{uuid4()}"
+    draft = OrreryResolutionDraft(
+        template_id="hide",
+        priority=80,
+        binding_hash=binding_hash,
+        bindings={"actor": actor_id},
+        binding_names={"actor": f"Courier {label}"},
+        branch_label="Issue 676 narration fencing probe",
+        narrative_stub="{actor} disappears below the viaduct.",
+        magnitude=0.72,
+    )
+    proposal = OrreryTickProposal(
+        anchor_chunk_id=chunk_id,
+        actor_count=1,
+        resolutions=(draft,),
+    )
+    result = commit_orrery_tick_sync(
+        conn,
+        proposal,
+        tick_chunk_id=chunk_id,
+        slot=676,
+    )
+    assert result.resolution_count == 1
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM orrery_resolutions WHERE binding_hash = %s",
+            (binding_hash,),
+        )
+        return int(cur.fetchone()[0]), chunk_id
+
+
+def _enqueue(conn: Any, resolution_id: int) -> None:
+    """Drive the public promotion entry point and prove it enqueued the target."""
+
+    promoted, skipped = promote_pending_resolutions_sync(
+        slot=676,
+        settings=_settings(),
+        conn=conn,
+    )
+    assert (promoted, skipped) == (1, 0)
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM orrery_narration_jobs WHERE resolution_id = %s",
+            (resolution_id,),
+        )
+        assert int(cur.fetchone()[0]) == 1
+
+
+def _drain(dbname: str, provider: Any) -> tuple[int, int]:
+    """Run the public narration drain with its own worker connection."""
+
+    conn = _connect(dbname)
+    try:
+        return drain_narration_outbox_sync(
+            slot=676,
+            settings=_settings(),
+            narration_provider=provider,
+            conn=conn,
+        )
+    finally:
+        conn.close()
+
+
+def test_duplicate_enqueue_collapses_to_one_effective_job() -> None:
+    """Repeated genuine promotion delivery cannot create a second active job."""
+
+    with _disposable_narration_db() as dbname:
+        conn = _connect(dbname)
+        try:
+            with conn:
+                resolution_id, _ = _materialize_pending_resolution(
+                    conn, label="duplicate-enqueue"
+                )
+            _enqueue(conn, resolution_id)
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE orrery_resolutions "
+                        "SET promotion_status = 'pending' WHERE id = %s",
+                        (resolution_id,),
+                    )
+            _enqueue(conn, resolution_id)
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT count(*) FROM orrery_narration_jobs "
+                    "WHERE resolution_id = %s AND superseded_at IS NULL",
+                    (resolution_id,),
+                )
+                assert int(cur.fetchone()[0]) == 1
+        finally:
+            conn.close()
+
+
+def test_expired_lease_reclaimed_and_original_completion_fenced() -> None:
+    """A reclaimer wins once and the original owner's late output is rejected."""
+
+    with _disposable_narration_db() as dbname:
+        conn = _connect(dbname)
+        try:
+            with conn:
+                resolution_id, _ = _materialize_pending_resolution(
+                    conn, label="expired-lease"
+                )
+            _enqueue(conn, resolution_id)
+        finally:
+            conn.close()
+
+        original_provider = _BlockingProvider()
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            original = executor.submit(_drain, dbname, original_provider)
+            assert original_provider.started.wait(timeout=10)
+
+            conn = _connect(dbname)
+            try:
+                with conn:
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "UPDATE orrery_narration_jobs "
+                            "SET lease_until = now() - interval '1 second' "
+                            "WHERE resolution_id = %s AND state = 'leased'",
+                            (resolution_id,),
+                        )
+                        assert cur.rowcount == 1
+            finally:
+                conn.close()
+
+            reclaimed = executor.submit(_drain, dbname, _ImmediateProvider())
+            assert reclaimed.result(timeout=10) == (1, 0)
+            original_provider.release.set()
+            assert original.result(timeout=10) == (0, 1)
+
+        conn = _connect(dbname)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT state::text, attempts, locked_by, lease_nonce "
+                    "FROM orrery_narration_jobs WHERE resolution_id = %s",
+                    (resolution_id,),
+                )
+                assert cur.fetchone() == ("succeeded", 2, None, None)
+                cur.execute(
+                    "SELECT count(*) FROM offscreen_narrations "
+                    "WHERE resolution_id = %s",
+                    (resolution_id,),
+                )
+                assert int(cur.fetchone()[0]) == 1
+        finally:
+            conn.close()
+
+
+def test_stale_anchor_completion_is_terminally_rejected() -> None:
+    """A resolution retargeted after enqueue cannot publish generated prose."""
+
+    with _disposable_narration_db() as dbname:
+        conn = _connect(dbname)
+        try:
+            with conn:
+                resolution_id, original_chunk = _materialize_pending_resolution(
+                    conn, label="stale-anchor"
+                )
+            _enqueue(conn, resolution_id)
+            with conn:
+                with conn.cursor() as cur:
+                    replacement_chunk = _insert_chunk(
+                        cur, "Replacement timeline anchor"
+                    )
+                    cur.execute(
+                        "UPDATE orrery_resolutions "
+                        "SET tick_chunk_id = %s WHERE id = %s",
+                        (replacement_chunk, resolution_id),
+                    )
+        finally:
+            conn.close()
+
+        assert _drain(dbname, _ImmediateProvider()) == (0, 1)
+
+        conn = _connect(dbname)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT state::text, anchor_tick_chunk_id, last_error "
+                    "FROM orrery_narration_jobs WHERE resolution_id = %s",
+                    (resolution_id,),
+                )
+                state, anchor_chunk, error = cur.fetchone()
+                assert state == "stale_rejected"
+                assert int(anchor_chunk) == original_chunk
+                assert "anchor changed" in error
+                cur.execute(
+                    "SELECT count(*) FROM offscreen_narrations "
+                    "WHERE resolution_id = %s",
+                    (resolution_id,),
+                )
+                assert int(cur.fetchone()[0]) == 0
+        finally:
+            conn.close()
+
+
+def test_normal_narration_path_succeeds_once_end_to_end() -> None:
+    """The genuine enqueue, lease, and completion path remains successful."""
+
+    with _disposable_narration_db() as dbname:
+        conn = _connect(dbname)
+        try:
+            with conn:
+                resolution_id, _ = _materialize_pending_resolution(
+                    conn, label="normal-path"
+                )
+            _enqueue(conn, resolution_id)
+        finally:
+            conn.close()
+
+        assert _drain(dbname, _ImmediateProvider()) == (1, 0)
+
+        conn = _connect(dbname)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT j.state::text, r.narration_status::text, n.id "
+                    "FROM orrery_narration_jobs AS j "
+                    "JOIN orrery_resolutions AS r ON r.id = j.resolution_id "
+                    "JOIN offscreen_narrations AS n ON n.resolution_id = r.id "
+                    "WHERE r.id = %s",
+                    (resolution_id,),
+                )
+                state, narration_status, _narration_id = cur.fetchone()
+                assert (state, narration_status) == ("succeeded", "succeeded")
+
+            with pytest.raises(UniqueViolation):
+                with conn:
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            """
+                            INSERT INTO offscreen_narrations (
+                                resolution_id, tick_chunk_id, text
+                            )
+                            SELECT id, tick_chunk_id, 'duplicate output'
+                            FROM orrery_resolutions
+                            WHERE id = %s
+                            """,
+                            (resolution_id,),
+                        )
+        finally:
+            conn.close()

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -31,6 +31,8 @@ class WorkerCursor:
         self.executed = []
         self._fetchall = []
         self._fetchone = None
+        self.rowcount = 0
+        self.current_lease = None
 
     def __enter__(self):
         return self
@@ -42,6 +44,7 @@ class WorkerCursor:
         self.executed.append((sql, params))
         self._fetchall = []
         self._fetchone = None
+        self.rowcount = 0
         normalized = " ".join(str(sql).split())
         if "AS non_terminal_jobs" in normalized:
             self._fetchone = {
@@ -59,8 +62,33 @@ class WorkerCursor:
             self._fetchall = self.promotion_rows
         elif "FROM orrery_narration_jobs j" in normalized:
             self._fetchall = self.job_rows
+        elif "SET state = 'leased'" in normalized:
+            self.current_lease = {
+                "locked_by": params[1],
+                "lease_nonce": params[2],
+            }
+            self.rowcount = 1
+        elif "/* orrery:narration:complete_fence */" in normalized:
+            job = self.job_rows[0]
+            self._fetchone = {
+                "state": "leased",
+                "locked_by": self.current_lease["locked_by"],
+                "lease_nonce": self.current_lease["lease_nonce"],
+                "lease_is_current": True,
+                "anchor_tick_chunk_id": job["anchor_tick_chunk_id"],
+                "anchor_world_layer": job["anchor_world_layer"],
+                "current_tick_chunk_id": job["anchor_tick_chunk_id"],
+                "current_world_layer": job["anchor_world_layer"],
+                "anchor_exists": True,
+            }
         elif "INSERT INTO offscreen_narrations" in normalized:
             self._fetchone = {"id": 501}
+            self.rowcount = 1
+        elif "RETURNING id" in normalized:
+            self._fetchone = {"id": self.job_rows[0]["job_id"]}
+            self.rowcount = 1
+        elif "UPDATE orrery_narration_jobs" in normalized:
+            self.rowcount = 1
 
     def fetchall(self):
         return self._fetchall
@@ -165,6 +193,8 @@ def _job_row():
         "event_ids": [20],
         "attempts": 0,
         "world_layer": "primary",
+        "anchor_tick_chunk_id": 100,
+        "anchor_world_layer": "primary",
     }
 
 
@@ -347,9 +377,12 @@ def test_drain_narration_outbox_does_not_lease_before_provider_ready() -> None:
             conn=WorkerConn(cursor),
         )
 
-    statements = "\n".join(sql for sql, _params in cursor.executed)
-
-    assert "state = 'leased'" not in statements
+    lease_updates = [
+        sql
+        for sql, _params in cursor.executed
+        if "UPDATE orrery_narration_jobs" in sql and "SET state = 'leased'" in sql
+    ]
+    assert lease_updates == []
 
 
 def test_drain_narration_outbox_requeues_transient_failures() -> None:
@@ -486,7 +519,7 @@ def test_process_orrery_outbox_includes_semantic_clearance(monkeypatch) -> None:
 def test_load_orrery_status_sync_counts_background_work() -> None:
     """Status snapshots expose the background-work backlog."""
 
-    cursor = WorkerCursor(count_rows=[1, 2, 3, 4, 5, 6, 7, 8, 9])
+    cursor = WorkerCursor(count_rows=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
     status = load_orrery_status_sync(conn=WorkerConn(cursor))
 
@@ -498,8 +531,9 @@ def test_load_orrery_status_sync_counts_background_work() -> None:
     assert status.queued_narration_jobs == 2
     assert status.leased_narration_jobs == 3
     assert status.failed_narration_jobs == 4
-    assert status.pending_offscreen_embeddings == 5
-    assert status.failed_offscreen_embeddings == 6
-    assert status.active_semantic_tags == 7
-    assert status.recent_resolutions == 8
-    assert status.recent_narrations == 9
+    assert status.stale_rejected_narration_jobs == 5
+    assert status.pending_offscreen_embeddings == 6
+    assert status.failed_offscreen_embeddings == 7
+    assert status.active_semantic_tags == 8
+    assert status.recent_resolutions == 9
+    assert status.recent_narrations == 10

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -74,13 +74,17 @@ class WorkerCursor:
                 "state": "leased",
                 "locked_by": self.current_lease["locked_by"],
                 "lease_nonce": self.current_lease["lease_nonce"],
-                "lease_is_current": True,
                 "anchor_tick_chunk_id": job["anchor_tick_chunk_id"],
                 "anchor_world_layer": job["anchor_world_layer"],
                 "current_tick_chunk_id": job["anchor_tick_chunk_id"],
-                "current_world_layer": job["anchor_world_layer"],
                 "anchor_exists": True,
             }
+        elif "/* orrery:narration:anchor_fence */" in normalized:
+            self._fetchone = {
+                "current_world_layer": self.job_rows[0]["anchor_world_layer"]
+            }
+        elif normalized.startswith("SELECT lease_until > clock_timestamp()"):
+            self._fetchone = {"lease_is_current": True}
         elif "INSERT INTO offscreen_narrations" in normalized:
             self._fetchone = {"id": 501}
             self.rowcount = 1
@@ -358,6 +362,11 @@ def test_drain_narration_outbox_persists_offscreen_narration() -> None:
     assert failed == 0
     assert provider.prompts
     assert "FOR UPDATE OF j SKIP LOCKED" in statements
+    assert "/* orrery:narration:anchor_fence */" in statements
+    assert "FOR SHARE" in statements
+    assert "clock_timestamp()" in statements
+    assert "lease_until > now()" not in statements
+    assert "lease_until < now()" not in statements
     assert "INSERT INTO offscreen_narrations" in statements
     assert "narration_status = 'succeeded'" in statements
     assert "state = 'succeeded'" in statements
@@ -402,7 +411,8 @@ def test_drain_narration_outbox_requeues_transient_failures() -> None:
     assert narrated == 0
     assert failed == 1
     assert "state = 'queued'" in statements
-    assert "available_at = now() + (%s * interval '1 second')" in statements
+    assert "available_at = clock_timestamp()" in statements
+    assert "+ (%s * interval '1 second')" in statements
     assert "narration_status = 'queued'" in statements
     assert "narration_status = 'failed'" not in statements
 


### PR DESCRIPTION
Closes #676.

Implements the issue's full design space as one coherent fencing model (the concerns compose — lease recovery without completion fencing would double-commit):

- **Owner + nonce fencing**: every acquired or reclaimed lease gets a fresh UUID nonce; success/failure writes prove current ownership, leased state, and unexpired lease under row locks.
- **Reclamation**: expired leases are reclaimed atomically on drain (retrograde-maturation precedent, strengthened with the nonce fence) — exactly one winner; the original worker's late completion is rejected.
- **Anchor freshness**: completion re-verifies the enqueued tick chunk + world layer; mismatch → terminal `stale_rejected` with reason, no output.
- **DB uniqueness**: one non-superseded job per resolution (partial), one narration output per resolution (unconditional); conflict-safe enqueue.
- **Config**: lease seconds + drain bounds in `nexus.toml`, Pydantic-validated.

PG suite drives the real enqueue/lease/complete paths: duplicate enqueue collapse, reclaim + stale-completion rejection, stale-anchor rejection, normal path green. mypy + flake8 clean. This is the durability substrate #677's experience-render jobs will ride.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG