### PR TITLE
Move Bleed Density to Config and Measure Bleed Uptake at Commit

### DIFF
--- a/migrations/103_bleed_uptake.sql
+++ b/migrations/103_bleed_uptake.sql
@@ -1,0 +1,9 @@
+ALTER TABLE orrery_resolutions
+    ADD COLUMN used_chunk_id bigint REFERENCES narrative_chunks(id),
+    ADD COLUMN use_count integer NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN orrery_resolutions.used_chunk_id IS
+    'Most recent accepted narrative chunk that used this offered Bleed resolution, detected by exact actor-name uptake.';
+
+COMMENT ON COLUMN orrery_resolutions.use_count IS
+    'Cumulative number of accepted narrative chunks that used this offered Bleed resolution by exact actor-name uptake.';

--- a/nexus.toml
+++ b/nexus.toml
@@ -518,6 +518,7 @@ model_ref = "@anthropic.default"
 #   retry_delay_seconds — backoff between attempts (default 300)
 
 [orrery.bleed]
+density = 0.20
 max_candidates = 3
 near_distance_max = 2
 reserved_remote_slots = 1

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -2276,7 +2276,8 @@ class LogonUtility:
                 "These are optional ambient peripherals from off-screen events. "
                 "Ignore freely, render subtly, or use them at any density that "
                 "fits the current scene. If you use one with an actor name, "
-                "include that exact name at least once in the prose. Do not "
+                "include that exact name at least once in the prose — uptake is "
+                "detected by matching that exact name. Do not "
                 "explain Orrery."
             )
             for item in bleed_menu[:5]:

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -1351,6 +1351,7 @@ class TurnCycleManager:
                 session,
                 anchor_chunk_id=anchor_chunk_id,
                 anchor_entity_ids=anchor_entity_ids,
+                density=bleed_settings.density,
                 max_candidates=max_candidates,
                 near_distance_max=bleed_settings.near_distance_max,
                 reserved_remote_slots=bleed_settings.reserved_remote_slots,

--- a/nexus/agents/orrery/bleed.py
+++ b/nexus/agents/orrery/bleed.py
@@ -7,12 +7,17 @@ from dataclasses import dataclass
 from decimal import Decimal
 import json
 import logging
+import re
 from typing import Any, Iterable, Mapping, Optional, Tuple
 
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 
+from nexus.agents.orrery.substrate import seeded_stochastic_rng
+
 logger = logging.getLogger("nexus.orrery.bleed")
+
+_WORD_RE = re.compile(r"\b\w+\b", re.UNICODE)
 
 _BLEED_GRAPH_NODES_SQL = """
     /* orrery:bleed_proximity_nodes */
@@ -215,12 +220,21 @@ def load_bleed_candidates(
     session: Any,
     *,
     anchor_chunk_id: int,
+    density: float,
     limit: Optional[int],
 ) -> list[BleedCandidate]:
     """Load narrated Orrery candidates that are eligible before the anchor."""
 
     if limit is not None and limit <= 0:
         return []
+    if not 0.0 <= density <= 1.0:
+        raise ValueError(f"Bleed density must be between 0.0 and 1.0, got {density}")
+    if density == 0.0:
+        return []
+    if density < 1.0:
+        rng = seeded_stochastic_rng("bleed", anchor_chunk_id, "density")
+        if rng.random() >= density:
+            return []
 
     limit_clause = "LIMIT :limit" if limit is not None else ""
     rows = session.execute(
@@ -239,7 +253,9 @@ def load_bleed_candidates(
                 n.perceptual_descriptor,
                 actor.name AS actor_name,
                 target.name AS target_name,
-                we.event_type
+                we.event_type,
+                r.offer_count,
+                r.use_count
             FROM orrery_resolutions r
             JOIN offscreen_narrations n ON n.id = r.narration_chunk_id
             LEFT JOIN entity_names_v actor ON actor.id = r.actor_entity_id
@@ -259,7 +275,8 @@ def load_bleed_candidates(
                  OR r.last_offered_chunk_id <> :anchor_chunk_id
               )
               AND r.offer_count < 3
-            ORDER BY r.tick_chunk_id DESC,
+            ORDER BY (r.offer_count >= 2 AND r.use_count = 0) ASC,
+                     r.tick_chunk_id DESC,
                      r.magnitude DESC NULLS LAST,
                      r.priority DESC,
                      r.id DESC
@@ -280,6 +297,7 @@ def select_bleed_menu(
     *,
     anchor_chunk_id: int,
     anchor_entity_ids: Iterable[int],
+    density: float,
     max_candidates: int,
     near_distance_max: int,
     reserved_remote_slots: int,
@@ -296,6 +314,7 @@ def select_bleed_menu(
     candidate_pool = load_bleed_candidates(
         session,
         anchor_chunk_id=anchor_chunk_id,
+        density=density,
         # The empty-anchor fallback needs only the top of the pure ordering;
         # the proximity path partitions a bounded scan window (scan_limit).
         limit=max_candidates if not anchors else scan_limit,
@@ -391,6 +410,153 @@ def record_bleed_offers(
         },
     )
     session.commit()
+
+
+def four_gram_overlap_ratio(stub_text: str, accepted_text: str) -> float:
+    """Return the share of offered-stub 4-grams present in accepted prose."""
+
+    stub_words = [word.casefold() for word in _WORD_RE.findall(stub_text)]
+    accepted_words = [word.casefold() for word in _WORD_RE.findall(accepted_text)]
+    stub_grams = {
+        tuple(stub_words[index : index + 4])
+        for index in range(max(0, len(stub_words) - 3))
+    }
+    if not stub_grams:
+        return 0.0
+    accepted_grams = {
+        tuple(accepted_words[index : index + 4])
+        for index in range(max(0, len(accepted_words) - 3))
+    }
+    return len(stub_grams & accepted_grams) / len(stub_grams)
+
+
+def record_bleed_uptake_sync(
+    conn: Any,
+    *,
+    offered_anchor_chunk_id: int,
+    accepted_chunk_id: int,
+    accepted_text: str,
+) -> int:
+    """Stamp exact-name uptake for Bleed offers used by an accepted chunk."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            /* orrery:bleed_uptake_candidates */
+            SELECT r.id, actor.name AS actor_name, n.text AS stub_text
+            FROM orrery_resolutions r
+            JOIN offscreen_narrations n ON n.id = r.narration_chunk_id
+            LEFT JOIN entity_names_v actor ON actor.id = r.actor_entity_id
+            WHERE r.last_offered_chunk_id = %s
+            ORDER BY r.id
+            """,
+            (offered_anchor_chunk_id,),
+        )
+        rows = cur.fetchall()
+
+    used_count = 0
+    for row in rows:
+        resolution_id = int(_row_value(row, "id", 0))
+        actor_name = _row_value(row, "actor_name", 1)
+        stub_text = str(_row_value(row, "stub_text", 2) or "")
+        name_matched = bool(actor_name and str(actor_name) in accepted_text)
+        overlap_ratio = four_gram_overlap_ratio(stub_text, accepted_text)
+        logger.info(
+            "Measured Orrery Bleed uptake",
+            extra={
+                "event": "orrery_bleed_uptake",
+                "resolution_id": resolution_id,
+                "offered_anchor_chunk_id": offered_anchor_chunk_id,
+                "accepted_chunk_id": accepted_chunk_id,
+                "actor_name": actor_name,
+                "name_matched": name_matched,
+                "four_gram_overlap_ratio": overlap_ratio,
+            },
+        )
+        if not name_matched:
+            continue
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                /* orrery:stamp_bleed_uptake */
+                UPDATE orrery_resolutions
+                SET used_chunk_id = %s,
+                    use_count = use_count + 1
+                WHERE id = %s
+                """,
+                (accepted_chunk_id, resolution_id),
+            )
+        used_count += 1
+    return used_count
+
+
+async def record_bleed_uptake_async(
+    conn: Any,
+    *,
+    offered_anchor_chunk_id: int,
+    accepted_chunk_id: int,
+    accepted_text: str,
+) -> int:
+    """Async stamp of exact-name uptake for offers used by an accepted chunk."""
+
+    rows = await conn.fetch(
+        """
+        /* orrery:bleed_uptake_candidates */
+        SELECT r.id, actor.name AS actor_name, n.text AS stub_text
+        FROM orrery_resolutions r
+        JOIN offscreen_narrations n ON n.id = r.narration_chunk_id
+        LEFT JOIN entity_names_v actor ON actor.id = r.actor_entity_id
+        WHERE r.last_offered_chunk_id = $1
+        ORDER BY r.id
+        """,
+        offered_anchor_chunk_id,
+    )
+
+    used_count = 0
+    for row in rows:
+        resolution_id = int(_row_value(row, "id", 0))
+        actor_name = _row_value(row, "actor_name", 1)
+        stub_text = str(_row_value(row, "stub_text", 2) or "")
+        name_matched = bool(actor_name and str(actor_name) in accepted_text)
+        overlap_ratio = four_gram_overlap_ratio(stub_text, accepted_text)
+        logger.info(
+            "Measured Orrery Bleed uptake",
+            extra={
+                "event": "orrery_bleed_uptake",
+                "resolution_id": resolution_id,
+                "offered_anchor_chunk_id": offered_anchor_chunk_id,
+                "accepted_chunk_id": accepted_chunk_id,
+                "actor_name": actor_name,
+                "name_matched": name_matched,
+                "four_gram_overlap_ratio": overlap_ratio,
+            },
+        )
+        if not name_matched:
+            continue
+        await conn.execute(
+            """
+            /* orrery:stamp_bleed_uptake */
+            UPDATE orrery_resolutions
+            SET used_chunk_id = $1,
+                use_count = use_count + 1
+            WHERE id = $2
+            """,
+            accepted_chunk_id,
+            resolution_id,
+        )
+        used_count += 1
+    return used_count
+
+
+def _row_value(row: Any, key: str, index: int) -> Any:
+    """Read one field from mapping-like or positional DB rows."""
+
+    if isinstance(row, Mapping):
+        return row[key]
+    try:
+        return row[key]
+    except (KeyError, TypeError):
+        return row[index]
 
 
 def _candidate_from_row(row: Mapping[str, Any]) -> BleedCandidate:

--- a/nexus/agents/orrery/bleed.py
+++ b/nexus/agents/orrery/bleed.py
@@ -275,8 +275,7 @@ def load_bleed_candidates(
                  OR r.last_offered_chunk_id <> :anchor_chunk_id
               )
               AND r.offer_count < 3
-            ORDER BY (r.offer_count >= 2 AND r.use_count = 0) ASC,
-                     r.tick_chunk_id DESC,
+            ORDER BY r.tick_chunk_id DESC,
                      r.magnitude DESC NULLS LAST,
                      r.priority DESC,
                      r.id DESC
@@ -289,7 +288,14 @@ def load_bleed_candidates(
         },
     ).mappings()
 
-    return [_candidate_from_row(row) for row in rows]
+    bounded_rows = list(rows)
+    bounded_rows.sort(
+        key=lambda row: bool(
+            int(row.get("offer_count") or 0) >= 2
+            and int(row.get("use_count") or 0) == 0
+        )
+    )
+    return [_candidate_from_row(row) for row in bounded_rows]
 
 
 def select_bleed_menu(
@@ -433,12 +439,15 @@ def four_gram_overlap_ratio(stub_text: str, accepted_text: str) -> float:
 def record_bleed_uptake_sync(
     conn: Any,
     *,
-    offered_anchor_chunk_id: int,
+    resolution_ids: Iterable[int],
     accepted_chunk_id: int,
     accepted_text: str,
 ) -> int:
     """Stamp exact-name uptake for Bleed offers used by an accepted chunk."""
 
+    offered_resolution_ids = tuple(int(value) for value in resolution_ids)
+    if not offered_resolution_ids:
+        return 0
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -447,10 +456,10 @@ def record_bleed_uptake_sync(
             FROM orrery_resolutions r
             JOIN offscreen_narrations n ON n.id = r.narration_chunk_id
             LEFT JOIN entity_names_v actor ON actor.id = r.actor_entity_id
-            WHERE r.last_offered_chunk_id = %s
+            WHERE r.id = ANY(%s)
             ORDER BY r.id
             """,
-            (offered_anchor_chunk_id,),
+            (list(offered_resolution_ids),),
         )
         rows = cur.fetchall()
 
@@ -459,14 +468,13 @@ def record_bleed_uptake_sync(
         resolution_id = int(_row_value(row, "id", 0))
         actor_name = _row_value(row, "actor_name", 1)
         stub_text = str(_row_value(row, "stub_text", 2) or "")
-        name_matched = bool(actor_name and str(actor_name) in accepted_text)
+        name_matched = _actor_name_matches(actor_name, accepted_text)
         overlap_ratio = four_gram_overlap_ratio(stub_text, accepted_text)
         logger.info(
             "Measured Orrery Bleed uptake",
             extra={
                 "event": "orrery_bleed_uptake",
                 "resolution_id": resolution_id,
-                "offered_anchor_chunk_id": offered_anchor_chunk_id,
                 "accepted_chunk_id": accepted_chunk_id,
                 "actor_name": actor_name,
                 "name_matched": name_matched,
@@ -493,12 +501,15 @@ def record_bleed_uptake_sync(
 async def record_bleed_uptake_async(
     conn: Any,
     *,
-    offered_anchor_chunk_id: int,
+    resolution_ids: Iterable[int],
     accepted_chunk_id: int,
     accepted_text: str,
 ) -> int:
     """Async stamp of exact-name uptake for offers used by an accepted chunk."""
 
+    offered_resolution_ids = tuple(int(value) for value in resolution_ids)
+    if not offered_resolution_ids:
+        return 0
     rows = await conn.fetch(
         """
         /* orrery:bleed_uptake_candidates */
@@ -506,10 +517,10 @@ async def record_bleed_uptake_async(
         FROM orrery_resolutions r
         JOIN offscreen_narrations n ON n.id = r.narration_chunk_id
         LEFT JOIN entity_names_v actor ON actor.id = r.actor_entity_id
-        WHERE r.last_offered_chunk_id = $1
+        WHERE r.id = ANY($1::bigint[])
         ORDER BY r.id
         """,
-        offered_anchor_chunk_id,
+        list(offered_resolution_ids),
     )
 
     used_count = 0
@@ -517,14 +528,13 @@ async def record_bleed_uptake_async(
         resolution_id = int(_row_value(row, "id", 0))
         actor_name = _row_value(row, "actor_name", 1)
         stub_text = str(_row_value(row, "stub_text", 2) or "")
-        name_matched = bool(actor_name and str(actor_name) in accepted_text)
+        name_matched = _actor_name_matches(actor_name, accepted_text)
         overlap_ratio = four_gram_overlap_ratio(stub_text, accepted_text)
         logger.info(
             "Measured Orrery Bleed uptake",
             extra={
                 "event": "orrery_bleed_uptake",
                 "resolution_id": resolution_id,
-                "offered_anchor_chunk_id": offered_anchor_chunk_id,
                 "accepted_chunk_id": accepted_chunk_id,
                 "actor_name": actor_name,
                 "name_matched": name_matched,
@@ -546,6 +556,14 @@ async def record_bleed_uptake_async(
         )
         used_count += 1
     return used_count
+
+
+def _actor_name_matches(actor_name: Any, accepted_text: str) -> bool:
+    """Return whether prose contains the full case-sensitive actor name."""
+
+    if not actor_name:
+        return False
+    return re.search(rf"\b{re.escape(str(actor_name))}\b", accepted_text) is not None
 
 
 def _row_value(row: Any, key: str, index: int) -> Any:

--- a/nexus/agents/orrery/substrate.py
+++ b/nexus/agents/orrery/substrate.py
@@ -3011,10 +3011,10 @@ class PackageSelectionOutcome:
     reason: str = "no_passing_candidate"
 
 
-def _package_selection_rng(digest: str, tick: int) -> random.Random:
-    """PRNG keyed on binding identity, persisted tick, and a distinct salt."""
+def seeded_stochastic_rng(identity: str, tick: int, salt: str) -> random.Random:
+    """Return the shared deterministic PRNG for Orrery stochastic selection."""
 
-    seed_material = f"{digest}:{tick}:package_selection"
+    seed_material = f"{identity}:{tick}:{salt}"
     return random.Random(int(sha256(seed_material.encode("utf-8")).hexdigest(), 16))
 
 
@@ -3121,7 +3121,7 @@ def select_package(
         for _template, _resolution, effective_priority in window
     ]
     digest = binding_hash(bindings)
-    rng = _package_selection_rng(digest, state.current_tick)
+    rng = seeded_stochastic_rng(digest, state.current_tick, "package_selection")
     chosen = rng.choices(window, weights=weights, k=1)[0]
     return PackageSelectionOutcome(
         winner=chosen[1],

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -19,6 +19,7 @@ from nexus.agents.logon.apex_schema import (
     ReferencedEntities,
     StateUpdates,
 )
+from nexus.agents.orrery.bleed import record_bleed_uptake_async
 from nexus.agents.orrery.events import commit_orrery_tick_async
 from nexus.agents.orrery.reconstruction import (
     capture_state_checkpoint_async,
@@ -728,6 +729,18 @@ async def commit_incubator_to_database(
                 drift_settings=orrery_settings.get("drift"),
                 reveal_settings=orrery_settings.get("reveal"),
             )
+            bleed_used_count = await record_bleed_uptake_async(
+                conn,
+                offered_anchor_chunk_id=incubator["parent_chunk_id"],
+                accepted_chunk_id=chunk_id,
+                accepted_text=storyteller_text,
+            )
+            if bleed_used_count:
+                logger.info(
+                    "Stamped %s Orrery Bleed uptake rows for chunk %s",
+                    bleed_used_count,
+                    chunk_id,
+                )
             if (
                 orrery_result.resolution_count
                 or orrery_result.skipped_existing_count

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -48,7 +48,7 @@ from nexus.api.choice_handling import (
     normalize_choice_object,
     selected_text_from_choice_object,
 )
-from nexus.api.lore_adapter import compute_raw_text
+from nexus.api.lore_adapter import compute_raw_text, split_staged_orrery_payload
 
 logger = logging.getLogger("nexus.api.commit_handler")
 
@@ -707,9 +707,12 @@ async def commit_incubator_to_database(
 
             # Step 9.5: Commit Orrery proposal inside the accepted-chunk transaction
             orrery_settings = _load_orrery_settings()
+            staged_orrery_proposal, bleed_offer_resolution_ids = (
+                split_staged_orrery_payload(incubator.get("orrery_proposal"))
+            )
             orrery_result = await commit_orrery_tick_async(
                 conn,
-                incubator.get("orrery_proposal"),
+                staged_orrery_proposal,
                 tick_chunk_id=chunk_id,
                 slot=slot,
                 world_layer=world_layer,
@@ -721,7 +724,7 @@ async def commit_incubator_to_database(
                 mood_settings=orrery_settings.get("mood"),
                 epistemics_settings=(
                     orrery_settings.get("epistemics")
-                    if incubator.get("orrery_proposal") is None
+                    if staged_orrery_proposal is None
                     else None
                 ),
                 contagion_settings=orrery_settings.get("contagion"),
@@ -731,7 +734,7 @@ async def commit_incubator_to_database(
             )
             bleed_used_count = await record_bleed_uptake_async(
                 conn,
-                offered_anchor_chunk_id=incubator["parent_chunk_id"],
+                resolution_ids=bleed_offer_resolution_ids,
                 accepted_chunk_id=chunk_id,
                 accepted_text=storyteller_text,
             )

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -40,7 +40,7 @@ from nexus.api.summary_triggers import (
     plan_summary_tasks,
     schedule_summary_generation,
 )
-from nexus.api.lore_adapter import compute_raw_text
+from nexus.api.lore_adapter import compute_raw_text, split_staged_orrery_payload
 from nexus.memory.correspondence import (
     correspondence_settings,
     insert_digest_version,
@@ -575,9 +575,12 @@ def commit_incubator_to_database_sync(
 
             # Step 9.5: Commit Orrery proposal inside the accepted-chunk transaction
             orrery_settings = _load_orrery_settings()
+            staged_orrery_proposal, bleed_offer_resolution_ids = (
+                split_staged_orrery_payload(incubator.get("orrery_proposal"))
+            )
             orrery_result = commit_orrery_tick_sync(
                 conn,
-                incubator.get("orrery_proposal"),
+                staged_orrery_proposal,
                 tick_chunk_id=chunk_id,
                 slot=slot,
                 world_layer=world_layer,
@@ -589,7 +592,7 @@ def commit_incubator_to_database_sync(
                 mood_settings=orrery_settings.get("mood"),
                 epistemics_settings=(
                     orrery_settings.get("epistemics")
-                    if incubator.get("orrery_proposal") is None
+                    if staged_orrery_proposal is None
                     else None
                 ),
                 contagion_settings=orrery_settings.get("contagion"),
@@ -599,7 +602,7 @@ def commit_incubator_to_database_sync(
             )
             bleed_used_count = record_bleed_uptake_sync(
                 conn,
-                offered_anchor_chunk_id=incubator["parent_chunk_id"],
+                resolution_ids=bleed_offer_resolution_ids,
                 accepted_chunk_id=chunk_id,
                 accepted_text=storyteller_text,
             )

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -21,6 +21,7 @@ from nexus.agents.logon.apex_schema import (
     FactionReference,
     StateUpdates,
 )
+from nexus.agents.orrery.bleed import record_bleed_uptake_sync
 from nexus.agents.orrery.events import commit_orrery_tick_sync
 from nexus.agents.orrery.retrograde_maturation import (
     enqueue_declared_entity_maturations,
@@ -596,6 +597,18 @@ def commit_incubator_to_database_sync(
                 drift_settings=orrery_settings.get("drift"),
                 reveal_settings=orrery_settings.get("reveal"),
             )
+            bleed_used_count = record_bleed_uptake_sync(
+                conn,
+                offered_anchor_chunk_id=incubator["parent_chunk_id"],
+                accepted_chunk_id=chunk_id,
+                accepted_text=storyteller_text,
+            )
+            if bleed_used_count:
+                logger.info(
+                    "Stamped %s Orrery Bleed uptake rows for chunk %s",
+                    bleed_used_count,
+                    chunk_id,
+                )
             if (
                 orrery_result.resolution_count
                 or orrery_result.skipped_existing_count

--- a/nexus/api/lore_adapter.py
+++ b/nexus/api/lore_adapter.py
@@ -7,7 +7,8 @@ Handles conversion between structured Pydantic models and database JSONB fields.
 """
 
 import logging
-from typing import Dict, Any, Optional, List
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
 from nexus.agents.logon.apex_schema import StateUpdates, StoryTurnResponse
 from nexus.api.choice_handling import (
     ChoiceObject,
@@ -17,6 +18,8 @@ from nexus.api.choice_handling import (
 from nexus.memory.correspondence import GeneratedCorrespondence
 
 logger = logging.getLogger("nexus.api.lore_adapter")
+
+_BLEED_OFFER_MANIFEST_KEY = "_bleed_offer_resolution_ids"
 
 
 def _model_to_json_dict(model: Any) -> Dict[str, Any]:
@@ -126,6 +129,7 @@ def response_to_incubator(
     user_text: str,
     session_id: str,
     orrery_proposal: Optional[Any] = None,
+    bleed_offer_resolution_ids: Iterable[int] = (),
     correspondence: Optional[GeneratedCorrespondence] = None,
 ) -> Dict[str, Any]:
     """
@@ -137,6 +141,7 @@ def response_to_incubator(
         user_text: The user's input text
         session_id: Session ID for tracking
         orrery_proposal: Optional no-write Orrery proposal from TurnContext
+        bleed_offer_resolution_ids: Resolutions offered to this exact draft
 
     Returns:
         Dictionary formatted for incubator table insertion
@@ -168,7 +173,10 @@ def response_to_incubator(
         "metadata_updates": extract_metadata_updates(response),
         "entity_updates": extract_entity_updates(response),
         "reference_updates": extract_reference_updates(response),
-        "orrery_proposal": _serialize_orrery_proposal(orrery_proposal),
+        "orrery_proposal": _serialize_orrery_staging(
+            orrery_proposal,
+            bleed_offer_resolution_ids=bleed_offer_resolution_ids,
+        ),
         "orrery_adjudications": extract_orrery_adjudications(response),
         "new_entities": extract_new_entities(response),
         "correspondence_writer_letter": (
@@ -195,6 +203,57 @@ def _serialize_orrery_proposal(proposal: Optional[Any]) -> Optional[Dict[str, An
     if isinstance(proposal, dict):
         return proposal
     raise TypeError(f"Unsupported Orrery proposal type: {type(proposal).__name__}")
+
+
+def _serialize_orrery_staging(
+    proposal: Optional[Any],
+    *,
+    bleed_offer_resolution_ids: Iterable[int],
+) -> Dict[str, Any]:
+    """Stage an Orrery proposal and exact-draft Bleed manifest in one JSONB value."""
+
+    payload = _serialize_orrery_proposal(proposal) or {}
+    raw_resolution_ids = tuple(bleed_offer_resolution_ids)
+    if any(
+        isinstance(resolution_id, bool) or not isinstance(resolution_id, int)
+        for resolution_id in raw_resolution_ids
+    ):
+        raise ValueError("Bleed offer resolution ids must be integers")
+    resolution_ids = tuple(raw_resolution_ids)
+    if any(resolution_id <= 0 for resolution_id in resolution_ids):
+        raise ValueError("Bleed offer resolution ids must be positive integers")
+    if len(set(resolution_ids)) != len(resolution_ids):
+        raise ValueError("Bleed offer resolution ids must be unique")
+    return {
+        **payload,
+        _BLEED_OFFER_MANIFEST_KEY: list(resolution_ids),
+    }
+
+
+def split_staged_orrery_payload(
+    value: Optional[Mapping[str, Any]],
+) -> Tuple[Optional[Dict[str, Any]], Tuple[int, ...]]:
+    """Separate the canonical proposal from its exact-draft Bleed manifest."""
+
+    if value is None:
+        return None, ()
+    payload = dict(value)
+    raw_resolution_ids = payload.pop(_BLEED_OFFER_MANIFEST_KEY, None)
+    if raw_resolution_ids is None:
+        return payload or None, ()
+    if not isinstance(raw_resolution_ids, list):
+        raise ValueError("Staged Bleed offer manifest must be a JSON array")
+    if any(
+        isinstance(resolution_id, bool) or not isinstance(resolution_id, int)
+        for resolution_id in raw_resolution_ids
+    ):
+        raise ValueError("Staged Bleed offer manifest ids must be integers")
+    resolution_ids = tuple(raw_resolution_ids)
+    if any(resolution_id <= 0 for resolution_id in resolution_ids):
+        raise ValueError("Staged Bleed offer manifest ids must be positive")
+    if len(set(resolution_ids)) != len(resolution_ids):
+        raise ValueError("Staged Bleed offer manifest ids must be unique")
+    return payload or None, resolution_ids
 
 
 def extract_metadata_updates(response: StoryTurnResponse) -> Dict[str, Any]:

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -247,6 +247,16 @@ async def generate_narrative_async(
                     orrery_proposal=(
                         lore.turn_context.orrery_proposal if lore.turn_context else None
                     ),
+                    bleed_offer_resolution_ids=(
+                        (
+                            candidate.resolution_id
+                            for candidate in getattr(
+                                lore.turn_context, "bleed_menu", ()
+                            )
+                        )
+                        if lore.turn_context is not None
+                        else ()
+                    ),
                     correspondence=(
                         getattr(lore.turn_context, "private_correspondence", None)
                         if lore.turn_context is not None

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1288,6 +1288,14 @@ class OrreryBleedSettings(BaseModel):
         exclude=True,
         description="Deprecated and ignored; Bleed scans the eligible ordered pool.",
     )
+    density: float = Field(
+        default=0.20,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Per-anchor deterministic probability of offering Bleed candidates."
+        ),
+    )
     max_candidates: int = Field(default=3, ge=0)
     near_distance_max: int = Field(default=2, ge=0)
     reserved_remote_slots: int = Field(default=1, ge=0)

--- a/prompts/storyteller_core.md
+++ b/prompts/storyteller_core.md
@@ -102,7 +102,7 @@ Skald freely improvises new details — places, NPCs, factions, anything not in 
 
 The world outside the current scene keeps moving whether or not the camera turns. **Orrery** is the clockwork that does this work: off-screen characters pursue routines and schemes, factions shift, pressure accumulates — and its activity arrives in Skald's context as proposals and fresh resolutions. Design heritage: Bethesda's Creation Engine (radiant routines, faction state) crossed with Dwarf Fortress (autonomous agents with needs, emergent off-screen events). Skald can trust the clockwork to keep ticking and give the scene at hand undivided attention.
 
-**Let the world breathe through the prose.** Roughly 10–20% of off-screen activity should bleed into the narrative — a distant siren matching a faction's move, an unopened message from a character on the other side of the city, environmental change, a news fragment. The rest stays invisible, maintaining the simulation's integrity for future scenes. When the context shows imminent off-screen activity, let it inform the scene's texture and timing.
+**Let the world breathe through the prose.** Off-screen activity bleeds in as texture — a distant siren matching a faction's move, an unopened message from a character on the other side of the city, environmental change, a news fragment. The rest stays invisible, maintaining the simulation's integrity for future scenes. When the context shows imminent off-screen activity, let it inform the scene's texture and timing.
 
 ---
 

--- a/scripts/qa_shift/README.md
+++ b/scripts/qa_shift/README.md
@@ -129,6 +129,10 @@ validation classes from only the current gateway process's log slice. A
 recovered retry still represents real cost and latency; a novel class must still
 meet the normal repeatability standard before publication.
 
+`finish` also writes `bleed_uptake.json` with the cumulative-counter deltas for
+offered and exact-name-used resolutions plus the uptake rate between the
+shift's start and finish snapshots.
+
 The repair-tax percentage is unavailable when final OpenAI usage is unknown or
 a rejection came from an unexpected provider, because those events do not share
 a trustworthy OpenAI denominator. Preserve the attempts and token evidence, and

--- a/scripts/qa_shift/mission_report_template.md
+++ b/scripts/qa_shift/mission_report_template.md
@@ -31,10 +31,17 @@ Summarize both failures and negative results from `probe_ledger.md`.
 - Stable-rate comparison:
 - `skald_writer` #639 tripwire:
 
+## Bleed uptake
+
+- Offered resolutions in shift window:
+- Used resolutions in shift window:
+- Uptake rate:
+
 ## Preserved evidence
 
 - `gateway-8012.log`:
 - `rejection_ledger.json`:
+- `bleed_uptake.json`:
 - `save_04_before.dump`:
 - Promoted seed and manifest:
 - Additional payloads/traces:

--- a/scripts/qa_shift/qa_shift.py
+++ b/scripts/qa_shift/qa_shift.py
@@ -21,6 +21,9 @@ from typing import Any, Callable, Mapping, Sequence, cast
 
 import tomlkit
 
+from nexus.api.db_pool import get_connection
+from nexus.api.slot_utils import slot_dbname
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONFIG_PATH = Path(__file__).with_name("qa_shift.toml")
@@ -58,6 +61,7 @@ class ShiftConfig:
 
 UsageReader = Callable[[Path, str | None], dict[str, Any]]
 JobsReader = Callable[[Path, int], dict[str, Any]]
+BleedUptakeReader = Callable[[Path, int], dict[str, Any]]
 
 
 def _required_int(table: Mapping[str, Any], key: str) -> int:
@@ -190,6 +194,77 @@ def _read_jobs(repo_root: Path, slot: int) -> dict[str, Any]:
             f"`nexus jobs --slot {slot} --json` reported failure: {payload}"
         )
     return payload
+
+
+def _read_bleed_uptake(
+    _repo_root: Path,
+    slot: int,
+) -> dict[str, Any]:
+    """Read cumulative Bleed offer and uptake counters for one QA slot."""
+
+    with get_connection(slot_dbname(slot), dict_cursor=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    COALESCE(sum(offer_count), 0)::bigint AS offered_count,
+                    COALESCE(sum(use_count), 0)::bigint AS used_count
+                FROM orrery_resolutions
+                """,
+            )
+            row = cur.fetchone()
+    if row is None:
+        raise ShiftError("Bleed uptake query returned no summary row")
+    return dict(row)
+
+
+def _bleed_uptake_summary(
+    payload: Mapping[str, Any],
+    *,
+    baseline_offered_count: int,
+    baseline_used_count: int,
+    started_at: datetime,
+    ended_at: datetime,
+) -> dict[str, Any]:
+    """Validate and annotate one shift-window Bleed uptake summary."""
+
+    offered_count, used_count = _bleed_uptake_counts(payload)
+    if offered_count < baseline_offered_count or used_count < baseline_used_count:
+        raise ShiftError("Bleed uptake counters decreased during the shift")
+    shift_offered_count = offered_count - baseline_offered_count
+    shift_used_count = used_count - baseline_used_count
+    uptake_rate_percent = (
+        round(shift_used_count * 100 / shift_offered_count, 4)
+        if shift_offered_count
+        else 0.0
+    )
+    return {
+        "started_at": _utc_text(started_at),
+        "ended_at": _utc_text(ended_at),
+        "offered_count": shift_offered_count,
+        "used_count": shift_used_count,
+        "uptake_rate_percent": uptake_rate_percent,
+    }
+
+
+def _bleed_uptake_counts(payload: Mapping[str, Any]) -> tuple[int, int]:
+    """Validate cumulative Bleed counters from the QA slot."""
+
+    offered_count = payload.get("offered_count")
+    used_count = payload.get("used_count")
+    if (
+        isinstance(offered_count, bool)
+        or not isinstance(offered_count, int)
+        or offered_count < 0
+    ):
+        raise ShiftError("Bleed uptake offered_count must be a non-negative integer")
+    if (
+        isinstance(used_count, bool)
+        or not isinstance(used_count, int)
+        or used_count < 0
+    ):
+        raise ShiftError("Bleed uptake used_count must be a non-negative integer")
+    return offered_count, used_count
 
 
 def _usage_snapshot(payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -520,6 +595,7 @@ def begin_shift(
     repo_root: Path = REPO_ROOT,
     usage_reader: UsageReader = _read_usage,
     jobs_reader: JobsReader = _read_jobs,
+    bleed_uptake_reader: BleedUptakeReader = _read_bleed_uptake,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     """Create a shift archive, isolated config, and usage baseline."""
@@ -543,6 +619,9 @@ def begin_shift(
             "OpenAI daily usage has reached the configured token fence "
             f"({usage['total']:,} >= {config.token_fence:,})."
         )
+    baseline_bleed_offered, baseline_bleed_used = _bleed_uptake_counts(
+        bleed_uptake_reader(repo_root, config.slot)
+    )
 
     archive_root = config.archive_root
     if not archive_root.is_absolute():
@@ -580,6 +659,8 @@ def begin_shift(
         "last_event_count": len(usage["events"]),
         "last_unknown_usage_events": usage["unknown"],
         "baseline_failed_jobs": jobs["counts"]["failed"],
+        "baseline_bleed_offered_count": baseline_bleed_offered,
+        "baseline_bleed_used_count": baseline_bleed_used,
         "checks": 0,
         "max_command_delta": 0,
         "config": _config_payload(config),
@@ -594,6 +675,10 @@ def begin_shift(
         "daily_limit": config.daily_token_limit,
         "token_fence": config.token_fence,
         "tokens_before_fence": config.token_fence - usage["total"],
+        "bleed_uptake_baseline": {
+            "offered_count": baseline_bleed_offered,
+            "used_count": baseline_bleed_used,
+        },
         "jobs": jobs,
     }
     _append_jsonl(
@@ -850,6 +935,7 @@ def finish_shift(
     repo_root: Path = REPO_ROOT,
     usage_reader: UsageReader = _read_usage,
     jobs_reader: JobsReader = _read_jobs,
+    bleed_uptake_reader: BleedUptakeReader = _read_bleed_uptake,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     """Capture final usage and close the shift state."""
@@ -882,6 +968,15 @@ def finish_shift(
         shift_openai_total=shift_openai_total,
     )
     _atomic_write_json(archive / "rejection_ledger.json", rejection_ledger)
+    started_at = _parse_utc(str(state["started_at"]))
+    bleed_uptake = _bleed_uptake_summary(
+        bleed_uptake_reader(repo_root, slot),
+        baseline_offered_count=int(state["baseline_bleed_offered_count"]),
+        baseline_used_count=int(state["baseline_bleed_used_count"]),
+        started_at=started_at,
+        ended_at=current_time,
+    )
+    _atomic_write_json(archive / "bleed_uptake.json", bleed_uptake)
     final_state = dict(state)
     final_state.update(
         {
@@ -903,6 +998,7 @@ def finish_shift(
                 "repair_tax_percent_unavailable_reasons"
             ],
             "skald_writer_tripwire": rejection_ledger["skald_writer_tripwire"],
+            "bleed_uptake": bleed_uptake,
             "jobs": jobs,
             "usage_settled": usage_settled,
             "baseline_failed_jobs": baseline_failed_jobs,
@@ -926,6 +1022,8 @@ def finish_shift(
         ],
         "skald_writer_tripwire": rejection_ledger["skald_writer_tripwire"],
         "rejection_ledger": str(archive / "rejection_ledger.json"),
+        "bleed_uptake": bleed_uptake,
+        "bleed_uptake_report": str(archive / "bleed_uptake.json"),
         "archive": str(archive),
         "jobs": jobs,
         "usage_settled": usage_settled,

--- a/tests/test_api/test_lore_adapter.py
+++ b/tests/test_api/test_lore_adapter.py
@@ -5,7 +5,7 @@ from nexus.agents.logon.apex_schema import (
     StateUpdates,
     StorytellerResponseExtended,
 )
-from nexus.api.lore_adapter import response_to_incubator
+from nexus.api.lore_adapter import response_to_incubator, split_staged_orrery_payload
 
 
 def test_response_to_incubator_serializes_current_reference_schema() -> None:
@@ -93,6 +93,47 @@ def test_response_to_incubator_serializes_current_reference_schema() -> None:
     # The commit path reparses this JSONB payload into the current schema.
     reparsed = ReferencedEntities(**reference_updates)
     assert reparsed.characters[1].character_name == "Jonas Vale"
+
+
+def test_response_to_incubator_stages_exact_draft_bleed_manifest() -> None:
+    """Regenerated staging replaces draft A's offers with draft B's manifest."""
+
+    response = StorytellerResponseExtended.model_validate(
+        {
+            "generation_model": "gpt-5.6-storyteller",
+            "narrative": "Ann waits beneath the pharmacy sign.",
+            "choices": ["Follow Ann.", "Answer the phone."],
+            "chunk_metadata": {
+                "chronology": {"episode_transition": "continue"},
+                "world_layer": "primary",
+            },
+            "referenced_entities": {"characters": [], "places": [], "factions": []},
+            "state_updates": {
+                "characters": [],
+                "relationships": [],
+                "locations": [],
+                "factions": [],
+            },
+        }
+    )
+
+    draft_a = response_to_incubator(
+        response=response,
+        parent_chunk_id=1,
+        user_text="Continue.",
+        session_id="draft-a",
+        bleed_offer_resolution_ids=[501],
+    )
+    draft_b = response_to_incubator(
+        response=response,
+        parent_chunk_id=1,
+        user_text="Continue.",
+        session_id="draft-b",
+        bleed_offer_resolution_ids=[],
+    )
+
+    assert split_staged_orrery_payload(draft_a["orrery_proposal"]) == (None, (501,))
+    assert split_staged_orrery_payload(draft_b["orrery_proposal"]) == (None, ())
 
 
 def test_response_to_incubator_threads_generation_model_verbatim() -> None:

--- a/tests/test_api/test_narrative_generation.py
+++ b/tests/test_api/test_narrative_generation.py
@@ -15,6 +15,7 @@ from nexus.agents.logon.apex_schema import (
     StorytellerResponseMinimal,
 )
 from nexus.api import narrative, narrative_generation
+from nexus.api.lore_adapter import split_staged_orrery_payload
 from nexus.api.narrative_schemas import (
     ContinueNarrativeRequest,
     RegenerateNarrativeRequest,
@@ -158,6 +159,7 @@ async def test_continuation_threads_logon_model_into_incubator(
             self.turn_context = SimpleNamespace(
                 error_log=[],
                 orrery_proposal=None,
+                bleed_menu=[SimpleNamespace(resolution_id=501)],
                 private_correspondence=GeneratedCorrespondence(
                     writer_letter=self.secret,
                     gaia_letter="PRIVATE-GAIA-PROGRESS-SENTINEL",
@@ -208,6 +210,10 @@ async def test_continuation_threads_logon_model_into_incubator(
     )
 
     assert written[0]["generation_model"] == "resolved-provider-model"
+    assert split_staged_orrery_payload(written[0]["orrery_proposal"]) == (
+        None,
+        (501,),
+    )
     assert written[0]["correspondence_writer_letter"] == SuccessfulLore.secret
     assert SuccessfulLore.calls == [("Continue.", 7, None)]
     assert [status for _session, status, _data in manager.events][-1] == "complete"

--- a/tests/test_commit_handler.py
+++ b/tests/test_commit_handler.py
@@ -47,6 +47,7 @@ class AsyncCommitConnection:
         self.factions = {}
         self.character_junctions = []
         self.place_junctions = []
+        self.bleed_offers = []
         self.statements = []
         self.parent_metadata = {
             "season": 1,
@@ -103,6 +104,12 @@ class AsyncCommitConnection:
 
     async def fetch(self, sql, *args):
         normalized = " ".join(sql.split())
+        if "/* orrery:bleed_uptake_candidates */" in normalized:
+            return [
+                offer
+                for offer in self.bleed_offers
+                if offer["last_offered_chunk_id"] == args[0]
+            ]
         if "SELECT id FROM characters WHERE name" in normalized:
             entity_id = self.characters.get(args[0])
             return [{"id": entity_id}] if entity_id is not None else []
@@ -127,7 +134,14 @@ class AsyncCommitConnection:
     async def execute(self, sql, *args):
         normalized = " ".join(sql.split())
         self.statements.append((normalized, args))
-        if "INSERT INTO characters" in normalized:
+        if "/* orrery:stamp_bleed_uptake */" in normalized:
+            chunk_id, resolution_id = args
+            offer = next(
+                offer for offer in self.bleed_offers if offer["id"] == resolution_id
+            )
+            offer["used_chunk_id"] = chunk_id
+            offer["use_count"] += 1
+        elif "INSERT INTO characters" in normalized:
             self.characters[args[0]] = 72
         elif "INSERT INTO chunk_character_references" in normalized:
             self.character_junctions.append(args)
@@ -221,6 +235,56 @@ async def test_async_commit_links_same_turn_character_declaration(monkeypatch):
 
     assert chunk_id == conn.chunk_id
     assert conn.character_junctions == [(conn.chunk_id, 72, "present")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name_present", (True, False))
+async def test_async_commit_measures_seeded_bleed_offer_uptake(
+    monkeypatch: pytest.MonkeyPatch,
+    name_present: bool,
+) -> None:
+    """The async commit path mirrors exact-name Bleed uptake stamping."""
+
+    conn = AsyncCommitConnection()
+    conn.incubator["new_entities"] = []
+    conn.incubator["reference_updates"] = {
+        "characters": [],
+        "places": [],
+        "factions": [],
+    }
+    conn.incubator["storyteller_text"] = (
+        "Mara Venn opens the rain-dark gate."
+        if name_present
+        else "The gatekeeper opens the rain-dark gate."
+    )
+    conn.bleed_offers = [
+        {
+            "id": 502,
+            "actor_name": "Mara Venn",
+            "stub_text": "Mara Venn opens the rain-dark gate.",
+            "last_offered_chunk_id": conn.incubator["parent_chunk_id"],
+            "used_chunk_id": None,
+            "use_count": 0,
+        }
+    ]
+
+    async def no_op(*_args, **_kwargs):
+        return None
+
+    async def empty_orrery_tick(*_args, **_kwargs):
+        return _empty_orrery_result()
+
+    monkeypatch.setattr(commit_handler, "set_commit_chunk_attribution_async", no_op)
+    monkeypatch.setattr(commit_handler, "commit_orrery_tick_async", empty_orrery_tick)
+    monkeypatch.setattr(
+        commit_handler, "_orrery_checkpoint_interval", lambda _settings: 0
+    )
+
+    chunk_id = await commit_incubator_to_database(conn, "bleed-session", slot=5)
+
+    offer = conn.bleed_offers[0]
+    assert offer["used_chunk_id"] == (chunk_id if name_present else None)
+    assert offer["use_count"] == (1 if name_present else 0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_commit_handler.py
+++ b/tests/test_commit_handler.py
@@ -105,11 +105,7 @@ class AsyncCommitConnection:
     async def fetch(self, sql, *args):
         normalized = " ".join(sql.split())
         if "/* orrery:bleed_uptake_candidates */" in normalized:
-            return [
-                offer
-                for offer in self.bleed_offers
-                if offer["last_offered_chunk_id"] == args[0]
-            ]
+            return [offer for offer in self.bleed_offers if offer["id"] in args[0]]
         if "SELECT id FROM characters WHERE name" in normalized:
             entity_id = self.characters.get(args[0])
             return [{"id": entity_id}] if entity_id is not None else []
@@ -257,6 +253,7 @@ async def test_async_commit_measures_seeded_bleed_offer_uptake(
         if name_present
         else "The gatekeeper opens the rain-dark gate."
     )
+    conn.incubator["orrery_proposal"] = {"_bleed_offer_resolution_ids": [502]}
     conn.bleed_offers = [
         {
             "id": 502,

--- a/tests/test_commit_handler_sync.py
+++ b/tests/test_commit_handler_sync.py
@@ -1,5 +1,6 @@
 """Unit tests for synchronous narrative commit helpers."""
 
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -78,6 +79,7 @@ class CommitCursor:
     def __init__(self, connection):
         self.connection = connection
         self.result = None
+        self.rows = []
         self.rowcount = 0
 
     def __enter__(self):
@@ -89,6 +91,7 @@ class CommitCursor:
     def execute(self, sql, params=None):
         normalized = " ".join(sql.split())
         self.connection.statements.append((normalized, params))
+        self.rows = []
         self.rowcount = 0
         if normalized.startswith("DELETE FROM incubator"):
             self.rowcount = 1
@@ -120,11 +123,31 @@ class CommitCursor:
         elif "INSERT INTO chunk_character_references" in normalized:
             self.connection.character_junctions.append(params)
             self.result = None
+        elif "/* orrery:bleed_uptake_candidates */" in normalized:
+            self.rows = [
+                offer
+                for offer in self.connection.bleed_offers
+                if offer["last_offered_chunk_id"] == params[0]
+            ]
+            self.result = None
+        elif "/* orrery:stamp_bleed_uptake */" in normalized:
+            chunk_id, resolution_id = params
+            offer = next(
+                offer
+                for offer in self.connection.bleed_offers
+                if offer["id"] == resolution_id
+            )
+            offer["used_chunk_id"] = chunk_id
+            offer["use_count"] += 1
+            self.result = None
         else:
             self.result = None
 
     def fetchone(self):
         return self.result
+
+    def fetchall(self):
+        return self.rows
 
 
 class CommitConnection:
@@ -137,6 +160,7 @@ class CommitConnection:
         self.factions = {}
         self.character_junctions = []
         self.place_junctions = []
+        self.bleed_offers = []
         self.statements = []
         self.rollback_called = False
         self.parent_metadata = {
@@ -265,6 +289,56 @@ def test_sync_commit_links_same_turn_character_declaration(monkeypatch):
         "FROM incubator" in sql and "FOR UPDATE" in sql
         for sql, _params in conn.statements
     )
+
+
+@pytest.mark.parametrize("name_present", (True, False))
+def test_sync_commit_measures_seeded_bleed_offer_uptake(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    name_present: bool,
+) -> None:
+    """The genuine commit path stamps only exact-name Bleed uptake."""
+
+    caplog.set_level(logging.INFO, logger="nexus.orrery.bleed")
+    conn = CommitConnection()
+    conn.incubator["new_entities"] = []
+    conn.incubator["reference_updates"] = {
+        "characters": [],
+        "places": [],
+        "factions": [],
+    }
+    conn.incubator["storyteller_text"] = (
+        "Iria Vale slips through the rain-dark station."
+        if name_present
+        else "The courier slips through the rain-dark station."
+    )
+    conn.bleed_offers = [
+        {
+            "id": 501,
+            "actor_name": "Iria Vale",
+            "stub_text": "Iria Vale slips through the rain-dark station.",
+            "last_offered_chunk_id": conn.incubator["parent_chunk_id"],
+            "used_chunk_id": None,
+            "use_count": 0,
+        }
+    ]
+    _patch_sync_commit_runtime(monkeypatch)
+
+    chunk_id = commit_incubator_to_database_sync(conn, "bleed-session", slot=5)
+
+    offer = conn.bleed_offers[0]
+    assert offer["used_chunk_id"] == (chunk_id if name_present else None)
+    assert offer["use_count"] == (1 if name_present else 0)
+    uptake_record = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "orrery_bleed_uptake"
+    )
+    assert uptake_record.name_matched is name_present
+    if name_present:
+        assert uptake_record.four_gram_overlap_ratio == 1.0
+    else:
+        assert 0.0 < uptake_record.four_gram_overlap_ratio < 1.0
 
 
 def test_sync_reconciled_mentions_flow_through_adapter_and_commit(monkeypatch):

--- a/tests/test_commit_handler_sync.py
+++ b/tests/test_commit_handler_sync.py
@@ -127,7 +127,7 @@ class CommitCursor:
             self.rows = [
                 offer
                 for offer in self.connection.bleed_offers
-                if offer["last_offered_chunk_id"] == params[0]
+                if offer["id"] in params[0]
             ]
             self.result = None
         elif "/* orrery:stamp_bleed_uptake */" in normalized:
@@ -312,6 +312,7 @@ def test_sync_commit_measures_seeded_bleed_offer_uptake(
         if name_present
         else "The courier slips through the rain-dark station."
     )
+    conn.incubator["orrery_proposal"] = {"_bleed_offer_resolution_ids": [501]}
     conn.bleed_offers = [
         {
             "id": 501,
@@ -339,6 +340,86 @@ def test_sync_commit_measures_seeded_bleed_offer_uptake(
         assert uptake_record.four_gram_overlap_ratio == 1.0
     else:
         assert 0.0 < uptake_record.four_gram_overlap_ratio < 1.0
+
+
+def test_sync_commit_does_not_stamp_offer_from_regenerated_away_draft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accepting draft B cannot consume resolution R offered only to draft A."""
+
+    conn = CommitConnection()
+    conn.incubator["new_entities"] = []
+    conn.incubator["reference_updates"] = {
+        "characters": [],
+        "places": [],
+        "factions": [],
+    }
+    conn.bleed_offers = [
+        {
+            "id": 501,
+            "actor_name": "Iria Vale",
+            "stub_text": "Iria Vale slips through the station.",
+            "last_offered_chunk_id": conn.incubator["parent_chunk_id"],
+            "used_chunk_id": None,
+            "use_count": 0,
+        }
+    ]
+    draft_a_staging = {"_bleed_offer_resolution_ids": [501]}
+    conn.incubator["orrery_proposal"] = draft_a_staging
+
+    conn.incubator["session_id"] = "draft-b"
+    conn.incubator["storyteller_text"] = "Iria Vale slips through the station."
+    conn.incubator["orrery_proposal"] = {"_bleed_offer_resolution_ids": []}
+    _patch_sync_commit_runtime(monkeypatch)
+
+    commit_incubator_to_database_sync(conn, "draft-b", slot=5)
+
+    assert draft_a_staging == {"_bleed_offer_resolution_ids": [501]}
+    assert conn.bleed_offers[0]["used_chunk_id"] is None
+    assert conn.bleed_offers[0]["use_count"] == 0
+    assert not any(
+        "orrery:bleed_uptake_candidates" in sql for sql, _params in conn.statements
+    )
+
+
+@pytest.mark.parametrize(
+    ("storyteller_text", "expected_use_count"),
+    (("Anna waits by the gate.", 0), ("Ann's coat is wet.", 1)),
+)
+def test_sync_commit_matches_actor_name_on_word_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    storyteller_text: str,
+    expected_use_count: int,
+) -> None:
+    """Ann does not match Anna but does match before a possessive apostrophe."""
+
+    conn = CommitConnection()
+    conn.incubator["new_entities"] = []
+    conn.incubator["reference_updates"] = {
+        "characters": [],
+        "places": [],
+        "factions": [],
+    }
+    conn.incubator["storyteller_text"] = storyteller_text
+    conn.incubator["orrery_proposal"] = {"_bleed_offer_resolution_ids": [503]}
+    conn.bleed_offers = [
+        {
+            "id": 503,
+            "actor_name": "Ann",
+            "stub_text": "Ann waits by the gate.",
+            "last_offered_chunk_id": conn.incubator["parent_chunk_id"],
+            "used_chunk_id": None,
+            "use_count": 0,
+        }
+    ]
+    _patch_sync_commit_runtime(monkeypatch)
+
+    chunk_id = commit_incubator_to_database_sync(conn, "boundary", slot=5)
+
+    assert conn.bleed_offers[0]["use_count"] == expected_use_count
+    assert conn.bleed_offers[0]["used_chunk_id"] == (
+        chunk_id if expected_use_count else None
+    )
 
 
 def test_sync_reconciled_mentions_flow_through_adapter_and_commit(monkeypatch):

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -448,8 +448,20 @@ def test_context_prompt_includes_orrery_bleed_menu_controls() -> None:
     assert "=== ORRERY AMBIENT PERIPHERALS ===" in prompt
     assert "optional ambient peripherals from off-screen events" in prompt
     assert "Ignore freely, render subtly" in prompt
-    assert "include that exact name at least once" in prompt
+    assert (
+        "If you use one with an actor name, include that exact name at least once "
+        "in the prose — uptake is detected by matching that exact name."
+    ) in prompt
     assert "[digital] Mara: street cameras briefly lose Mara" in prompt
+
+
+def test_storyteller_core_has_no_model_side_bleed_density_target() -> None:
+    """Bleed pacing lives in seeded selection code, not Storyteller prose."""
+
+    prompt = (PROMPTS_DIR / "storyteller_core.md").read_text(encoding="utf-8")
+
+    assert "Roughly 10–20% of off-screen activity should bleed" not in prompt
+    assert "The rest stays invisible, maintaining the simulation's integrity" in prompt
 
 
 def test_context_prompt_renders_anchor_scene_conditions() -> None:

--- a/tests/test_orrery/test_bleed.py
+++ b/tests/test_orrery/test_bleed.py
@@ -180,6 +180,7 @@ def _select(
         session,
         anchor_chunk_id=100,
         anchor_entity_ids=anchor_entity_ids,
+        density=1.0,
         max_candidates=max_candidates,
         near_distance_max=near_distance_max,
         reserved_remote_slots=reserved_remote_slots,
@@ -200,6 +201,7 @@ def _settings():
         "orrery": {
             "enabled": True,
             "bleed": {
+                "density": 1.0,
                 "max_candidates": 3,
             },
         },
@@ -212,6 +214,7 @@ def test_load_bleed_candidates_coerces_descriptor() -> None:
     candidates = load_bleed_candidates(
         FakeSession(candidate_rows=[_candidate_row()]),
         anchor_chunk_id=100,
+        density=1.0,
         limit=3,
     )
 
@@ -220,6 +223,46 @@ def test_load_bleed_candidates_coerces_descriptor() -> None:
     assert candidates[0].channel == "digital"
     assert candidates[0].summary == "street cameras briefly lose Mara"
     assert candidates[0].magnitude == 0.72
+
+
+def test_bleed_density_draw_is_deterministic_for_anchor_chunk() -> None:
+    """The same persisted anchor identity produces the same offer decision."""
+
+    first_session = FakeSession(candidate_rows=[_candidate_row()])
+    second_session = FakeSession(candidate_rows=[_candidate_row()])
+
+    first = load_bleed_candidates(
+        first_session,
+        anchor_chunk_id=173,
+        density=0.5,
+        limit=3,
+    )
+    second = load_bleed_candidates(
+        second_session,
+        anchor_chunk_id=173,
+        density=0.5,
+        limit=3,
+    )
+
+    assert first == second
+    assert bool(first_session.executed) is bool(second_session.executed)
+
+
+def test_bleed_density_zero_skips_candidate_query() -> None:
+    """A failing density decision offers no candidates and does no scan."""
+
+    session = FakeSession(candidate_rows=[_candidate_row()])
+
+    assert (
+        load_bleed_candidates(
+            session,
+            anchor_chunk_id=173,
+            density=0.0,
+            limit=3,
+        )
+        == []
+    )
+    assert session.executed == []
 
 
 def test_select_bleed_menu_returns_top_candidate_without_recording_offers() -> None:
@@ -398,6 +441,7 @@ def test_empty_anchor_preserves_existing_order_without_graph_queries() -> None:
         for candidate in load_bleed_candidates(
             session,
             anchor_chunk_id=100,
+            density=1.0,
             limit=2,
         )
     ]
@@ -463,6 +507,7 @@ def test_select_bleed_menu_is_deterministic_with_tie_order() -> None:
     candidate_sql = next(
         sql for sql, _ in session.executed if "orrery:bleed_candidates" in sql
     )
+    assert "r.offer_count >= 2 AND r.use_count = 0" in candidate_sql
     assert "r.id DESC" in candidate_sql
 
 
@@ -603,6 +648,7 @@ async def test_call_apex_ai_records_bleed_offers_after_generation_success() -> N
     context.bleed_menu = load_bleed_candidates(
         FakeSession(candidate_rows=[_candidate_row()]),
         anchor_chunk_id=100,
+        density=1.0,
         limit=1,
     )
     context.phase_states["orrery_bleed"] = {
@@ -645,6 +691,7 @@ async def test_call_apex_ai_does_not_record_bleed_offers_on_generation_failure()
     context.bleed_menu = load_bleed_candidates(
         FakeSession(candidate_rows=[_candidate_row()]),
         anchor_chunk_id=100,
+        density=1.0,
         limit=1,
     )
     context.phase_states["orrery_bleed"] = {

--- a/tests/test_orrery/test_bleed.py
+++ b/tests/test_orrery/test_bleed.py
@@ -507,8 +507,54 @@ def test_select_bleed_menu_is_deterministic_with_tie_order() -> None:
     candidate_sql = next(
         sql for sql, _ in session.executed if "orrery:bleed_candidates" in sql
     )
-    assert "r.offer_count >= 2 AND r.use_count = 0" in candidate_sql
+    assert "r.offer_count >= 2 AND r.use_count = 0" not in candidate_sql
     assert "r.id DESC" in candidate_sql
+
+
+def test_bounded_scan_of_only_deprioritized_candidates_remains_reachable() -> None:
+    """Sort-back happens inside the fetched window and cannot starve that window."""
+
+    rows = [_candidate_row_with_id(value) for value in (30, 20, 10)]
+    for row in rows:
+        row["offer_count"] = 2
+        row["use_count"] = 0
+    session = FakeSession(
+        candidate_rows=rows,
+        graph_nodes=[{"entity_id": 1}],
+        graph_edges=[],
+    )
+
+    result = _select(
+        session,
+        anchor_entity_ids=(1,),
+        max_candidates=2,
+        scan_limit=2,
+    )
+
+    assert result.candidates_considered == 2
+    assert [candidate.resolution_id for candidate in result.selected] == [30, 20]
+    candidate_params = next(
+        params for sql, params in session.executed if "orrery:bleed_candidates" in sql
+    )
+    assert candidate_params["limit"] == 2
+
+
+def test_deprioritization_sorts_to_back_only_within_fetched_window() -> None:
+    """Fresh candidates lead while repeatedly unused rows remain eligible."""
+
+    rows = [_candidate_row_with_id(value) for value in (30, 20, 10)]
+    rows[0].update({"offer_count": 2, "use_count": 0})
+    rows[1].update({"offer_count": 1, "use_count": 0})
+    rows[2].update({"offer_count": 2, "use_count": 0})
+
+    candidates = load_bleed_candidates(
+        FakeSession(candidate_rows=rows),
+        anchor_chunk_id=100,
+        density=1.0,
+        limit=3,
+    )
+
+    assert [candidate.resolution_id for candidate in candidates] == [20, 30, 10]
 
 
 @pytest.mark.asyncio

--- a/tests/test_orrery/test_bleed_proximity_live.py
+++ b/tests/test_orrery/test_bleed_proximity_live.py
@@ -390,6 +390,7 @@ def _select(
         db["session"],
         anchor_chunk_id=int(db["chunks"][anchor_chunk]),
         anchor_entity_ids=anchor_entity_ids,
+        density=1.0,
         max_candidates=max_candidates,
         near_distance_max=near_distance_max,
         reserved_remote_slots=reserved_remote_slots,
@@ -464,6 +465,7 @@ def test_live_faction_anchor_and_empty_anchor_fallback(
     old_order = load_bleed_candidates(
         db["session"],
         anchor_chunk_id=db["chunks"]["empty"],
+        density=1.0,
         limit=3,
     )
     fallback = _select(
@@ -537,6 +539,7 @@ class _FixtureLore:
             "orrery": {
                 "enabled": True,
                 "bleed": {
+                    "density": 1.0,
                     "max_candidates": 2,
                     "near_distance_max": 2,
                     "reserved_remote_slots": 1,

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -338,11 +338,20 @@ def test_orrery_bleed_accepts_deprecated_selection_keys() -> None:
     )
 
     assert settings.max_candidates == 3
+    assert settings.density == 0.20
     assert settings.near_distance_max == 2
     assert settings.reserved_remote_slots == 1
     dumped = settings.model_dump()
     assert "latency_budget_ms" not in dumped
     assert "candidate_pool_multiplier" not in dumped
+
+
+@pytest.mark.parametrize("density", (-0.01, 1.01))
+def test_orrery_bleed_density_must_be_probability(density: float) -> None:
+    """Bleed density rejects values outside the closed probability interval."""
+
+    with pytest.raises(ValidationError):
+        OrreryBleedSettings(density=density)
 
 
 def test_orrery_bleed_reserved_remote_slots_must_fit_menu() -> None:

--- a/tests/test_orrery/test_live_cycle.py
+++ b/tests/test_orrery/test_live_cycle.py
@@ -253,6 +253,7 @@ def test_live_orrery_cycle_resolve_commit_promote_narrate_bleed() -> None:
                     session,
                     anchor_chunk_id=anchor_chunk_id,
                 ),
+                density=1.0,
                 max_candidates=int(bleed_settings["max_candidates"]),
                 near_distance_max=int(bleed_settings["near_distance_max"]),
                 reserved_remote_slots=int(bleed_settings["reserved_remote_slots"]),

--- a/tests/test_qa_shift.py
+++ b/tests/test_qa_shift.py
@@ -116,6 +116,20 @@ def _settled_jobs_reader(_root: Path, _slot: int) -> dict[str, object]:
     return _jobs()
 
 
+def _bleed_uptake_reader(
+    _root: Path,
+    _slot: int,
+) -> dict[str, object]:
+    return {"offered_count": 4, "used_count": 1}
+
+
+def _empty_bleed_uptake_reader(
+    _root: Path,
+    _slot: int,
+) -> dict[str, object]:
+    return {"offered_count": 0, "used_count": 0}
+
+
 def _state(config: qa_shift.ShiftConfig) -> dict[str, object]:
     return {
         "schema_version": 1,
@@ -157,6 +171,7 @@ def test_begin_creates_archive_and_pins_every_openai_role(
         config=config,
         usage_reader=lambda _root, _day: _usage(total=123),
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_empty_bleed_uptake_reader,
         now=NOW,
     )
 
@@ -167,6 +182,8 @@ def test_begin_creates_archive_and_pins_every_openai_role(
     roles = model["api_models"]["openai"]["roles"]
 
     assert state["baseline_total"] == 123
+    assert state["baseline_bleed_offered_count"] == 0
+    assert state["baseline_bleed_used_count"] == 0
     assert state["status"] == "active"
     assert model["default_slot_model"] == "gpt-5.6-terra"
     assert set(roles) >= {"default", "gaia"}
@@ -184,6 +201,7 @@ def test_begin_creates_archive_and_pins_every_openai_role(
     assert "## Structured-output rejection ledger" in ledger
     assert "Repair tax" in ledger
     assert "## Structured-output rejections" in report
+    assert "## Bleed uptake" in report
     assert "Repair tax" in report
     assert "Seed-promotion disposition" in report
 
@@ -198,6 +216,7 @@ def test_generated_runtime_environment_selects_qa_config(
         config=config,
         usage_reader=lambda _root, _day: _usage(total=123),
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_empty_bleed_uptake_reader,
         now=NOW,
     )
     archive = Path(result["archive"])
@@ -431,6 +450,7 @@ def test_pending_post_check_retains_late_usage_in_causal_command_delta(
         config=config,
         usage_reader=lambda _root, _day: _usage(total=100),
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_empty_bleed_uptake_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -509,6 +529,7 @@ def test_failure_during_pending_stops_after_settlement_with_full_delta(
         config=config,
         usage_reader=lambda _root, _day: _usage(total=100),
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_empty_bleed_uptake_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -569,6 +590,7 @@ def test_check_reads_queue_before_usage_to_close_settlement_race(
         config=config,
         usage_reader=lambda _root, _day: _usage(total=100),
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_empty_bleed_uptake_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -643,6 +665,7 @@ def test_preexisting_failed_jobs_become_shift_baseline(tmp_path: Path) -> None:
         config=config,
         usage_reader=lambda _root, _day: _usage(total=100),
         jobs_reader=lambda _root, _slot: _jobs(failed_jobs=2),
+        bleed_uptake_reader=_empty_bleed_uptake_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -736,6 +759,7 @@ def test_check_and_finish_persist_end_to_end_tally(tmp_path: Path) -> None:
         config=config,
         usage_reader=lambda _root, _day: _usage(total=100),
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_empty_bleed_uptake_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -753,6 +777,7 @@ def test_check_and_finish_persist_end_to_end_tally(tmp_path: Path) -> None:
         exit_condition="dry_well",
         usage_reader=lambda _root, _day: _usage(total=350, events=[first_event]),
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_bleed_uptake_reader,
         now=NOW + timedelta(minutes=2),
     )
 
@@ -768,6 +793,10 @@ def test_check_and_finish_persist_end_to_end_tally(tmp_path: Path) -> None:
     assert state["exit_condition"] == "dry_well"
     assert (archive / "usage_end.json").exists()
     assert (archive / "rejection_ledger.json").exists()
+    assert (archive / "bleed_uptake.json").exists()
+    assert finish["bleed_uptake"]["offered_count"] == 4
+    assert finish["bleed_uptake"]["used_count"] == 1
+    assert finish["bleed_uptake"]["uptake_rate_percent"] == 25.0
     assert finish["rejected_attempts"] == 0
     assert finish["repair_tax_tokens"] == 0
     assert finish["repair_tax_percent"] == 0.0
@@ -797,6 +826,7 @@ def test_finish_persists_exact_repair_tax_and_writer_tripwire(
             events=[historical_rejection],
         ),
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_empty_bleed_uptake_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -821,6 +851,7 @@ def test_finish_persists_exact_repair_tax_and_writer_tripwire(
             events=[historical_rejection, writer_rejection, accepted_retry],
         ),
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_bleed_uptake_reader,
         now=NOW + timedelta(minutes=2),
     )
     ledger = json.loads((archive / "rejection_ledger.json").read_text())
@@ -871,6 +902,7 @@ def test_finish_withholds_repair_tax_percent_for_untrusted_denominator(
         config=config,
         usage_reader=lambda _root, _day: _usage(total=100),
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_empty_bleed_uptake_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -888,6 +920,7 @@ def test_finish_withholds_repair_tax_percent_for_untrusted_denominator(
             events=[rejection],
         ),
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_bleed_uptake_reader,
         now=NOW + timedelta(minutes=2),
     )
     ledger = json.loads((archive / "rejection_ledger.json").read_text())
@@ -905,6 +938,7 @@ def test_finish_reads_original_quota_day_after_rollover(tmp_path: Path) -> None:
         config=config,
         usage_reader=lambda _root, _day: _usage(total=100),
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_empty_bleed_uptake_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -930,6 +964,7 @@ def test_finish_reads_original_quota_day_after_rollover(tmp_path: Path) -> None:
         exit_condition="token_fence",
         usage_reader=read_original_day,
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_bleed_uptake_reader,
         now=datetime(2026, 7, 31, 0, 2, tzinfo=timezone.utc),
     )
     state = json.loads((archive / "shift_state.json").read_text())
@@ -957,6 +992,7 @@ def test_finish_reports_maturation_settlement_without_refusal(
         config=config,
         usage_reader=lambda _root, _day: _usage(total=100),
         jobs_reader=_settled_jobs_reader,
+        bleed_uptake_reader=_empty_bleed_uptake_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -966,6 +1002,7 @@ def test_finish_reports_maturation_settlement_without_refusal(
         exit_condition="blocked",
         usage_reader=lambda _root, _day: _usage(total=125),
         jobs_reader=lambda _root, _slot: _jobs(state=job_state),
+        bleed_uptake_reader=_bleed_uptake_reader,
         now=NOW + timedelta(minutes=1),
     )
     final_state = json.loads((archive / "shift_state.json").read_text())
@@ -984,6 +1021,7 @@ def test_finish_marks_new_maturation_failure_unsettled(tmp_path: Path) -> None:
         config=config,
         usage_reader=lambda _root, _day: _usage(total=100),
         jobs_reader=lambda _root, _slot: _jobs(failed_jobs=1),
+        bleed_uptake_reader=_empty_bleed_uptake_reader,
         now=NOW,
     )
     archive = Path(begin["archive"])
@@ -993,6 +1031,7 @@ def test_finish_marks_new_maturation_failure_unsettled(tmp_path: Path) -> None:
         exit_condition="blocked",
         usage_reader=lambda _root, _day: _usage(total=125),
         jobs_reader=lambda _root, _slot: _jobs(failed_jobs=2),
+        bleed_uptake_reader=_bleed_uptake_reader,
         now=NOW + timedelta(minutes=1),
     )
 


### PR DESCRIPTION
Closes #686. Loom-ruled density default: **0.20**.

Two coupled changes from the MGO review (SkyrimNet's silence-dice pattern, verified live at 52% there):

**Density as a selection-time draw** — `[orrery.bleed] density = 0.20` gates candidate offering per turn via the package-selection seeded-RNG idiom keyed on anchor chunk identity (deterministic under replay; draw happens before candidate SQL). The prompt's "roughly 10–20%" sentence is gone — pacing is no longer a model instruction — while the bleed-texture examples stay (coordinator restored them post-build; they teach register, the quota didn't).

**Uptake measurement** — migration 103 (`used_chunk_id`, `use_count` on `orrery_resolutions`); post-commit exact-name match against storyteller prose only (choice text can't trigger uptake); offered-repeatedly-never-used candidates sort to the back without touching the `offer_count < 3` gate; QA-shift uptake report from cumulative deltas; log-only 4-gram overlap ratio as the stub-verbatim-uptake test feeding the R5 follow-on.

The exact-name rule now explains its own mechanism ("uptake is detected by matching that exact name") — the explain-the-consequence pattern.

mypy/flake8/black clean; real-path commit-handler tests both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG