### PR TITLE
Add Durable Multi-Participant Interaction Threads with Fail-Closed Authorization

### DIFF
--- a/migrations/105_interaction_threads.sql
+++ b/migrations/105_interaction_threads.sql
@@ -18,7 +18,8 @@ CREATE TABLE IF NOT EXISTS interactions (
     lease_until TIMESTAMPTZ,
     recovery_command_id UUID,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (status <> 'in_progress' OR lease_until IS NOT NULL)
 );
 
 COMMENT ON TABLE interactions IS
@@ -42,7 +43,7 @@ COMMENT ON COLUMN interactions.anchor_chunk_id IS
 COMMENT ON COLUMN interactions.timeline_id IS
     'Expected canonical world-layer timeline identity rechecked under row lock at execution.';
 COMMENT ON COLUMN interactions.lease_until IS
-    'Explicit handler lease deadline; only expired non-NULL leases are recovery candidates.';
+    'Required handler lease deadline while in progress; start stamps it and only expired leases are recovery candidates.';
 COMMENT ON COLUMN interactions.recovery_command_id IS
     'Recovery command currently claiming an expired interaction while cleanup hooks complete.';
 COMMENT ON COLUMN interactions.created_at IS
@@ -209,6 +210,9 @@ COMMENT ON COLUMN interaction_events.occurred_at IS
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_interaction_events_command_step
     ON interaction_events (interaction_id, command_id, command_step);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_interaction_events_creation_command
+    ON interaction_events (command_id)
+    WHERE event_type = 'proposed' AND command_step = 'command';
 CREATE INDEX IF NOT EXISTS idx_interaction_events_command_lookup
     ON interaction_events (command_id, command_step, id);
 CREATE INDEX IF NOT EXISTS idx_interaction_events_replay

--- a/migrations/105_interaction_threads.sql
+++ b/migrations/105_interaction_threads.sql
@@ -15,6 +15,8 @@ CREATE TABLE IF NOT EXISTS interactions (
     anchor_chunk_id BIGINT NOT NULL
         REFERENCES narrative_chunks(id) ON DELETE RESTRICT,
     timeline_id TEXT NOT NULL CHECK (btrim(timeline_id) <> ''),
+    lease_until TIMESTAMPTZ,
+    recovery_command_id UUID,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -26,27 +28,31 @@ COMMENT ON COLUMN interactions.id IS
 COMMENT ON COLUMN interactions.kind IS
     'Consumer-defined interaction kind; this infrastructure does not assign gameplay meaning.';
 COMMENT ON COLUMN interactions.executor_namespace IS
-    'Validated namespace that owns interpretation of typed transition names and payloads.';
+    'Validated registry namespace that owns the allowed typed transition vocabulary.';
 COMMENT ON COLUMN interactions.status IS
     'Current lifecycle state: proposed, in_progress, completed, stopped, or interrupted.';
 COMMENT ON COLUMN interactions.policy IS
-    'Declared authorization policy; every read is validated fail-closed by the application Pydantic model.';
+    'Declared authorization policy including per-action material payload fields; validated fail-closed by Pydantic.';
 COMMENT ON COLUMN interactions.continuation_id IS
     'Stable identity shared by every revision of this interaction continuation.';
 COMMENT ON COLUMN interactions.revision IS
-    'Monotonic execution revision; authorizations are valid only for the exact revision that received them.';
+    'Monotonic execution or membership revision; authorizations bind to exactly one revision.';
 COMMENT ON COLUMN interactions.anchor_chunk_id IS
-    'Narrative anchor that must still be current when start, transition, or completion executes.';
+    'Expected narrative head rechecked against locked canonical narrative and metadata rows at execution.';
 COMMENT ON COLUMN interactions.timeline_id IS
-    'Opaque timeline identity that must still match the authoritative execution timeline.';
+    'Expected canonical world-layer timeline identity rechecked under row lock at execution.';
+COMMENT ON COLUMN interactions.lease_until IS
+    'Explicit handler lease deadline; only expired non-NULL leases are recovery candidates.';
+COMMENT ON COLUMN interactions.recovery_command_id IS
+    'Recovery command currently claiming an expired interaction while cleanup hooks complete.';
 COMMENT ON COLUMN interactions.created_at IS
     'Trusted-handler proposal time.';
 COMMENT ON COLUMN interactions.updated_at IS
-    'Time of the latest lifecycle, authorization, or recovery mutation.';
+    'Time of the latest lifecycle, membership, authorization, lease, or recovery mutation.';
 
 CREATE INDEX IF NOT EXISTS idx_interactions_recovery
-    ON interactions (updated_at, id)
-    WHERE status = 'in_progress';
+    ON interactions (lease_until, id)
+    WHERE status = 'in_progress' AND lease_until IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS interaction_participants (
     id BIGSERIAL PRIMARY KEY,
@@ -55,29 +61,36 @@ CREATE TABLE IF NOT EXISTS interaction_participants (
     participant_entity_id BIGINT NOT NULL
         REFERENCES entities(id) ON DELETE RESTRICT,
     joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    joined_revision BIGINT NOT NULL CHECK (joined_revision >= 1),
     left_at TIMESTAMPTZ,
-    CHECK (left_at IS NULL OR left_at >= joined_at)
+    left_revision BIGINT CHECK (left_revision IS NULL OR left_revision >= joined_revision),
+    CHECK (left_at IS NULL OR left_at >= joined_at),
+    CHECK ((left_at IS NULL) = (left_revision IS NULL))
 );
 
 COMMENT ON TABLE interaction_participants IS
-    'Historical interaction membership; a new row represents each join interval.';
+    'Revisioned historical interaction membership; a new row represents each join interval.';
 COMMENT ON COLUMN interaction_participants.id IS
     'Stable identifier for one participant membership interval.';
 COMMENT ON COLUMN interaction_participants.interaction_id IS
     'Interaction thread to which this membership interval belongs.';
 COMMENT ON COLUMN interaction_participants.participant_entity_id IS
-    'Entity-spine participant whose independent authorization is required while active.';
+    'Entity-spine participant whose independent exact-envelope authorization is required while active.';
 COMMENT ON COLUMN interaction_participants.joined_at IS
     'Time this membership interval became active.';
+COMMENT ON COLUMN interaction_participants.joined_revision IS
+    'Interaction revision created by this join, or revision one for proposal membership.';
 COMMENT ON COLUMN interaction_participants.left_at IS
     'Time this membership interval ended; NULL means currently active.';
+COMMENT ON COLUMN interaction_participants.left_revision IS
+    'Interaction revision created by leave or terminal closure; NULL while active.';
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_interaction_participants_active
     ON interaction_participants (interaction_id, participant_entity_id)
     WHERE left_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_interaction_participants_history
     ON interaction_participants (
-        interaction_id, participant_entity_id, joined_at, id
+        interaction_id, participant_entity_id, joined_revision, id
     );
 
 CREATE TABLE IF NOT EXISTS interaction_authorizations (
@@ -87,6 +100,7 @@ CREATE TABLE IF NOT EXISTS interaction_authorizations (
     participant_entity_id BIGINT NOT NULL
         REFERENCES entities(id) ON DELETE RESTRICT,
     action TEXT NOT NULL CHECK (action ~ '^[a-z][a-z0-9_.:-]*$'),
+    envelope_hash TEXT NOT NULL CHECK (envelope_hash ~ '^[0-9a-f]{64}$'),
     continuation_id UUID NOT NULL,
     interaction_revision BIGINT NOT NULL CHECK (interaction_revision >= 1),
     granted BOOLEAN NOT NULL CHECK (granted IS TRUE),
@@ -104,36 +118,38 @@ CREATE TABLE IF NOT EXISTS interaction_authorizations (
 );
 
 COMMENT ON TABLE interaction_authorizations IS
-    'Participant-specific positive grants scoped to one action, continuation, revision, and bounded validity interval.';
+    'Participant-specific positive grants bound to a canonical action, transition, material-term envelope.';
 COMMENT ON COLUMN interaction_authorizations.id IS
-    'Stable grant record identifier retained after expiry, revocation, or supersession.';
+    'Stable grant record identifier retained after expiry or revocation.';
 COMMENT ON COLUMN interaction_authorizations.interaction_id IS
-    'Interaction whose action this grant may authorize.';
+    'Interaction whose exact command envelope this grant may authorize.';
 COMMENT ON COLUMN interaction_authorizations.participant_entity_id IS
     'Single participant who explicitly supplied this positive grant.';
 COMMENT ON COLUMN interaction_authorizations.action IS
     'Exact policy-declared action authorized by this grant.';
+COMMENT ON COLUMN interaction_authorizations.envelope_hash IS
+    'SHA-256 of stable canonical JSON over action, transition type, and policy-declared material term values.';
 COMMENT ON COLUMN interaction_authorizations.continuation_id IS
     'Continuation identity captured at grant time; mismatches deny as stale.';
 COMMENT ON COLUMN interaction_authorizations.interaction_revision IS
-    'Interaction revision captured at grant time; prior revisions deny as stale.';
+    'Interaction revision captured at grant time; membership or lifecycle revision changes deny as stale.';
 COMMENT ON COLUMN interaction_authorizations.granted IS
     'Explicit positive grant marker; database constraints reject false or NULL authorization.';
 COMMENT ON COLUMN interaction_authorizations.granted_by_handler IS
-    'Trusted handler identity that recorded the participant-specific grant.';
+    'Construction-injected trusted handler identity that recorded the participant grant.';
 COMMENT ON COLUMN interaction_authorizations.granted_at IS
-    'Beginning of the bounded interval during which the grant can be evaluated.';
+    'Beginning of the bounded interval during which the exact-envelope grant can be evaluated.';
 COMMENT ON COLUMN interaction_authorizations.expires_at IS
     'Required finite end of the grant validity interval.';
 COMMENT ON COLUMN interaction_authorizations.revoked_at IS
-    'Immediate revocation time; any non-NULL value denies authorization.';
+    'Immediate revocation time; any non-NULL value denies this grant.';
 COMMENT ON COLUMN interaction_authorizations.revoked_by_handler IS
-    'Trusted handler identity that recorded revocation or supersession.';
+    'Construction-injected trusted handler identity that recorded revocation.';
 
 CREATE INDEX IF NOT EXISTS idx_interaction_authorizations_evaluation
     ON interaction_authorizations (
         interaction_id, action, participant_entity_id,
-        interaction_revision DESC, id DESC
+        interaction_revision DESC, envelope_hash, id DESC
     );
 
 CREATE TABLE IF NOT EXISTS interaction_events (
@@ -143,40 +159,63 @@ CREATE TABLE IF NOT EXISTS interaction_events (
     event_type TEXT NOT NULL
         CHECK (event_type IN (
             'proposed', 'authorized', 'started', 'transitioned',
-            'completed', 'stopped', 'interrupted'
+            'completed', 'stopped', 'interrupted', 'membership_joined',
+            'membership_left', 'lease_touched', 'recovery_claimed',
+            'cleanup_completed'
         )),
     interaction_revision BIGINT NOT NULL CHECK (interaction_revision >= 1),
     actor_participant_entity_id BIGINT
         REFERENCES entities(id) ON DELETE RESTRICT,
     actor_handler TEXT,
+    command_id UUID NOT NULL,
+    command_step TEXT NOT NULL CHECK (btrim(command_step) <> ''),
+    command_fingerprint TEXT NOT NULL
+        CHECK (command_fingerprint ~ '^[0-9a-f]{64}$'),
     payload JSONB NOT NULL DEFAULT '{}'::jsonb
         CHECK (jsonb_typeof(payload) = 'object'),
+    outcome JSONB NOT NULL DEFAULT '{}'::jsonb
+        CHECK (jsonb_typeof(outcome) = 'object'),
     occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CHECK (num_nonnulls(actor_participant_entity_id, actor_handler) <= 1),
     CHECK (actor_handler IS NULL OR btrim(actor_handler) <> '')
 );
 
 COMMENT ON TABLE interaction_events IS
-    'Immutable append-only lifecycle ledger from proposal through terminal outcome.';
+    'Immutable command-idempotency, cleanup-completion, and lifecycle replay ledger.';
 COMMENT ON COLUMN interaction_events.id IS
     'Monotonic event identifier used to replay one interaction in write order.';
 COMMENT ON COLUMN interaction_events.interaction_id IS
-    'Interaction thread whose lifecycle emitted this event.';
+    'Interaction thread whose command or cleanup step emitted this event.';
 COMMENT ON COLUMN interaction_events.event_type IS
-    'Lifecycle event: proposed, authorized, started, transitioned, completed, stopped, or interrupted.';
+    'Lifecycle, membership, authorization, lease, or cleanup-completion event type.';
 COMMENT ON COLUMN interaction_events.interaction_revision IS
     'Interaction revision in effect immediately after this event.';
 COMMENT ON COLUMN interaction_events.actor_participant_entity_id IS
-    'Participant actor for unilateral stop events; NULL for handler or system actions.';
+    'Participant actor for unilateral stop events; NULL for handler actions.';
 COMMENT ON COLUMN interaction_events.actor_handler IS
-    'Trusted handler actor for handler-recorded events; NULL for participant or anonymous system actions.';
+    'Construction-injected trusted handler actor; NULL for participant actions.';
+COMMENT ON COLUMN interaction_events.command_id IS
+    'Caller-supplied idempotency UUID; retries return its recorded outcome.';
+COMMENT ON COLUMN interaction_events.command_step IS
+    'Canonical command step or named cleanup-hook completion within one command.';
+COMMENT ON COLUMN interaction_events.command_fingerprint IS
+    'SHA-256 of stable canonical command content; reuse with changed content is rejected.';
 COMMENT ON COLUMN interaction_events.payload IS
-    'Typed executor or authorization metadata needed to reconstruct the lifecycle without mutating prior events.';
+    'Complete replay data for the lifecycle, membership, authorization, lease, or cleanup event.';
+COMMENT ON COLUMN interaction_events.outcome IS
+    'Recorded command result returned unchanged on an idempotent retry.';
 COMMENT ON COLUMN interaction_events.occurred_at IS
     'Authoritative event time supplied by the transactional lifecycle service.';
 
+CREATE UNIQUE INDEX IF NOT EXISTS idx_interaction_events_command_step
+    ON interaction_events (interaction_id, command_id, command_step);
+CREATE INDEX IF NOT EXISTS idx_interaction_events_command_lookup
+    ON interaction_events (command_id, command_step, id);
 CREATE INDEX IF NOT EXISTS idx_interaction_events_replay
     ON interaction_events (interaction_id, id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_interaction_cleanup_completion
+    ON interaction_events (interaction_id, ((payload ->> 'hook_name')))
+    WHERE event_type = 'cleanup_completed';
 
 CREATE OR REPLACE FUNCTION reject_interaction_event_mutation()
 RETURNS trigger
@@ -188,7 +227,7 @@ END;
 $$;
 
 COMMENT ON FUNCTION reject_interaction_event_mutation() IS
-    'Rejects UPDATE and DELETE so interaction lifecycle history remains replayable.';
+    'Rejects UPDATE and DELETE so interaction command outcomes and history remain replayable.';
 
 DROP TRIGGER IF EXISTS interaction_events_append_only ON interaction_events;
 CREATE TRIGGER interaction_events_append_only
@@ -196,4 +235,4 @@ BEFORE UPDATE OR DELETE ON interaction_events
 FOR EACH ROW EXECUTE FUNCTION reject_interaction_event_mutation();
 
 COMMENT ON TRIGGER interaction_events_append_only ON interaction_events IS
-    'Prevents mutation or deletion of persisted interaction lifecycle events.';
+    'Prevents mutation or deletion of persisted interaction command and lifecycle events.';

--- a/migrations/105_interaction_threads.sql
+++ b/migrations/105_interaction_threads.sql
@@ -1,0 +1,199 @@
+-- Durable multi-participant interaction threads with fail-closed authorization.
+
+CREATE TABLE IF NOT EXISTS interactions (
+    id UUID PRIMARY KEY,
+    kind TEXT NOT NULL CHECK (btrim(kind) <> ''),
+    executor_namespace TEXT NOT NULL
+        CHECK (executor_namespace ~ '^[a-z][a-z0-9_.-]*$'),
+    status TEXT NOT NULL
+        CHECK (status IN (
+            'proposed', 'in_progress', 'completed', 'stopped', 'interrupted'
+        )),
+    policy JSONB NOT NULL CHECK (jsonb_typeof(policy) = 'object'),
+    continuation_id UUID NOT NULL,
+    revision BIGINT NOT NULL DEFAULT 1 CHECK (revision >= 1),
+    anchor_chunk_id BIGINT NOT NULL
+        REFERENCES narrative_chunks(id) ON DELETE RESTRICT,
+    timeline_id TEXT NOT NULL CHECK (btrim(timeline_id) <> ''),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE interactions IS
+    'Durable coordination root for a typed, policy-authorized multi-participant interaction.';
+COMMENT ON COLUMN interactions.id IS
+    'Application-generated stable UUID for the interaction thread.';
+COMMENT ON COLUMN interactions.kind IS
+    'Consumer-defined interaction kind; this infrastructure does not assign gameplay meaning.';
+COMMENT ON COLUMN interactions.executor_namespace IS
+    'Validated namespace that owns interpretation of typed transition names and payloads.';
+COMMENT ON COLUMN interactions.status IS
+    'Current lifecycle state: proposed, in_progress, completed, stopped, or interrupted.';
+COMMENT ON COLUMN interactions.policy IS
+    'Declared authorization policy; every read is validated fail-closed by the application Pydantic model.';
+COMMENT ON COLUMN interactions.continuation_id IS
+    'Stable identity shared by every revision of this interaction continuation.';
+COMMENT ON COLUMN interactions.revision IS
+    'Monotonic execution revision; authorizations are valid only for the exact revision that received them.';
+COMMENT ON COLUMN interactions.anchor_chunk_id IS
+    'Narrative anchor that must still be current when start, transition, or completion executes.';
+COMMENT ON COLUMN interactions.timeline_id IS
+    'Opaque timeline identity that must still match the authoritative execution timeline.';
+COMMENT ON COLUMN interactions.created_at IS
+    'Trusted-handler proposal time.';
+COMMENT ON COLUMN interactions.updated_at IS
+    'Time of the latest lifecycle, authorization, or recovery mutation.';
+
+CREATE INDEX IF NOT EXISTS idx_interactions_recovery
+    ON interactions (updated_at, id)
+    WHERE status = 'in_progress';
+
+CREATE TABLE IF NOT EXISTS interaction_participants (
+    id BIGSERIAL PRIMARY KEY,
+    interaction_id UUID NOT NULL
+        REFERENCES interactions(id) ON DELETE RESTRICT,
+    participant_entity_id BIGINT NOT NULL
+        REFERENCES entities(id) ON DELETE RESTRICT,
+    joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    left_at TIMESTAMPTZ,
+    CHECK (left_at IS NULL OR left_at >= joined_at)
+);
+
+COMMENT ON TABLE interaction_participants IS
+    'Historical interaction membership; a new row represents each join interval.';
+COMMENT ON COLUMN interaction_participants.id IS
+    'Stable identifier for one participant membership interval.';
+COMMENT ON COLUMN interaction_participants.interaction_id IS
+    'Interaction thread to which this membership interval belongs.';
+COMMENT ON COLUMN interaction_participants.participant_entity_id IS
+    'Entity-spine participant whose independent authorization is required while active.';
+COMMENT ON COLUMN interaction_participants.joined_at IS
+    'Time this membership interval became active.';
+COMMENT ON COLUMN interaction_participants.left_at IS
+    'Time this membership interval ended; NULL means currently active.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_interaction_participants_active
+    ON interaction_participants (interaction_id, participant_entity_id)
+    WHERE left_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_interaction_participants_history
+    ON interaction_participants (
+        interaction_id, participant_entity_id, joined_at, id
+    );
+
+CREATE TABLE IF NOT EXISTS interaction_authorizations (
+    id BIGSERIAL PRIMARY KEY,
+    interaction_id UUID NOT NULL
+        REFERENCES interactions(id) ON DELETE RESTRICT,
+    participant_entity_id BIGINT NOT NULL
+        REFERENCES entities(id) ON DELETE RESTRICT,
+    action TEXT NOT NULL CHECK (action ~ '^[a-z][a-z0-9_.:-]*$'),
+    continuation_id UUID NOT NULL,
+    interaction_revision BIGINT NOT NULL CHECK (interaction_revision >= 1),
+    granted BOOLEAN NOT NULL CHECK (granted IS TRUE),
+    granted_by_handler TEXT NOT NULL CHECK (btrim(granted_by_handler) <> ''),
+    granted_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    revoked_at TIMESTAMPTZ,
+    revoked_by_handler TEXT,
+    CHECK (expires_at > granted_at),
+    CHECK (revoked_at IS NULL OR revoked_at >= granted_at),
+    CHECK (
+        (revoked_at IS NULL AND revoked_by_handler IS NULL)
+        OR (revoked_at IS NOT NULL AND btrim(revoked_by_handler) <> '')
+    )
+);
+
+COMMENT ON TABLE interaction_authorizations IS
+    'Participant-specific positive grants scoped to one action, continuation, revision, and bounded validity interval.';
+COMMENT ON COLUMN interaction_authorizations.id IS
+    'Stable grant record identifier retained after expiry, revocation, or supersession.';
+COMMENT ON COLUMN interaction_authorizations.interaction_id IS
+    'Interaction whose action this grant may authorize.';
+COMMENT ON COLUMN interaction_authorizations.participant_entity_id IS
+    'Single participant who explicitly supplied this positive grant.';
+COMMENT ON COLUMN interaction_authorizations.action IS
+    'Exact policy-declared action authorized by this grant.';
+COMMENT ON COLUMN interaction_authorizations.continuation_id IS
+    'Continuation identity captured at grant time; mismatches deny as stale.';
+COMMENT ON COLUMN interaction_authorizations.interaction_revision IS
+    'Interaction revision captured at grant time; prior revisions deny as stale.';
+COMMENT ON COLUMN interaction_authorizations.granted IS
+    'Explicit positive grant marker; database constraints reject false or NULL authorization.';
+COMMENT ON COLUMN interaction_authorizations.granted_by_handler IS
+    'Trusted handler identity that recorded the participant-specific grant.';
+COMMENT ON COLUMN interaction_authorizations.granted_at IS
+    'Beginning of the bounded interval during which the grant can be evaluated.';
+COMMENT ON COLUMN interaction_authorizations.expires_at IS
+    'Required finite end of the grant validity interval.';
+COMMENT ON COLUMN interaction_authorizations.revoked_at IS
+    'Immediate revocation time; any non-NULL value denies authorization.';
+COMMENT ON COLUMN interaction_authorizations.revoked_by_handler IS
+    'Trusted handler identity that recorded revocation or supersession.';
+
+CREATE INDEX IF NOT EXISTS idx_interaction_authorizations_evaluation
+    ON interaction_authorizations (
+        interaction_id, action, participant_entity_id,
+        interaction_revision DESC, id DESC
+    );
+
+CREATE TABLE IF NOT EXISTS interaction_events (
+    id BIGSERIAL PRIMARY KEY,
+    interaction_id UUID NOT NULL
+        REFERENCES interactions(id) ON DELETE RESTRICT,
+    event_type TEXT NOT NULL
+        CHECK (event_type IN (
+            'proposed', 'authorized', 'started', 'transitioned',
+            'completed', 'stopped', 'interrupted'
+        )),
+    interaction_revision BIGINT NOT NULL CHECK (interaction_revision >= 1),
+    actor_participant_entity_id BIGINT
+        REFERENCES entities(id) ON DELETE RESTRICT,
+    actor_handler TEXT,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb
+        CHECK (jsonb_typeof(payload) = 'object'),
+    occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (num_nonnulls(actor_participant_entity_id, actor_handler) <= 1),
+    CHECK (actor_handler IS NULL OR btrim(actor_handler) <> '')
+);
+
+COMMENT ON TABLE interaction_events IS
+    'Immutable append-only lifecycle ledger from proposal through terminal outcome.';
+COMMENT ON COLUMN interaction_events.id IS
+    'Monotonic event identifier used to replay one interaction in write order.';
+COMMENT ON COLUMN interaction_events.interaction_id IS
+    'Interaction thread whose lifecycle emitted this event.';
+COMMENT ON COLUMN interaction_events.event_type IS
+    'Lifecycle event: proposed, authorized, started, transitioned, completed, stopped, or interrupted.';
+COMMENT ON COLUMN interaction_events.interaction_revision IS
+    'Interaction revision in effect immediately after this event.';
+COMMENT ON COLUMN interaction_events.actor_participant_entity_id IS
+    'Participant actor for unilateral stop events; NULL for handler or system actions.';
+COMMENT ON COLUMN interaction_events.actor_handler IS
+    'Trusted handler actor for handler-recorded events; NULL for participant or anonymous system actions.';
+COMMENT ON COLUMN interaction_events.payload IS
+    'Typed executor or authorization metadata needed to reconstruct the lifecycle without mutating prior events.';
+COMMENT ON COLUMN interaction_events.occurred_at IS
+    'Authoritative event time supplied by the transactional lifecycle service.';
+
+CREATE INDEX IF NOT EXISTS idx_interaction_events_replay
+    ON interaction_events (interaction_id, id);
+
+CREATE OR REPLACE FUNCTION reject_interaction_event_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'interaction lifecycle events are append-only';
+END;
+$$;
+
+COMMENT ON FUNCTION reject_interaction_event_mutation() IS
+    'Rejects UPDATE and DELETE so interaction lifecycle history remains replayable.';
+
+DROP TRIGGER IF EXISTS interaction_events_append_only ON interaction_events;
+CREATE TRIGGER interaction_events_append_only
+BEFORE UPDATE OR DELETE ON interaction_events
+FOR EACH ROW EXECUTE FUNCTION reject_interaction_event_mutation();
+
+COMMENT ON TRIGGER interaction_events_append_only ON interaction_events IS
+    'Prevents mutation or deletion of persisted interaction lifecycle events.';

--- a/nexus/interactions/__init__.py
+++ b/nexus/interactions/__init__.py
@@ -1,0 +1,56 @@
+"""Durable interaction threads with explicit fail-closed authorization.
+
+Authorization grants are a trusted-handler boundary, never a model-output
+boundary. See :mod:`nexus.interactions.service` for the enforced capability
+contract and transactional lifecycle semantics.
+"""
+
+from nexus.interactions.models import (
+    AuthorizationDecision,
+    AuthorizationPolicy,
+    AuthorizationRule,
+    DenialReason,
+    InteractionEvent,
+    InteractionEventType,
+    InteractionProposal,
+    InteractionSnapshot,
+    InteractionStatus,
+    InteractionTransition,
+    ReplayedInteraction,
+    TimelineAnchor,
+)
+from nexus.interactions.service import (
+    AuthorizationRecordNotFound,
+    InteractionAuthorizationDenied,
+    InteractionError,
+    InteractionNotFound,
+    InteractionService,
+    InteractionStateError,
+    RecoveryCleanupHook,
+    TrustedHandler,
+    UntrustedHandlerError,
+)
+
+__all__ = [
+    "AuthorizationDecision",
+    "AuthorizationPolicy",
+    "AuthorizationRecordNotFound",
+    "AuthorizationRule",
+    "DenialReason",
+    "InteractionAuthorizationDenied",
+    "InteractionError",
+    "InteractionEvent",
+    "InteractionEventType",
+    "InteractionNotFound",
+    "InteractionProposal",
+    "InteractionService",
+    "InteractionSnapshot",
+    "InteractionStateError",
+    "InteractionStatus",
+    "InteractionTransition",
+    "RecoveryCleanupHook",
+    "ReplayedInteraction",
+    "TimelineAnchor",
+    "TrustedHandler",
+    "UntrustedHandlerError",
+]

--- a/nexus/interactions/__init__.py
+++ b/nexus/interactions/__init__.py
@@ -7,6 +7,7 @@ contract and transactional lifecycle semantics.
 
 from nexus.interactions.models import (
     AuthorizationDecision,
+    AuthorizationEnvelope,
     AuthorizationPolicy,
     AuthorizationRule,
     DenialReason,
@@ -16,26 +17,31 @@ from nexus.interactions.models import (
     InteractionSnapshot,
     InteractionStatus,
     InteractionTransition,
+    MembershipHistoryState,
     ReplayedInteraction,
     TimelineAnchor,
 )
 from nexus.interactions.service import (
     AuthorizationRecordNotFound,
+    CommandIdConflict,
     InteractionAuthorizationDenied,
     InteractionError,
     InteractionNotFound,
     InteractionService,
     InteractionStateError,
-    RecoveryCleanupHook,
+    NamedRecoveryCleanupHook,
     TrustedHandler,
     UntrustedHandlerError,
+    UnknownExecutorTransition,
 )
 
 __all__ = [
     "AuthorizationDecision",
+    "AuthorizationEnvelope",
     "AuthorizationPolicy",
     "AuthorizationRecordNotFound",
     "AuthorizationRule",
+    "CommandIdConflict",
     "DenialReason",
     "InteractionAuthorizationDenied",
     "InteractionError",
@@ -48,9 +54,11 @@ __all__ = [
     "InteractionStateError",
     "InteractionStatus",
     "InteractionTransition",
-    "RecoveryCleanupHook",
+    "MembershipHistoryState",
+    "NamedRecoveryCleanupHook",
     "ReplayedInteraction",
     "TimelineAnchor",
     "TrustedHandler",
     "UntrustedHandlerError",
+    "UnknownExecutorTransition",
 ]

--- a/nexus/interactions/evaluator.py
+++ b/nexus/interactions/evaluator.py
@@ -1,0 +1,109 @@
+"""Pure fail-closed authorization evaluation for interaction execution."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import ValidationError
+
+from nexus.interactions.models import (
+    AuthorizationDecision,
+    AuthorizationGrantState,
+    DenialReason,
+)
+
+
+def evaluate_authorizations(
+    *,
+    participant_entity_ids: Iterable[int],
+    authorization_rows: Iterable[dict[str, Any]],
+    action: str,
+    continuation_id: UUID,
+    interaction_revision: int,
+    evaluated_at: datetime,
+) -> AuthorizationDecision:
+    """Require a current positive grant from every active participant.
+
+    The evaluator never infers approval. Missing rows, invalid row shapes, old
+    continuation or revision identities, revocation, expiry, and future-dated
+    grants all produce an explicit denial.
+    """
+    rows_by_participant: dict[int, list[dict[str, Any]]] = {}
+    for row in authorization_rows:
+        raw_participant_id = row.get("participant_entity_id")
+        if not isinstance(raw_participant_id, int):
+            return AuthorizationDecision(
+                allowed=False,
+                reason=DenialReason.MALFORMED_AUTHORIZATION,
+            )
+        rows_by_participant.setdefault(raw_participant_id, []).append(row)
+
+    for participant_id in participant_entity_ids:
+        participant_rows = rows_by_participant.get(participant_id, [])
+        if not participant_rows:
+            return AuthorizationDecision(
+                allowed=False,
+                reason=DenialReason.MISSING_AUTHORIZATION,
+                participant_entity_id=participant_id,
+            )
+
+        current_rows = [
+            row
+            for row in participant_rows
+            if row.get("continuation_id") == continuation_id
+            and row.get("interaction_revision") == interaction_revision
+        ]
+        if not current_rows:
+            return AuthorizationDecision(
+                allowed=False,
+                reason=DenialReason.STALE_AUTHORIZATION,
+                participant_entity_id=participant_id,
+            )
+
+        try:
+            latest_row = max(current_rows, key=lambda row: int(row.get("id", -1)))
+        except (TypeError, ValueError):
+            return AuthorizationDecision(
+                allowed=False,
+                reason=DenialReason.MALFORMED_AUTHORIZATION,
+                participant_entity_id=participant_id,
+            )
+        try:
+            grant = AuthorizationGrantState.model_validate(latest_row)
+        except (TypeError, ValueError, ValidationError):
+            return AuthorizationDecision(
+                allowed=False,
+                reason=DenialReason.MALFORMED_AUTHORIZATION,
+                participant_entity_id=participant_id,
+            )
+
+        if grant.action != action:
+            return AuthorizationDecision(
+                allowed=False,
+                reason=DenialReason.MALFORMED_AUTHORIZATION,
+                participant_entity_id=participant_id,
+            )
+
+        if grant.revoked_at is not None:
+            return AuthorizationDecision(
+                allowed=False,
+                reason=DenialReason.REVOKED_AUTHORIZATION,
+                participant_entity_id=participant_id,
+            )
+        if grant.granted_at > evaluated_at:
+            return AuthorizationDecision(
+                allowed=False,
+                reason=DenialReason.MALFORMED_AUTHORIZATION,
+                participant_entity_id=participant_id,
+            )
+        if grant.expires_at <= evaluated_at:
+            return AuthorizationDecision(
+                allowed=False,
+                reason=DenialReason.EXPIRED_AUTHORIZATION,
+                participant_entity_id=participant_id,
+            )
+
+    return AuthorizationDecision(allowed=True)

--- a/nexus/interactions/evaluator.py
+++ b/nexus/interactions/evaluator.py
@@ -1,7 +1,9 @@
-"""Pure fail-closed authorization evaluation for interaction execution."""
+"""Canonical term binding and fail-closed interaction authorization."""
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Iterable
 from datetime import datetime
 from typing import Any
@@ -11,9 +13,40 @@ from pydantic import ValidationError
 
 from nexus.interactions.models import (
     AuthorizationDecision,
+    AuthorizationEnvelope,
     AuthorizationGrantState,
+    AuthorizationPolicy,
     DenialReason,
 )
+
+
+def canonical_envelope_hash(
+    policy: AuthorizationPolicy, envelope: AuthorizationEnvelope
+) -> str:
+    """Hash action, transition type, and policy-declared material terms."""
+    rule = policy.actions.get(envelope.action)
+    if rule is None:
+        raise ValueError(f"authorization action is not declared: {envelope.action}")
+    material_terms: dict[str, dict[str, Any]] = {}
+    for field in sorted(rule.material_fields):
+        if field in envelope.payload:
+            material_terms[field] = {
+                "present": True,
+                "value": envelope.payload[field],
+            }
+        else:
+            material_terms[field] = {"present": False}
+    canonical = json.dumps(
+        {
+            "action": envelope.action,
+            "transition_type": envelope.transition_type,
+            "material_terms": material_terms,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 def evaluate_authorizations(
@@ -21,25 +54,20 @@ def evaluate_authorizations(
     participant_entity_ids: Iterable[int],
     authorization_rows: Iterable[dict[str, Any]],
     action: str,
+    envelope_hash: str,
     continuation_id: UUID,
     interaction_revision: int,
     evaluated_at: datetime,
 ) -> AuthorizationDecision:
-    """Require a current positive grant from every active participant.
-
-    The evaluator never infers approval. Missing rows, invalid row shapes, old
-    continuation or revision identities, revocation, expiry, and future-dated
-    grants all produce an explicit denial.
-    """
+    """Require one exact current-envelope grant from every active participant."""
     rows_by_participant: dict[int, list[dict[str, Any]]] = {}
     for row in authorization_rows:
-        raw_participant_id = row.get("participant_entity_id")
-        if not isinstance(raw_participant_id, int):
+        participant_id = row.get("participant_entity_id")
+        if not isinstance(participant_id, int):
             return AuthorizationDecision(
-                allowed=False,
-                reason=DenialReason.MALFORMED_AUTHORIZATION,
+                allowed=False, reason=DenialReason.MALFORMED_AUTHORIZATION
             )
-        rows_by_participant.setdefault(raw_participant_id, []).append(row)
+        rows_by_participant.setdefault(participant_id, []).append(row)
 
     for participant_id in participant_entity_ids:
         participant_rows = rows_by_participant.get(participant_id, [])
@@ -49,7 +77,6 @@ def evaluate_authorizations(
                 reason=DenialReason.MISSING_AUTHORIZATION,
                 participant_entity_id=participant_id,
             )
-
         current_rows = [
             row
             for row in participant_rows
@@ -62,48 +89,50 @@ def evaluate_authorizations(
                 reason=DenialReason.STALE_AUTHORIZATION,
                 participant_entity_id=participant_id,
             )
-
-        try:
-            latest_row = max(current_rows, key=lambda row: int(row.get("id", -1)))
-        except (TypeError, ValueError):
+        exact_rows = [
+            row for row in current_rows if row.get("envelope_hash") == envelope_hash
+        ]
+        if not exact_rows:
             return AuthorizationDecision(
                 allowed=False,
-                reason=DenialReason.MALFORMED_AUTHORIZATION,
-                participant_entity_id=participant_id,
-            )
-        try:
-            grant = AuthorizationGrantState.model_validate(latest_row)
-        except (TypeError, ValueError, ValidationError):
-            return AuthorizationDecision(
-                allowed=False,
-                reason=DenialReason.MALFORMED_AUTHORIZATION,
+                reason=DenialReason.AUTHORIZATION_TERMS_CHANGED,
                 participant_entity_id=participant_id,
             )
 
-        if grant.action != action:
-            return AuthorizationDecision(
-                allowed=False,
-                reason=DenialReason.MALFORMED_AUTHORIZATION,
-                participant_entity_id=participant_id,
-            )
+        validated: list[AuthorizationGrantState] = []
+        for row in exact_rows:
+            try:
+                grant = AuthorizationGrantState.model_validate(row)
+            except (TypeError, ValueError, ValidationError):
+                return AuthorizationDecision(
+                    allowed=False,
+                    reason=DenialReason.MALFORMED_AUTHORIZATION,
+                    participant_entity_id=participant_id,
+                )
+            if grant.action != action:
+                return AuthorizationDecision(
+                    allowed=False,
+                    reason=DenialReason.MALFORMED_AUTHORIZATION,
+                    participant_entity_id=participant_id,
+                )
+            validated.append(grant)
 
-        if grant.revoked_at is not None:
-            return AuthorizationDecision(
-                allowed=False,
-                reason=DenialReason.REVOKED_AUTHORIZATION,
-                participant_entity_id=participant_id,
-            )
-        if grant.granted_at > evaluated_at:
-            return AuthorizationDecision(
-                allowed=False,
-                reason=DenialReason.MALFORMED_AUTHORIZATION,
-                participant_entity_id=participant_id,
-            )
-        if grant.expires_at <= evaluated_at:
-            return AuthorizationDecision(
-                allowed=False,
-                reason=DenialReason.EXPIRED_AUTHORIZATION,
-                participant_entity_id=participant_id,
-            )
+        if any(
+            grant.revoked_at is None
+            and grant.granted_at <= evaluated_at < grant.expires_at
+            for grant in validated
+        ):
+            continue
+        if any(grant.granted_at > evaluated_at for grant in validated):
+            reason = DenialReason.MALFORMED_AUTHORIZATION
+        elif all(grant.revoked_at is not None for grant in validated):
+            reason = DenialReason.REVOKED_AUTHORIZATION
+        else:
+            reason = DenialReason.EXPIRED_AUTHORIZATION
+        return AuthorizationDecision(
+            allowed=False,
+            reason=reason,
+            participant_entity_id=participant_id,
+        )
 
     return AuthorizationDecision(allowed=True)

--- a/nexus/interactions/models.py
+++ b/nexus/interactions/models.py
@@ -1,0 +1,223 @@
+"""Validated public data models for durable interaction threads."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Annotated, Any, Literal
+from uuid import UUID, uuid4
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+
+
+NamespacedIdentifier = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=1,
+        pattern=r"^[a-z][a-z0-9_.-]*$",
+    ),
+]
+ActionName = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=1,
+        pattern=r"^[a-z][a-z0-9_.:-]*$",
+    ),
+]
+NonEmptyText = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+class InteractionStatus(str, Enum):
+    """Durable lifecycle states for an interaction."""
+
+    PROPOSED = "proposed"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    STOPPED = "stopped"
+    INTERRUPTED = "interrupted"
+
+
+class InteractionEventType(str, Enum):
+    """Append-only lifecycle event vocabulary."""
+
+    PROPOSED = "proposed"
+    AUTHORIZED = "authorized"
+    STARTED = "started"
+    TRANSITIONED = "transitioned"
+    COMPLETED = "completed"
+    STOPPED = "stopped"
+    INTERRUPTED = "interrupted"
+
+
+class DenialReason(str, Enum):
+    """Typed fail-closed reasons returned by authorization and freshness checks."""
+
+    MISSING_AUTHORIZATION = "missing_authorization"
+    MALFORMED_AUTHORIZATION = "malformed_authorization"
+    MALFORMED_POLICY = "malformed_policy"
+    EXPIRED_AUTHORIZATION = "expired_authorization"
+    REVOKED_AUTHORIZATION = "revoked_authorization"
+    STALE_AUTHORIZATION = "stale_authorization"
+    ACTION_NOT_DECLARED = "action_not_declared"
+    EVALUATION_UNAVAILABLE = "evaluation_unavailable"
+    STALE_ANCHOR = "stale_anchor"
+    STALE_TIMELINE = "stale_timeline"
+
+
+class AuthorizationRule(_StrictModel):
+    """One action's all-participant, bounded-validity authorization rule."""
+
+    max_validity_seconds: int = Field(gt=0)
+    require_all_active_participants: Literal[True] = True
+
+
+class AuthorizationPolicy(_StrictModel):
+    """Declared action policy validated again at every execution boundary."""
+
+    actions: dict[ActionName, AuthorizationRule] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _require_lifecycle_actions(self) -> "AuthorizationPolicy":
+        """Start and completion can never execute without declared policies."""
+        missing = {"start", "complete"} - set(self.actions)
+        if missing:
+            raise ValueError(
+                "authorization policy must declare lifecycle actions: "
+                f"{sorted(missing)}"
+            )
+        return self
+
+
+class TimelineAnchor(_StrictModel):
+    """Authoritative story position used for post-latency freshness checks."""
+
+    anchor_chunk_id: int = Field(gt=0)
+    timeline_id: NonEmptyText
+
+
+class InteractionProposal(_StrictModel):
+    """Trusted-handler input for creating a proposed interaction."""
+
+    kind: NonEmptyText
+    executor_namespace: NamespacedIdentifier
+    policy: AuthorizationPolicy
+    participant_entity_ids: list[int] = Field(min_length=2)
+    anchor: TimelineAnchor
+    continuation_id: UUID = Field(default_factory=uuid4)
+
+    @field_validator("participant_entity_ids")
+    @classmethod
+    def _participants_are_unique_and_positive(cls, value: list[int]) -> list[int]:
+        if any(participant_id <= 0 for participant_id in value):
+            raise ValueError("participant entity IDs must be positive")
+        if len(set(value)) != len(value):
+            raise ValueError("participant entity IDs must be unique")
+        return value
+
+
+class InteractionTransition(_StrictModel):
+    """Typed executor transition plus the exact action that authorizes it."""
+
+    transition_type: NamespacedIdentifier
+    authorization_action: ActionName
+    payload: dict[str, JsonValue] = Field(default_factory=dict)
+
+
+class InteractionSnapshot(_StrictModel):
+    """Materialized durable state returned by lifecycle operations."""
+
+    id: UUID
+    kind: str
+    executor_namespace: str
+    status: InteractionStatus
+    policy: AuthorizationPolicy
+    continuation_id: UUID
+    revision: int
+    anchor: TimelineAnchor
+    participant_entity_ids: tuple[int, ...]
+    created_at: datetime
+    updated_at: datetime
+
+
+class AuthorizationDecision(_StrictModel):
+    """Result of the fail-closed evaluator."""
+
+    allowed: bool
+    reason: DenialReason | None = None
+    participant_entity_id: int | None = None
+
+    @model_validator(mode="after")
+    def _reason_matches_outcome(self) -> "AuthorizationDecision":
+        if self.allowed and (
+            self.reason is not None or self.participant_entity_id is not None
+        ):
+            raise ValueError("allowed decisions cannot carry denial details")
+        if not self.allowed and self.reason is None:
+            raise ValueError("denied decisions require a typed reason")
+        return self
+
+
+class AuthorizationGrantState(_StrictModel):
+    """Validated database shape for one participant-specific positive grant."""
+
+    id: int
+    participant_entity_id: int
+    action: ActionName
+    continuation_id: UUID
+    interaction_revision: int = Field(gt=0)
+    granted: Literal[True]
+    granted_at: datetime
+    expires_at: datetime
+    revoked_at: datetime | None
+
+    @model_validator(mode="after")
+    def _bounded_interval_is_well_formed(self) -> "AuthorizationGrantState":
+        timestamps = [self.granted_at, self.expires_at]
+        if self.revoked_at is not None:
+            timestamps.append(self.revoked_at)
+        if any(
+            value.tzinfo is None or value.utcoffset() is None for value in timestamps
+        ):
+            raise ValueError("authorization timestamps must be timezone-aware")
+        if self.expires_at <= self.granted_at:
+            raise ValueError("authorization expiry must follow grant time")
+        if self.revoked_at is not None and self.revoked_at < self.granted_at:
+            raise ValueError("authorization revocation cannot precede grant time")
+        return self
+
+
+class InteractionEvent(_StrictModel):
+    """One immutable event from the lifecycle ledger."""
+
+    id: int
+    interaction_id: UUID
+    event_type: InteractionEventType
+    interaction_revision: int
+    actor_participant_entity_id: int | None
+    actor_handler: str | None
+    payload: dict[str, Any]
+    occurred_at: datetime
+
+
+class ReplayedInteraction(_StrictModel):
+    """Lifecycle state reconstructed exclusively from append-only events."""
+
+    interaction_id: UUID
+    status: InteractionStatus
+    revision: int
+    transition_types: tuple[str, ...]
+    authorization_events: int

--- a/nexus/interactions/models.py
+++ b/nexus/interactions/models.py
@@ -34,7 +34,16 @@ ActionName = Annotated[
         pattern=r"^[a-z][a-z0-9_.:-]*$",
     ),
 ]
+MaterialField = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=1,
+        pattern=r"^[A-Za-z_][A-Za-z0-9_]*$",
+    ),
+]
 NonEmptyText = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+EnvelopeHash = Annotated[str, StringConstraints(pattern=r"^[0-9a-f]{64}$")]
 
 
 class _StrictModel(BaseModel):
@@ -52,7 +61,7 @@ class InteractionStatus(str, Enum):
 
 
 class InteractionEventType(str, Enum):
-    """Append-only lifecycle event vocabulary."""
+    """Append-only interaction event vocabulary."""
 
     PROPOSED = "proposed"
     AUTHORIZED = "authorized"
@@ -61,10 +70,15 @@ class InteractionEventType(str, Enum):
     COMPLETED = "completed"
     STOPPED = "stopped"
     INTERRUPTED = "interrupted"
+    MEMBERSHIP_JOINED = "membership_joined"
+    MEMBERSHIP_LEFT = "membership_left"
+    LEASE_TOUCHED = "lease_touched"
+    RECOVERY_CLAIMED = "recovery_claimed"
+    CLEANUP_COMPLETED = "cleanup_completed"
 
 
 class DenialReason(str, Enum):
-    """Typed fail-closed reasons returned by authorization and freshness checks."""
+    """Typed fail-closed authorization, vocabulary, and freshness reasons."""
 
     MISSING_AUTHORIZATION = "missing_authorization"
     MALFORMED_AUTHORIZATION = "malformed_authorization"
@@ -72,17 +86,27 @@ class DenialReason(str, Enum):
     EXPIRED_AUTHORIZATION = "expired_authorization"
     REVOKED_AUTHORIZATION = "revoked_authorization"
     STALE_AUTHORIZATION = "stale_authorization"
+    AUTHORIZATION_TERMS_CHANGED = "authorization_terms_changed"
     ACTION_NOT_DECLARED = "action_not_declared"
+    UNKNOWN_TRANSITION = "unknown_transition"
     EVALUATION_UNAVAILABLE = "evaluation_unavailable"
     STALE_ANCHOR = "stale_anchor"
     STALE_TIMELINE = "stale_timeline"
 
 
 class AuthorizationRule(_StrictModel):
-    """One action's all-participant, bounded-validity authorization rule."""
+    """One action's all-participant, bounded, material-term policy."""
 
     max_validity_seconds: int = Field(gt=0)
+    material_fields: tuple[MaterialField, ...] = ()
     require_all_active_participants: Literal[True] = True
+
+    @field_validator("material_fields")
+    @classmethod
+    def _material_fields_are_unique(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(value) != len(set(value)):
+            raise ValueError("material payload fields must be unique")
+        return value
 
 
 class AuthorizationPolicy(_StrictModel):
@@ -92,21 +116,33 @@ class AuthorizationPolicy(_StrictModel):
 
     @model_validator(mode="after")
     def _require_lifecycle_actions(self) -> "AuthorizationPolicy":
-        """Start and completion can never execute without declared policies."""
         missing = {"start", "complete"} - set(self.actions)
         if missing:
             raise ValueError(
                 "authorization policy must declare lifecycle actions: "
                 f"{sorted(missing)}"
             )
+        for lifecycle_action in ("start", "complete"):
+            if self.actions[lifecycle_action].material_fields:
+                raise ValueError(
+                    f"{lifecycle_action} cannot declare material payload fields"
+                )
         return self
 
 
 class TimelineAnchor(_StrictModel):
-    """Authoritative story position used for post-latency freshness checks."""
+    """Expected authoritative story position for execution fencing."""
 
     anchor_chunk_id: int = Field(gt=0)
     timeline_id: NonEmptyText
+
+
+class AuthorizationEnvelope(_StrictModel):
+    """Action, transition type, and proposed terms presented for authorization."""
+
+    action: ActionName
+    transition_type: NamespacedIdentifier
+    payload: dict[str, JsonValue] = Field(default_factory=dict)
 
 
 class InteractionProposal(_StrictModel):
@@ -136,6 +172,14 @@ class InteractionTransition(_StrictModel):
     authorization_action: ActionName
     payload: dict[str, JsonValue] = Field(default_factory=dict)
 
+    def authorization_envelope(self) -> AuthorizationEnvelope:
+        """Return the actual command envelope revalidated at execution."""
+        return AuthorizationEnvelope(
+            action=self.authorization_action,
+            transition_type=self.transition_type,
+            payload=self.payload,
+        )
+
 
 class InteractionSnapshot(_StrictModel):
     """Materialized durable state returned by lifecycle operations."""
@@ -149,6 +193,7 @@ class InteractionSnapshot(_StrictModel):
     revision: int
     anchor: TimelineAnchor
     participant_entity_ids: tuple[int, ...]
+    lease_until: datetime | None
     created_at: datetime
     updated_at: datetime
 
@@ -177,6 +222,7 @@ class AuthorizationGrantState(_StrictModel):
     id: int
     participant_entity_id: int
     action: ActionName
+    envelope_hash: EnvelopeHash
     continuation_id: UUID
     interaction_revision: int = Field(gt=0)
     granted: Literal[True]
@@ -201,7 +247,7 @@ class AuthorizationGrantState(_StrictModel):
 
 
 class InteractionEvent(_StrictModel):
-    """One immutable event from the lifecycle ledger."""
+    """One immutable command or cleanup event from the lifecycle ledger."""
 
     id: int
     interaction_id: UUID
@@ -209,15 +255,33 @@ class InteractionEvent(_StrictModel):
     interaction_revision: int
     actor_participant_entity_id: int | None
     actor_handler: str | None
+    command_id: UUID
+    command_step: str
+    command_fingerprint: EnvelopeHash
     payload: dict[str, Any]
+    outcome: dict[str, Any]
     occurred_at: datetime
 
 
+class MembershipHistoryState(_StrictModel):
+    """One reconstructed participant membership interval."""
+
+    membership_id: int
+    participant_entity_id: int
+    joined_at: datetime
+    joined_revision: int
+    left_at: datetime | None = None
+    left_revision: int | None = None
+
+
 class ReplayedInteraction(_StrictModel):
-    """Lifecycle state reconstructed exclusively from append-only events."""
+    """Full interaction state reconstructed from durable rows or events."""
 
     interaction_id: UUID
     status: InteractionStatus
     revision: int
+    active_participant_entity_ids: tuple[int, ...]
+    membership_history: tuple[MembershipHistoryState, ...]
+    grants: tuple[AuthorizationGrantState, ...]
     transition_types: tuple[str, ...]
-    authorization_events: int
+    lease_until: datetime | None

--- a/nexus/interactions/service.py
+++ b/nexus/interactions/service.py
@@ -1,0 +1,960 @@
+"""Transactional lifecycle API for durable interaction threads.
+
+Trust boundary
+--------------
+Only trusted, non-model handler code may call proposal, authorization, execution,
+or recovery methods. A handler must first bind an opaque capability to this exact
+service instance; every privileged method verifies that capability. Pydantic wire
+or LLM output models cannot represent or manufacture it. Model-generated content
+may be carried inside an already-authorized transition payload, but no payload,
+tool result, or structured model response can create or satisfy an authorization
+record. Participant ``stop`` is intentionally separate: any current participant
+can stop unilaterally and immediately without a handler, peer grant, or veto path.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Sequence
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID, uuid4
+
+from pydantic import ValidationError
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from nexus.interactions.evaluator import evaluate_authorizations
+from nexus.interactions.models import (
+    AuthorizationDecision,
+    AuthorizationPolicy,
+    DenialReason,
+    InteractionEvent,
+    InteractionEventType,
+    InteractionProposal,
+    InteractionSnapshot,
+    InteractionStatus,
+    InteractionTransition,
+    ReplayedInteraction,
+    TimelineAnchor,
+)
+
+
+class InteractionError(RuntimeError):
+    """Base class for typed interaction lifecycle failures."""
+
+
+class InteractionNotFound(InteractionError):
+    """Raised when an interaction ID has no durable record."""
+
+
+class InteractionStateError(InteractionError):
+    """Raised when a lifecycle method is invalid for the current status."""
+
+
+class InteractionAuthorizationDenied(InteractionError):
+    """Fail-closed execution denial with a machine-readable reason."""
+
+    def __init__(self, decision: AuthorizationDecision) -> None:
+        self.decision = decision
+        if decision.reason is None:
+            raise ValueError("authorization denial requires a typed reason")
+        detail = f"interaction authorization denied: {decision.reason.value}"
+        if decision.participant_entity_id is not None:
+            detail += f" for participant {decision.participant_entity_id}"
+        super().__init__(detail)
+
+
+class UntrustedHandlerError(InteractionError):
+    """Raised when a privileged API receives no valid handler capability."""
+
+
+class AuthorizationRecordNotFound(InteractionError):
+    """Raised when revocation cannot find a current grant record."""
+
+
+class TrustedHandler:
+    """Opaque capability issued by one service to one trusted handler identity."""
+
+    __slots__ = ("identity", "_service_nonce")
+
+    def __init__(self, identity: str, service_nonce: object) -> None:
+        self.identity = identity
+        self._service_nonce = service_nonce
+
+
+SessionFactory = Callable[[], Session]
+FreshnessResolver = Callable[[Session], TimelineAnchor]
+EvaluationTimeProvider = Callable[[Session], datetime]
+RecoveryCleanupHook = Callable[[Session, InteractionSnapshot], None]
+
+
+def _database_time(session: Session) -> datetime:
+    value = session.execute(text("SELECT CURRENT_TIMESTAMP")).scalar_one()
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        raise RuntimeError("database returned an invalid interaction evaluation time")
+    return value
+
+
+class InteractionService:
+    """Own transactional persistence, evaluation, recovery, and history replay."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        *,
+        freshness_resolver: FreshnessResolver,
+        evaluation_time_provider: EvaluationTimeProvider = _database_time,
+    ) -> None:
+        self._session_factory = session_factory
+        self._freshness_resolver = freshness_resolver
+        self._evaluation_time_provider = evaluation_time_provider
+        self._handler_nonce = object()
+
+    def bind_trusted_handler(self, identity: str) -> TrustedHandler:
+        """Bind trusted bootstrap code to an opaque service-local capability."""
+        normalized = identity.strip()
+        if not normalized:
+            raise ValueError("trusted handler identity must not be empty")
+        return TrustedHandler(normalized, self._handler_nonce)
+
+    def propose(
+        self, caller: TrustedHandler, proposal: InteractionProposal
+    ) -> InteractionSnapshot:
+        """Persist a proposed interaction, initial memberships, and first event."""
+        handler = self._require_handler(caller)
+        interaction_id = uuid4()
+        with self._session_factory() as session, session.begin():
+            now = self._evaluation_time(session)
+            session.execute(
+                text(
+                    """
+                    INSERT INTO interactions (
+                        id, kind, executor_namespace, status, policy,
+                        continuation_id, revision, anchor_chunk_id, timeline_id,
+                        created_at, updated_at
+                    ) VALUES (
+                        :id, :kind, :executor_namespace, 'proposed',
+                        CAST(:policy AS JSONB), :continuation_id, 1,
+                        :anchor_chunk_id, :timeline_id, :now, :now
+                    )
+                    """
+                ),
+                {
+                    "id": interaction_id,
+                    "kind": proposal.kind,
+                    "executor_namespace": proposal.executor_namespace,
+                    "policy": proposal.policy.model_dump_json(),
+                    "continuation_id": proposal.continuation_id,
+                    "anchor_chunk_id": proposal.anchor.anchor_chunk_id,
+                    "timeline_id": proposal.anchor.timeline_id,
+                    "now": now,
+                },
+            )
+            for participant_id in proposal.participant_entity_ids:
+                session.execute(
+                    text(
+                        """
+                        INSERT INTO interaction_participants (
+                            interaction_id, participant_entity_id, joined_at
+                        ) VALUES (:interaction_id, :participant_id, :joined_at)
+                        """
+                    ),
+                    {
+                        "interaction_id": interaction_id,
+                        "participant_id": participant_id,
+                        "joined_at": now,
+                    },
+                )
+            self._append_event(
+                session,
+                interaction_id=interaction_id,
+                event_type=InteractionEventType.PROPOSED,
+                revision=1,
+                occurred_at=now,
+                actor_handler=handler.identity,
+                payload={
+                    "kind": proposal.kind,
+                    "executor_namespace": proposal.executor_namespace,
+                    "participant_entity_ids": proposal.participant_entity_ids,
+                    "continuation_id": str(proposal.continuation_id),
+                    "anchor": proposal.anchor.model_dump(mode="json"),
+                },
+            )
+            return self._snapshot(session, interaction_id, lock=False)
+
+    def grant(
+        self,
+        caller: TrustedHandler,
+        *,
+        interaction_id: UUID,
+        participant_entity_id: int,
+        action: str,
+        expires_at: datetime,
+    ) -> int:
+        """Record one explicit participant grant from trusted handler code only."""
+        handler = self._require_handler(caller)
+        if expires_at.tzinfo is None or expires_at.utcoffset() is None:
+            raise ValueError("authorization expiry must be timezone-aware")
+        with self._session_factory() as session, session.begin():
+            interaction = self._locked_row(session, interaction_id)
+            self._require_open(interaction)
+            policy = self._validated_policy(interaction)
+            rule = policy.actions.get(action)
+            if rule is None:
+                raise InteractionAuthorizationDenied(
+                    AuthorizationDecision(
+                        allowed=False, reason=DenialReason.ACTION_NOT_DECLARED
+                    )
+                )
+            self._require_active_participant(
+                session, interaction_id, participant_entity_id
+            )
+            now = self._evaluation_time(session)
+            validity_seconds = (expires_at - now).total_seconds()
+            if validity_seconds <= 0:
+                raise ValueError("authorization expiry must be in the future")
+            if validity_seconds > rule.max_validity_seconds:
+                raise ValueError(
+                    f"authorization validity {validity_seconds:.6f}s exceeds "
+                    f"policy maximum {rule.max_validity_seconds}s"
+                )
+
+            session.execute(
+                text(
+                    """
+                    UPDATE interaction_authorizations
+                    SET revoked_at = :now,
+                        revoked_by_handler = :handler
+                    WHERE interaction_id = :interaction_id
+                      AND participant_entity_id = :participant_id
+                      AND action = :action
+                      AND continuation_id = :continuation_id
+                      AND interaction_revision = :revision
+                      AND revoked_at IS NULL
+                    """
+                ),
+                {
+                    "now": now,
+                    "handler": handler.identity,
+                    "interaction_id": interaction_id,
+                    "participant_id": participant_entity_id,
+                    "action": action,
+                    "continuation_id": interaction["continuation_id"],
+                    "revision": interaction["revision"],
+                },
+            )
+            grant_id = int(
+                session.execute(
+                    text(
+                        """
+                        INSERT INTO interaction_authorizations (
+                            interaction_id, participant_entity_id, action,
+                            continuation_id, interaction_revision, granted,
+                            granted_by_handler, granted_at, expires_at
+                        ) VALUES (
+                            :interaction_id, :participant_id, :action,
+                            :continuation_id, :revision, TRUE,
+                            :handler, :granted_at, :expires_at
+                        )
+                        RETURNING id
+                        """
+                    ),
+                    {
+                        "interaction_id": interaction_id,
+                        "participant_id": participant_entity_id,
+                        "action": action,
+                        "continuation_id": interaction["continuation_id"],
+                        "revision": interaction["revision"],
+                        "handler": handler.identity,
+                        "granted_at": now,
+                        "expires_at": expires_at,
+                    },
+                ).scalar_one()
+            )
+            self._touch(session, interaction_id, now)
+            self._append_event(
+                session,
+                interaction_id=interaction_id,
+                event_type=InteractionEventType.AUTHORIZED,
+                revision=int(interaction["revision"]),
+                occurred_at=now,
+                actor_handler=handler.identity,
+                payload={
+                    "state": "granted",
+                    "grant_id": grant_id,
+                    "participant_entity_id": participant_entity_id,
+                    "action": action,
+                    "expires_at": expires_at.isoformat(),
+                },
+            )
+            return grant_id
+
+    def revoke(
+        self,
+        caller: TrustedHandler,
+        *,
+        interaction_id: UUID,
+        participant_entity_id: int,
+        action: str,
+    ) -> int:
+        """Immediately revoke the latest current-revision participant grant."""
+        handler = self._require_handler(caller)
+        with self._session_factory() as session, session.begin():
+            interaction = self._locked_row(session, interaction_id)
+            self._require_open(interaction)
+            self._require_active_participant(
+                session, interaction_id, participant_entity_id
+            )
+            now = self._evaluation_time(session)
+            grant_id = session.execute(
+                text(
+                    """
+                    UPDATE interaction_authorizations
+                    SET revoked_at = :now,
+                        revoked_by_handler = :handler
+                    WHERE id = (
+                        SELECT id
+                        FROM interaction_authorizations
+                        WHERE interaction_id = :interaction_id
+                          AND participant_entity_id = :participant_id
+                          AND action = :action
+                          AND continuation_id = :continuation_id
+                          AND interaction_revision = :revision
+                          AND revoked_at IS NULL
+                        ORDER BY id DESC
+                        LIMIT 1
+                        FOR UPDATE
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "now": now,
+                    "handler": handler.identity,
+                    "interaction_id": interaction_id,
+                    "participant_id": participant_entity_id,
+                    "action": action,
+                    "continuation_id": interaction["continuation_id"],
+                    "revision": interaction["revision"],
+                },
+            ).scalar_one_or_none()
+            if grant_id is None:
+                raise AuthorizationRecordNotFound(
+                    f"no current grant for participant {participant_entity_id} "
+                    f"and action {action}"
+                )
+            self._touch(session, interaction_id, now)
+            self._append_event(
+                session,
+                interaction_id=interaction_id,
+                event_type=InteractionEventType.AUTHORIZED,
+                revision=int(interaction["revision"]),
+                occurred_at=now,
+                actor_handler=handler.identity,
+                payload={
+                    "state": "revoked",
+                    "grant_id": int(grant_id),
+                    "participant_entity_id": participant_entity_id,
+                    "action": action,
+                },
+            )
+            return int(grant_id)
+
+    def evaluate(self, *, interaction_id: UUID, action: str) -> AuthorizationDecision:
+        """Evaluate current grants without mutating lifecycle state."""
+        try:
+            with self._session_factory() as session, session.begin():
+                interaction = self._locked_row(session, interaction_id)
+                return self._authorization_decision(session, interaction, action)
+        except InteractionAuthorizationDenied as exc:
+            return exc.decision
+
+    def start(
+        self, caller: TrustedHandler, *, interaction_id: UUID
+    ) -> InteractionSnapshot:
+        """Start transactionally after current grants and freshness revalidate."""
+        return self._execute_status_change(
+            caller,
+            interaction_id=interaction_id,
+            expected_status=InteractionStatus.PROPOSED,
+            action="start",
+            event_type=InteractionEventType.STARTED,
+            target_status=InteractionStatus.IN_PROGRESS,
+            payload={},
+            terminal=False,
+        )
+
+    def transition(
+        self,
+        caller: TrustedHandler,
+        *,
+        interaction_id: UUID,
+        transition: InteractionTransition,
+    ) -> InteractionSnapshot:
+        """Apply one typed executor transition after execution-time revalidation."""
+        return self._execute_status_change(
+            caller,
+            interaction_id=interaction_id,
+            expected_status=InteractionStatus.IN_PROGRESS,
+            action=transition.authorization_action,
+            event_type=InteractionEventType.TRANSITIONED,
+            target_status=InteractionStatus.IN_PROGRESS,
+            payload={
+                "transition_type": transition.transition_type,
+                "authorization_action": transition.authorization_action,
+                "payload": transition.payload,
+            },
+            terminal=False,
+        )
+
+    def complete(
+        self, caller: TrustedHandler, *, interaction_id: UUID
+    ) -> InteractionSnapshot:
+        """Complete transactionally after current grants and freshness revalidate."""
+        return self._execute_status_change(
+            caller,
+            interaction_id=interaction_id,
+            expected_status=InteractionStatus.IN_PROGRESS,
+            action="complete",
+            event_type=InteractionEventType.COMPLETED,
+            target_status=InteractionStatus.COMPLETED,
+            payload={},
+            terminal=True,
+        )
+
+    def stop(
+        self, *, interaction_id: UUID, participant_entity_id: int
+    ) -> InteractionSnapshot:
+        """Stop immediately at any current participant's unilateral request."""
+        with self._session_factory() as session, session.begin():
+            interaction = self._locked_row(session, interaction_id)
+            self._require_open(interaction)
+            self._require_active_participant(
+                session, interaction_id, participant_entity_id
+            )
+            now = self._evaluation_time(session)
+            revision = int(interaction["revision"]) + 1
+            self._update_status(
+                session,
+                interaction_id=interaction_id,
+                status=InteractionStatus.STOPPED,
+                revision=revision,
+                updated_at=now,
+            )
+            self._close_memberships(session, interaction_id, now)
+            self._append_event(
+                session,
+                interaction_id=interaction_id,
+                event_type=InteractionEventType.STOPPED,
+                revision=revision,
+                occurred_at=now,
+                actor_participant_entity_id=participant_entity_id,
+                payload={"reason": "participant_withdrawal"},
+            )
+            return self._snapshot(session, interaction_id, lock=False)
+
+    def recover(
+        self,
+        caller: TrustedHandler,
+        *,
+        orphaned_before: datetime,
+        cleanup_hooks: Sequence[RecoveryCleanupHook] = (),
+    ) -> tuple[UUID, ...]:
+        """Interrupt orphaned in-progress threads exactly once; never resume them."""
+        handler = self._require_handler(caller)
+        if orphaned_before.tzinfo is None or orphaned_before.utcoffset() is None:
+            raise ValueError("orphan recovery cutoff must be timezone-aware")
+        recovered: list[UUID] = []
+        with self._session_factory() as session, session.begin():
+            interaction_ids = tuple(
+                session.execute(
+                    text(
+                        """
+                        SELECT id
+                        FROM interactions
+                        WHERE status = 'in_progress'
+                          AND updated_at < :orphaned_before
+                        ORDER BY updated_at, id
+                        FOR UPDATE SKIP LOCKED
+                        """
+                    ),
+                    {"orphaned_before": orphaned_before},
+                ).scalars()
+            )
+            for interaction_id in interaction_ids:
+                snapshot = self._snapshot(session, interaction_id, lock=False)
+                for cleanup_hook in cleanup_hooks:
+                    cleanup_hook(session, snapshot)
+                now = self._evaluation_time(session)
+                revision = snapshot.revision + 1
+                self._update_status(
+                    session,
+                    interaction_id=interaction_id,
+                    status=InteractionStatus.INTERRUPTED,
+                    revision=revision,
+                    updated_at=now,
+                )
+                self._close_memberships(session, interaction_id, now)
+                self._append_event(
+                    session,
+                    interaction_id=interaction_id,
+                    event_type=InteractionEventType.INTERRUPTED,
+                    revision=revision,
+                    occurred_at=now,
+                    actor_handler=handler.identity,
+                    payload={"reason": "orphan_recovery"},
+                )
+                recovered.append(interaction_id)
+        return tuple(recovered)
+
+    def get(self, interaction_id: UUID) -> InteractionSnapshot:
+        """Read one durable interaction and its current active membership."""
+        with self._session_factory() as session, session.begin():
+            return self._snapshot(session, interaction_id, lock=False)
+
+    def history(self, interaction_id: UUID) -> tuple[InteractionEvent, ...]:
+        """Read immutable lifecycle events in replay order."""
+        with self._session_factory() as session, session.begin():
+            if (
+                session.execute(
+                    text("SELECT 1 FROM interactions WHERE id = :id"),
+                    {"id": interaction_id},
+                ).scalar_one_or_none()
+                is None
+            ):
+                raise InteractionNotFound(f"interaction {interaction_id} was not found")
+            rows = session.execute(
+                text(
+                    """
+                    SELECT id, interaction_id, event_type,
+                           interaction_revision,
+                           actor_participant_entity_id, actor_handler,
+                           payload, occurred_at
+                    FROM interaction_events
+                    WHERE interaction_id = :interaction_id
+                    ORDER BY id
+                    """
+                ),
+                {"interaction_id": interaction_id},
+            ).mappings()
+            return tuple(InteractionEvent.model_validate(dict(row)) for row in rows)
+
+    def replay(self, interaction_id: UUID) -> ReplayedInteraction:
+        """Reconstruct lifecycle state exclusively from the append-only ledger."""
+        events = self.history(interaction_id)
+        if not events or events[0].event_type is not InteractionEventType.PROPOSED:
+            raise InteractionStateError(
+                f"interaction {interaction_id} has no valid proposed event"
+            )
+        status = InteractionStatus.PROPOSED
+        transitions: list[str] = []
+        authorization_events = 0
+        revision = events[0].interaction_revision
+        for event in events[1:]:
+            revision = event.interaction_revision
+            if event.event_type is InteractionEventType.AUTHORIZED:
+                authorization_events += 1
+            elif event.event_type is InteractionEventType.STARTED:
+                if status is not InteractionStatus.PROPOSED:
+                    raise InteractionStateError("started event followed invalid state")
+                status = InteractionStatus.IN_PROGRESS
+            elif event.event_type is InteractionEventType.TRANSITIONED:
+                if status is not InteractionStatus.IN_PROGRESS:
+                    raise InteractionStateError(
+                        "transitioned event followed invalid state"
+                    )
+                transition_type = event.payload.get("transition_type")
+                if not isinstance(transition_type, str) or not transition_type:
+                    raise InteractionStateError("transition event payload is malformed")
+                transitions.append(transition_type)
+            elif event.event_type is InteractionEventType.COMPLETED:
+                if status is not InteractionStatus.IN_PROGRESS:
+                    raise InteractionStateError(
+                        "completed event followed invalid state"
+                    )
+                status = InteractionStatus.COMPLETED
+            elif event.event_type is InteractionEventType.STOPPED:
+                if status not in {
+                    InteractionStatus.PROPOSED,
+                    InteractionStatus.IN_PROGRESS,
+                }:
+                    raise InteractionStateError("stopped event followed invalid state")
+                status = InteractionStatus.STOPPED
+            elif event.event_type is InteractionEventType.INTERRUPTED:
+                if status is not InteractionStatus.IN_PROGRESS:
+                    raise InteractionStateError(
+                        "interrupted event followed invalid state"
+                    )
+                status = InteractionStatus.INTERRUPTED
+            elif event.event_type is InteractionEventType.PROPOSED:
+                raise InteractionStateError("duplicate proposed event")
+        return ReplayedInteraction(
+            interaction_id=interaction_id,
+            status=status,
+            revision=revision,
+            transition_types=tuple(transitions),
+            authorization_events=authorization_events,
+        )
+
+    def _execute_status_change(
+        self,
+        caller: TrustedHandler,
+        *,
+        interaction_id: UUID,
+        expected_status: InteractionStatus,
+        action: str,
+        event_type: InteractionEventType,
+        target_status: InteractionStatus,
+        payload: dict[str, Any],
+        terminal: bool,
+    ) -> InteractionSnapshot:
+        handler = self._require_handler(caller)
+        with self._session_factory() as session, session.begin():
+            interaction = self._locked_row(session, interaction_id)
+            self._require_status(interaction, expected_status)
+            decision = self._authorization_decision(session, interaction, action)
+            if not decision.allowed:
+                raise InteractionAuthorizationDenied(decision)
+            self._require_fresh_anchor(session, interaction)
+            now = self._evaluation_time(session)
+            revision = int(interaction["revision"]) + 1
+            self._update_status(
+                session,
+                interaction_id=interaction_id,
+                status=target_status,
+                revision=revision,
+                updated_at=now,
+            )
+            if terminal:
+                self._close_memberships(session, interaction_id, now)
+            self._append_event(
+                session,
+                interaction_id=interaction_id,
+                event_type=event_type,
+                revision=revision,
+                occurred_at=now,
+                actor_handler=handler.identity,
+                payload=payload,
+            )
+            return self._snapshot(session, interaction_id, lock=False)
+
+    def _authorization_decision(
+        self, session: Session, interaction: dict[str, Any], action: str
+    ) -> AuthorizationDecision:
+        try:
+            policy = self._validated_policy(interaction)
+            if action not in policy.actions:
+                return AuthorizationDecision(
+                    allowed=False, reason=DenialReason.ACTION_NOT_DECLARED
+                )
+            participant_ids = self._active_participant_ids(session, interaction["id"])
+            if not participant_ids:
+                return AuthorizationDecision(
+                    allowed=False, reason=DenialReason.MALFORMED_AUTHORIZATION
+                )
+            rows = [
+                dict(row)
+                for row in session.execute(
+                    text(
+                        """
+                        SELECT id, participant_entity_id, action,
+                               continuation_id, interaction_revision, granted,
+                               granted_at, expires_at, revoked_at
+                        FROM interaction_authorizations
+                        WHERE interaction_id = :interaction_id
+                          AND action = :action
+                        ORDER BY id
+                        """
+                    ),
+                    {"interaction_id": interaction["id"], "action": action},
+                ).mappings()
+            ]
+            return evaluate_authorizations(
+                participant_entity_ids=participant_ids,
+                authorization_rows=rows,
+                action=action,
+                continuation_id=interaction["continuation_id"],
+                interaction_revision=int(interaction["revision"]),
+                evaluated_at=self._evaluation_time(session),
+            )
+        except InteractionAuthorizationDenied as exc:
+            return exc.decision
+        except SQLAlchemyError as exc:
+            raise InteractionAuthorizationDenied(
+                AuthorizationDecision(
+                    allowed=False, reason=DenialReason.EVALUATION_UNAVAILABLE
+                )
+            ) from exc
+
+    def _require_fresh_anchor(
+        self, session: Session, interaction: dict[str, Any]
+    ) -> None:
+        try:
+            current = self._freshness_resolver(session)
+        except Exception as exc:
+            raise InteractionAuthorizationDenied(
+                AuthorizationDecision(
+                    allowed=False, reason=DenialReason.EVALUATION_UNAVAILABLE
+                )
+            ) from exc
+        if current.timeline_id != interaction["timeline_id"]:
+            raise InteractionAuthorizationDenied(
+                AuthorizationDecision(allowed=False, reason=DenialReason.STALE_TIMELINE)
+            )
+        if current.anchor_chunk_id != interaction["anchor_chunk_id"]:
+            raise InteractionAuthorizationDenied(
+                AuthorizationDecision(allowed=False, reason=DenialReason.STALE_ANCHOR)
+            )
+
+    def _validated_policy(self, interaction: dict[str, Any]) -> AuthorizationPolicy:
+        try:
+            return AuthorizationPolicy.model_validate(interaction["policy"])
+        except (TypeError, ValueError, ValidationError) as exc:
+            raise InteractionAuthorizationDenied(
+                AuthorizationDecision(
+                    allowed=False, reason=DenialReason.MALFORMED_POLICY
+                )
+            ) from exc
+
+    def _require_handler(self, caller: TrustedHandler) -> TrustedHandler:
+        if not isinstance(caller, TrustedHandler):
+            raise UntrustedHandlerError("privileged interaction API requires a handler")
+        if caller._service_nonce is not self._handler_nonce:
+            raise UntrustedHandlerError(
+                "trusted handler capability belongs to a different service"
+            )
+        return caller
+
+    @staticmethod
+    def _require_open(interaction: dict[str, Any]) -> None:
+        if interaction["status"] not in {
+            InteractionStatus.PROPOSED.value,
+            InteractionStatus.IN_PROGRESS.value,
+        }:
+            raise InteractionStateError(
+                f"interaction {interaction['id']} is terminal: "
+                f"{interaction['status']}"
+            )
+
+    @staticmethod
+    def _require_status(
+        interaction: dict[str, Any], expected: InteractionStatus
+    ) -> None:
+        if interaction["status"] != expected.value:
+            raise InteractionStateError(
+                f"interaction {interaction['id']} is {interaction['status']}; "
+                f"expected {expected.value}"
+            )
+
+    def _locked_row(self, session: Session, interaction_id: UUID) -> dict[str, Any]:
+        row = (
+            session.execute(
+                text(
+                    """
+                SELECT id, kind, executor_namespace, status, policy,
+                       continuation_id, revision, anchor_chunk_id, timeline_id,
+                       created_at, updated_at
+                FROM interactions
+                WHERE id = :interaction_id
+                FOR UPDATE
+                """
+                ),
+                {"interaction_id": interaction_id},
+            )
+            .mappings()
+            .one_or_none()
+        )
+        if row is None:
+            raise InteractionNotFound(f"interaction {interaction_id} was not found")
+        return dict(row)
+
+    def _snapshot(
+        self, session: Session, interaction_id: UUID, *, lock: bool
+    ) -> InteractionSnapshot:
+        suffix = " FOR UPDATE" if lock else ""
+        row = (
+            session.execute(
+                text(
+                    """
+                SELECT id, kind, executor_namespace, status, policy,
+                       continuation_id, revision, anchor_chunk_id, timeline_id,
+                       created_at, updated_at
+                FROM interactions
+                WHERE id = :interaction_id
+                """
+                    + suffix
+                ),
+                {"interaction_id": interaction_id},
+            )
+            .mappings()
+            .one_or_none()
+        )
+        if row is None:
+            raise InteractionNotFound(f"interaction {interaction_id} was not found")
+        interaction = dict(row)
+        try:
+            policy = AuthorizationPolicy.model_validate(interaction["policy"])
+        except ValidationError as exc:
+            raise InteractionAuthorizationDenied(
+                AuthorizationDecision(
+                    allowed=False, reason=DenialReason.MALFORMED_POLICY
+                )
+            ) from exc
+        return InteractionSnapshot(
+            id=interaction["id"],
+            kind=interaction["kind"],
+            executor_namespace=interaction["executor_namespace"],
+            status=interaction["status"],
+            policy=policy,
+            continuation_id=interaction["continuation_id"],
+            revision=interaction["revision"],
+            anchor=TimelineAnchor(
+                anchor_chunk_id=interaction["anchor_chunk_id"],
+                timeline_id=interaction["timeline_id"],
+            ),
+            participant_entity_ids=self._active_participant_ids(
+                session, interaction_id
+            ),
+            created_at=interaction["created_at"],
+            updated_at=interaction["updated_at"],
+        )
+
+    @staticmethod
+    def _active_participant_ids(
+        session: Session, interaction_id: UUID
+    ) -> tuple[int, ...]:
+        return tuple(
+            int(value)
+            for value in session.execute(
+                text(
+                    """
+                    SELECT participant_entity_id
+                    FROM interaction_participants
+                    WHERE interaction_id = :interaction_id
+                      AND left_at IS NULL
+                    ORDER BY id
+                    """
+                ),
+                {"interaction_id": interaction_id},
+            ).scalars()
+        )
+
+    @staticmethod
+    def _require_active_participant(
+        session: Session, interaction_id: UUID, participant_entity_id: int
+    ) -> None:
+        present = session.execute(
+            text(
+                """
+                SELECT 1
+                FROM interaction_participants
+                WHERE interaction_id = :interaction_id
+                  AND participant_entity_id = :participant_id
+                  AND left_at IS NULL
+                FOR UPDATE
+                """
+            ),
+            {
+                "interaction_id": interaction_id,
+                "participant_id": participant_entity_id,
+            },
+        ).scalar_one_or_none()
+        if present is None:
+            raise InteractionStateError(
+                f"entity {participant_entity_id} is not a current participant"
+            )
+
+    def _evaluation_time(self, session: Session) -> datetime:
+        value = self._evaluation_time_provider(session)
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise RuntimeError("interaction evaluation time must be timezone-aware")
+        return value.astimezone(timezone.utc)
+
+    @staticmethod
+    def _touch(session: Session, interaction_id: UUID, updated_at: datetime) -> None:
+        session.execute(
+            text("UPDATE interactions SET updated_at = :at WHERE id = :id"),
+            {"at": updated_at, "id": interaction_id},
+        )
+
+    @staticmethod
+    def _update_status(
+        session: Session,
+        *,
+        interaction_id: UUID,
+        status: InteractionStatus,
+        revision: int,
+        updated_at: datetime,
+    ) -> None:
+        session.execute(
+            text(
+                """
+                UPDATE interactions
+                SET status = :status,
+                    revision = :revision,
+                    updated_at = :updated_at
+                WHERE id = :interaction_id
+                """
+            ),
+            {
+                "status": status.value,
+                "revision": revision,
+                "updated_at": updated_at,
+                "interaction_id": interaction_id,
+            },
+        )
+
+    @staticmethod
+    def _close_memberships(
+        session: Session, interaction_id: UUID, left_at: datetime
+    ) -> None:
+        session.execute(
+            text(
+                """
+                UPDATE interaction_participants
+                SET left_at = :left_at
+                WHERE interaction_id = :interaction_id
+                  AND left_at IS NULL
+                """
+            ),
+            {"left_at": left_at, "interaction_id": interaction_id},
+        )
+
+    @staticmethod
+    def _append_event(
+        session: Session,
+        *,
+        interaction_id: UUID,
+        event_type: InteractionEventType,
+        revision: int,
+        occurred_at: datetime,
+        payload: dict[str, Any],
+        actor_participant_entity_id: int | None = None,
+        actor_handler: str | None = None,
+    ) -> None:
+        session.execute(
+            text(
+                """
+                INSERT INTO interaction_events (
+                    interaction_id, event_type, interaction_revision,
+                    actor_participant_entity_id, actor_handler,
+                    payload, occurred_at
+                ) VALUES (
+                    :interaction_id, :event_type, :revision,
+                    :actor_participant_entity_id, :actor_handler,
+                    CAST(:payload AS JSONB), :occurred_at
+                )
+                """
+            ),
+            {
+                "interaction_id": interaction_id,
+                "event_type": event_type.value,
+                "revision": revision,
+                "actor_participant_entity_id": actor_participant_entity_id,
+                "actor_handler": actor_handler,
+                "payload": json.dumps(payload),
+                "occurred_at": occurred_at,
+            },
+        )

--- a/nexus/interactions/service.py
+++ b/nexus/interactions/service.py
@@ -1,11 +1,12 @@
 """Transactional lifecycle API for durable interaction threads.
 
-Trust and composition boundary
-------------------------------
-The sole trusted-handler capability is minted during service construction and
-delivered to the composition root through a constructor callback. The service
-has no post-construction capability factory. Pydantic wire or model output
-cannot represent the service-local nonce, create a grant, or satisfy one.
+Trust boundary: the handler capability is a composition discipline, not an
+in-process security seal. Any Python code with database credentials can construct
+a service and mint grants; that caller class is trusted by definition. The
+enforced invariant is that no structured-output, wire, or model-derived value can
+reach grant creation: grant APIs accept only trusted-handler calls made by
+application composition code, and no adapter translates model output into
+authorization.
 
 The composition root must also provide an expected-identity resolver and an
 executor vocabulary registry. The resolver receives only the stored expected
@@ -88,6 +89,10 @@ class CommandIdConflict(InteractionError):
     """Raised when a caller reuses a command UUID with different content."""
 
 
+class _CreationCommandAlreadyRecorded(RuntimeError):
+    """Roll back a losing creation attempt before reading the winning outcome."""
+
+
 class UnknownExecutorTransition(InteractionAuthorizationDenied):
     """Typed denial for a transition outside its namespace vocabulary."""
 
@@ -121,12 +126,11 @@ class NamedRecoveryCleanupHook:
 
 SessionFactory = Callable[[], Session]
 ExpectedIdentityResolver = Callable[[TimelineAnchor], TimelineAnchor]
-EvaluationTimeProvider = Callable[[Session], datetime]
 CapabilityReceiver = Callable[[TrustedHandler], None]
 
 
 def _database_time(session: Session) -> datetime:
-    value = session.execute(text("SELECT CURRENT_TIMESTAMP")).scalar_one()
+    value = session.execute(text("SELECT clock_timestamp()")).scalar_one()
     if not isinstance(value, datetime) or value.tzinfo is None:
         raise RuntimeError("database returned an invalid interaction evaluation time")
     return value
@@ -153,7 +157,6 @@ class InteractionService:
         capability_receiver: CapabilityReceiver,
         expected_identity_resolver: ExpectedIdentityResolver,
         executor_registry: Mapping[str, Sequence[str]],
-        evaluation_time_provider: EvaluationTimeProvider = _database_time,
     ) -> None:
         identity = trusted_handler_identity.strip()
         if not identity:
@@ -169,7 +172,6 @@ class InteractionService:
             for namespace, transitions in self._executor_registry.items()
         ):
             raise ValueError("executor registry requires non-empty vocabularies")
-        self._evaluation_time_provider = evaluation_time_provider
         self._handler_nonce = object()
         capability_receiver(TrustedHandler(identity, self._handler_nonce))
 
@@ -185,91 +187,104 @@ class InteractionService:
         fingerprint = self._fingerprint(
             "propose", {"proposal": proposal.model_dump(mode="json")}
         )
-        with self._session_factory() as session, session.begin():
-            recorded = self._recorded_command(
-                session, command_id=command_id, fingerprint=fingerprint
-            )
-            if recorded is not None:
-                return InteractionSnapshot.model_validate(
-                    recorded["outcome"]["snapshot"]
-                )
-            interaction_id = uuid4()
-            now = self._evaluation_time(session)
-            session.execute(
-                text(
-                    """
-                    INSERT INTO interactions (
-                        id, kind, executor_namespace, status, policy,
-                        continuation_id, revision, anchor_chunk_id, timeline_id,
-                        created_at, updated_at
-                    ) VALUES (
-                        :id, :kind, :executor_namespace, 'proposed',
-                        CAST(:policy AS JSONB), :continuation_id, 1,
-                        :anchor_chunk_id, :timeline_id, :now, :now
-                    )
-                    """
-                ),
-                {
-                    "id": interaction_id,
-                    "kind": proposal.kind,
-                    "executor_namespace": proposal.executor_namespace,
-                    "policy": proposal.policy.model_dump_json(),
-                    "continuation_id": proposal.continuation_id,
-                    "anchor_chunk_id": proposal.anchor.anchor_chunk_id,
-                    "timeline_id": proposal.anchor.timeline_id,
-                    "now": now,
-                },
-            )
-            memberships: list[dict[str, Any]] = []
-            for participant_id in proposal.participant_entity_ids:
-                membership_id = int(
+        with self._session_factory() as session:
+            try:
+                with session.begin():
+                    interaction_id = uuid4()
+                    now = self._evaluation_time(session)
                     session.execute(
                         text(
                             """
-                            INSERT INTO interaction_participants (
-                                interaction_id, participant_entity_id,
-                                joined_at, joined_revision
-                            ) VALUES (:interaction_id, :participant_id, :now, 1)
-                            RETURNING id
+                            INSERT INTO interactions (
+                                id, kind, executor_namespace, status, policy,
+                                continuation_id, revision, anchor_chunk_id,
+                                timeline_id, created_at, updated_at
+                            ) VALUES (
+                                :id, :kind, :executor_namespace, 'proposed',
+                                CAST(:policy AS JSONB), :continuation_id, 1,
+                                :anchor_chunk_id, :timeline_id, :now, :now
+                            )
                             """
                         ),
                         {
-                            "interaction_id": interaction_id,
-                            "participant_id": participant_id,
+                            "id": interaction_id,
+                            "kind": proposal.kind,
+                            "executor_namespace": proposal.executor_namespace,
+                            "policy": proposal.policy.model_dump_json(),
+                            "continuation_id": proposal.continuation_id,
+                            "anchor_chunk_id": proposal.anchor.anchor_chunk_id,
+                            "timeline_id": proposal.anchor.timeline_id,
                             "now": now,
                         },
-                    ).scalar_one()
-                )
-                memberships.append(
-                    {
-                        "membership_id": membership_id,
-                        "participant_entity_id": participant_id,
-                        "joined_at": now.isoformat(),
-                        "joined_revision": 1,
-                    }
-                )
-            snapshot = self._snapshot(session, interaction_id)
-            self._append_event(
-                session,
-                interaction_id=interaction_id,
-                event_type=InteractionEventType.PROPOSED,
-                revision=1,
-                occurred_at=now,
-                actor_handler=handler.identity,
-                command_id=command_id,
-                command_step="command",
-                fingerprint=fingerprint,
-                payload={
-                    "kind": proposal.kind,
-                    "executor_namespace": proposal.executor_namespace,
-                    "policy": proposal.policy.model_dump(mode="json"),
-                    "continuation_id": str(proposal.continuation_id),
-                    "anchor": proposal.anchor.model_dump(mode="json"),
-                    "memberships": memberships,
-                },
-                outcome={"snapshot": snapshot.model_dump(mode="json")},
-            )
-            return snapshot
+                    )
+                    memberships: list[dict[str, Any]] = []
+                    for participant_id in proposal.participant_entity_ids:
+                        membership_id = int(
+                            session.execute(
+                                text(
+                                    """
+                                    INSERT INTO interaction_participants (
+                                        interaction_id, participant_entity_id,
+                                        joined_at, joined_revision
+                                    ) VALUES (
+                                        :interaction_id, :participant_id, :now, 1
+                                    )
+                                    RETURNING id
+                                    """
+                                ),
+                                {
+                                    "interaction_id": interaction_id,
+                                    "participant_id": participant_id,
+                                    "now": now,
+                                },
+                            ).scalar_one()
+                        )
+                        memberships.append(
+                            {
+                                "membership_id": membership_id,
+                                "participant_entity_id": participant_id,
+                                "joined_at": now.isoformat(),
+                                "joined_revision": 1,
+                            }
+                        )
+                    snapshot = self._snapshot(session, interaction_id)
+                    inserted = self._append_event(
+                        session,
+                        interaction_id=interaction_id,
+                        event_type=InteractionEventType.PROPOSED,
+                        revision=1,
+                        occurred_at=now,
+                        actor_handler=handler.identity,
+                        command_id=command_id,
+                        command_step="command",
+                        fingerprint=fingerprint,
+                        payload={
+                            "kind": proposal.kind,
+                            "executor_namespace": proposal.executor_namespace,
+                            "policy": proposal.policy.model_dump(mode="json"),
+                            "continuation_id": str(proposal.continuation_id),
+                            "anchor": proposal.anchor.model_dump(mode="json"),
+                            "memberships": memberships,
+                        },
+                        outcome={"snapshot": snapshot.model_dump(mode="json")},
+                        on_conflict_do_nothing=True,
+                    )
+                    if not inserted:
+                        raise _CreationCommandAlreadyRecorded
+                    return snapshot
+            except _CreationCommandAlreadyRecorded:
+                session.rollback()
+                with session.begin():
+                    recorded = self._recorded_command(
+                        session, command_id=command_id, fingerprint=fingerprint
+                    )
+                    if recorded is None:
+                        raise RuntimeError(
+                            "conflicting proposal command has no recorded outcome"
+                        )
+                    return InteractionSnapshot.model_validate(
+                        recorded["outcome"]["snapshot"]
+                    )
 
     def grant(
         self,
@@ -494,9 +509,11 @@ class InteractionService:
         caller: TrustedHandler,
         *,
         interaction_id: UUID,
+        lease_until: datetime,
         command_id: UUID,
     ) -> InteractionSnapshot:
         """Start after exact-envelope authorization and locked freshness checks."""
+        self._require_aware(lease_until, "interaction lease")
         return self._execute_status_change(
             caller,
             interaction_id=interaction_id,
@@ -505,8 +522,9 @@ class InteractionService:
             envelope=self._lifecycle_envelope("start"),
             event_type=InteractionEventType.STARTED,
             target_status=InteractionStatus.IN_PROGRESS,
-            payload={},
+            payload={"lease_until": lease_until.isoformat()},
             terminal=False,
+            lease_until=lease_until,
         )
 
     def transition(
@@ -532,6 +550,7 @@ class InteractionService:
                 "payload": transition.payload,
             },
             terminal=False,
+            lease_until=None,
         )
 
     def complete(
@@ -552,6 +571,7 @@ class InteractionService:
             target_status=InteractionStatus.COMPLETED,
             payload={},
             terminal=True,
+            lease_until=None,
         )
 
     def stop(
@@ -852,6 +872,7 @@ class InteractionService:
             raise ValueError("recovery cleanup hook names must be unique")
         fingerprint = self._fingerprint("recover", {"hook_names": hook_names})
         recovered: list[UUID] = []
+        claimed_candidates: list[UUID] = []
         with self._session_factory() as session, session.begin():
             command_rows = self._validate_command_reuse(
                 session, command_id, fingerprint
@@ -872,7 +893,6 @@ class InteractionService:
                     {"command_id": command_id},
                 ).scalars()
             )
-            now = self._evaluation_time(session)
             if command_rows:
                 candidates = tuple(
                     dict.fromkeys(row["interaction_id"] for row in command_rows)
@@ -886,12 +906,12 @@ class InteractionService:
                             FROM interactions
                             WHERE status = 'in_progress'
                               AND lease_until IS NOT NULL
-                              AND lease_until <= :now
+                              AND lease_until <= clock_timestamp()
+                              AND recovery_command_id IS NULL
                             ORDER BY lease_until, id
                             FOR UPDATE SKIP LOCKED
                             """
-                        ),
-                        {"now": now},
+                        )
                     ).scalars()
                 )
             for interaction_id in candidates:
@@ -913,18 +933,38 @@ class InteractionService:
                     },
                 ).scalar_one_or_none()
                 if claimed is not None:
+                    owner = session.execute(
+                        text(
+                            """
+                            SELECT recovery_command_id
+                            FROM interactions
+                            WHERE id = :interaction_id
+                            """
+                        ),
+                        {"interaction_id": interaction_id},
+                    ).scalar_one_or_none()
+                    if owner == command_id:
+                        claimed_candidates.append(interaction_id)
                     continue
-                session.execute(
+                claimed_interaction_id = session.execute(
                     text(
                         """
                         UPDATE interactions
                         SET recovery_command_id = :command_id
                         WHERE id = :interaction_id
+                          AND status = 'in_progress'
+                          AND lease_until IS NOT NULL
+                          AND lease_until <= clock_timestamp()
+                          AND recovery_command_id IS NULL
+                        RETURNING id
                         """
                     ),
                     {"command_id": command_id, "interaction_id": interaction_id},
-                )
+                ).scalar_one_or_none()
+                if claimed_interaction_id is None:
+                    continue
                 interaction = self._locked_row(session, interaction_id)
+                now = self._evaluation_time(session)
                 self._append_event(
                     session,
                     interaction_id=interaction_id,
@@ -938,7 +978,8 @@ class InteractionService:
                     payload={"lease_until": interaction["lease_until"].isoformat()},
                     outcome={"claimed": True},
                 )
-        for interaction_id in candidates:
+                claimed_candidates.append(interaction_id)
+        for interaction_id in claimed_candidates:
             if interaction_id in recovered:
                 continue
             if not self._run_cleanup_hooks(
@@ -956,6 +997,7 @@ class InteractionService:
                     interaction["status"] != InteractionStatus.IN_PROGRESS.value
                     or interaction["lease_until"] is None
                     or interaction["lease_until"] > now
+                    or interaction["recovery_command_id"] != command_id
                 ):
                     continue
                 recorded = self._recorded_command(
@@ -1111,6 +1153,7 @@ class InteractionService:
                 lease_until = datetime.fromisoformat(payload["lease_until"])
             elif event.event_type is InteractionEventType.STARTED:
                 status = InteractionStatus.IN_PROGRESS
+                lease_until = datetime.fromisoformat(payload["lease_until"])
             elif event.event_type is InteractionEventType.TRANSITIONED:
                 status = InteractionStatus.IN_PROGRESS
                 transitions.append(str(payload["transition_type"]))
@@ -1160,6 +1203,7 @@ class InteractionService:
         target_status: InteractionStatus,
         payload: dict[str, Any],
         terminal: bool,
+        lease_until: datetime | None,
     ) -> InteractionSnapshot:
         handler = self._require_handler(caller)
         fingerprint = self._fingerprint(
@@ -1191,6 +1235,8 @@ class InteractionService:
                 raise InteractionAuthorizationDenied(decision)
             self._require_fresh_anchor_under_lock(session, interaction)
             now = self._evaluation_time(session)
+            if lease_until is not None and lease_until <= now:
+                raise ValueError("interaction lease must expire in the future")
             revision = int(interaction["revision"]) + 1
             closed = (
                 self._close_memberships(session, interaction_id, now, revision)
@@ -1204,6 +1250,7 @@ class InteractionService:
                 revision=revision,
                 updated_at=now,
                 clear_lease=terminal,
+                lease_until=lease_until,
             )
             snapshot = self._snapshot(session, interaction_id)
             event_payload = dict(payload)
@@ -1339,6 +1386,7 @@ class InteractionService:
                     interaction["status"] != InteractionStatus.IN_PROGRESS.value
                     or interaction["lease_until"] is None
                     or interaction["lease_until"] > now
+                    or interaction["recovery_command_id"] != command_id
                 ):
                     return False
                 completed = session.execute(
@@ -1591,7 +1639,7 @@ class InteractionService:
             )
 
     def _evaluation_time(self, session: Session) -> datetime:
-        value = self._evaluation_time_provider(session)
+        value = _database_time(session)
         self._require_aware(value, "interaction evaluation time")
         return value.astimezone(timezone.utc)
 
@@ -1635,6 +1683,7 @@ class InteractionService:
         revision: int,
         updated_at: datetime,
         clear_lease: bool,
+        lease_until: datetime | None = None,
     ) -> None:
         session.execute(
             text(
@@ -1642,7 +1691,9 @@ class InteractionService:
                 UPDATE interactions
                 SET status = :status, revision = :revision,
                     lease_until = CASE
-                        WHEN :clear_lease THEN NULL ELSE lease_until
+                        WHEN :clear_lease THEN NULL
+                        WHEN :lease_until IS NOT NULL THEN :lease_until
+                        ELSE lease_until
                     END,
                     recovery_command_id = CASE
                         WHEN :clear_lease THEN NULL ELSE recovery_command_id
@@ -1656,6 +1707,7 @@ class InteractionService:
                 "revision": revision,
                 "updated_at": updated_at,
                 "clear_lease": clear_lease,
+                "lease_until": lease_until,
                 "interaction_id": interaction_id,
             },
         )
@@ -1708,10 +1760,12 @@ class InteractionService:
         outcome: dict[str, Any],
         actor_participant_entity_id: int | None = None,
         actor_handler: str | None = None,
-    ) -> None:
-        session.execute(
+        on_conflict_do_nothing: bool = False,
+    ) -> bool:
+        conflict_clause = "ON CONFLICT DO NOTHING" if on_conflict_do_nothing else ""
+        inserted = session.execute(
             text(
-                """
+                f"""
                 INSERT INTO interaction_events (
                     interaction_id, event_type, interaction_revision,
                     actor_participant_entity_id, actor_handler,
@@ -1723,6 +1777,8 @@ class InteractionService:
                     :command_id, :command_step, :fingerprint,
                     CAST(:payload AS JSONB), CAST(:outcome AS JSONB), :occurred_at
                 )
+                {conflict_clause}
+                RETURNING id
                 """
             ),
             {
@@ -1738,7 +1794,8 @@ class InteractionService:
                 "outcome": json.dumps(outcome),
                 "occurred_at": occurred_at,
             },
-        )
+        ).scalar_one_or_none()
+        return inserted is not None
 
     @staticmethod
     def _membership_states(

--- a/nexus/interactions/service.py
+++ b/nexus/interactions/service.py
@@ -1,23 +1,27 @@
 """Transactional lifecycle API for durable interaction threads.
 
-Trust boundary
---------------
-Only trusted, non-model handler code may call proposal, authorization, execution,
-or recovery methods. A handler must first bind an opaque capability to this exact
-service instance; every privileged method verifies that capability. Pydantic wire
-or LLM output models cannot represent or manufacture it. Model-generated content
-may be carried inside an already-authorized transition payload, but no payload,
-tool result, or structured model response can create or satisfy an authorization
-record. Participant ``stop`` is intentionally separate: any current participant
-can stop unilaterally and immediately without a handler, peer grant, or veto path.
+Trust and composition boundary
+------------------------------
+The sole trusted-handler capability is minted during service construction and
+delivered to the composition root through a constructor callback. The service
+has no post-construction capability factory. Pydantic wire or model output
+cannot represent the service-local nonce, create a grant, or satisfy one.
+
+The composition root must also provide an expected-identity resolver and an
+executor vocabulary registry. The resolver receives only the stored expected
+identity and has no database access. This service itself locks and reads the
+canonical narrative/chunk-metadata head before every authorized state write.
+Registering this infrastructure with a gameplay handler remains out of scope.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, NoReturn
 from uuid import UUID, uuid4
 
 from pydantic import ValidationError
@@ -25,9 +29,14 @@ from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from nexus.interactions.evaluator import evaluate_authorizations
+from nexus.interactions.evaluator import (
+    canonical_envelope_hash,
+    evaluate_authorizations,
+)
 from nexus.interactions.models import (
     AuthorizationDecision,
+    AuthorizationEnvelope,
+    AuthorizationGrantState,
     AuthorizationPolicy,
     DenialReason,
     InteractionEvent,
@@ -36,6 +45,7 @@ from nexus.interactions.models import (
     InteractionSnapshot,
     InteractionStatus,
     InteractionTransition,
+    MembershipHistoryState,
     ReplayedInteraction,
     TimelineAnchor,
 )
@@ -71,11 +81,24 @@ class UntrustedHandlerError(InteractionError):
 
 
 class AuthorizationRecordNotFound(InteractionError):
-    """Raised when revocation cannot find a current grant record."""
+    """Raised when revocation cannot find an exact current-envelope grant."""
+
+
+class CommandIdConflict(InteractionError):
+    """Raised when a caller reuses a command UUID with different content."""
+
+
+class UnknownExecutorTransition(InteractionAuthorizationDenied):
+    """Typed denial for a transition outside its namespace vocabulary."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            AuthorizationDecision(allowed=False, reason=DenialReason.UNKNOWN_TRANSITION)
+        )
 
 
 class TrustedHandler:
-    """Opaque capability issued by one service to one trusted handler identity."""
+    """Opaque capability minted only while an InteractionService is constructed."""
 
     __slots__ = ("identity", "_service_nonce")
 
@@ -84,10 +107,22 @@ class TrustedHandler:
         self._service_nonce = service_nonce
 
 
+@dataclass(frozen=True)
+class NamedRecoveryCleanupHook:
+    """Named transactional cleanup whose completion is durably deduplicated."""
+
+    name: str
+    callback: Callable[[Session, InteractionSnapshot], None]
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("recovery cleanup hook name must not be empty")
+
+
 SessionFactory = Callable[[], Session]
-FreshnessResolver = Callable[[Session], TimelineAnchor]
+ExpectedIdentityResolver = Callable[[TimelineAnchor], TimelineAnchor]
 EvaluationTimeProvider = Callable[[Session], datetime]
-RecoveryCleanupHook = Callable[[Session, InteractionSnapshot], None]
+CapabilityReceiver = Callable[[TrustedHandler], None]
 
 
 def _database_time(session: Session) -> datetime:
@@ -97,35 +132,68 @@ def _database_time(session: Session) -> datetime:
     return value
 
 
+def _stable_hash(value: dict[str, Any]) -> str:
+    canonical = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
 class InteractionService:
-    """Own transactional persistence, evaluation, recovery, and history replay."""
+    """Own transactional persistence, fencing, recovery, and full replay."""
 
     def __init__(
         self,
         session_factory: SessionFactory,
         *,
-        freshness_resolver: FreshnessResolver,
+        trusted_handler_identity: str,
+        capability_receiver: CapabilityReceiver,
+        expected_identity_resolver: ExpectedIdentityResolver,
+        executor_registry: Mapping[str, Sequence[str]],
         evaluation_time_provider: EvaluationTimeProvider = _database_time,
     ) -> None:
+        identity = trusted_handler_identity.strip()
+        if not identity:
+            raise ValueError("trusted handler identity must not be empty")
         self._session_factory = session_factory
-        self._freshness_resolver = freshness_resolver
+        self._expected_identity_resolver = expected_identity_resolver
+        self._executor_registry = {
+            namespace: frozenset(transitions)
+            for namespace, transitions in executor_registry.items()
+        }
+        if not self._executor_registry or any(
+            not namespace or not transitions
+            for namespace, transitions in self._executor_registry.items()
+        ):
+            raise ValueError("executor registry requires non-empty vocabularies")
         self._evaluation_time_provider = evaluation_time_provider
         self._handler_nonce = object()
-
-    def bind_trusted_handler(self, identity: str) -> TrustedHandler:
-        """Bind trusted bootstrap code to an opaque service-local capability."""
-        normalized = identity.strip()
-        if not normalized:
-            raise ValueError("trusted handler identity must not be empty")
-        return TrustedHandler(normalized, self._handler_nonce)
+        capability_receiver(TrustedHandler(identity, self._handler_nonce))
 
     def propose(
-        self, caller: TrustedHandler, proposal: InteractionProposal
+        self,
+        caller: TrustedHandler,
+        proposal: InteractionProposal,
+        *,
+        command_id: UUID,
     ) -> InteractionSnapshot:
-        """Persist a proposed interaction, initial memberships, and first event."""
+        """Persist or idempotently return a proposed interaction."""
         handler = self._require_handler(caller)
-        interaction_id = uuid4()
+        fingerprint = self._fingerprint(
+            "propose", {"proposal": proposal.model_dump(mode="json")}
+        )
         with self._session_factory() as session, session.begin():
+            recorded = self._recorded_command(
+                session, command_id=command_id, fingerprint=fingerprint
+            )
+            if recorded is not None:
+                return InteractionSnapshot.model_validate(
+                    recorded["outcome"]["snapshot"]
+                )
+            interaction_id = uuid4()
             now = self._evaluation_time(session)
             session.execute(
                 text(
@@ -152,21 +220,35 @@ class InteractionService:
                     "now": now,
                 },
             )
+            memberships: list[dict[str, Any]] = []
             for participant_id in proposal.participant_entity_ids:
-                session.execute(
-                    text(
-                        """
-                        INSERT INTO interaction_participants (
-                            interaction_id, participant_entity_id, joined_at
-                        ) VALUES (:interaction_id, :participant_id, :joined_at)
-                        """
-                    ),
-                    {
-                        "interaction_id": interaction_id,
-                        "participant_id": participant_id,
-                        "joined_at": now,
-                    },
+                membership_id = int(
+                    session.execute(
+                        text(
+                            """
+                            INSERT INTO interaction_participants (
+                                interaction_id, participant_entity_id,
+                                joined_at, joined_revision
+                            ) VALUES (:interaction_id, :participant_id, :now, 1)
+                            RETURNING id
+                            """
+                        ),
+                        {
+                            "interaction_id": interaction_id,
+                            "participant_id": participant_id,
+                            "now": now,
+                        },
+                    ).scalar_one()
                 )
+                memberships.append(
+                    {
+                        "membership_id": membership_id,
+                        "participant_entity_id": participant_id,
+                        "joined_at": now.isoformat(),
+                        "joined_revision": 1,
+                    }
+                )
+            snapshot = self._snapshot(session, interaction_id)
             self._append_event(
                 session,
                 interaction_id=interaction_id,
@@ -174,15 +256,20 @@ class InteractionService:
                 revision=1,
                 occurred_at=now,
                 actor_handler=handler.identity,
+                command_id=command_id,
+                command_step="command",
+                fingerprint=fingerprint,
                 payload={
                     "kind": proposal.kind,
                     "executor_namespace": proposal.executor_namespace,
-                    "participant_entity_ids": proposal.participant_entity_ids,
+                    "policy": proposal.policy.model_dump(mode="json"),
                     "continuation_id": str(proposal.continuation_id),
                     "anchor": proposal.anchor.model_dump(mode="json"),
+                    "memberships": memberships,
                 },
+                outcome={"snapshot": snapshot.model_dump(mode="json")},
             )
-            return self._snapshot(session, interaction_id, lock=False)
+            return snapshot
 
     def grant(
         self,
@@ -190,24 +277,39 @@ class InteractionService:
         *,
         interaction_id: UUID,
         participant_entity_id: int,
-        action: str,
+        envelope: AuthorizationEnvelope,
         expires_at: datetime,
+        command_id: UUID,
     ) -> int:
-        """Record one explicit participant grant from trusted handler code only."""
+        """Record one explicit exact-envelope grant, idempotently."""
         handler = self._require_handler(caller)
-        if expires_at.tzinfo is None or expires_at.utcoffset() is None:
-            raise ValueError("authorization expiry must be timezone-aware")
+        self._require_aware(expires_at, "authorization expiry")
+        fingerprint = self._fingerprint(
+            "grant",
+            {
+                "interaction_id": str(interaction_id),
+                "participant_entity_id": participant_entity_id,
+                "envelope": envelope.model_dump(mode="json"),
+                "expires_at": expires_at.isoformat(),
+            },
+        )
         with self._session_factory() as session, session.begin():
+            recorded = self._recorded_command(
+                session,
+                command_id=command_id,
+                fingerprint=fingerprint,
+                interaction_id=interaction_id,
+            )
+            if recorded is not None:
+                return int(recorded["outcome"]["grant_id"])
             interaction = self._locked_row(session, interaction_id)
             self._require_open(interaction)
+            self._require_not_recovering(interaction)
             policy = self._validated_policy(interaction)
-            rule = policy.actions.get(action)
+            rule = policy.actions.get(envelope.action)
             if rule is None:
-                raise InteractionAuthorizationDenied(
-                    AuthorizationDecision(
-                        allowed=False, reason=DenialReason.ACTION_NOT_DECLARED
-                    )
-                )
+                self._deny(DenialReason.ACTION_NOT_DECLARED)
+            self._validate_envelope_transition(interaction, envelope)
             self._require_active_participant(
                 session, interaction_id, participant_entity_id
             )
@@ -215,48 +317,26 @@ class InteractionService:
             validity_seconds = (expires_at - now).total_seconds()
             if validity_seconds <= 0:
                 raise ValueError("authorization expiry must be in the future")
-            if validity_seconds > rule.max_validity_seconds:
+            if rule is None or validity_seconds > rule.max_validity_seconds:
+                maximum = rule.max_validity_seconds if rule is not None else 0
                 raise ValueError(
                     f"authorization validity {validity_seconds:.6f}s exceeds "
-                    f"policy maximum {rule.max_validity_seconds}s"
+                    f"policy maximum {maximum}s"
                 )
-
-            session.execute(
-                text(
-                    """
-                    UPDATE interaction_authorizations
-                    SET revoked_at = :now,
-                        revoked_by_handler = :handler
-                    WHERE interaction_id = :interaction_id
-                      AND participant_entity_id = :participant_id
-                      AND action = :action
-                      AND continuation_id = :continuation_id
-                      AND interaction_revision = :revision
-                      AND revoked_at IS NULL
-                    """
-                ),
-                {
-                    "now": now,
-                    "handler": handler.identity,
-                    "interaction_id": interaction_id,
-                    "participant_id": participant_entity_id,
-                    "action": action,
-                    "continuation_id": interaction["continuation_id"],
-                    "revision": interaction["revision"],
-                },
-            )
+            envelope_hash = canonical_envelope_hash(policy, envelope)
             grant_id = int(
                 session.execute(
                     text(
                         """
                         INSERT INTO interaction_authorizations (
                             interaction_id, participant_entity_id, action,
-                            continuation_id, interaction_revision, granted,
+                            envelope_hash, continuation_id,
+                            interaction_revision, granted,
                             granted_by_handler, granted_at, expires_at
                         ) VALUES (
                             :interaction_id, :participant_id, :action,
-                            :continuation_id, :revision, TRUE,
-                            :handler, :granted_at, :expires_at
+                            :envelope_hash, :continuation_id,
+                            :revision, TRUE, :handler, :now, :expires_at
                         )
                         RETURNING id
                         """
@@ -264,16 +344,17 @@ class InteractionService:
                     {
                         "interaction_id": interaction_id,
                         "participant_id": participant_entity_id,
-                        "action": action,
+                        "action": envelope.action,
+                        "envelope_hash": envelope_hash,
                         "continuation_id": interaction["continuation_id"],
                         "revision": interaction["revision"],
                         "handler": handler.identity,
-                        "granted_at": now,
+                        "now": now,
                         "expires_at": expires_at,
                     },
                 ).scalar_one()
             )
-            self._touch(session, interaction_id, now)
+            self._touch_updated_at(session, interaction_id, now)
             self._append_event(
                 session,
                 interaction_id=interaction_id,
@@ -281,13 +362,24 @@ class InteractionService:
                 revision=int(interaction["revision"]),
                 occurred_at=now,
                 actor_handler=handler.identity,
+                command_id=command_id,
+                command_step="command",
+                fingerprint=fingerprint,
                 payload={
                     "state": "granted",
+                    "id": grant_id,
                     "grant_id": grant_id,
                     "participant_entity_id": participant_entity_id,
-                    "action": action,
+                    "action": envelope.action,
+                    "envelope_hash": envelope_hash,
+                    "continuation_id": str(interaction["continuation_id"]),
+                    "interaction_revision": int(interaction["revision"]),
+                    "granted": True,
+                    "granted_at": now.isoformat(),
                     "expires_at": expires_at.isoformat(),
+                    "revoked_at": None,
                 },
+                outcome={"grant_id": grant_id},
             )
             return grant_id
 
@@ -297,55 +389,73 @@ class InteractionService:
         *,
         interaction_id: UUID,
         participant_entity_id: int,
-        action: str,
-    ) -> int:
-        """Immediately revoke the latest current-revision participant grant."""
+        envelope: AuthorizationEnvelope,
+        command_id: UUID,
+    ) -> tuple[int, ...]:
+        """Revoke every current exact-envelope grant, idempotently."""
         handler = self._require_handler(caller)
+        fingerprint = self._fingerprint(
+            "revoke",
+            {
+                "interaction_id": str(interaction_id),
+                "participant_entity_id": participant_entity_id,
+                "envelope": envelope.model_dump(mode="json"),
+            },
+        )
         with self._session_factory() as session, session.begin():
+            recorded = self._recorded_command(
+                session,
+                command_id=command_id,
+                fingerprint=fingerprint,
+                interaction_id=interaction_id,
+            )
+            if recorded is not None:
+                return tuple(int(value) for value in recorded["outcome"]["grant_ids"])
             interaction = self._locked_row(session, interaction_id)
             self._require_open(interaction)
+            self._require_not_recovering(interaction)
+            policy = self._validated_policy(interaction)
+            self._validate_envelope_transition(interaction, envelope)
+            envelope_hash = canonical_envelope_hash(policy, envelope)
             self._require_active_participant(
                 session, interaction_id, participant_entity_id
             )
             now = self._evaluation_time(session)
-            grant_id = session.execute(
-                text(
-                    """
-                    UPDATE interaction_authorizations
-                    SET revoked_at = :now,
-                        revoked_by_handler = :handler
-                    WHERE id = (
-                        SELECT id
-                        FROM interaction_authorizations
+            grant_ids = tuple(
+                int(value)
+                for value in session.execute(
+                    text(
+                        """
+                        UPDATE interaction_authorizations
+                        SET revoked_at = :now, revoked_by_handler = :handler
                         WHERE interaction_id = :interaction_id
                           AND participant_entity_id = :participant_id
                           AND action = :action
+                          AND envelope_hash = :envelope_hash
                           AND continuation_id = :continuation_id
                           AND interaction_revision = :revision
                           AND revoked_at IS NULL
-                        ORDER BY id DESC
-                        LIMIT 1
-                        FOR UPDATE
-                    )
-                    RETURNING id
-                    """
-                ),
-                {
-                    "now": now,
-                    "handler": handler.identity,
-                    "interaction_id": interaction_id,
-                    "participant_id": participant_entity_id,
-                    "action": action,
-                    "continuation_id": interaction["continuation_id"],
-                    "revision": interaction["revision"],
-                },
-            ).scalar_one_or_none()
-            if grant_id is None:
+                        RETURNING id
+                        """
+                    ),
+                    {
+                        "now": now,
+                        "handler": handler.identity,
+                        "interaction_id": interaction_id,
+                        "participant_id": participant_entity_id,
+                        "action": envelope.action,
+                        "envelope_hash": envelope_hash,
+                        "continuation_id": interaction["continuation_id"],
+                        "revision": interaction["revision"],
+                    },
+                ).scalars()
+            )
+            if not grant_ids:
                 raise AuthorizationRecordNotFound(
-                    f"no current grant for participant {participant_entity_id} "
-                    f"and action {action}"
+                    "no current exact-envelope grant for participant "
+                    f"{participant_entity_id}"
                 )
-            self._touch(session, interaction_id, now)
+            self._touch_updated_at(session, interaction_id, now)
             self._append_event(
                 session,
                 interaction_id=interaction_id,
@@ -353,33 +463,46 @@ class InteractionService:
                 revision=int(interaction["revision"]),
                 occurred_at=now,
                 actor_handler=handler.identity,
+                command_id=command_id,
+                command_step="command",
+                fingerprint=fingerprint,
                 payload={
                     "state": "revoked",
-                    "grant_id": int(grant_id),
+                    "grant_ids": list(grant_ids),
                     "participant_entity_id": participant_entity_id,
-                    "action": action,
+                    "action": envelope.action,
+                    "envelope_hash": envelope_hash,
+                    "revoked_at": now.isoformat(),
                 },
+                outcome={"grant_ids": list(grant_ids)},
             )
-            return int(grant_id)
+            return grant_ids
 
-    def evaluate(self, *, interaction_id: UUID, action: str) -> AuthorizationDecision:
-        """Evaluate current grants without mutating lifecycle state."""
+    def evaluate(
+        self, *, interaction_id: UUID, envelope: AuthorizationEnvelope
+    ) -> AuthorizationDecision:
+        """Evaluate current exact-envelope grants without lifecycle mutation."""
         try:
             with self._session_factory() as session, session.begin():
                 interaction = self._locked_row(session, interaction_id)
-                return self._authorization_decision(session, interaction, action)
+                return self._authorization_decision(session, interaction, envelope)
         except InteractionAuthorizationDenied as exc:
             return exc.decision
 
     def start(
-        self, caller: TrustedHandler, *, interaction_id: UUID
+        self,
+        caller: TrustedHandler,
+        *,
+        interaction_id: UUID,
+        command_id: UUID,
     ) -> InteractionSnapshot:
-        """Start transactionally after current grants and freshness revalidate."""
+        """Start after exact-envelope authorization and locked freshness checks."""
         return self._execute_status_change(
             caller,
             interaction_id=interaction_id,
+            command_id=command_id,
             expected_status=InteractionStatus.PROPOSED,
-            action="start",
+            envelope=self._lifecycle_envelope("start"),
             event_type=InteractionEventType.STARTED,
             target_status=InteractionStatus.IN_PROGRESS,
             payload={},
@@ -392,13 +515,15 @@ class InteractionService:
         *,
         interaction_id: UUID,
         transition: InteractionTransition,
+        command_id: UUID,
     ) -> InteractionSnapshot:
-        """Apply one typed executor transition after execution-time revalidation."""
+        """Apply a registered typed transition after execution-time revalidation."""
         return self._execute_status_change(
             caller,
             interaction_id=interaction_id,
+            command_id=command_id,
             expected_status=InteractionStatus.IN_PROGRESS,
-            action=transition.authorization_action,
+            envelope=transition.authorization_envelope(),
             event_type=InteractionEventType.TRANSITIONED,
             target_status=InteractionStatus.IN_PROGRESS,
             payload={
@@ -410,14 +535,19 @@ class InteractionService:
         )
 
     def complete(
-        self, caller: TrustedHandler, *, interaction_id: UUID
+        self,
+        caller: TrustedHandler,
+        *,
+        interaction_id: UUID,
+        command_id: UUID,
     ) -> InteractionSnapshot:
-        """Complete transactionally after current grants and freshness revalidate."""
+        """Complete after exact-envelope authorization and locked freshness checks."""
         return self._execute_status_change(
             caller,
             interaction_id=interaction_id,
+            command_id=command_id,
             expected_status=InteractionStatus.IN_PROGRESS,
-            action="complete",
+            envelope=self._lifecycle_envelope("complete"),
             event_type=InteractionEventType.COMPLETED,
             target_status=InteractionStatus.COMPLETED,
             payload={},
@@ -425,10 +555,31 @@ class InteractionService:
         )
 
     def stop(
-        self, *, interaction_id: UUID, participant_entity_id: int
+        self,
+        *,
+        interaction_id: UUID,
+        participant_entity_id: int,
+        command_id: UUID,
     ) -> InteractionSnapshot:
-        """Stop immediately at any current participant's unilateral request."""
+        """Stop immediately and idempotently at any current participant's request."""
+        fingerprint = self._fingerprint(
+            "stop",
+            {
+                "interaction_id": str(interaction_id),
+                "participant_entity_id": participant_entity_id,
+            },
+        )
         with self._session_factory() as session, session.begin():
+            recorded = self._recorded_command(
+                session,
+                command_id=command_id,
+                fingerprint=fingerprint,
+                interaction_id=interaction_id,
+            )
+            if recorded is not None:
+                return InteractionSnapshot.model_validate(
+                    recorded["outcome"]["snapshot"]
+                )
             interaction = self._locked_row(session, interaction_id)
             self._require_open(interaction)
             self._require_active_participant(
@@ -436,14 +587,16 @@ class InteractionService:
             )
             now = self._evaluation_time(session)
             revision = int(interaction["revision"]) + 1
+            closed = self._close_memberships(session, interaction_id, now, revision)
             self._update_status(
                 session,
                 interaction_id=interaction_id,
                 status=InteractionStatus.STOPPED,
                 revision=revision,
                 updated_at=now,
+                clear_lease=True,
             )
-            self._close_memberships(session, interaction_id, now)
+            snapshot = self._snapshot(session, interaction_id)
             self._append_event(
                 session,
                 interaction_id=interaction_id,
@@ -451,52 +604,379 @@ class InteractionService:
                 revision=revision,
                 occurred_at=now,
                 actor_participant_entity_id=participant_entity_id,
-                payload={"reason": "participant_withdrawal"},
+                command_id=command_id,
+                command_step="command",
+                fingerprint=fingerprint,
+                payload={
+                    "reason": "participant_withdrawal",
+                    "closed_memberships": closed,
+                },
+                outcome={"snapshot": snapshot.model_dump(mode="json")},
             )
-            return self._snapshot(session, interaction_id, lock=False)
+            return snapshot
+
+    def join(
+        self,
+        caller: TrustedHandler,
+        *,
+        interaction_id: UUID,
+        participant_entity_id: int,
+        command_id: UUID,
+    ) -> InteractionSnapshot:
+        """Join a participant, bumping revision and invalidating prior grants."""
+        handler = self._require_handler(caller)
+        fingerprint = self._fingerprint(
+            "join",
+            {
+                "interaction_id": str(interaction_id),
+                "participant_entity_id": participant_entity_id,
+            },
+        )
+        with self._session_factory() as session, session.begin():
+            recorded = self._recorded_command(
+                session,
+                command_id=command_id,
+                fingerprint=fingerprint,
+                interaction_id=interaction_id,
+            )
+            if recorded is not None:
+                return InteractionSnapshot.model_validate(
+                    recorded["outcome"]["snapshot"]
+                )
+            interaction = self._locked_row(session, interaction_id)
+            self._require_open(interaction)
+            self._require_not_recovering(interaction)
+            if participant_entity_id in self._active_participant_ids(
+                session, interaction_id
+            ):
+                raise InteractionStateError("participant is already active")
+            now = self._evaluation_time(session)
+            revision = int(interaction["revision"]) + 1
+            membership_id = int(
+                session.execute(
+                    text(
+                        """
+                        INSERT INTO interaction_participants (
+                            interaction_id, participant_entity_id,
+                            joined_at, joined_revision
+                        ) VALUES (
+                            :interaction_id, :participant_id, :now, :revision
+                        ) RETURNING id
+                        """
+                    ),
+                    {
+                        "interaction_id": interaction_id,
+                        "participant_id": participant_entity_id,
+                        "now": now,
+                        "revision": revision,
+                    },
+                ).scalar_one()
+            )
+            self._bump_revision(session, interaction_id, revision, now)
+            snapshot = self._snapshot(session, interaction_id)
+            self._append_event(
+                session,
+                interaction_id=interaction_id,
+                event_type=InteractionEventType.MEMBERSHIP_JOINED,
+                revision=revision,
+                occurred_at=now,
+                actor_handler=handler.identity,
+                command_id=command_id,
+                command_step="command",
+                fingerprint=fingerprint,
+                payload={
+                    "membership_id": membership_id,
+                    "participant_entity_id": participant_entity_id,
+                    "joined_at": now.isoformat(),
+                    "joined_revision": revision,
+                },
+                outcome={"snapshot": snapshot.model_dump(mode="json")},
+            )
+            return snapshot
+
+    def leave(
+        self,
+        caller: TrustedHandler,
+        *,
+        interaction_id: UUID,
+        participant_entity_id: int,
+        command_id: UUID,
+    ) -> InteractionSnapshot:
+        """End one membership interval and invalidate prior-revision grants."""
+        handler = self._require_handler(caller)
+        fingerprint = self._fingerprint(
+            "leave",
+            {
+                "interaction_id": str(interaction_id),
+                "participant_entity_id": participant_entity_id,
+            },
+        )
+        with self._session_factory() as session, session.begin():
+            recorded = self._recorded_command(
+                session,
+                command_id=command_id,
+                fingerprint=fingerprint,
+                interaction_id=interaction_id,
+            )
+            if recorded is not None:
+                return InteractionSnapshot.model_validate(
+                    recorded["outcome"]["snapshot"]
+                )
+            interaction = self._locked_row(session, interaction_id)
+            self._require_open(interaction)
+            self._require_not_recovering(interaction)
+            self._require_active_participant(
+                session, interaction_id, participant_entity_id
+            )
+            now = self._evaluation_time(session)
+            revision = int(interaction["revision"]) + 1
+            membership_id = int(
+                session.execute(
+                    text(
+                        """
+                        UPDATE interaction_participants
+                        SET left_at = :now, left_revision = :revision
+                        WHERE interaction_id = :interaction_id
+                          AND participant_entity_id = :participant_id
+                          AND left_at IS NULL
+                        RETURNING id
+                        """
+                    ),
+                    {
+                        "now": now,
+                        "revision": revision,
+                        "interaction_id": interaction_id,
+                        "participant_id": participant_entity_id,
+                    },
+                ).scalar_one()
+            )
+            self._bump_revision(session, interaction_id, revision, now)
+            snapshot = self._snapshot(session, interaction_id)
+            self._append_event(
+                session,
+                interaction_id=interaction_id,
+                event_type=InteractionEventType.MEMBERSHIP_LEFT,
+                revision=revision,
+                occurred_at=now,
+                actor_handler=handler.identity,
+                command_id=command_id,
+                command_step="command",
+                fingerprint=fingerprint,
+                payload={
+                    "membership_id": membership_id,
+                    "participant_entity_id": participant_entity_id,
+                    "left_at": now.isoformat(),
+                    "left_revision": revision,
+                },
+                outcome={"snapshot": snapshot.model_dump(mode="json")},
+            )
+            return snapshot
+
+    def touch(
+        self,
+        caller: TrustedHandler,
+        *,
+        interaction_id: UUID,
+        lease_until: datetime,
+        command_id: UUID,
+    ) -> InteractionSnapshot:
+        """Stamp or renew an explicit in-progress handler lease."""
+        handler = self._require_handler(caller)
+        self._require_aware(lease_until, "interaction lease")
+        fingerprint = self._fingerprint(
+            "touch",
+            {
+                "interaction_id": str(interaction_id),
+                "lease_until": lease_until.isoformat(),
+            },
+        )
+        with self._session_factory() as session, session.begin():
+            recorded = self._recorded_command(
+                session,
+                command_id=command_id,
+                fingerprint=fingerprint,
+                interaction_id=interaction_id,
+            )
+            if recorded is not None:
+                return InteractionSnapshot.model_validate(
+                    recorded["outcome"]["snapshot"]
+                )
+            interaction = self._locked_row(session, interaction_id)
+            self._require_status(interaction, InteractionStatus.IN_PROGRESS)
+            if interaction["recovery_command_id"] is not None:
+                raise InteractionStateError("interaction is claimed for recovery")
+            now = self._evaluation_time(session)
+            if lease_until <= now:
+                raise ValueError("interaction lease must expire in the future")
+            session.execute(
+                text(
+                    """
+                    UPDATE interactions
+                    SET lease_until = :lease_until, updated_at = :now
+                    WHERE id = :interaction_id
+                    """
+                ),
+                {
+                    "lease_until": lease_until,
+                    "now": now,
+                    "interaction_id": interaction_id,
+                },
+            )
+            snapshot = self._snapshot(session, interaction_id)
+            self._append_event(
+                session,
+                interaction_id=interaction_id,
+                event_type=InteractionEventType.LEASE_TOUCHED,
+                revision=int(interaction["revision"]),
+                occurred_at=now,
+                actor_handler=handler.identity,
+                command_id=command_id,
+                command_step="command",
+                fingerprint=fingerprint,
+                payload={"lease_until": lease_until.isoformat()},
+                outcome={"snapshot": snapshot.model_dump(mode="json")},
+            )
+            return snapshot
 
     def recover(
         self,
         caller: TrustedHandler,
         *,
-        orphaned_before: datetime,
-        cleanup_hooks: Sequence[RecoveryCleanupHook] = (),
+        command_id: UUID,
+        cleanup_hooks: Sequence[NamedRecoveryCleanupHook] = (),
     ) -> tuple[UUID, ...]:
-        """Interrupt orphaned in-progress threads exactly once; never resume them."""
+        """Interrupt lease-expired interactions with durable per-hook completion."""
         handler = self._require_handler(caller)
-        if orphaned_before.tzinfo is None or orphaned_before.utcoffset() is None:
-            raise ValueError("orphan recovery cutoff must be timezone-aware")
+        hook_names = [hook.name for hook in cleanup_hooks]
+        if len(hook_names) != len(set(hook_names)):
+            raise ValueError("recovery cleanup hook names must be unique")
+        fingerprint = self._fingerprint("recover", {"hook_names": hook_names})
         recovered: list[UUID] = []
         with self._session_factory() as session, session.begin():
-            interaction_ids = tuple(
+            command_rows = self._validate_command_reuse(
+                session, command_id, fingerprint
+            )
+            recovered.extend(
+                UUID(str(value))
+                for value in session.execute(
+                    text(
+                        """
+                        SELECT interaction_id
+                        FROM interaction_events
+                        WHERE command_id = :command_id
+                          AND command_step = 'command'
+                          AND event_type = 'interrupted'
+                        ORDER BY id
+                        """
+                    ),
+                    {"command_id": command_id},
+                ).scalars()
+            )
+            now = self._evaluation_time(session)
+            if command_rows:
+                candidates = tuple(
+                    dict.fromkeys(row["interaction_id"] for row in command_rows)
+                )
+            else:
+                candidates = tuple(
+                    session.execute(
+                        text(
+                            """
+                            SELECT id
+                            FROM interactions
+                            WHERE status = 'in_progress'
+                              AND lease_until IS NOT NULL
+                              AND lease_until <= :now
+                            ORDER BY lease_until, id
+                            FOR UPDATE SKIP LOCKED
+                            """
+                        ),
+                        {"now": now},
+                    ).scalars()
+                )
+            for interaction_id in candidates:
+                if interaction_id in recovered:
+                    continue
+                claimed = session.execute(
+                    text(
+                        """
+                        SELECT 1
+                        FROM interaction_events
+                        WHERE interaction_id = :interaction_id
+                          AND command_id = :command_id
+                          AND command_step = 'claim'
+                        """
+                    ),
+                    {
+                        "interaction_id": interaction_id,
+                        "command_id": command_id,
+                    },
+                ).scalar_one_or_none()
+                if claimed is not None:
+                    continue
                 session.execute(
                     text(
                         """
-                        SELECT id
-                        FROM interactions
-                        WHERE status = 'in_progress'
-                          AND updated_at < :orphaned_before
-                        ORDER BY updated_at, id
-                        FOR UPDATE SKIP LOCKED
+                        UPDATE interactions
+                        SET recovery_command_id = :command_id
+                        WHERE id = :interaction_id
                         """
                     ),
-                    {"orphaned_before": orphaned_before},
-                ).scalars()
-            )
-            for interaction_id in interaction_ids:
-                snapshot = self._snapshot(session, interaction_id, lock=False)
-                for cleanup_hook in cleanup_hooks:
-                    cleanup_hook(session, snapshot)
+                    {"command_id": command_id, "interaction_id": interaction_id},
+                )
+                interaction = self._locked_row(session, interaction_id)
+                self._append_event(
+                    session,
+                    interaction_id=interaction_id,
+                    event_type=InteractionEventType.RECOVERY_CLAIMED,
+                    revision=int(interaction["revision"]),
+                    occurred_at=now,
+                    actor_handler=handler.identity,
+                    command_id=command_id,
+                    command_step="claim",
+                    fingerprint=fingerprint,
+                    payload={"lease_until": interaction["lease_until"].isoformat()},
+                    outcome={"claimed": True},
+                )
+        for interaction_id in candidates:
+            if interaction_id in recovered:
+                continue
+            if not self._run_cleanup_hooks(
+                handler=handler,
+                interaction_id=interaction_id,
+                command_id=command_id,
+                fingerprint=fingerprint,
+                cleanup_hooks=cleanup_hooks,
+            ):
+                continue
+            with self._session_factory() as session, session.begin():
+                interaction = self._locked_row(session, interaction_id)
                 now = self._evaluation_time(session)
-                revision = snapshot.revision + 1
+                if (
+                    interaction["status"] != InteractionStatus.IN_PROGRESS.value
+                    or interaction["lease_until"] is None
+                    or interaction["lease_until"] > now
+                ):
+                    continue
+                recorded = self._recorded_command(
+                    session,
+                    command_id=command_id,
+                    fingerprint=fingerprint,
+                    interaction_id=interaction_id,
+                )
+                if recorded is not None:
+                    recovered.append(interaction_id)
+                    continue
+                revision = int(interaction["revision"]) + 1
+                closed = self._close_memberships(session, interaction_id, now, revision)
                 self._update_status(
                     session,
                     interaction_id=interaction_id,
                     status=InteractionStatus.INTERRUPTED,
                     revision=revision,
                     updated_at=now,
+                    clear_lease=True,
                 )
-                self._close_memberships(session, interaction_id, now)
                 self._append_event(
                     session,
                     interaction_id=interaction_id,
@@ -504,18 +984,25 @@ class InteractionService:
                     revision=revision,
                     occurred_at=now,
                     actor_handler=handler.identity,
-                    payload={"reason": "orphan_recovery"},
+                    command_id=command_id,
+                    command_step="command",
+                    fingerprint=fingerprint,
+                    payload={
+                        "reason": "expired_handler_lease",
+                        "closed_memberships": closed,
+                    },
+                    outcome={"interaction_id": str(interaction_id)},
                 )
                 recovered.append(interaction_id)
-        return tuple(recovered)
+        return tuple(dict.fromkeys(recovered))
 
     def get(self, interaction_id: UUID) -> InteractionSnapshot:
         """Read one durable interaction and its current active membership."""
         with self._session_factory() as session, session.begin():
-            return self._snapshot(session, interaction_id, lock=False)
+            return self._snapshot(session, interaction_id)
 
     def history(self, interaction_id: UUID) -> tuple[InteractionEvent, ...]:
-        """Read immutable lifecycle events in replay order."""
+        """Read immutable command and lifecycle events in replay order."""
         with self._session_factory() as session, session.begin():
             if (
                 session.execute(
@@ -531,7 +1018,8 @@ class InteractionService:
                     SELECT id, interaction_id, event_type,
                            interaction_revision,
                            actor_participant_entity_id, actor_handler,
-                           payload, occurred_at
+                           command_id, command_step, command_fingerprint,
+                           payload, outcome, occurred_at
                     FROM interaction_events
                     WHERE interaction_id = :interaction_id
                     ORDER BY id
@@ -541,61 +1029,123 @@ class InteractionService:
             ).mappings()
             return tuple(InteractionEvent.model_validate(dict(row)) for row in rows)
 
+    def current_state(self, interaction_id: UUID) -> ReplayedInteraction:
+        """Read full live membership and grant state for replay parity checks."""
+        with self._session_factory() as session, session.begin():
+            interaction = self._locked_row(session, interaction_id)
+            memberships = self._membership_states(session, interaction_id)
+            grants = self._grant_states(session, interaction_id)
+            transitions = tuple(
+                str(payload["transition_type"])
+                for payload in session.execute(
+                    text(
+                        """
+                        SELECT payload
+                        FROM interaction_events
+                        WHERE interaction_id = :interaction_id
+                          AND event_type = 'transitioned'
+                        ORDER BY id
+                        """
+                    ),
+                    {"interaction_id": interaction_id},
+                ).scalars()
+            )
+            return self._state_model(interaction, memberships, grants, transitions)
+
     def replay(self, interaction_id: UUID) -> ReplayedInteraction:
-        """Reconstruct lifecycle state exclusively from the append-only ledger."""
+        """Reconstruct status, membership history, grants, lease, and transitions."""
         events = self.history(interaction_id)
         if not events or events[0].event_type is not InteractionEventType.PROPOSED:
-            raise InteractionStateError(
-                f"interaction {interaction_id} has no valid proposed event"
-            )
-        status = InteractionStatus.PROPOSED
+            raise InteractionStateError("interaction has no valid proposed event")
+        memberships: dict[int, MembershipHistoryState] = {}
+        grants: dict[int, AuthorizationGrantState] = {}
         transitions: list[str] = []
-        authorization_events = 0
-        revision = events[0].interaction_revision
-        for event in events[1:]:
+        status = InteractionStatus.PROPOSED
+        revision = 1
+        lease_until: datetime | None = None
+        for event in events:
             revision = event.interaction_revision
-            if event.event_type is InteractionEventType.AUTHORIZED:
-                authorization_events += 1
+            payload = event.payload
+            if event.event_type is InteractionEventType.PROPOSED:
+                for item in payload["memberships"]:
+                    membership_state = MembershipHistoryState.model_validate(item)
+                    memberships[membership_state.membership_id] = membership_state
+            elif event.event_type is InteractionEventType.AUTHORIZED:
+                if payload["state"] == "granted":
+                    grant_state = AuthorizationGrantState.model_validate(
+                        {
+                            key: payload[key]
+                            for key in (
+                                "id",
+                                "participant_entity_id",
+                                "action",
+                                "envelope_hash",
+                                "continuation_id",
+                                "interaction_revision",
+                                "granted",
+                                "granted_at",
+                                "expires_at",
+                                "revoked_at",
+                            )
+                        }
+                    )
+                    grants[grant_state.id] = grant_state
+                else:
+                    revoked_at = datetime.fromisoformat(payload["revoked_at"])
+                    for grant_id in payload["grant_ids"]:
+                        grants[int(grant_id)] = grants[int(grant_id)].model_copy(
+                            update={"revoked_at": revoked_at}
+                        )
+            elif event.event_type is InteractionEventType.MEMBERSHIP_JOINED:
+                membership_state = MembershipHistoryState.model_validate(payload)
+                memberships[membership_state.membership_id] = membership_state
+            elif event.event_type is InteractionEventType.MEMBERSHIP_LEFT:
+                membership_id = int(payload["membership_id"])
+                memberships[membership_id] = memberships[membership_id].model_copy(
+                    update={
+                        "left_at": datetime.fromisoformat(payload["left_at"]),
+                        "left_revision": int(payload["left_revision"]),
+                    }
+                )
+            elif event.event_type is InteractionEventType.LEASE_TOUCHED:
+                lease_until = datetime.fromisoformat(payload["lease_until"])
             elif event.event_type is InteractionEventType.STARTED:
-                if status is not InteractionStatus.PROPOSED:
-                    raise InteractionStateError("started event followed invalid state")
                 status = InteractionStatus.IN_PROGRESS
             elif event.event_type is InteractionEventType.TRANSITIONED:
-                if status is not InteractionStatus.IN_PROGRESS:
-                    raise InteractionStateError(
-                        "transitioned event followed invalid state"
-                    )
-                transition_type = event.payload.get("transition_type")
-                if not isinstance(transition_type, str) or not transition_type:
-                    raise InteractionStateError("transition event payload is malformed")
-                transitions.append(transition_type)
+                status = InteractionStatus.IN_PROGRESS
+                transitions.append(str(payload["transition_type"]))
             elif event.event_type is InteractionEventType.COMPLETED:
-                if status is not InteractionStatus.IN_PROGRESS:
-                    raise InteractionStateError(
-                        "completed event followed invalid state"
-                    )
                 status = InteractionStatus.COMPLETED
+                lease_until = None
             elif event.event_type is InteractionEventType.STOPPED:
-                if status not in {
-                    InteractionStatus.PROPOSED,
-                    InteractionStatus.IN_PROGRESS,
-                }:
-                    raise InteractionStateError("stopped event followed invalid state")
                 status = InteractionStatus.STOPPED
+                lease_until = None
             elif event.event_type is InteractionEventType.INTERRUPTED:
-                if status is not InteractionStatus.IN_PROGRESS:
-                    raise InteractionStateError(
-                        "interrupted event followed invalid state"
-                    )
                 status = InteractionStatus.INTERRUPTED
-            elif event.event_type is InteractionEventType.PROPOSED:
-                raise InteractionStateError("duplicate proposed event")
+                lease_until = None
+            if "closed_memberships" in payload:
+                for closed in payload["closed_memberships"]:
+                    membership_id = int(closed["membership_id"])
+                    memberships[membership_id] = memberships[membership_id].model_copy(
+                        update={
+                            "left_at": datetime.fromisoformat(closed["left_at"]),
+                            "left_revision": int(closed["left_revision"]),
+                        }
+                    )
+        membership_values = tuple(memberships[key] for key in sorted(memberships))
         return ReplayedInteraction(
             interaction_id=interaction_id,
             status=status,
             revision=revision,
+            active_participant_entity_ids=tuple(
+                state.participant_entity_id
+                for state in membership_values
+                if state.left_at is None
+            ),
+            membership_history=membership_values,
+            grants=tuple(grants[key] for key in sorted(grants)),
             transition_types=tuple(transitions),
-            authorization_events=authorization_events,
+            lease_until=lease_until,
         )
 
     def _execute_status_change(
@@ -603,32 +1153,65 @@ class InteractionService:
         caller: TrustedHandler,
         *,
         interaction_id: UUID,
+        command_id: UUID,
         expected_status: InteractionStatus,
-        action: str,
+        envelope: AuthorizationEnvelope,
         event_type: InteractionEventType,
         target_status: InteractionStatus,
         payload: dict[str, Any],
         terminal: bool,
     ) -> InteractionSnapshot:
         handler = self._require_handler(caller)
+        fingerprint = self._fingerprint(
+            event_type.value,
+            {
+                "interaction_id": str(interaction_id),
+                "envelope": envelope.model_dump(mode="json"),
+                "payload": payload,
+            },
+        )
         with self._session_factory() as session, session.begin():
+            recorded = self._recorded_command(
+                session,
+                command_id=command_id,
+                fingerprint=fingerprint,
+                interaction_id=interaction_id,
+            )
+            if recorded is not None:
+                return InteractionSnapshot.model_validate(
+                    recorded["outcome"]["snapshot"]
+                )
             interaction = self._locked_row(session, interaction_id)
             self._require_status(interaction, expected_status)
-            decision = self._authorization_decision(session, interaction, action)
+            self._require_not_recovering(interaction)
+            decision = self._authorization_decision(session, interaction, envelope)
             if not decision.allowed:
+                if decision.reason is DenialReason.UNKNOWN_TRANSITION:
+                    raise UnknownExecutorTransition()
                 raise InteractionAuthorizationDenied(decision)
-            self._require_fresh_anchor(session, interaction)
+            self._require_fresh_anchor_under_lock(session, interaction)
             now = self._evaluation_time(session)
             revision = int(interaction["revision"]) + 1
+            closed = (
+                self._close_memberships(session, interaction_id, now, revision)
+                if terminal
+                else []
+            )
             self._update_status(
                 session,
                 interaction_id=interaction_id,
                 status=target_status,
                 revision=revision,
                 updated_at=now,
+                clear_lease=terminal,
             )
-            if terminal:
-                self._close_memberships(session, interaction_id, now)
+            snapshot = self._snapshot(session, interaction_id)
+            event_payload = dict(payload)
+            event_payload["envelope_hash"] = canonical_envelope_hash(
+                self._validated_policy(interaction), envelope
+            )
+            if closed:
+                event_payload["closed_memberships"] = closed
             self._append_event(
                 session,
                 interaction_id=interaction_id,
@@ -636,21 +1219,29 @@ class InteractionService:
                 revision=revision,
                 occurred_at=now,
                 actor_handler=handler.identity,
-                payload=payload,
+                command_id=command_id,
+                command_step="command",
+                fingerprint=fingerprint,
+                payload=event_payload,
+                outcome={"snapshot": snapshot.model_dump(mode="json")},
             )
-            return self._snapshot(session, interaction_id, lock=False)
+            return snapshot
 
     def _authorization_decision(
-        self, session: Session, interaction: dict[str, Any], action: str
+        self,
+        session: Session,
+        interaction: dict[str, Any],
+        envelope: AuthorizationEnvelope,
     ) -> AuthorizationDecision:
         try:
             policy = self._validated_policy(interaction)
-            if action not in policy.actions:
+            if envelope.action not in policy.actions:
                 return AuthorizationDecision(
                     allowed=False, reason=DenialReason.ACTION_NOT_DECLARED
                 )
-            participant_ids = self._active_participant_ids(session, interaction["id"])
-            if not participant_ids:
+            self._validate_envelope_transition(interaction, envelope)
+            participants = self._active_participant_ids(session, interaction["id"])
+            if not participants:
                 return AuthorizationDecision(
                     allowed=False, reason=DenialReason.MALFORMED_AUTHORIZATION
                 )
@@ -659,7 +1250,7 @@ class InteractionService:
                 for row in session.execute(
                     text(
                         """
-                        SELECT id, participant_entity_id, action,
+                        SELECT id, participant_entity_id, action, envelope_hash,
                                continuation_id, interaction_revision, granted,
                                granted_at, expires_at, revoked_at
                         FROM interaction_authorizations
@@ -668,13 +1259,17 @@ class InteractionService:
                         ORDER BY id
                         """
                     ),
-                    {"interaction_id": interaction["id"], "action": action},
+                    {
+                        "interaction_id": interaction["id"],
+                        "action": envelope.action,
+                    },
                 ).mappings()
             ]
             return evaluate_authorizations(
-                participant_entity_ids=participant_ids,
+                participant_entity_ids=participants,
                 authorization_rows=rows,
-                action=action,
+                action=envelope.action,
+                envelope_hash=canonical_envelope_hash(policy, envelope),
                 continuation_id=interaction["continuation_id"],
                 interaction_revision=int(interaction["revision"]),
                 evaluated_at=self._evaluation_time(session),
@@ -688,25 +1283,186 @@ class InteractionService:
                 )
             ) from exc
 
-    def _require_fresh_anchor(
+    def _require_fresh_anchor_under_lock(
         self, session: Session, interaction: dict[str, Any]
     ) -> None:
+        stored = TimelineAnchor(
+            anchor_chunk_id=interaction["anchor_chunk_id"],
+            timeline_id=interaction["timeline_id"],
+        )
         try:
-            current = self._freshness_resolver(session)
+            expected = self._expected_identity_resolver(stored)
+            authoritative = (
+                session.execute(
+                    text(
+                        """
+                    SELECT nc.id AS anchor_chunk_id,
+                           cm.world_layer::text AS timeline_id
+                    FROM narrative_chunks nc
+                    JOIN chunk_metadata cm ON cm.chunk_id = nc.id
+                    ORDER BY nc.id DESC
+                    LIMIT 1
+                    FOR UPDATE OF nc, cm
+                    """
+                    )
+                )
+                .mappings()
+                .one_or_none()
+            )
         except Exception as exc:
             raise InteractionAuthorizationDenied(
                 AuthorizationDecision(
                     allowed=False, reason=DenialReason.EVALUATION_UNAVAILABLE
                 )
             ) from exc
-        if current.timeline_id != interaction["timeline_id"]:
-            raise InteractionAuthorizationDenied(
-                AuthorizationDecision(allowed=False, reason=DenialReason.STALE_TIMELINE)
+        if authoritative is None:
+            self._deny(DenialReason.EVALUATION_UNAVAILABLE)
+        if authoritative["timeline_id"] != expected.timeline_id:
+            self._deny(DenialReason.STALE_TIMELINE)
+        if authoritative["anchor_chunk_id"] != expected.anchor_chunk_id:
+            self._deny(DenialReason.STALE_ANCHOR)
+
+    def _run_cleanup_hooks(
+        self,
+        *,
+        handler: TrustedHandler,
+        interaction_id: UUID,
+        command_id: UUID,
+        fingerprint: str,
+        cleanup_hooks: Sequence[NamedRecoveryCleanupHook],
+    ) -> bool:
+        for hook in cleanup_hooks:
+            with self._session_factory() as session, session.begin():
+                interaction = self._locked_row(session, interaction_id)
+                now = self._evaluation_time(session)
+                if (
+                    interaction["status"] != InteractionStatus.IN_PROGRESS.value
+                    or interaction["lease_until"] is None
+                    or interaction["lease_until"] > now
+                ):
+                    return False
+                completed = session.execute(
+                    text(
+                        """
+                        SELECT 1
+                        FROM interaction_events
+                        WHERE interaction_id = :interaction_id
+                          AND event_type = 'cleanup_completed'
+                          AND payload ->> 'hook_name' = :hook_name
+                        """
+                    ),
+                    {
+                        "interaction_id": interaction_id,
+                        "hook_name": hook.name,
+                    },
+                ).scalar_one_or_none()
+                if completed is not None:
+                    continue
+                snapshot = self._snapshot(session, interaction_id)
+                hook.callback(session, snapshot)
+                self._append_event(
+                    session,
+                    interaction_id=interaction_id,
+                    event_type=InteractionEventType.CLEANUP_COMPLETED,
+                    revision=int(interaction["revision"]),
+                    occurred_at=now,
+                    actor_handler=handler.identity,
+                    command_id=command_id,
+                    command_step=f"cleanup:{hook.name}",
+                    fingerprint=fingerprint,
+                    payload={"hook_name": hook.name},
+                    outcome={"completed": True, "hook_name": hook.name},
+                )
+        return True
+
+    def _validate_transition(
+        self, interaction: dict[str, Any], transition_type: str
+    ) -> None:
+        vocabulary = self._executor_registry.get(interaction["executor_namespace"])
+        if vocabulary is None or transition_type not in vocabulary:
+            raise UnknownExecutorTransition()
+
+    def _validate_envelope_transition(
+        self, interaction: dict[str, Any], envelope: AuthorizationEnvelope
+    ) -> None:
+        lifecycle_type = f"lifecycle.{envelope.action}"
+        if envelope.action in {"start", "complete"}:
+            if envelope.transition_type != lifecycle_type or envelope.payload:
+                self._deny(DenialReason.AUTHORIZATION_TERMS_CHANGED)
+            return
+        self._validate_transition(interaction, envelope.transition_type)
+
+    def _recorded_command(
+        self,
+        session: Session,
+        *,
+        command_id: UUID,
+        fingerprint: str,
+        interaction_id: UUID | None = None,
+    ) -> dict[str, Any] | None:
+        rows = self._validate_command_reuse(session, command_id, fingerprint)
+        for row in rows:
+            if row["command_step"] != "command":
+                continue
+            if interaction_id is None or row["interaction_id"] == interaction_id:
+                return row
+        return None
+
+    @staticmethod
+    def _validate_command_reuse(
+        session: Session, command_id: UUID, fingerprint: str
+    ) -> list[dict[str, Any]]:
+        rows = [
+            dict(row)
+            for row in session.execute(
+                text(
+                    """
+                    SELECT interaction_id, command_step,
+                           command_fingerprint, outcome
+                    FROM interaction_events
+                    WHERE command_id = :command_id
+                    ORDER BY id
+                    """
+                ),
+                {"command_id": command_id},
+            ).mappings()
+        ]
+        if any(row["command_fingerprint"] != fingerprint for row in rows):
+            raise CommandIdConflict(
+                f"command_id {command_id} was reused with different content"
             )
-        if current.anchor_chunk_id != interaction["anchor_chunk_id"]:
-            raise InteractionAuthorizationDenied(
-                AuthorizationDecision(allowed=False, reason=DenialReason.STALE_ANCHOR)
+        return rows
+
+    @staticmethod
+    def _fingerprint(command: str, content: dict[str, Any]) -> str:
+        return _stable_hash({"command": command, "content": content})
+
+    def _require_handler(self, caller: TrustedHandler) -> TrustedHandler:
+        if not isinstance(caller, TrustedHandler):
+            raise UntrustedHandlerError("privileged interaction API requires a handler")
+        if caller._service_nonce is not self._handler_nonce:
+            raise UntrustedHandlerError(
+                "trusted handler capability belongs to a different service"
             )
+        return caller
+
+    @staticmethod
+    def _deny(reason: DenialReason) -> NoReturn:
+        raise InteractionAuthorizationDenied(
+            AuthorizationDecision(allowed=False, reason=reason)
+        )
+
+    @staticmethod
+    def _require_aware(value: datetime, label: str) -> None:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError(f"{label} must be timezone-aware")
+
+    @staticmethod
+    def _lifecycle_envelope(action: str) -> AuthorizationEnvelope:
+        return AuthorizationEnvelope(
+            action=action,
+            transition_type=f"lifecycle.{action}",
+        )
 
     def _validated_policy(self, interaction: dict[str, Any]) -> AuthorizationPolicy:
         try:
@@ -717,15 +1473,6 @@ class InteractionService:
                     allowed=False, reason=DenialReason.MALFORMED_POLICY
                 )
             ) from exc
-
-    def _require_handler(self, caller: TrustedHandler) -> TrustedHandler:
-        if not isinstance(caller, TrustedHandler):
-            raise UntrustedHandlerError("privileged interaction API requires a handler")
-        if caller._service_nonce is not self._handler_nonce:
-            raise UntrustedHandlerError(
-                "trusted handler capability belongs to a different service"
-            )
-        return caller
 
     @staticmethod
     def _require_open(interaction: dict[str, Any]) -> None:
@@ -748,6 +1495,11 @@ class InteractionService:
                 f"expected {expected.value}"
             )
 
+    @staticmethod
+    def _require_not_recovering(interaction: dict[str, Any]) -> None:
+        if interaction["recovery_command_id"] is not None:
+            raise InteractionStateError("interaction is claimed for recovery")
+
     def _locked_row(self, session: Session, interaction_id: UUID) -> dict[str, Any]:
         row = (
             session.execute(
@@ -755,7 +1507,7 @@ class InteractionService:
                     """
                 SELECT id, kind, executor_namespace, status, policy,
                        continuation_id, revision, anchor_chunk_id, timeline_id,
-                       created_at, updated_at
+                       lease_until, recovery_command_id, created_at, updated_at
                 FROM interactions
                 WHERE id = :interaction_id
                 FOR UPDATE
@@ -770,38 +1522,9 @@ class InteractionService:
             raise InteractionNotFound(f"interaction {interaction_id} was not found")
         return dict(row)
 
-    def _snapshot(
-        self, session: Session, interaction_id: UUID, *, lock: bool
-    ) -> InteractionSnapshot:
-        suffix = " FOR UPDATE" if lock else ""
-        row = (
-            session.execute(
-                text(
-                    """
-                SELECT id, kind, executor_namespace, status, policy,
-                       continuation_id, revision, anchor_chunk_id, timeline_id,
-                       created_at, updated_at
-                FROM interactions
-                WHERE id = :interaction_id
-                """
-                    + suffix
-                ),
-                {"interaction_id": interaction_id},
-            )
-            .mappings()
-            .one_or_none()
-        )
-        if row is None:
-            raise InteractionNotFound(f"interaction {interaction_id} was not found")
-        interaction = dict(row)
-        try:
-            policy = AuthorizationPolicy.model_validate(interaction["policy"])
-        except ValidationError as exc:
-            raise InteractionAuthorizationDenied(
-                AuthorizationDecision(
-                    allowed=False, reason=DenialReason.MALFORMED_POLICY
-                )
-            ) from exc
+    def _snapshot(self, session: Session, interaction_id: UUID) -> InteractionSnapshot:
+        interaction = self._locked_row(session, interaction_id)
+        policy = self._validated_policy(interaction)
         return InteractionSnapshot(
             id=interaction["id"],
             kind=interaction["kind"],
@@ -817,6 +1540,7 @@ class InteractionService:
             participant_entity_ids=self._active_participant_ids(
                 session, interaction_id
             ),
+            lease_until=interaction["lease_until"],
             created_at=interaction["created_at"],
             updated_at=interaction["updated_at"],
         )
@@ -868,15 +1592,38 @@ class InteractionService:
 
     def _evaluation_time(self, session: Session) -> datetime:
         value = self._evaluation_time_provider(session)
-        if value.tzinfo is None or value.utcoffset() is None:
-            raise RuntimeError("interaction evaluation time must be timezone-aware")
+        self._require_aware(value, "interaction evaluation time")
         return value.astimezone(timezone.utc)
 
     @staticmethod
-    def _touch(session: Session, interaction_id: UUID, updated_at: datetime) -> None:
+    def _touch_updated_at(
+        session: Session, interaction_id: UUID, updated_at: datetime
+    ) -> None:
         session.execute(
             text("UPDATE interactions SET updated_at = :at WHERE id = :id"),
             {"at": updated_at, "id": interaction_id},
+        )
+
+    @staticmethod
+    def _bump_revision(
+        session: Session,
+        interaction_id: UUID,
+        revision: int,
+        updated_at: datetime,
+    ) -> None:
+        session.execute(
+            text(
+                """
+                UPDATE interactions
+                SET revision = :revision, updated_at = :updated_at
+                WHERE id = :interaction_id
+                """
+            ),
+            {
+                "revision": revision,
+                "updated_at": updated_at,
+                "interaction_id": interaction_id,
+            },
         )
 
     @staticmethod
@@ -887,13 +1634,19 @@ class InteractionService:
         status: InteractionStatus,
         revision: int,
         updated_at: datetime,
+        clear_lease: bool,
     ) -> None:
         session.execute(
             text(
                 """
                 UPDATE interactions
-                SET status = :status,
-                    revision = :revision,
+                SET status = :status, revision = :revision,
+                    lease_until = CASE
+                        WHEN :clear_lease THEN NULL ELSE lease_until
+                    END,
+                    recovery_command_id = CASE
+                        WHEN :clear_lease THEN NULL ELSE recovery_command_id
+                    END,
                     updated_at = :updated_at
                 WHERE id = :interaction_id
                 """
@@ -902,25 +1655,43 @@ class InteractionService:
                 "status": status.value,
                 "revision": revision,
                 "updated_at": updated_at,
+                "clear_lease": clear_lease,
                 "interaction_id": interaction_id,
             },
         )
 
     @staticmethod
     def _close_memberships(
-        session: Session, interaction_id: UUID, left_at: datetime
-    ) -> None:
-        session.execute(
+        session: Session,
+        interaction_id: UUID,
+        left_at: datetime,
+        left_revision: int,
+    ) -> list[dict[str, Any]]:
+        rows = session.execute(
             text(
                 """
                 UPDATE interaction_participants
-                SET left_at = :left_at
+                SET left_at = :left_at, left_revision = :left_revision
                 WHERE interaction_id = :interaction_id
                   AND left_at IS NULL
+                RETURNING id, participant_entity_id
                 """
             ),
-            {"left_at": left_at, "interaction_id": interaction_id},
-        )
+            {
+                "left_at": left_at,
+                "left_revision": left_revision,
+                "interaction_id": interaction_id,
+            },
+        ).mappings()
+        return [
+            {
+                "membership_id": int(row["id"]),
+                "participant_entity_id": int(row["participant_entity_id"]),
+                "left_at": left_at.isoformat(),
+                "left_revision": left_revision,
+            }
+            for row in rows
+        ]
 
     @staticmethod
     def _append_event(
@@ -930,7 +1701,11 @@ class InteractionService:
         event_type: InteractionEventType,
         revision: int,
         occurred_at: datetime,
+        command_id: UUID,
+        command_step: str,
+        fingerprint: str,
         payload: dict[str, Any],
+        outcome: dict[str, Any],
         actor_participant_entity_id: int | None = None,
         actor_handler: str | None = None,
     ) -> None:
@@ -940,11 +1715,13 @@ class InteractionService:
                 INSERT INTO interaction_events (
                     interaction_id, event_type, interaction_revision,
                     actor_participant_entity_id, actor_handler,
-                    payload, occurred_at
+                    command_id, command_step, command_fingerprint,
+                    payload, outcome, occurred_at
                 ) VALUES (
                     :interaction_id, :event_type, :revision,
                     :actor_participant_entity_id, :actor_handler,
-                    CAST(:payload AS JSONB), :occurred_at
+                    :command_id, :command_step, :fingerprint,
+                    CAST(:payload AS JSONB), CAST(:outcome AS JSONB), :occurred_at
                 )
                 """
             ),
@@ -954,7 +1731,70 @@ class InteractionService:
                 "revision": revision,
                 "actor_participant_entity_id": actor_participant_entity_id,
                 "actor_handler": actor_handler,
+                "command_id": command_id,
+                "command_step": command_step,
+                "fingerprint": fingerprint,
                 "payload": json.dumps(payload),
+                "outcome": json.dumps(outcome),
                 "occurred_at": occurred_at,
             },
+        )
+
+    @staticmethod
+    def _membership_states(
+        session: Session, interaction_id: UUID
+    ) -> tuple[MembershipHistoryState, ...]:
+        rows = session.execute(
+            text(
+                """
+                SELECT id AS membership_id, participant_entity_id,
+                       joined_at, joined_revision, left_at, left_revision
+                FROM interaction_participants
+                WHERE interaction_id = :interaction_id
+                ORDER BY id
+                """
+            ),
+            {"interaction_id": interaction_id},
+        ).mappings()
+        return tuple(MembershipHistoryState.model_validate(dict(row)) for row in rows)
+
+    @staticmethod
+    def _grant_states(
+        session: Session, interaction_id: UUID
+    ) -> tuple[AuthorizationGrantState, ...]:
+        rows = session.execute(
+            text(
+                """
+                SELECT id, participant_entity_id, action, envelope_hash,
+                       continuation_id, interaction_revision, granted,
+                       granted_at, expires_at, revoked_at
+                FROM interaction_authorizations
+                WHERE interaction_id = :interaction_id
+                ORDER BY id
+                """
+            ),
+            {"interaction_id": interaction_id},
+        ).mappings()
+        return tuple(AuthorizationGrantState.model_validate(dict(row)) for row in rows)
+
+    @staticmethod
+    def _state_model(
+        interaction: dict[str, Any],
+        memberships: tuple[MembershipHistoryState, ...],
+        grants: tuple[AuthorizationGrantState, ...],
+        transitions: tuple[str, ...],
+    ) -> ReplayedInteraction:
+        return ReplayedInteraction(
+            interaction_id=interaction["id"],
+            status=interaction["status"],
+            revision=interaction["revision"],
+            active_participant_entity_ids=tuple(
+                state.participant_entity_id
+                for state in memberships
+                if state.left_at is None
+            ),
+            membership_history=memberships,
+            grants=grants,
+            transition_types=transitions,
+            lease_until=interaction["lease_until"],
         )

--- a/tests/test_interaction_boundary.py
+++ b/tests/test_interaction_boundary.py
@@ -1,0 +1,34 @@
+"""Static trust-boundary guards for interaction authorization."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def test_wire_and_adapter_layers_cannot_reach_interaction_grants() -> None:
+    """Keep model-facing modules outside the interaction grant import graph."""
+    nexus_root = Path(__file__).resolve().parents[1] / "nexus"
+    candidates = set((nexus_root / "api").rglob("*.py"))
+    candidates.update(nexus_root.rglob("*wire*.py"))
+    candidates.update(nexus_root.rglob("*adapter*.py"))
+    candidates.update(nexus_root.rglob("*schemas.py"))
+    violations: list[str] = []
+    for path in sorted(candidates):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and (node.module or "").startswith(
+                "nexus.interactions"
+            ):
+                violations.append(f"{path}: imports {node.module}")
+            elif isinstance(node, ast.Import) and any(
+                alias.name.startswith("nexus.interactions") for alias in node.names
+            ):
+                violations.append(f"{path}: imports nexus.interactions")
+            elif (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "grant"
+            ):
+                violations.append(f"{path}: calls a grant API")
+    assert violations == []

--- a/tests/test_interactions_pg.py
+++ b/tests/test_interactions_pg.py
@@ -1,0 +1,570 @@
+"""Real-PostgreSQL acceptance tests for durable interaction threads."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+import psycopg2
+import pytest
+from psycopg2 import sql
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.orm import Session, sessionmaker
+
+from nexus.interactions import (
+    AuthorizationPolicy,
+    AuthorizationRule,
+    DenialReason,
+    InteractionAuthorizationDenied,
+    InteractionEventType,
+    InteractionProposal,
+    InteractionService,
+    InteractionSnapshot,
+    InteractionStatus,
+    InteractionTransition,
+    TimelineAnchor,
+    UntrustedHandlerError,
+)
+from nexus.interactions.service import TrustedHandler
+
+
+pytestmark = pytest.mark.requires_postgres
+
+
+def _connect(dbname: str) -> Any:
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+@pytest.fixture()
+def disposable_interaction_db() -> Iterator[str]:
+    """Clone the template, apply migration 105 twice, then drop the clone."""
+    dbname = f"nexus_test_interactions_{uuid.uuid4().hex[:12]}"
+    admin = _connect("postgres")
+    admin.autocommit = True
+    try:
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier("NEXUS_template"),
+                )
+            )
+        migration = Path("migrations/105_interaction_threads.sql").read_text()
+        with _connect(dbname) as conn, conn.cursor() as cur:
+            cur.execute(migration)
+            cur.execute(migration)
+        yield dbname
+    finally:
+        with admin.cursor() as cur:
+            cur.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (dbname,),
+            )
+            cur.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+            )
+        admin.close()
+
+
+@dataclass
+class _RuntimeState:
+    now: datetime
+    anchor: TimelineAnchor
+
+    def resolve_anchor(self, _session: Session) -> TimelineAnchor:
+        """Return the test's current authoritative timeline position."""
+        return self.anchor
+
+    def evaluation_time(self, _session: Session) -> datetime:
+        """Return the controllable evaluation time."""
+        return self.now
+
+
+@dataclass
+class _InteractionHarness:
+    engine: Engine
+    session_factory: sessionmaker[Session]
+    service: InteractionService
+    handler: TrustedHandler
+    runtime: _RuntimeState
+    participant_ids: tuple[int, int]
+
+
+@pytest.fixture()
+def interaction_harness(
+    disposable_interaction_db: str,
+) -> Iterator[_InteractionHarness]:
+    """Build the genuine service over a disposable migrated PostgreSQL DB."""
+    engine = create_engine(
+        "postgresql+psycopg2://"
+        f"{os.environ.get('PGUSER', 'pythagor')}@"
+        f"{os.environ.get('PGHOST', 'localhost')}:"
+        f"{os.environ.get('PGPORT', '5432')}/{disposable_interaction_db}"
+    )
+    factory = sessionmaker(engine, expire_on_commit=False)
+    with factory() as session, session.begin():
+        participant_ids = tuple(
+            int(value)
+            for value in session.execute(
+                text(
+                    """
+                    INSERT INTO entities (kind, is_active)
+                    VALUES ('character', TRUE), ('character', TRUE)
+                    RETURNING id
+                    """
+                )
+            ).scalars()
+        )
+        anchor_chunk_id = int(
+            session.execute(
+                text(
+                    """
+                    INSERT INTO narrative_chunks (raw_text, storyteller_text)
+                    VALUES ('interaction anchor', 'interaction anchor')
+                    RETURNING id
+                    """
+                )
+            ).scalar_one()
+        )
+
+    runtime = _RuntimeState(
+        now=datetime(2035, 1, 2, 3, 4, tzinfo=timezone.utc),
+        anchor=TimelineAnchor(
+            anchor_chunk_id=anchor_chunk_id,
+            timeline_id="primary:continuity-a",
+        ),
+    )
+    service = InteractionService(
+        factory,
+        freshness_resolver=runtime.resolve_anchor,
+        evaluation_time_provider=runtime.evaluation_time,
+    )
+    harness = _InteractionHarness(
+        engine=engine,
+        session_factory=factory,
+        service=service,
+        handler=service.bind_trusted_handler("test.trusted-handler"),
+        runtime=runtime,
+        participant_ids=(participant_ids[0], participant_ids[1]),
+    )
+    try:
+        yield harness
+    finally:
+        engine.dispose()
+
+
+def _proposal(harness: _InteractionHarness) -> InteractionProposal:
+    return InteractionProposal(
+        kind="negotiation",
+        executor_namespace="nexus.test.negotiation",
+        policy=AuthorizationPolicy(
+            actions={
+                "start": AuthorizationRule(max_validity_seconds=120),
+                "advance": AuthorizationRule(max_validity_seconds=120),
+                "complete": AuthorizationRule(max_validity_seconds=120),
+            }
+        ),
+        participant_entity_ids=list(harness.participant_ids),
+        anchor=harness.runtime.anchor,
+    )
+
+
+def _propose(harness: _InteractionHarness) -> uuid.UUID:
+    return harness.service.propose(harness.handler, _proposal(harness)).id
+
+
+def _grant_all(
+    harness: _InteractionHarness,
+    interaction_id: uuid.UUID,
+    action: str,
+    *,
+    validity_seconds: int = 60,
+) -> None:
+    expires_at = harness.runtime.now + timedelta(seconds=validity_seconds)
+    for participant_id in harness.participant_ids:
+        harness.service.grant(
+            harness.handler,
+            interaction_id=interaction_id,
+            participant_entity_id=participant_id,
+            action=action,
+            expires_at=expires_at,
+        )
+
+
+def _assert_denied(
+    expected_reason: DenialReason,
+    operation: Any,
+) -> InteractionAuthorizationDenied:
+    with pytest.raises(InteractionAuthorizationDenied) as caught:
+        operation()
+    assert caught.value.decision.reason is expected_reason
+    return caught.value
+
+
+def test_each_participant_needs_an_independent_positive_grant(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    interaction_id = _propose(harness)
+    first, second = harness.participant_ids
+    harness.service.grant(
+        harness.handler,
+        interaction_id=interaction_id,
+        participant_entity_id=first,
+        action="start",
+        expires_at=harness.runtime.now + timedelta(seconds=60),
+    )
+
+    denial = _assert_denied(
+        DenialReason.MISSING_AUTHORIZATION,
+        lambda: harness.service.start(harness.handler, interaction_id=interaction_id),
+    )
+    assert denial.decision.participant_entity_id == second
+
+    harness.service.grant(
+        harness.handler,
+        interaction_id=interaction_id,
+        participant_entity_id=second,
+        action="start",
+        expires_at=harness.runtime.now + timedelta(seconds=60),
+    )
+    assert (
+        harness.service.start(harness.handler, interaction_id=interaction_id).status
+        is InteractionStatus.IN_PROGRESS
+    )
+
+
+def test_expired_revoked_stale_and_malformed_authorization_deny_typed(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+
+    expired_id = _propose(harness)
+    _grant_all(harness, expired_id, "start", validity_seconds=30)
+    harness.runtime.now += timedelta(seconds=31)
+    _assert_denied(
+        DenialReason.EXPIRED_AUTHORIZATION,
+        lambda: harness.service.start(harness.handler, interaction_id=expired_id),
+    )
+
+    revoked_id = _propose(harness)
+    _grant_all(harness, revoked_id, "start")
+    harness.service.revoke(
+        harness.handler,
+        interaction_id=revoked_id,
+        participant_entity_id=harness.participant_ids[1],
+        action="start",
+    )
+    _assert_denied(
+        DenialReason.REVOKED_AUTHORIZATION,
+        lambda: harness.service.start(harness.handler, interaction_id=revoked_id),
+    )
+
+    stale_id = _propose(harness)
+    _grant_all(harness, stale_id, "start")
+    _grant_all(harness, stale_id, "advance")
+    harness.service.start(harness.handler, interaction_id=stale_id)
+    _assert_denied(
+        DenialReason.STALE_AUTHORIZATION,
+        lambda: harness.service.transition(
+            harness.handler,
+            interaction_id=stale_id,
+            transition=InteractionTransition(
+                transition_type="negotiation.advance",
+                authorization_action="advance",
+            ),
+        ),
+    )
+
+    malformed_id = _propose(harness)
+    _grant_all(harness, malformed_id, "start")
+    future_granted_at = harness.runtime.now + timedelta(seconds=10)
+    future_expires_at = future_granted_at + timedelta(seconds=10)
+    with harness.session_factory() as session, session.begin():
+        session.execute(
+            text(
+                """
+                UPDATE interaction_authorizations
+                SET granted_at = :granted_at, expires_at = :expires_at
+                WHERE interaction_id = :interaction_id
+                  AND participant_entity_id = :participant_id
+                  AND action = 'start'
+                """
+            ),
+            {
+                "granted_at": future_granted_at,
+                "expires_at": future_expires_at,
+                "interaction_id": malformed_id,
+                "participant_id": harness.participant_ids[0],
+            },
+        )
+    _assert_denied(
+        DenialReason.MALFORMED_AUTHORIZATION,
+        lambda: harness.service.start(harness.handler, interaction_id=malformed_id),
+    )
+
+
+def test_malformed_policy_and_unavailable_freshness_fail_closed(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    malformed_id = _propose(harness)
+    with harness.session_factory() as session, session.begin():
+        session.execute(
+            text(
+                """
+                UPDATE interactions
+                SET policy = CAST(:policy AS JSONB)
+                WHERE id = :interaction_id
+                """
+            ),
+            {
+                "interaction_id": malformed_id,
+                "policy": '{"actions":{"start":{"max_validity_seconds":0}}}',
+            },
+        )
+    _assert_denied(
+        DenialReason.MALFORMED_POLICY,
+        lambda: harness.service.start(harness.handler, interaction_id=malformed_id),
+    )
+
+    unavailable_id = _propose(harness)
+    _grant_all(harness, unavailable_id, "start")
+
+    def unavailable(_session: Session) -> TimelineAnchor:
+        raise RuntimeError("authoritative timeline store unavailable")
+
+    unavailable_service = InteractionService(
+        harness.session_factory,
+        freshness_resolver=unavailable,
+        evaluation_time_provider=harness.runtime.evaluation_time,
+    )
+    unavailable_handler = unavailable_service.bind_trusted_handler("recovery.test")
+    _assert_denied(
+        DenialReason.EVALUATION_UNAVAILABLE,
+        lambda: unavailable_service.start(
+            unavailable_handler, interaction_id=unavailable_id
+        ),
+    )
+
+
+def test_model_shaped_input_cannot_act_as_trusted_grant_caller(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    interaction_id = _propose(harness)
+    with pytest.raises(UntrustedHandlerError):
+        harness.service.grant(
+            _proposal(harness),  # type: ignore[arg-type]
+            interaction_id=interaction_id,
+            participant_entity_id=harness.participant_ids[0],
+            action="start",
+            expires_at=harness.runtime.now + timedelta(seconds=60),
+        )
+
+
+def test_any_participant_can_stop_immediately_without_peer_or_handler_veto(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    interaction_id = _propose(harness)
+    withdrawing_participant = harness.participant_ids[1]
+
+    stopped = harness.service.stop(
+        interaction_id=interaction_id,
+        participant_entity_id=withdrawing_participant,
+    )
+
+    assert stopped.status is InteractionStatus.STOPPED
+    events = harness.service.history(interaction_id)
+    assert [event.event_type for event in events] == [
+        InteractionEventType.PROPOSED,
+        InteractionEventType.STOPPED,
+    ]
+    assert events[-1].actor_participant_entity_id == withdrawing_participant
+    assert events[-1].payload == {"reason": "participant_withdrawal"}
+
+
+def test_stale_anchor_rejects_start_and_transition(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    stale_start_id = _propose(harness)
+    _grant_all(harness, stale_start_id, "start")
+    original_anchor = harness.runtime.anchor
+    harness.runtime.anchor = TimelineAnchor(
+        anchor_chunk_id=original_anchor.anchor_chunk_id + 1000,
+        timeline_id=original_anchor.timeline_id,
+    )
+    _assert_denied(
+        DenialReason.STALE_ANCHOR,
+        lambda: harness.service.start(harness.handler, interaction_id=stale_start_id),
+    )
+
+    harness.runtime.anchor = original_anchor
+    stale_transition_id = _propose(harness)
+    _grant_all(harness, stale_transition_id, "start")
+    harness.service.start(harness.handler, interaction_id=stale_transition_id)
+    _grant_all(harness, stale_transition_id, "advance")
+    harness.runtime.anchor = TimelineAnchor(
+        anchor_chunk_id=original_anchor.anchor_chunk_id + 1000,
+        timeline_id=original_anchor.timeline_id,
+    )
+    _assert_denied(
+        DenialReason.STALE_ANCHOR,
+        lambda: harness.service.transition(
+            harness.handler,
+            interaction_id=stale_transition_id,
+            transition=InteractionTransition(
+                transition_type="negotiation.counteroffer",
+                authorization_action="advance",
+            ),
+        ),
+    )
+
+
+def test_recovery_interrupts_orphans_with_cleanup_exactly_once(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    interaction_id = _propose(harness)
+    _grant_all(harness, interaction_id, "start")
+    harness.service.start(harness.handler, interaction_id=interaction_id)
+    harness.runtime.now += timedelta(minutes=10)
+    cleanup_calls: list[uuid.UUID] = []
+
+    def cleanup(_session: Session, interaction: InteractionSnapshot) -> None:
+        cleanup_calls.append(interaction.id)
+
+    first = harness.service.recover(
+        harness.handler,
+        orphaned_before=harness.runtime.now,
+        cleanup_hooks=(cleanup,),
+    )
+    second = harness.service.recover(
+        harness.handler,
+        orphaned_before=harness.runtime.now,
+        cleanup_hooks=(cleanup,),
+    )
+
+    assert first == (interaction_id,)
+    assert second == ()
+    assert cleanup_calls == [interaction_id]
+    assert harness.service.get(interaction_id).status is InteractionStatus.INTERRUPTED
+    assert (
+        sum(
+            event.event_type is InteractionEventType.INTERRUPTED
+            for event in harness.service.history(interaction_id)
+        )
+        == 1
+    )
+
+
+def test_lifecycle_events_replay_full_history(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    interaction_id = _propose(harness)
+    _grant_all(harness, interaction_id, "start")
+    harness.service.start(harness.handler, interaction_id=interaction_id)
+    _grant_all(harness, interaction_id, "advance")
+    harness.service.transition(
+        harness.handler,
+        interaction_id=interaction_id,
+        transition=InteractionTransition(
+            transition_type="negotiation.counteroffer",
+            authorization_action="advance",
+            payload={"amount": 42, "currency": "septim"},
+        ),
+    )
+    _grant_all(harness, interaction_id, "complete")
+    harness.service.complete(harness.handler, interaction_id=interaction_id)
+
+    events = harness.service.history(interaction_id)
+    assert [event.event_type for event in events] == [
+        InteractionEventType.PROPOSED,
+        InteractionEventType.AUTHORIZED,
+        InteractionEventType.AUTHORIZED,
+        InteractionEventType.STARTED,
+        InteractionEventType.AUTHORIZED,
+        InteractionEventType.AUTHORIZED,
+        InteractionEventType.TRANSITIONED,
+        InteractionEventType.AUTHORIZED,
+        InteractionEventType.AUTHORIZED,
+        InteractionEventType.COMPLETED,
+    ]
+    assert [event.interaction_revision for event in events] == [
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        3,
+        3,
+        3,
+        4,
+    ]
+    assert events[6].payload == {
+        "transition_type": "negotiation.counteroffer",
+        "authorization_action": "advance",
+        "payload": {"amount": 42, "currency": "septim"},
+    }
+    replayed = harness.service.replay(interaction_id)
+    assert replayed.status is InteractionStatus.COMPLETED
+    assert replayed.revision == 4
+    assert replayed.transition_types == ("negotiation.counteroffer",)
+    assert replayed.authorization_events == 6
+
+
+def test_migration_comments_every_column_and_events_are_append_only(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    with harness.session_factory() as session, session.begin():
+        uncommented = session.execute(
+            text(
+                """
+                SELECT table_name, column_name
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name IN (
+                      'interactions', 'interaction_participants',
+                      'interaction_authorizations', 'interaction_events'
+                  )
+                  AND col_description(
+                      (quote_ident(table_schema) || '.' ||
+                       quote_ident(table_name))::regclass::oid,
+                      ordinal_position
+                  ) IS NULL
+                ORDER BY table_name, ordinal_position
+                """
+            )
+        ).all()
+    assert uncommented == []
+
+    interaction_id = _propose(harness)
+    with pytest.raises(DBAPIError, match="append-only"):
+        with harness.session_factory() as session, session.begin():
+            session.execute(
+                text(
+                    """
+                    UPDATE interaction_events
+                    SET payload = CAST(:payload AS JSONB)
+                    WHERE interaction_id = :interaction_id
+                    """
+                ),
+                {"interaction_id": interaction_id, "payload": '{"tampered":true}'},
+            )

--- a/tests/test_interactions_pg.py
+++ b/tests/test_interactions_pg.py
@@ -1,4 +1,4 @@
-"""Real-PostgreSQL acceptance tests for durable interaction threads."""
+"""Public-API PostgreSQL acceptance tests for interaction threads."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Callable, Iterator
 
 import psycopg2
 import pytest
@@ -18,8 +18,10 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session, sessionmaker
 
 from nexus.interactions import (
+    AuthorizationEnvelope,
     AuthorizationPolicy,
     AuthorizationRule,
+    CommandIdConflict,
     DenialReason,
     InteractionAuthorizationDenied,
     InteractionEventType,
@@ -28,10 +30,12 @@ from nexus.interactions import (
     InteractionSnapshot,
     InteractionStatus,
     InteractionTransition,
+    NamedRecoveryCleanupHook,
     TimelineAnchor,
+    TrustedHandler,
+    UnknownExecutorTransition,
     UntrustedHandlerError,
 )
-from nexus.interactions.service import TrustedHandler
 
 
 pytestmark = pytest.mark.requires_postgres
@@ -81,11 +85,11 @@ def disposable_interaction_db() -> Iterator[str]:
 @dataclass
 class _RuntimeState:
     now: datetime
-    anchor: TimelineAnchor
 
-    def resolve_anchor(self, _session: Session) -> TimelineAnchor:
-        """Return the test's current authoritative timeline position."""
-        return self.anchor
+    @staticmethod
+    def expected_identity(stored: TimelineAnchor) -> TimelineAnchor:
+        """Return expected identities without database access."""
+        return stored
 
     def evaluation_time(self, _session: Session) -> datetime:
         """Return the controllable evaluation time."""
@@ -99,7 +103,64 @@ class _InteractionHarness:
     service: InteractionService
     handler: TrustedHandler
     runtime: _RuntimeState
-    participant_ids: tuple[int, int]
+    participant_ids: tuple[int, int, int]
+    anchor: TimelineAnchor
+
+
+def _seed_anchor(session: Session, *, scene: int) -> TimelineAnchor:
+    chunk_id = int(
+        session.execute(
+            text(
+                """
+                INSERT INTO narrative_chunks (raw_text, storyteller_text)
+                VALUES (:text, :text)
+                RETURNING id
+                """
+            ),
+            {"text": f"interaction anchor {scene}"},
+        ).scalar_one()
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO chunk_metadata (
+                chunk_id, season, episode, scene, world_layer, slug
+            ) VALUES (
+                :chunk_id, 1, 1, :scene, 'primary', :slug
+            )
+            """
+        ),
+        {
+            "chunk_id": chunk_id,
+            "scene": scene,
+            "slug": f"I{scene:04d}",
+        },
+    )
+    return TimelineAnchor(anchor_chunk_id=chunk_id, timeline_id="primary")
+
+
+def _construct_service(
+    factory: sessionmaker[Session],
+    runtime: _RuntimeState,
+    *,
+    expected_identity: Callable[[TimelineAnchor], TimelineAnchor] | None = None,
+) -> tuple[InteractionService, TrustedHandler]:
+    capabilities: list[TrustedHandler] = []
+    service = InteractionService(
+        factory,
+        trusted_handler_identity="test.trusted-handler",
+        capability_receiver=capabilities.append,
+        expected_identity_resolver=expected_identity or runtime.expected_identity,
+        executor_registry={
+            "nexus.test.negotiation": (
+                "negotiation.counteroffer",
+                "negotiation.accept",
+            )
+        },
+        evaluation_time_provider=runtime.evaluation_time,
+    )
+    assert len(capabilities) == 1
+    return service, capabilities[0]
 
 
 @pytest.fixture()
@@ -121,46 +182,32 @@ def interaction_harness(
                 text(
                     """
                     INSERT INTO entities (kind, is_active)
-                    VALUES ('character', TRUE), ('character', TRUE)
+                    VALUES
+                        ('character', TRUE),
+                        ('character', TRUE),
+                        ('character', TRUE)
                     RETURNING id
                     """
                 )
             ).scalars()
         )
-        anchor_chunk_id = int(
-            session.execute(
-                text(
-                    """
-                    INSERT INTO narrative_chunks (raw_text, storyteller_text)
-                    VALUES ('interaction anchor', 'interaction anchor')
-                    RETURNING id
-                    """
-                )
-            ).scalar_one()
-        )
-
-    runtime = _RuntimeState(
-        now=datetime(2035, 1, 2, 3, 4, tzinfo=timezone.utc),
-        anchor=TimelineAnchor(
-            anchor_chunk_id=anchor_chunk_id,
-            timeline_id="primary:continuity-a",
-        ),
-    )
-    service = InteractionService(
-        factory,
-        freshness_resolver=runtime.resolve_anchor,
-        evaluation_time_provider=runtime.evaluation_time,
-    )
-    harness = _InteractionHarness(
-        engine=engine,
-        session_factory=factory,
-        service=service,
-        handler=service.bind_trusted_handler("test.trusted-handler"),
-        runtime=runtime,
-        participant_ids=(participant_ids[0], participant_ids[1]),
-    )
+        anchor = _seed_anchor(session, scene=901)
+    runtime = _RuntimeState(now=datetime(2035, 1, 2, 3, 4, tzinfo=timezone.utc))
+    service, handler = _construct_service(factory, runtime)
     try:
-        yield harness
+        yield _InteractionHarness(
+            engine=engine,
+            session_factory=factory,
+            service=service,
+            handler=handler,
+            runtime=runtime,
+            participant_ids=(
+                participant_ids[0],
+                participant_ids[1],
+                participant_ids[2],
+            ),
+            anchor=anchor,
+        )
     finally:
         engine.dispose()
 
@@ -172,40 +219,71 @@ def _proposal(harness: _InteractionHarness) -> InteractionProposal:
         policy=AuthorizationPolicy(
             actions={
                 "start": AuthorizationRule(max_validity_seconds=120),
-                "advance": AuthorizationRule(max_validity_seconds=120),
+                "advance": AuthorizationRule(
+                    max_validity_seconds=120,
+                    material_fields=("amount", "currency"),
+                ),
                 "complete": AuthorizationRule(max_validity_seconds=120),
             }
         ),
-        participant_entity_ids=list(harness.participant_ids),
-        anchor=harness.runtime.anchor,
+        participant_entity_ids=list(harness.participant_ids[:2]),
+        anchor=harness.anchor,
     )
 
 
-def _propose(harness: _InteractionHarness) -> uuid.UUID:
-    return harness.service.propose(harness.handler, _proposal(harness)).id
+def _propose(
+    harness: _InteractionHarness, *, command_id: uuid.UUID | None = None
+) -> tuple[uuid.UUID, uuid.UUID]:
+    command = command_id or uuid.uuid4()
+    snapshot = harness.service.propose(
+        harness.handler,
+        _proposal(harness),
+        command_id=command,
+    )
+    return snapshot.id, command
+
+
+def _lifecycle_envelope(action: str) -> AuthorizationEnvelope:
+    return AuthorizationEnvelope(
+        action=action,
+        transition_type=f"lifecycle.{action}",
+    )
+
+
+def _transition(*, amount: int = 42, currency: str = "septim") -> InteractionTransition:
+    return InteractionTransition(
+        transition_type="negotiation.counteroffer",
+        authorization_action="advance",
+        payload={"amount": amount, "currency": currency, "flavor": "non-material"},
+    )
 
 
 def _grant_all(
     harness: _InteractionHarness,
     interaction_id: uuid.UUID,
-    action: str,
+    envelope: AuthorizationEnvelope,
     *,
+    participant_ids: tuple[int, ...] | None = None,
     validity_seconds: int = 60,
-) -> None:
-    expires_at = harness.runtime.now + timedelta(seconds=validity_seconds)
-    for participant_id in harness.participant_ids:
-        harness.service.grant(
-            harness.handler,
-            interaction_id=interaction_id,
-            participant_entity_id=participant_id,
-            action=action,
-            expires_at=expires_at,
+) -> tuple[int, ...]:
+    grants: list[int] = []
+    for participant_id in participant_ids or harness.participant_ids[:2]:
+        grants.append(
+            harness.service.grant(
+                harness.handler,
+                interaction_id=interaction_id,
+                participant_entity_id=participant_id,
+                envelope=envelope,
+                expires_at=harness.runtime.now + timedelta(seconds=validity_seconds),
+                command_id=uuid.uuid4(),
+            )
         )
+    return tuple(grants)
 
 
 def _assert_denied(
     expected_reason: DenialReason,
-    operation: Any,
+    operation: Callable[[], object],
 ) -> InteractionAuthorizationDenied:
     with pytest.raises(InteractionAuthorizationDenied) as caught:
         operation()
@@ -213,23 +291,28 @@ def _assert_denied(
     return caught.value
 
 
-def test_each_participant_needs_an_independent_positive_grant(
+def test_independent_grants_and_fail_closed_states(
     interaction_harness: _InteractionHarness,
 ) -> None:
     harness = interaction_harness
-    interaction_id = _propose(harness)
-    first, second = harness.participant_ids
+    start_envelope = _lifecycle_envelope("start")
+    interaction_id, _ = _propose(harness)
+    first, second = harness.participant_ids[:2]
     harness.service.grant(
         harness.handler,
         interaction_id=interaction_id,
         participant_entity_id=first,
-        action="start",
-        expires_at=harness.runtime.now + timedelta(seconds=60),
+        envelope=start_envelope,
+        expires_at=harness.runtime.now + timedelta(seconds=30),
+        command_id=uuid.uuid4(),
     )
-
     denial = _assert_denied(
         DenialReason.MISSING_AUTHORIZATION,
-        lambda: harness.service.start(harness.handler, interaction_id=interaction_id),
+        lambda: harness.service.start(
+            harness.handler,
+            interaction_id=interaction_id,
+            command_id=uuid.uuid4(),
+        ),
     )
     assert denial.decision.participant_entity_id == second
 
@@ -237,90 +320,456 @@ def test_each_participant_needs_an_independent_positive_grant(
         harness.handler,
         interaction_id=interaction_id,
         participant_entity_id=second,
-        action="start",
-        expires_at=harness.runtime.now + timedelta(seconds=60),
+        envelope=start_envelope,
+        expires_at=harness.runtime.now + timedelta(seconds=30),
+        command_id=uuid.uuid4(),
     )
-    assert (
-        harness.service.start(harness.handler, interaction_id=interaction_id).status
-        is InteractionStatus.IN_PROGRESS
-    )
-
-
-def test_expired_revoked_stale_and_malformed_authorization_deny_typed(
-    interaction_harness: _InteractionHarness,
-) -> None:
-    harness = interaction_harness
-
-    expired_id = _propose(harness)
-    _grant_all(harness, expired_id, "start", validity_seconds=30)
     harness.runtime.now += timedelta(seconds=31)
     _assert_denied(
         DenialReason.EXPIRED_AUTHORIZATION,
-        lambda: harness.service.start(harness.handler, interaction_id=expired_id),
-    )
-
-    revoked_id = _propose(harness)
-    _grant_all(harness, revoked_id, "start")
-    harness.service.revoke(
-        harness.handler,
-        interaction_id=revoked_id,
-        participant_entity_id=harness.participant_ids[1],
-        action="start",
-    )
-    _assert_denied(
-        DenialReason.REVOKED_AUTHORIZATION,
-        lambda: harness.service.start(harness.handler, interaction_id=revoked_id),
-    )
-
-    stale_id = _propose(harness)
-    _grant_all(harness, stale_id, "start")
-    _grant_all(harness, stale_id, "advance")
-    harness.service.start(harness.handler, interaction_id=stale_id)
-    _assert_denied(
-        DenialReason.STALE_AUTHORIZATION,
-        lambda: harness.service.transition(
+        lambda: harness.service.start(
             harness.handler,
-            interaction_id=stale_id,
-            transition=InteractionTransition(
-                transition_type="negotiation.advance",
-                authorization_action="advance",
-            ),
+            interaction_id=interaction_id,
+            command_id=uuid.uuid4(),
         ),
     )
 
-    malformed_id = _propose(harness)
-    _grant_all(harness, malformed_id, "start")
-    future_granted_at = harness.runtime.now + timedelta(seconds=10)
-    future_expires_at = future_granted_at + timedelta(seconds=10)
+    revoked_id, _ = _propose(harness)
+    _grant_all(harness, revoked_id, start_envelope)
+    harness.service.revoke(
+        harness.handler,
+        interaction_id=revoked_id,
+        participant_entity_id=second,
+        envelope=start_envelope,
+        command_id=uuid.uuid4(),
+    )
+    _assert_denied(
+        DenialReason.REVOKED_AUTHORIZATION,
+        lambda: harness.service.start(
+            harness.handler,
+            interaction_id=revoked_id,
+            command_id=uuid.uuid4(),
+        ),
+    )
+    assert harness.service.replay(revoked_id) == harness.service.current_state(
+        revoked_id
+    )
+
+
+def test_material_term_drift_requires_fresh_authorization(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    interaction_id, _ = _propose(harness)
+    _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
+    harness.service.start(
+        harness.handler,
+        interaction_id=interaction_id,
+        command_id=uuid.uuid4(),
+    )
+    authorized = _transition(amount=42)
+    _grant_all(harness, interaction_id, authorized.authorization_envelope())
+
+    _assert_denied(
+        DenialReason.AUTHORIZATION_TERMS_CHANGED,
+        lambda: harness.service.transition(
+            harness.handler,
+            interaction_id=interaction_id,
+            transition=_transition(amount=43),
+            command_id=uuid.uuid4(),
+        ),
+    )
+    changed_non_material = _transition(amount=42)
+    changed_non_material.payload["flavor"] = "different but non-material"
+    result = harness.service.transition(
+        harness.handler,
+        interaction_id=interaction_id,
+        transition=changed_non_material,
+        command_id=uuid.uuid4(),
+    )
+    assert result.status is InteractionStatus.IN_PROGRESS
+
+
+def test_constructor_only_capability_and_executor_vocabulary(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    assert not hasattr(harness.service, "bind_trusted_handler")
+    interaction_id, _ = _propose(harness)
+    with pytest.raises(UntrustedHandlerError):
+        harness.service.grant(
+            _proposal(harness),  # type: ignore[arg-type]
+            interaction_id=interaction_id,
+            participant_entity_id=harness.participant_ids[0],
+            envelope=_lifecycle_envelope("start"),
+            expires_at=harness.runtime.now + timedelta(seconds=60),
+            command_id=uuid.uuid4(),
+        )
+
+    _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
+    harness.service.start(
+        harness.handler,
+        interaction_id=interaction_id,
+        command_id=uuid.uuid4(),
+    )
+    unknown = InteractionTransition(
+        transition_type="negotiation.unregistered",
+        authorization_action="advance",
+        payload={"amount": 42, "currency": "septim"},
+    )
+    with pytest.raises(UnknownExecutorTransition) as caught:
+        harness.service.transition(
+            harness.handler,
+            interaction_id=interaction_id,
+            transition=unknown,
+            command_id=uuid.uuid4(),
+        )
+    assert caught.value.decision.reason is DenialReason.UNKNOWN_TRANSITION
+
+
+def test_command_retries_return_recorded_outcome_without_new_event(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    propose_command = uuid.uuid4()
+    proposal = _proposal(harness)
+    first_snapshot = harness.service.propose(
+        harness.handler, proposal, command_id=propose_command
+    )
+    retry_snapshot = harness.service.propose(
+        harness.handler, proposal, command_id=propose_command
+    )
+    assert first_snapshot == retry_snapshot
+    first = first_snapshot.id
+
+    _grant_all(harness, first, _lifecycle_envelope("start"))
+    start_command = uuid.uuid4()
+    first_start = harness.service.start(
+        harness.handler, interaction_id=first, command_id=start_command
+    )
+    retry_start = harness.service.start(
+        harness.handler, interaction_id=first, command_id=start_command
+    )
+    assert retry_start == first_start
+    assert (
+        sum(
+            event.event_type is InteractionEventType.STARTED
+            for event in harness.service.history(first)
+        )
+        == 1
+    )
+
+    stop_command = uuid.uuid4()
+    first_stop = harness.service.stop(
+        interaction_id=first,
+        participant_entity_id=harness.participant_ids[1],
+        command_id=stop_command,
+    )
+    retry_stop = harness.service.stop(
+        interaction_id=first,
+        participant_entity_id=harness.participant_ids[1],
+        command_id=stop_command,
+    )
+    assert retry_stop == first_stop
+    assert (
+        sum(
+            event.event_type is InteractionEventType.STOPPED
+            for event in harness.service.history(first)
+        )
+        == 1
+    )
+    with pytest.raises(CommandIdConflict):
+        harness.service.complete(
+            harness.handler, interaction_id=first, command_id=stop_command
+        )
+
+
+def test_locked_authoritative_head_rejects_stale_start_and_unavailable_identity(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    interaction_id, _ = _propose(harness)
+    _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
+    with harness.session_factory() as session, session.begin():
+        current_anchor = _seed_anchor(session, scene=902)
+    _assert_denied(
+        DenialReason.STALE_ANCHOR,
+        lambda: harness.service.start(
+            harness.handler,
+            interaction_id=interaction_id,
+            command_id=uuid.uuid4(),
+        ),
+    )
+
+    def unavailable(_stored: TimelineAnchor) -> TimelineAnchor:
+        raise RuntimeError("expected identity unavailable")
+
+    unavailable_service, unavailable_handler = _construct_service(
+        harness.session_factory,
+        harness.runtime,
+        expected_identity=unavailable,
+    )
+    _assert_denied(
+        DenialReason.EVALUATION_UNAVAILABLE,
+        lambda: unavailable_service.start(
+            unavailable_handler,
+            interaction_id=interaction_id,
+            command_id=uuid.uuid4(),
+        ),
+    )
+
+    transition_proposal = _proposal(harness).model_copy(
+        update={"anchor": current_anchor}
+    )
+    transition_interaction = harness.service.propose(
+        harness.handler,
+        transition_proposal,
+        command_id=uuid.uuid4(),
+    ).id
+    _grant_all(harness, transition_interaction, _lifecycle_envelope("start"))
+    harness.service.start(
+        harness.handler,
+        interaction_id=transition_interaction,
+        command_id=uuid.uuid4(),
+    )
+    transition = _transition()
+    _grant_all(harness, transition_interaction, transition.authorization_envelope())
+    with harness.session_factory() as session, session.begin():
+        _seed_anchor(session, scene=903)
+    _assert_denied(
+        DenialReason.STALE_ANCHOR,
+        lambda: harness.service.transition(
+            harness.handler,
+            interaction_id=transition_interaction,
+            transition=transition,
+            command_id=uuid.uuid4(),
+        ),
+    )
+
+
+def test_membership_changes_bump_revision_void_grants_and_replay_history(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    interaction_id, _ = _propose(harness)
+    _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
+    joined = harness.service.join(
+        harness.handler,
+        interaction_id=interaction_id,
+        participant_entity_id=harness.participant_ids[2],
+        command_id=uuid.uuid4(),
+    )
+    assert joined.revision == 2
+    _assert_denied(
+        DenialReason.STALE_AUTHORIZATION,
+        lambda: harness.service.start(
+            harness.handler,
+            interaction_id=interaction_id,
+            command_id=uuid.uuid4(),
+        ),
+    )
+    left = harness.service.leave(
+        harness.handler,
+        interaction_id=interaction_id,
+        participant_entity_id=harness.participant_ids[2],
+        command_id=uuid.uuid4(),
+    )
+    assert left.revision == 3
+    _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
+    harness.service.start(
+        harness.handler,
+        interaction_id=interaction_id,
+        command_id=uuid.uuid4(),
+    )
+    assert harness.service.replay(interaction_id) == harness.service.current_state(
+        interaction_id
+    )
+
+
+def test_explicit_lease_and_cleanup_completion_make_recovery_idempotent(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    no_lease_id, _ = _propose(harness)
+    _grant_all(harness, no_lease_id, _lifecycle_envelope("start"))
+    harness.service.start(
+        harness.handler,
+        interaction_id=no_lease_id,
+        command_id=uuid.uuid4(),
+    )
+    harness.runtime.now += timedelta(days=1)
+    assert harness.service.recover(harness.handler, command_id=uuid.uuid4()) == ()
+
+    interaction_id, _ = _propose(harness)
+    _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
+    harness.service.start(
+        harness.handler,
+        interaction_id=interaction_id,
+        command_id=uuid.uuid4(),
+    )
+    harness.service.touch(
+        harness.handler,
+        interaction_id=interaction_id,
+        lease_until=harness.runtime.now + timedelta(seconds=30),
+        command_id=uuid.uuid4(),
+    )
+    harness.runtime.now += timedelta(seconds=31)
+    cleanup_calls: list[uuid.UUID] = []
+
+    def cleanup(_session: Session, snapshot: InteractionSnapshot) -> None:
+        cleanup_calls.append(snapshot.id)
+
+    recovery_command = uuid.uuid4()
+    hooks = (NamedRecoveryCleanupHook("release_executor", cleanup),)
+    first = harness.service.recover(
+        harness.handler,
+        command_id=recovery_command,
+        cleanup_hooks=hooks,
+    )
+    second = harness.service.recover(
+        harness.handler,
+        command_id=recovery_command,
+        cleanup_hooks=hooks,
+    )
+    assert first == second == (interaction_id,)
+    assert cleanup_calls == [interaction_id]
+    events = harness.service.history(interaction_id)
+    assert (
+        sum(
+            event.event_type is InteractionEventType.CLEANUP_COMPLETED
+            for event in events
+        )
+        == 1
+    )
+    assert (
+        sum(event.event_type is InteractionEventType.INTERRUPTED for event in events)
+        == 1
+    )
+    assert harness.service.replay(interaction_id) == harness.service.current_state(
+        interaction_id
+    )
+
+
+def test_cooperative_public_api_flow_replay_equals_live_state(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    interaction_id, _ = _propose(harness)
+    _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
+    harness.service.start(
+        harness.handler,
+        interaction_id=interaction_id,
+        command_id=uuid.uuid4(),
+    )
+    harness.service.touch(
+        harness.handler,
+        interaction_id=interaction_id,
+        lease_until=harness.runtime.now + timedelta(seconds=90),
+        command_id=uuid.uuid4(),
+    )
+    transition = _transition()
+    _grant_all(harness, interaction_id, transition.authorization_envelope())
+    harness.service.transition(
+        harness.handler,
+        interaction_id=interaction_id,
+        transition=transition,
+        command_id=uuid.uuid4(),
+    )
+    _grant_all(harness, interaction_id, _lifecycle_envelope("complete"))
+    completed = harness.service.complete(
+        harness.handler,
+        interaction_id=interaction_id,
+        command_id=uuid.uuid4(),
+    )
+    assert completed.status is InteractionStatus.COMPLETED
+    assert harness.service.recover(harness.handler, command_id=uuid.uuid4()) == ()
+    assert harness.service.replay(interaction_id) == harness.service.current_state(
+        interaction_id
+    )
+
+
+def test_adversarial_public_api_flow_stops_and_replays_exactly(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    interaction_id, _ = _propose(harness)
+    _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
+    harness.service.start(
+        harness.handler,
+        interaction_id=interaction_id,
+        command_id=uuid.uuid4(),
+    )
+    authorized = _transition(amount=7)
+    _grant_all(harness, interaction_id, authorized.authorization_envelope())
+    _assert_denied(
+        DenialReason.AUTHORIZATION_TERMS_CHANGED,
+        lambda: harness.service.transition(
+            harness.handler,
+            interaction_id=interaction_id,
+            transition=_transition(amount=7000),
+            command_id=uuid.uuid4(),
+        ),
+    )
+    harness.service.transition(
+        harness.handler,
+        interaction_id=interaction_id,
+        transition=authorized,
+        command_id=uuid.uuid4(),
+    )
+    stop_command = uuid.uuid4()
+    stopped = harness.service.stop(
+        interaction_id=interaction_id,
+        participant_entity_id=harness.participant_ids[0],
+        command_id=stop_command,
+    )
+    assert stopped.status is InteractionStatus.STOPPED
+    assert (
+        harness.service.stop(
+            interaction_id=interaction_id,
+            participant_entity_id=harness.participant_ids[0],
+            command_id=stop_command,
+        )
+        == stopped
+    )
+    assert harness.service.recover(harness.handler, command_id=uuid.uuid4()) == ()
+    assert harness.service.replay(interaction_id) == harness.service.current_state(
+        interaction_id
+    )
+
+
+def test_malformed_stored_authorization_and_policy_deny_typed(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    interaction_id, _ = _propose(harness)
+    _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
     with harness.session_factory() as session, session.begin():
         session.execute(
             text(
                 """
                 UPDATE interaction_authorizations
-                SET granted_at = :granted_at, expires_at = :expires_at
+                SET granted_at = :future, expires_at = :expiry
                 WHERE interaction_id = :interaction_id
                   AND participant_entity_id = :participant_id
-                  AND action = 'start'
                 """
             ),
             {
-                "granted_at": future_granted_at,
-                "expires_at": future_expires_at,
-                "interaction_id": malformed_id,
+                "future": harness.runtime.now + timedelta(seconds=10),
+                "expiry": harness.runtime.now + timedelta(seconds=20),
+                "interaction_id": interaction_id,
                 "participant_id": harness.participant_ids[0],
             },
         )
     _assert_denied(
         DenialReason.MALFORMED_AUTHORIZATION,
-        lambda: harness.service.start(harness.handler, interaction_id=malformed_id),
+        lambda: harness.service.start(
+            harness.handler,
+            interaction_id=interaction_id,
+            command_id=uuid.uuid4(),
+        ),
     )
 
-
-def test_malformed_policy_and_unavailable_freshness_fail_closed(
-    interaction_harness: _InteractionHarness,
-) -> None:
-    harness = interaction_harness
-    malformed_id = _propose(harness)
+    malformed_id, _ = _propose(harness)
     with harness.session_factory() as session, session.begin():
         session.execute(
             text(
@@ -337,199 +786,15 @@ def test_malformed_policy_and_unavailable_freshness_fail_closed(
         )
     _assert_denied(
         DenialReason.MALFORMED_POLICY,
-        lambda: harness.service.start(harness.handler, interaction_id=malformed_id),
-    )
-
-    unavailable_id = _propose(harness)
-    _grant_all(harness, unavailable_id, "start")
-
-    def unavailable(_session: Session) -> TimelineAnchor:
-        raise RuntimeError("authoritative timeline store unavailable")
-
-    unavailable_service = InteractionService(
-        harness.session_factory,
-        freshness_resolver=unavailable,
-        evaluation_time_provider=harness.runtime.evaluation_time,
-    )
-    unavailable_handler = unavailable_service.bind_trusted_handler("recovery.test")
-    _assert_denied(
-        DenialReason.EVALUATION_UNAVAILABLE,
-        lambda: unavailable_service.start(
-            unavailable_handler, interaction_id=unavailable_id
-        ),
-    )
-
-
-def test_model_shaped_input_cannot_act_as_trusted_grant_caller(
-    interaction_harness: _InteractionHarness,
-) -> None:
-    harness = interaction_harness
-    interaction_id = _propose(harness)
-    with pytest.raises(UntrustedHandlerError):
-        harness.service.grant(
-            _proposal(harness),  # type: ignore[arg-type]
-            interaction_id=interaction_id,
-            participant_entity_id=harness.participant_ids[0],
-            action="start",
-            expires_at=harness.runtime.now + timedelta(seconds=60),
-        )
-
-
-def test_any_participant_can_stop_immediately_without_peer_or_handler_veto(
-    interaction_harness: _InteractionHarness,
-) -> None:
-    harness = interaction_harness
-    interaction_id = _propose(harness)
-    withdrawing_participant = harness.participant_ids[1]
-
-    stopped = harness.service.stop(
-        interaction_id=interaction_id,
-        participant_entity_id=withdrawing_participant,
-    )
-
-    assert stopped.status is InteractionStatus.STOPPED
-    events = harness.service.history(interaction_id)
-    assert [event.event_type for event in events] == [
-        InteractionEventType.PROPOSED,
-        InteractionEventType.STOPPED,
-    ]
-    assert events[-1].actor_participant_entity_id == withdrawing_participant
-    assert events[-1].payload == {"reason": "participant_withdrawal"}
-
-
-def test_stale_anchor_rejects_start_and_transition(
-    interaction_harness: _InteractionHarness,
-) -> None:
-    harness = interaction_harness
-    stale_start_id = _propose(harness)
-    _grant_all(harness, stale_start_id, "start")
-    original_anchor = harness.runtime.anchor
-    harness.runtime.anchor = TimelineAnchor(
-        anchor_chunk_id=original_anchor.anchor_chunk_id + 1000,
-        timeline_id=original_anchor.timeline_id,
-    )
-    _assert_denied(
-        DenialReason.STALE_ANCHOR,
-        lambda: harness.service.start(harness.handler, interaction_id=stale_start_id),
-    )
-
-    harness.runtime.anchor = original_anchor
-    stale_transition_id = _propose(harness)
-    _grant_all(harness, stale_transition_id, "start")
-    harness.service.start(harness.handler, interaction_id=stale_transition_id)
-    _grant_all(harness, stale_transition_id, "advance")
-    harness.runtime.anchor = TimelineAnchor(
-        anchor_chunk_id=original_anchor.anchor_chunk_id + 1000,
-        timeline_id=original_anchor.timeline_id,
-    )
-    _assert_denied(
-        DenialReason.STALE_ANCHOR,
-        lambda: harness.service.transition(
+        lambda: harness.service.start(
             harness.handler,
-            interaction_id=stale_transition_id,
-            transition=InteractionTransition(
-                transition_type="negotiation.counteroffer",
-                authorization_action="advance",
-            ),
+            interaction_id=malformed_id,
+            command_id=uuid.uuid4(),
         ),
     )
 
 
-def test_recovery_interrupts_orphans_with_cleanup_exactly_once(
-    interaction_harness: _InteractionHarness,
-) -> None:
-    harness = interaction_harness
-    interaction_id = _propose(harness)
-    _grant_all(harness, interaction_id, "start")
-    harness.service.start(harness.handler, interaction_id=interaction_id)
-    harness.runtime.now += timedelta(minutes=10)
-    cleanup_calls: list[uuid.UUID] = []
-
-    def cleanup(_session: Session, interaction: InteractionSnapshot) -> None:
-        cleanup_calls.append(interaction.id)
-
-    first = harness.service.recover(
-        harness.handler,
-        orphaned_before=harness.runtime.now,
-        cleanup_hooks=(cleanup,),
-    )
-    second = harness.service.recover(
-        harness.handler,
-        orphaned_before=harness.runtime.now,
-        cleanup_hooks=(cleanup,),
-    )
-
-    assert first == (interaction_id,)
-    assert second == ()
-    assert cleanup_calls == [interaction_id]
-    assert harness.service.get(interaction_id).status is InteractionStatus.INTERRUPTED
-    assert (
-        sum(
-            event.event_type is InteractionEventType.INTERRUPTED
-            for event in harness.service.history(interaction_id)
-        )
-        == 1
-    )
-
-
-def test_lifecycle_events_replay_full_history(
-    interaction_harness: _InteractionHarness,
-) -> None:
-    harness = interaction_harness
-    interaction_id = _propose(harness)
-    _grant_all(harness, interaction_id, "start")
-    harness.service.start(harness.handler, interaction_id=interaction_id)
-    _grant_all(harness, interaction_id, "advance")
-    harness.service.transition(
-        harness.handler,
-        interaction_id=interaction_id,
-        transition=InteractionTransition(
-            transition_type="negotiation.counteroffer",
-            authorization_action="advance",
-            payload={"amount": 42, "currency": "septim"},
-        ),
-    )
-    _grant_all(harness, interaction_id, "complete")
-    harness.service.complete(harness.handler, interaction_id=interaction_id)
-
-    events = harness.service.history(interaction_id)
-    assert [event.event_type for event in events] == [
-        InteractionEventType.PROPOSED,
-        InteractionEventType.AUTHORIZED,
-        InteractionEventType.AUTHORIZED,
-        InteractionEventType.STARTED,
-        InteractionEventType.AUTHORIZED,
-        InteractionEventType.AUTHORIZED,
-        InteractionEventType.TRANSITIONED,
-        InteractionEventType.AUTHORIZED,
-        InteractionEventType.AUTHORIZED,
-        InteractionEventType.COMPLETED,
-    ]
-    assert [event.interaction_revision for event in events] == [
-        1,
-        1,
-        1,
-        2,
-        2,
-        2,
-        3,
-        3,
-        3,
-        4,
-    ]
-    assert events[6].payload == {
-        "transition_type": "negotiation.counteroffer",
-        "authorization_action": "advance",
-        "payload": {"amount": 42, "currency": "septim"},
-    }
-    replayed = harness.service.replay(interaction_id)
-    assert replayed.status is InteractionStatus.COMPLETED
-    assert replayed.revision == 4
-    assert replayed.transition_types == ("negotiation.counteroffer",)
-    assert replayed.authorization_events == 6
-
-
-def test_migration_comments_every_column_and_events_are_append_only(
+def test_migration_comments_columns_and_events_are_append_only(
     interaction_harness: _InteractionHarness,
 ) -> None:
     harness = interaction_harness
@@ -555,7 +820,7 @@ def test_migration_comments_every_column_and_events_are_append_only(
         ).all()
     assert uncommented == []
 
-    interaction_id = _propose(harness)
+    interaction_id, _ = _propose(harness)
     with pytest.raises(DBAPIError, match="append-only"):
         with harness.session_factory() as session, session.begin():
             session.execute(

--- a/tests/test_interactions_pg.py
+++ b/tests/test_interactions_pg.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import os
+import threading
+import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -83,26 +86,11 @@ def disposable_interaction_db() -> Iterator[str]:
 
 
 @dataclass
-class _RuntimeState:
-    now: datetime
-
-    @staticmethod
-    def expected_identity(stored: TimelineAnchor) -> TimelineAnchor:
-        """Return expected identities without database access."""
-        return stored
-
-    def evaluation_time(self, _session: Session) -> datetime:
-        """Return the controllable evaluation time."""
-        return self.now
-
-
-@dataclass
 class _InteractionHarness:
     engine: Engine
     session_factory: sessionmaker[Session]
     service: InteractionService
     handler: TrustedHandler
-    runtime: _RuntimeState
     participant_ids: tuple[int, int, int]
     anchor: TimelineAnchor
 
@@ -141,7 +129,6 @@ def _seed_anchor(session: Session, *, scene: int) -> TimelineAnchor:
 
 def _construct_service(
     factory: sessionmaker[Session],
-    runtime: _RuntimeState,
     *,
     expected_identity: Callable[[TimelineAnchor], TimelineAnchor] | None = None,
 ) -> tuple[InteractionService, TrustedHandler]:
@@ -150,14 +137,13 @@ def _construct_service(
         factory,
         trusted_handler_identity="test.trusted-handler",
         capability_receiver=capabilities.append,
-        expected_identity_resolver=expected_identity or runtime.expected_identity,
+        expected_identity_resolver=expected_identity or (lambda stored: stored),
         executor_registry={
             "nexus.test.negotiation": (
                 "negotiation.counteroffer",
                 "negotiation.accept",
             )
         },
-        evaluation_time_provider=runtime.evaluation_time,
     )
     assert len(capabilities) == 1
     return service, capabilities[0]
@@ -192,15 +178,13 @@ def interaction_harness(
             ).scalars()
         )
         anchor = _seed_anchor(session, scene=901)
-    runtime = _RuntimeState(now=datetime(2035, 1, 2, 3, 4, tzinfo=timezone.utc))
-    service, handler = _construct_service(factory, runtime)
+    service, handler = _construct_service(factory)
     try:
         yield _InteractionHarness(
             engine=engine,
             session_factory=factory,
             service=service,
             handler=handler,
-            runtime=runtime,
             participant_ids=(
                 participant_ids[0],
                 participant_ids[1],
@@ -231,6 +215,10 @@ def _proposal(harness: _InteractionHarness) -> InteractionProposal:
     )
 
 
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
 def _propose(
     harness: _InteractionHarness, *, command_id: uuid.UUID | None = None
 ) -> tuple[uuid.UUID, uuid.UUID]:
@@ -241,6 +229,21 @@ def _propose(
         command_id=command,
     )
     return snapshot.id, command
+
+
+def _start(
+    harness: _InteractionHarness,
+    interaction_id: uuid.UUID,
+    *,
+    command_id: uuid.UUID | None = None,
+    lease_seconds: float = 60,
+) -> InteractionSnapshot:
+    return harness.service.start(
+        harness.handler,
+        interaction_id=interaction_id,
+        lease_until=_utc_now() + timedelta(seconds=lease_seconds),
+        command_id=command_id or uuid.uuid4(),
+    )
 
 
 def _lifecycle_envelope(action: str) -> AuthorizationEnvelope:
@@ -264,7 +267,7 @@ def _grant_all(
     envelope: AuthorizationEnvelope,
     *,
     participant_ids: tuple[int, ...] | None = None,
-    validity_seconds: int = 60,
+    validity_seconds: float = 60,
 ) -> tuple[int, ...]:
     grants: list[int] = []
     for participant_id in participant_ids or harness.participant_ids[:2]:
@@ -274,7 +277,7 @@ def _grant_all(
                 interaction_id=interaction_id,
                 participant_entity_id=participant_id,
                 envelope=envelope,
-                expires_at=harness.runtime.now + timedelta(seconds=validity_seconds),
+                expires_at=_utc_now() + timedelta(seconds=validity_seconds),
                 command_id=uuid.uuid4(),
             )
         )
@@ -303,16 +306,12 @@ def test_independent_grants_and_fail_closed_states(
         interaction_id=interaction_id,
         participant_entity_id=first,
         envelope=start_envelope,
-        expires_at=harness.runtime.now + timedelta(seconds=30),
+        expires_at=_utc_now() + timedelta(seconds=30),
         command_id=uuid.uuid4(),
     )
     denial = _assert_denied(
         DenialReason.MISSING_AUTHORIZATION,
-        lambda: harness.service.start(
-            harness.handler,
-            interaction_id=interaction_id,
-            command_id=uuid.uuid4(),
-        ),
+        lambda: _start(harness, interaction_id),
     )
     assert denial.decision.participant_entity_id == second
 
@@ -321,17 +320,13 @@ def test_independent_grants_and_fail_closed_states(
         interaction_id=interaction_id,
         participant_entity_id=second,
         envelope=start_envelope,
-        expires_at=harness.runtime.now + timedelta(seconds=30),
+        expires_at=_utc_now() + timedelta(seconds=0.2),
         command_id=uuid.uuid4(),
     )
-    harness.runtime.now += timedelta(seconds=31)
+    time.sleep(0.25)
     _assert_denied(
         DenialReason.EXPIRED_AUTHORIZATION,
-        lambda: harness.service.start(
-            harness.handler,
-            interaction_id=interaction_id,
-            command_id=uuid.uuid4(),
-        ),
+        lambda: _start(harness, interaction_id),
     )
 
     revoked_id, _ = _propose(harness)
@@ -345,11 +340,7 @@ def test_independent_grants_and_fail_closed_states(
     )
     _assert_denied(
         DenialReason.REVOKED_AUTHORIZATION,
-        lambda: harness.service.start(
-            harness.handler,
-            interaction_id=revoked_id,
-            command_id=uuid.uuid4(),
-        ),
+        lambda: _start(harness, revoked_id),
     )
     assert harness.service.replay(revoked_id) == harness.service.current_state(
         revoked_id
@@ -362,11 +353,7 @@ def test_material_term_drift_requires_fresh_authorization(
     harness = interaction_harness
     interaction_id, _ = _propose(harness)
     _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
-    harness.service.start(
-        harness.handler,
-        interaction_id=interaction_id,
-        command_id=uuid.uuid4(),
-    )
+    _start(harness, interaction_id)
     authorized = _transition(amount=42)
     _grant_all(harness, interaction_id, authorized.authorization_envelope())
 
@@ -402,16 +389,12 @@ def test_constructor_only_capability_and_executor_vocabulary(
             interaction_id=interaction_id,
             participant_entity_id=harness.participant_ids[0],
             envelope=_lifecycle_envelope("start"),
-            expires_at=harness.runtime.now + timedelta(seconds=60),
+            expires_at=_utc_now() + timedelta(seconds=60),
             command_id=uuid.uuid4(),
         )
 
     _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
-    harness.service.start(
-        harness.handler,
-        interaction_id=interaction_id,
-        command_id=uuid.uuid4(),
-    )
+    _start(harness, interaction_id)
     unknown = InteractionTransition(
         transition_type="negotiation.unregistered",
         authorization_action="advance",
@@ -444,11 +427,18 @@ def test_command_retries_return_recorded_outcome_without_new_event(
 
     _grant_all(harness, first, _lifecycle_envelope("start"))
     start_command = uuid.uuid4()
+    lease_until = _utc_now() + timedelta(seconds=60)
     first_start = harness.service.start(
-        harness.handler, interaction_id=first, command_id=start_command
+        harness.handler,
+        interaction_id=first,
+        lease_until=lease_until,
+        command_id=start_command,
     )
     retry_start = harness.service.start(
-        harness.handler, interaction_id=first, command_id=start_command
+        harness.handler,
+        interaction_id=first,
+        lease_until=lease_until,
+        command_id=start_command,
     )
     assert retry_start == first_start
     assert (
@@ -484,6 +474,83 @@ def test_command_retries_return_recorded_outcome_without_new_event(
         )
 
 
+def test_concurrent_proposals_share_one_database_enforced_outcome(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    command_id = uuid.uuid4()
+    proposal = _proposal(harness)
+    barrier = threading.Barrier(12)
+
+    def propose_once() -> InteractionSnapshot:
+        barrier.wait()
+        return harness.service.propose(
+            harness.handler,
+            proposal,
+            command_id=command_id,
+        )
+
+    with ThreadPoolExecutor(max_workers=12) as executor:
+        snapshots = tuple(executor.map(lambda _index: propose_once(), range(12)))
+
+    assert len({snapshot.id for snapshot in snapshots}) == 1
+    assert all(snapshot == snapshots[0] for snapshot in snapshots)
+    with harness.session_factory() as session, session.begin():
+        interaction_count = session.execute(
+            text("SELECT count(*) FROM interactions")
+        ).scalar_one()
+        proposed_event_count = session.execute(
+            text(
+                """
+                SELECT count(*)
+                FROM interaction_events
+                WHERE command_id = :command_id
+                  AND event_type = 'proposed'
+                """
+            ),
+            {"command_id": command_id},
+        ).scalar_one()
+    assert interaction_count == 1
+    assert proposed_event_count == 1
+
+
+def test_grant_expiry_uses_wall_clock_after_transaction_lock_stall(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    interaction_id, _ = _propose(harness)
+    _grant_all(
+        harness,
+        interaction_id,
+        _lifecycle_envelope("start"),
+        validity_seconds=1,
+    )
+    lock_session = harness.session_factory()
+    lock_transaction = lock_session.begin()
+    lock_session.execute(
+        text("SELECT id FROM interactions WHERE id = :id FOR UPDATE"),
+        {"id": interaction_id},
+    ).scalar_one()
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(
+                harness.service.start,
+                harness.handler,
+                interaction_id=interaction_id,
+                lease_until=_utc_now() + timedelta(seconds=30),
+                command_id=uuid.uuid4(),
+            )
+            time.sleep(4.5)
+            lock_transaction.commit()
+            with pytest.raises(InteractionAuthorizationDenied) as caught:
+                future.result()
+    finally:
+        if lock_transaction.is_active:
+            lock_transaction.rollback()
+        lock_session.close()
+    assert caught.value.decision.reason is DenialReason.EXPIRED_AUTHORIZATION
+
+
 def test_locked_authoritative_head_rejects_stale_start_and_unavailable_identity(
     interaction_harness: _InteractionHarness,
 ) -> None:
@@ -494,11 +561,7 @@ def test_locked_authoritative_head_rejects_stale_start_and_unavailable_identity(
         current_anchor = _seed_anchor(session, scene=902)
     _assert_denied(
         DenialReason.STALE_ANCHOR,
-        lambda: harness.service.start(
-            harness.handler,
-            interaction_id=interaction_id,
-            command_id=uuid.uuid4(),
-        ),
+        lambda: _start(harness, interaction_id),
     )
 
     def unavailable(_stored: TimelineAnchor) -> TimelineAnchor:
@@ -506,7 +569,6 @@ def test_locked_authoritative_head_rejects_stale_start_and_unavailable_identity(
 
     unavailable_service, unavailable_handler = _construct_service(
         harness.session_factory,
-        harness.runtime,
         expected_identity=unavailable,
     )
     _assert_denied(
@@ -514,6 +576,7 @@ def test_locked_authoritative_head_rejects_stale_start_and_unavailable_identity(
         lambda: unavailable_service.start(
             unavailable_handler,
             interaction_id=interaction_id,
+            lease_until=_utc_now() + timedelta(seconds=60),
             command_id=uuid.uuid4(),
         ),
     )
@@ -527,11 +590,7 @@ def test_locked_authoritative_head_rejects_stale_start_and_unavailable_identity(
         command_id=uuid.uuid4(),
     ).id
     _grant_all(harness, transition_interaction, _lifecycle_envelope("start"))
-    harness.service.start(
-        harness.handler,
-        interaction_id=transition_interaction,
-        command_id=uuid.uuid4(),
-    )
+    _start(harness, transition_interaction)
     transition = _transition()
     _grant_all(harness, transition_interaction, transition.authorization_envelope())
     with harness.session_factory() as session, session.begin():
@@ -562,11 +621,7 @@ def test_membership_changes_bump_revision_void_grants_and_replay_history(
     assert joined.revision == 2
     _assert_denied(
         DenialReason.STALE_AUTHORIZATION,
-        lambda: harness.service.start(
-            harness.handler,
-            interaction_id=interaction_id,
-            command_id=uuid.uuid4(),
-        ),
+        lambda: _start(harness, interaction_id),
     )
     left = harness.service.leave(
         harness.handler,
@@ -576,11 +631,7 @@ def test_membership_changes_bump_revision_void_grants_and_replay_history(
     )
     assert left.revision == 3
     _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
-    harness.service.start(
-        harness.handler,
-        interaction_id=interaction_id,
-        command_id=uuid.uuid4(),
-    )
+    _start(harness, interaction_id)
     assert harness.service.replay(interaction_id) == harness.service.current_state(
         interaction_id
     )
@@ -590,30 +641,11 @@ def test_explicit_lease_and_cleanup_completion_make_recovery_idempotent(
     interaction_harness: _InteractionHarness,
 ) -> None:
     harness = interaction_harness
-    no_lease_id, _ = _propose(harness)
-    _grant_all(harness, no_lease_id, _lifecycle_envelope("start"))
-    harness.service.start(
-        harness.handler,
-        interaction_id=no_lease_id,
-        command_id=uuid.uuid4(),
-    )
-    harness.runtime.now += timedelta(days=1)
-    assert harness.service.recover(harness.handler, command_id=uuid.uuid4()) == ()
-
     interaction_id, _ = _propose(harness)
     _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
-    harness.service.start(
-        harness.handler,
-        interaction_id=interaction_id,
-        command_id=uuid.uuid4(),
-    )
-    harness.service.touch(
-        harness.handler,
-        interaction_id=interaction_id,
-        lease_until=harness.runtime.now + timedelta(seconds=30),
-        command_id=uuid.uuid4(),
-    )
-    harness.runtime.now += timedelta(seconds=31)
+    started = _start(harness, interaction_id, lease_seconds=0.2)
+    assert started.lease_until is not None
+    time.sleep(0.25)
     cleanup_calls: list[uuid.UUID] = []
 
     def cleanup(_session: Session, snapshot: InteractionSnapshot) -> None:
@@ -650,21 +682,69 @@ def test_explicit_lease_and_cleanup_completion_make_recovery_idempotent(
     )
 
 
+def test_concurrent_recoverers_execute_cleanup_under_one_exclusive_claim(
+    interaction_harness: _InteractionHarness,
+) -> None:
+    harness = interaction_harness
+    interaction_id, _ = _propose(harness)
+    _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
+    _start(harness, interaction_id, lease_seconds=0.2)
+    time.sleep(0.25)
+    cleanup_calls: list[uuid.UUID] = []
+    cleanup_lock = threading.Lock()
+
+    def cleanup(_session: Session, snapshot: InteractionSnapshot) -> None:
+        with cleanup_lock:
+            cleanup_calls.append(snapshot.id)
+        time.sleep(0.2)
+
+    barrier = threading.Barrier(2)
+
+    def recover_once() -> tuple[uuid.UUID, ...]:
+        barrier.wait()
+        return harness.service.recover(
+            harness.handler,
+            command_id=uuid.uuid4(),
+            cleanup_hooks=(NamedRecoveryCleanupHook("exclusive_cleanup", cleanup),),
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = tuple(executor.map(lambda _index: recover_once(), range(2)))
+
+    assert sorted(len(outcome) for outcome in outcomes) == [0, 1]
+    assert cleanup_calls == [interaction_id]
+    events = harness.service.history(interaction_id)
+    assert (
+        sum(
+            event.event_type is InteractionEventType.RECOVERY_CLAIMED
+            for event in events
+        )
+        == 1
+    )
+    assert (
+        sum(
+            event.event_type is InteractionEventType.CLEANUP_COMPLETED
+            for event in events
+        )
+        == 1
+    )
+    assert (
+        sum(event.event_type is InteractionEventType.INTERRUPTED for event in events)
+        == 1
+    )
+
+
 def test_cooperative_public_api_flow_replay_equals_live_state(
     interaction_harness: _InteractionHarness,
 ) -> None:
     harness = interaction_harness
     interaction_id, _ = _propose(harness)
     _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
-    harness.service.start(
-        harness.handler,
-        interaction_id=interaction_id,
-        command_id=uuid.uuid4(),
-    )
+    _start(harness, interaction_id)
     harness.service.touch(
         harness.handler,
         interaction_id=interaction_id,
-        lease_until=harness.runtime.now + timedelta(seconds=90),
+        lease_until=_utc_now() + timedelta(seconds=90),
         command_id=uuid.uuid4(),
     )
     transition = _transition()
@@ -694,11 +774,7 @@ def test_adversarial_public_api_flow_stops_and_replays_exactly(
     harness = interaction_harness
     interaction_id, _ = _propose(harness)
     _grant_all(harness, interaction_id, _lifecycle_envelope("start"))
-    harness.service.start(
-        harness.handler,
-        interaction_id=interaction_id,
-        command_id=uuid.uuid4(),
-    )
+    _start(harness, interaction_id)
     authorized = _transition(amount=7)
     _grant_all(harness, interaction_id, authorized.authorization_envelope())
     _assert_denied(
@@ -754,19 +830,15 @@ def test_malformed_stored_authorization_and_policy_deny_typed(
                 """
             ),
             {
-                "future": harness.runtime.now + timedelta(seconds=10),
-                "expiry": harness.runtime.now + timedelta(seconds=20),
+                "future": _utc_now() + timedelta(seconds=10),
+                "expiry": _utc_now() + timedelta(seconds=20),
                 "interaction_id": interaction_id,
                 "participant_id": harness.participant_ids[0],
             },
         )
     _assert_denied(
         DenialReason.MALFORMED_AUTHORIZATION,
-        lambda: harness.service.start(
-            harness.handler,
-            interaction_id=interaction_id,
-            command_id=uuid.uuid4(),
-        ),
+        lambda: _start(harness, interaction_id),
     )
 
     malformed_id, _ = _propose(harness)
@@ -786,11 +858,7 @@ def test_malformed_stored_authorization_and_policy_deny_typed(
         )
     _assert_denied(
         DenialReason.MALFORMED_POLICY,
-        lambda: harness.service.start(
-            harness.handler,
-            interaction_id=malformed_id,
-            command_id=uuid.uuid4(),
-        ),
+        lambda: _start(harness, malformed_id),
     )
 
 


### PR DESCRIPTION
Closes #682.

The interaction-thread primitive from the MGO review — OStimNet's thread-lifecycle patterns with its authorization semantics **inverted** (their `GetJsonBool(..., true)` fail-open default is the named counterexample; here absence of a grant is always denial).

- **Schema (105)**: `interactions`, `interaction_participants`, `interaction_authorizations`, `interaction_events` (append-only), all column-commented.
- **Fail-closed evaluator**: explicit positive grants per participant per action, time-bounded and revision-scoped; every denial typed; no default-true anywhere.
- **Execution-time revalidation**: start/transition/complete lock and re-verify policy, membership, grants, expiry, anchor, and timeline — proposal-time state proves nothing.
- **Unilateral stop**: capability-free for participants; handler operations gate on a service-local capability, structurally unreachable from wire/LLM structures.
- **Recovery**: orphan cutoff → `interrupted` exactly once, cleanup hooks transactional.

Infrastructure layer only (no gameplay consumer yet — negotiations/rituals/duels adopt it when they arrive). Full acceptance suite from the issue drives the real module API; mypy/flake8/black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG