### PR TITLE
Add Presence-Weighted Retrieval to MEMNON Hybrid Search

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -944,6 +944,8 @@ use_query_type_weights = true
 use_query_type_temporal_factors = true
 target_model = "inf-retriever-v1-1.5b"
 temporal_boost_factor = 0.6
+presence_boost_enabled = false  # Measured arm; enable only after live evaluation
+presence_boost_factor = 0.15
 
 [memnon.retrieval.hybrid_search.weights_by_query_type.character]
 vector = 0.8
@@ -977,6 +979,15 @@ event = 0.4
 location = 0.25
 theme = 0.3
 general = 0.4
+
+[memnon.retrieval.hybrid_search.presence_boost_factors]
+# Co-presence is most informative for character and relationship queries.
+character = 0.25
+relationship = 0.25
+event = 0.10
+location = 0.05
+theme = 0.05
+general = 0.15
 
 [memnon.retrieval.cross_encoder_reranking]
 # Cross-encoder reranking for improved relevance.

--- a/nexus/agents/lore/utils/entity_queries.py
+++ b/nexus/agents/lore/utils/entity_queries.py
@@ -25,6 +25,26 @@ FACTION_TAG_CONTEXT_CATEGORY_SQL = ", ".join(
 )
 
 
+def fetch_present_character_ids(session: Session, chunk_id: int) -> List[int]:
+    """Return the exact present-character roster recorded for one chunk."""
+
+    if chunk_id <= 0:
+        raise ValueError("chunk_id must be positive")
+    rows = session.execute(
+        text(
+            """
+            SELECT character_id
+            FROM chunk_character_references
+            WHERE chunk_id = :chunk_id
+              AND reference::text = 'present'
+            ORDER BY character_id
+            """
+        ),
+        {"chunk_id": chunk_id},
+    ).fetchall()
+    return sorted({int(row.character_id) for row in rows})
+
+
 def fetch_all_characters_with_references(
     session: Session,
     featured_chunk_ids: List[int],

--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -37,6 +37,7 @@ class TurnContext:
     phase_states: Dict[str, Any] = field(default_factory=dict)
     warm_slice: List[Dict] = field(default_factory=list)
     entity_data: Dict[str, Any] = field(default_factory=dict)
+    present_character_ids: List[int] = field(default_factory=list)
     retrieved_passages: List[Dict] = field(default_factory=list)
     context_payload: Dict[str, Any] = field(default_factory=dict)
     apex_response: Optional[str] = None

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -24,6 +24,7 @@ try:
         fetch_all_factions_with_references,
         fetch_all_places_with_references,
         fetch_place_ids_by_names,
+        fetch_present_character_ids,
     )
     from nexus.agents.logon.apex_schema import (
         StoryTurnResponse,
@@ -57,6 +58,7 @@ except ImportError:
         fetch_all_factions_with_references,
         fetch_all_places_with_references,
         fetch_place_ids_by_names,
+        fetch_present_character_ids,
     )
     from nexus.agents.logon.apex_schema import (
         StoryTurnResponse,
@@ -496,6 +498,13 @@ class TurnCycleManager:
             logger.warning("No chunk IDs in warm slice for entity queries")
             warm_chunk_ids = []
 
+        if turn_context.target_chunk_id is not None:
+            with self.lore.memnon.Session() as session:
+                turn_context.present_character_ids = fetch_present_character_ids(
+                    session,
+                    turn_context.target_chunk_id,
+                )
+
         # Query characters with baseline + featured structure
         characters_data: Dict[str, List[Dict[str, Any]]] = {
             "baseline": [],
@@ -755,11 +764,16 @@ class TurnCycleManager:
             try:
                 # MEMNON's SearchManager uses the query type internally
                 # to adjust vector/text weights for optimal results
-                results = self.lore.memnon.query_memory(
-                    query=query_obj["text"],
-                    k=15,  # Get more results since we'll deduplicate
-                    use_hybrid=True,
-                )
+                search_kwargs: Dict[str, Any] = {
+                    "query": query_obj["text"],
+                    "k": 15,  # Get more results since we'll deduplicate
+                    "use_hybrid": True,
+                }
+                if turn_context.present_character_ids:
+                    search_kwargs["present_character_ids"] = (
+                        turn_context.present_character_ids
+                    )
+                results = self.lore.memnon.query_memory(**search_kwargs)
 
                 # Track query types for logging
                 query_type = query_obj["type"]

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -254,6 +254,16 @@ class TurnCycleManager:
                 f"Invalid LORE retrieval max_deep_queries setting: {budget!r}"
             ) from exc
 
+    def _presence_boost_enabled(self) -> bool:
+        """Return the required MEMNON presence-boost feature flag."""
+
+        enabled = self.settings["Agent Settings"]["MEMNON"]["retrieval"][
+            "hybrid_search"
+        ]["presence_boost_enabled"]
+        if not isinstance(enabled, bool):
+            raise TypeError("presence_boost_enabled must be a boolean")
+        return enabled
+
     def _raw_chunk_retrieval_query(self, turn_context: TurnContext) -> Optional[str]:
         """Resolve the current/parent chunk text to use as a baseline query."""
 
@@ -498,7 +508,7 @@ class TurnCycleManager:
             logger.warning("No chunk IDs in warm slice for entity queries")
             warm_chunk_ids = []
 
-        if turn_context.target_chunk_id is not None:
+        if self._presence_boost_enabled() and turn_context.target_chunk_id is not None:
             with self.lore.memnon.Session() as session:
                 turn_context.present_character_ids = fetch_present_character_ids(
                     session,
@@ -769,7 +779,10 @@ class TurnCycleManager:
                     "k": 15,  # Get more results since we'll deduplicate
                     "use_hybrid": True,
                 }
-                if turn_context.present_character_ids:
+                if (
+                    self._presence_boost_enabled()
+                    and turn_context.present_character_ids
+                ):
                     search_kwargs["present_character_ids"] = (
                         turn_context.present_character_ids
                     )

--- a/nexus/agents/memnon/memnon.py
+++ b/nexus/agents/memnon/memnon.py
@@ -21,7 +21,7 @@ import logging
 import json
 import time
 import requests
-from typing import Dict, List, Tuple, Optional, Union, Any, Set
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 from datetime import datetime, date
 from pathlib import Path
 
@@ -1758,6 +1758,7 @@ class MEMNON:
         filters: Optional[Dict[str, Any]] = None,
         k: Optional[int] = None,
         use_hybrid: bool = True,
+        present_character_ids: Optional[Sequence[int]] = None,
     ) -> Dict[str, Any]:
         """
         Execute a query against memory and return matching results.
@@ -1768,6 +1769,7 @@ class MEMNON:
             filters: Optional metadata filters
             k: Maximum number of results to return
             use_hybrid: Whether to use hybrid search
+            present_character_ids: Character IDs present in the retrieval anchor
 
         Returns:
             Dictionary containing query results and metadata
@@ -1856,6 +1858,7 @@ class MEMNON:
                         query_text=strategy["query"],
                         filters=strategy.get("filters"),
                         top_k=strategy.get("limit", k),
+                        present_character_ids=present_character_ids,
                     )
                     all_results.extend(results)
 

--- a/nexus/agents/memnon/utils/continuous_temporal_search.py
+++ b/nexus/agents/memnon/utils/continuous_temporal_search.py
@@ -8,7 +8,7 @@ applies scaled boosting based on how well a document's temporal position matches
 
 import re
 import logging
-from typing import Dict, List, Optional, Any, Tuple, Union, Set
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 from nexus.memory.context_state import is_retrograde_summary
 
@@ -288,6 +288,8 @@ def execute_time_aware_search(
     filters: Optional[Dict[str, Any]] = None,
     top_k: int = 10,
     idf_dict=None,
+    present_character_ids: Optional[Sequence[int]] = None,
+    presence_boost_factor: float = 0.0,
 ) -> List[Dict[str, Any]]:
     """
     Execute a time-aware search using continuous temporal scaling.
@@ -303,6 +305,8 @@ def execute_time_aware_search(
         filters: Optional metadata filters
         top_k: Maximum number of results to return
         idf_dict: Optional IDF dictionary for term weighting
+        present_character_ids: Character IDs present in the retrieval anchor
+        presence_boost_factor: Additive score boost for co-present narrative chunks
 
     Returns:
         List of matching chunks with scores and metadata
@@ -333,15 +337,17 @@ def execute_time_aware_search(
                 f"Query is temporally neutral, using standard hybrid search: {query_text}"
             )
             return db_access.execute_hybrid_search(
-                db_url,
-                query_text,
-                query_embedding,
-                model_key,
-                vector_weight,
-                text_weight,
-                filters,
-                top_k,
-                idf_dict,
+                db_url=db_url,
+                query_text=query_text,
+                query_embedding=query_embedding,
+                model_key=model_key,
+                vector_weight=vector_weight,
+                text_weight=text_weight,
+                filters=filters,
+                top_k=top_k,
+                idf_dict=idf_dict,
+                present_character_ids=present_character_ids,
+                presence_boost_factor=presence_boost_factor,
             )
 
         # For temporal queries, perform hybrid search but apply temporal boosting
@@ -364,22 +370,28 @@ def execute_time_aware_search(
             password=password,
             database=database,
         )
+        conn.set_session(readonly=True)
 
         # Get total number of chunks for normalization
-        total_chunks = get_total_chunks(conn)
+        try:
+            total_chunks = get_total_chunks(conn)
+        finally:
+            conn.close()
         logger.debug(f"Total chunks for temporal normalization: {total_chunks}")
 
         # Execute standard hybrid search but with increased result count
         original_results = db_access.execute_hybrid_search(
-            db_url,
-            query_text,
-            query_embedding,
-            model_key,
-            vector_weight,
-            text_weight,
-            filters,
-            top_k * 2,  # Get more results for reranking
-            idf_dict,
+            db_url=db_url,
+            query_text=query_text,
+            query_embedding=query_embedding,
+            model_key=model_key,
+            vector_weight=vector_weight,
+            text_weight=text_weight,
+            filters=filters,
+            top_k=top_k * 2,  # Get more results for reranking
+            idf_dict=idf_dict,
+            present_character_ids=present_character_ids,
+            presence_boost_factor=presence_boost_factor,
         )
 
         # Apply temporal boosting to each result using the continuous approach
@@ -434,15 +446,17 @@ def execute_time_aware_search(
         # Fall back to standard hybrid search
         logger.info("Falling back to standard hybrid search after error")
         return db_access.execute_hybrid_search(
-            db_url,
-            query_text,
-            query_embedding,
-            model_key,
-            vector_weight,
-            text_weight,
-            filters,
-            top_k,
-            idf_dict,
+            db_url=db_url,
+            query_text=query_text,
+            query_embedding=query_embedding,
+            model_key=model_key,
+            vector_weight=vector_weight,
+            text_weight=text_weight,
+            filters=filters,
+            top_k=top_k,
+            idf_dict=idf_dict,
+            present_character_ids=present_character_ids,
+            presence_boost_factor=presence_boost_factor,
         )
 
 
@@ -457,6 +471,8 @@ def execute_multi_model_time_aware_search(
     filters: Optional[Dict[str, Any]] = None,
     top_k: int = 10,
     idf_dict=None,
+    present_character_ids: Optional[Sequence[int]] = None,
+    presence_boost_factor: float = 0.0,
 ) -> List[Dict[str, Any]]:
     """
     Execute a time-aware search using multiple embedding models simultaneously.
@@ -472,6 +488,8 @@ def execute_multi_model_time_aware_search(
         filters: Optional metadata filters
         top_k: Maximum number of results to return
         idf_dict: Optional IDF dictionary for term weighting
+        present_character_ids: Character IDs present in the retrieval anchor
+        presence_boost_factor: Additive score boost for co-present narrative chunks
 
     Returns:
         List of matching chunks with scores and metadata
@@ -502,15 +520,17 @@ def execute_multi_model_time_aware_search(
                 f"Query is temporally neutral, using standard multi-model hybrid search: {query_text}"
             )
             return db_access.execute_multi_model_hybrid_search(
-                db_url,
-                query_text,
-                query_embeddings,
-                model_weights,
-                vector_weight,
-                text_weight,
-                filters,
-                top_k,
-                idf_dict,
+                db_url=db_url,
+                query_text=query_text,
+                query_embeddings=query_embeddings,
+                model_weights=model_weights,
+                vector_weight=vector_weight,
+                text_weight=text_weight,
+                filters=filters,
+                top_k=top_k,
+                idf_dict=idf_dict,
+                present_character_ids=present_character_ids,
+                presence_boost_factor=presence_boost_factor,
             )
 
         # For temporal queries, perform multi-model hybrid search but apply temporal boosting
@@ -533,22 +553,28 @@ def execute_multi_model_time_aware_search(
             password=password,
             database=database,
         )
+        conn.set_session(readonly=True)
 
         # Get total number of chunks for normalization
-        total_chunks = get_total_chunks(conn)
+        try:
+            total_chunks = get_total_chunks(conn)
+        finally:
+            conn.close()
         logger.debug(f"Total chunks for temporal normalization: {total_chunks}")
 
         # Execute standard multi-model hybrid search but with increased result count
         original_results = db_access.execute_multi_model_hybrid_search(
-            db_url,
-            query_text,
-            query_embeddings,
-            model_weights,
-            vector_weight,
-            text_weight,
-            filters,
-            top_k * 2,  # Get more results for reranking
-            idf_dict,
+            db_url=db_url,
+            query_text=query_text,
+            query_embeddings=query_embeddings,
+            model_weights=model_weights,
+            vector_weight=vector_weight,
+            text_weight=text_weight,
+            filters=filters,
+            top_k=top_k * 2,  # Get more results for reranking
+            idf_dict=idf_dict,
+            present_character_ids=present_character_ids,
+            presence_boost_factor=presence_boost_factor,
         )
 
         # Apply temporal boosting to each result using the continuous approach
@@ -603,13 +629,15 @@ def execute_multi_model_time_aware_search(
         # Fall back to standard multi-model hybrid search
         logger.info("Falling back to standard multi-model hybrid search after error")
         return db_access.execute_multi_model_hybrid_search(
-            db_url,
-            query_text,
-            query_embeddings,
-            model_weights,
-            vector_weight,
-            text_weight,
-            filters,
-            top_k,
-            idf_dict,
+            db_url=db_url,
+            query_text=query_text,
+            query_embeddings=query_embeddings,
+            model_weights=model_weights,
+            vector_weight=vector_weight,
+            text_weight=text_weight,
+            filters=filters,
+            top_k=top_k,
+            idf_dict=idf_dict,
+            present_character_ids=present_character_ids,
+            presence_boost_factor=presence_boost_factor,
         )

--- a/nexus/agents/memnon/utils/db_access.py
+++ b/nexus/agents/memnon/utils/db_access.py
@@ -7,7 +7,7 @@ and hybrid search capabilities with PostgreSQL.
 
 import logging
 import psycopg2
-from typing import Dict, List, Tuple, Optional, Union, Any
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 from urllib.parse import urlparse
 
 from nexus.agents.orrery.reconstruction import playable_narrative_predicate
@@ -43,6 +43,52 @@ def _retrograde_summaries_allowed(filters: Optional[Dict[str, Any]]) -> bool:
     """
     narrative_filter_keys = {"season", "episode", "world_layer"}
     return not any(key in narrative_filter_keys for key in (filters or {}))
+
+
+def _presence_boosts_for_narrative_results(
+    cursor: Any,
+    results: Dict[str, Dict[str, Any]],
+    present_character_ids: Sequence[int],
+    presence_boost_factor: float,
+) -> Dict[str, float]:
+    """Return SQL-computed presence bonuses for narrative candidates only."""
+
+    narrative_chunk_ids = [
+        int(result["chunk_id"])
+        for result in results.values()
+        if result.get("content_type") == "narrative"
+    ]
+    if not narrative_chunk_ids or not present_character_ids:
+        return {}
+
+    cursor.execute(
+        """
+        SELECT
+            nc.id,
+            CASE
+                WHEN present_reference.chunk_id IS NOT NULL THEN %s
+                ELSE 0.0
+            END AS presence_boost
+        FROM narrative_chunks AS nc
+        LEFT JOIN (
+            SELECT DISTINCT chunk_id
+            FROM chunk_character_references
+            WHERE character_id = ANY(%s)
+              AND reference::text = 'present'
+        ) AS present_reference ON present_reference.chunk_id = nc.id
+        WHERE nc.id = ANY(%s)
+        """,
+        (
+            presence_boost_factor,
+            list(present_character_ids),
+            narrative_chunk_ids,
+        ),
+    )
+    return {
+        str(chunk_id): float(boost)
+        for chunk_id, boost in cursor.fetchall()
+        if float(boost) > 0.0
+    }
 
 
 def _retrograde_summary_result(
@@ -447,6 +493,8 @@ def execute_hybrid_search(
     filters: Optional[Dict[str, Any]] = None,
     top_k: int = 10,
     idf_dict=None,
+    present_character_ids: Optional[Sequence[int]] = None,
+    presence_boost_factor: float = 0.0,
 ) -> List[Dict[str, Any]]:
     """Search narrative and Retrograde summary corpora with one model.
 
@@ -464,6 +512,8 @@ def execute_hybrid_search(
         filters=filters,
         top_k=top_k,
         idf_dict=idf_dict,
+        present_character_ids=present_character_ids,
+        presence_boost_factor=presence_boost_factor,
     )
     for result in results:
         result["source"] = "hybrid_search"
@@ -635,6 +685,8 @@ def execute_multi_model_hybrid_search(
     filters: Optional[Dict[str, Any]] = None,
     top_k: int = 10,
     idf_dict=None,
+    present_character_ids: Optional[Sequence[int]] = None,
+    presence_boost_factor: float = 0.0,
 ) -> List[Dict[str, Any]]:
     """
     Execute a hybrid search using multiple embedding models simultaneously.
@@ -649,10 +701,18 @@ def execute_multi_model_hybrid_search(
         filters: Optional metadata filters
         top_k: Maximum number of results to return
         idf_dict: Optional IDF dictionary for term weighting
+        present_character_ids: Character IDs present in the retrieval anchor
+        presence_boost_factor: Additive score boost for co-present narrative chunks
 
     Returns:
         List of matching chunks with scores and metadata
     """
+    if presence_boost_factor < 0.0:
+        raise ValueError("presence_boost_factor must be non-negative")
+    normalized_present_ids = tuple(
+        sorted({int(character_id) for character_id in present_character_ids or ()})
+    )
+
     try:
         # Parse database URL
         parsed_url = urlparse(db_url)
@@ -692,6 +752,7 @@ def execute_multi_model_hybrid_search(
             password=password,
             database=database,
         )
+        conn.set_session(readonly=True)
 
         results = {}  # Will hold all results by chunk_id
 
@@ -1234,6 +1295,15 @@ def execute_multi_model_hybrid_search(
                                     "vector_score": 0.0,  # Will be calculated next
                                 }
 
+                presence_boosts: Dict[str, float] = {}
+                if normalized_present_ids and presence_boost_factor > 0.0:
+                    presence_boosts = _presence_boosts_for_narrative_results(
+                        cursor,
+                        results,
+                        normalized_present_ids,
+                        presence_boost_factor,
+                    )
+
                 # Calculate weighted average vector score using model weights
                 logger.debug(
                     f"Calculating weighted average vector scores with weights: {model_weights}"
@@ -1261,6 +1331,9 @@ def execute_multi_model_hybrid_search(
                     result["score"] = (result["vector_score"] * vector_weight) + (
                         result["text_score"] * text_weight
                     )
+                    if chunk_id in presence_boosts:
+                        result["presence_boost"] = presence_boosts[chunk_id]
+                        result["score"] += presence_boosts[chunk_id]
                     result["source"] = "multi_model_hybrid_search"
 
                 # Create a list from the results dictionary and sort by score

--- a/nexus/agents/memnon/utils/search.py
+++ b/nexus/agents/memnon/utils/search.py
@@ -8,7 +8,7 @@ across different data sources.
 import logging
 import json
 import re
-from typing import Dict, List, Optional, Any, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 from nexus.agents.orrery.reconstruction import playable_narrative_predicate
 
@@ -75,6 +75,8 @@ class SearchManager:
         query_text: str,
         filters: Optional[Dict[str, Any]] = None,
         top_k: Optional[int] = None,
+        present_character_ids: Optional[Sequence[int]] = None,
+        presence_boost_enabled: Optional[bool] = None,
     ) -> List[Dict[str, Any]]:
         """
         Perform hybrid search using both vector embeddings and text search.
@@ -84,6 +86,8 @@ class SearchManager:
             query_text: The query text
             filters: Optional metadata filters to apply
             top_k: Maximum number of results to return
+            present_character_ids: Character IDs present in the retrieval anchor
+            presence_boost_enabled: Optional measurement override for the config flag
 
         Returns:
             List of matching chunks with scores and metadata
@@ -102,6 +106,20 @@ class SearchManager:
             query_info = self.query_analyzer.analyze_query(query_text)
             query_type = query_info.get("type", "general")
             logger.debug(f"Query classified as type: {query_type}")
+
+            apply_presence_boost = (
+                hybrid_config.get("presence_boost_enabled", False)
+                if presence_boost_enabled is None
+                else presence_boost_enabled
+            )
+            presence_boost_factor = 0.0
+            if apply_presence_boost and present_character_ids:
+                presence_boost_factor = hybrid_config.get(
+                    "presence_boost_factors", {}
+                ).get(
+                    query_type,
+                    hybrid_config.get("presence_boost_factor", 0.15),
+                )
 
             # Get weights based on query type or use defaults
             if hybrid_config.get(
@@ -217,6 +235,8 @@ class SearchManager:
                     filters=filters,
                     top_k=top_k,
                     idf_dict=self.idf_dictionary,
+                    present_character_ids=present_character_ids,
+                    presence_boost_factor=presence_boost_factor,
                 )
             else:
                 # Use standard multi-model hybrid search for non-temporal queries
@@ -235,6 +255,8 @@ class SearchManager:
                     filters=filters,
                     top_k=top_k,
                     idf_dict=self.idf_dictionary,
+                    present_character_ids=present_character_ids,
+                    presence_boost_factor=presence_boost_factor,
                 )
 
             logger.info(f"Multi-model hybrid search returned {len(results)} results")

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -2572,10 +2572,46 @@ class HybridSearchConfig(BaseModel):
     text_weight_default: float = Field(..., ge=0.0, le=1.0)
     weights_by_query_type: Dict[str, QueryTypeWeights]
     temporal_boost_factors: Dict[str, float]
+    presence_boost_enabled: bool = False
+    presence_boost_factor: float = Field(0.15, ge=0.0, le=1.0)
+    presence_boost_factors: Dict[str, float]
     use_query_type_weights: bool
     use_query_type_temporal_factors: bool
     target_model: str
     temporal_boost_factor: float = Field(..., ge=0.0)
+
+    @field_validator("presence_boost_factors")
+    @classmethod
+    def _validate_presence_boost_factors(
+        cls, factors: Dict[str, float]
+    ) -> Dict[str, float]:
+        """Require every configured presence factor to be a bounded fraction."""
+
+        invalid = {
+            query_type: factor
+            for query_type, factor in factors.items()
+            if factor < 0.0 or factor > 1.0
+        }
+        if invalid:
+            raise ValueError(
+                f"presence boost factors must be between 0.0 and 1.0: {invalid}"
+            )
+        return factors
+
+    @model_validator(mode="after")
+    def _validate_presence_factor_shape(self) -> "HybridSearchConfig":
+        """Keep presence factors aligned with the configured query-type table."""
+
+        temporal_types = set(self.temporal_boost_factors)
+        presence_types = set(self.presence_boost_factors)
+        if presence_types != temporal_types:
+            missing = sorted(temporal_types - presence_types)
+            extra = sorted(presence_types - temporal_types)
+            raise ValueError(
+                "presence boost factor query types must match temporal boost "
+                f"factor query types; missing={missing}, extra={extra}"
+            )
+        return self
 
 
 class RerankerCandidate(BaseModel):

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -2572,8 +2572,8 @@ class HybridSearchConfig(BaseModel):
     text_weight_default: float = Field(..., ge=0.0, le=1.0)
     weights_by_query_type: Dict[str, QueryTypeWeights]
     temporal_boost_factors: Dict[str, float]
-    presence_boost_enabled: bool = False
-    presence_boost_factor: float = Field(0.15, ge=0.0, le=1.0)
+    presence_boost_enabled: bool
+    presence_boost_factor: float = Field(..., ge=0.0, le=1.0)
     presence_boost_factors: Dict[str, float]
     use_query_type_weights: bool
     use_query_type_temporal_factors: bool

--- a/scripts/measure_presence_boost.py
+++ b/scripts/measure_presence_boost.py
@@ -67,6 +67,12 @@ class CachingEmbeddingManager:
 class ReadOnlyIDFDictionary(IDFDictionary):
     """Build production query weights without reading or writing a cache file."""
 
+    def __init__(self, db_url: str) -> None:
+        self.db_url = db_url
+        self.idf_dict: Dict[str, float] = {}
+        self.total_docs = 0
+        self.last_updated = 0
+
     def _load_from_cache(self) -> bool:
         return False
 

--- a/scripts/measure_presence_boost.py
+++ b/scripts/measure_presence_boost.py
@@ -1,0 +1,336 @@
+"""Measure MEMNON presence-weighted retrieval against one database.
+
+The harness reads accepted chunks and their exact presence rosters, then runs
+the production hybrid-search entry point with the configured presence arm off
+and on. Every database statement issued by this script and the scorer is a
+SELECT.
+
+Usage:
+    python scripts/measure_presence_boost.py save_02 --top-k 15
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+import json
+import os
+from typing import Any, Dict, Iterable, Mapping, Sequence
+from urllib.parse import quote
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+from nexus.agents.memnon.utils.embedding_manager import EmbeddingManager
+from nexus.agents.memnon.utils.idf_dictionary import IDFDictionary
+from nexus.agents.memnon.utils.search import SearchManager
+from nexus.agents.orrery.reconstruction import playable_narrative_predicate
+from nexus.config import load_settings_as_dict
+
+
+@dataclass(frozen=True)
+class AcceptedChunk:
+    """One accepted narrative chunk and its exact present-character roster."""
+
+    chunk_id: int
+    raw_text: str
+    present_character_ids: tuple[int, ...]
+
+
+class CachingEmbeddingManager:
+    """Reuse each query embedding across the off/on counterfactual pair."""
+
+    def __init__(self, manager: EmbeddingManager) -> None:
+        self._manager = manager
+        self._cache: Dict[tuple[str, str], list[float]] = {}
+
+    def get_available_models(self) -> list[str]:
+        """Return the wrapped manager's active model keys."""
+
+        return self._manager.get_available_models()
+
+    def generate_embedding(self, query_text: str, model_key: str) -> list[float]:
+        """Return one cached embedding for a query/model pair."""
+
+        cache_key = (query_text, model_key)
+        if cache_key not in self._cache:
+            embedding = self._manager.generate_embedding(query_text, model_key)
+            if embedding is None:
+                raise RuntimeError(
+                    f"Embedding model {model_key!r} returned no query embedding"
+                )
+            self._cache[cache_key] = embedding
+        return self._cache[cache_key]
+
+
+class ReadOnlyIDFDictionary(IDFDictionary):
+    """Build production query weights without reading or writing a cache file."""
+
+    def _load_from_cache(self) -> bool:
+        return False
+
+    def _save_to_cache(self) -> bool:
+        return True
+
+
+def database_url(database: str) -> str:
+    """Build a PostgreSQL URL for an explicit database name."""
+
+    if not database or "/" in database or "\x00" in database:
+        raise ValueError(f"Invalid PostgreSQL database name: {database!r}")
+    user = quote(os.environ.get("PGUSER", "pythagor"), safe="")
+    password = os.environ.get("PGPASSWORD")
+    credentials = user if password is None else f"{user}:{quote(password, safe='')}"
+    host = os.environ.get("PGHOST", "localhost")
+    port = int(os.environ.get("PGPORT", "5432"))
+    return f"postgresql://{credentials}@{host}:{port}/{quote(database, safe='')}"
+
+
+def load_measurement_corpus(
+    connection: Any,
+) -> tuple[list[AcceptedChunk], Dict[int, str]]:
+    """Load accepted raw chunks, presence references, and character names."""
+
+    connection.set_session(readonly=True)
+    with connection.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(
+            f"""
+            SELECT
+                nc.id AS chunk_id,
+                nc.raw_text,
+                COALESCE(
+                    array_agg(DISTINCT ccr.character_id ORDER BY ccr.character_id)
+                        FILTER (WHERE ccr.reference::text = 'present'),
+                    ARRAY[]::bigint[]
+                ) AS present_character_ids
+            FROM narrative_chunks AS nc
+            LEFT JOIN chunk_character_references AS ccr ON ccr.chunk_id = nc.id
+            WHERE {playable_narrative_predicate()}
+            GROUP BY nc.id, nc.raw_text
+            ORDER BY nc.id
+            """
+        )
+        chunks = []
+        for row in cursor.fetchall():
+            chunk_id = int(row["chunk_id"])
+            raw_text = str(row["raw_text"] or "")
+            if not raw_text.strip():
+                raise RuntimeError(
+                    f"Accepted chunk {chunk_id} has no raw_text retrieval query"
+                )
+            chunks.append(
+                AcceptedChunk(
+                    chunk_id=chunk_id,
+                    raw_text=raw_text,
+                    present_character_ids=tuple(
+                        int(character_id)
+                        for character_id in row["present_character_ids"]
+                    ),
+                )
+            )
+        cursor.execute("SELECT id, name FROM characters ORDER BY id")
+        character_names = {
+            int(row["id"]): str(row["name"]) for row in cursor.fetchall()
+        }
+    return chunks, character_names
+
+
+def _narrative_rank_by_id(results: Iterable[Mapping[str, Any]]) -> Dict[int, int]:
+    """Map narrative chunk IDs to one-based result ranks."""
+
+    ranks: Dict[int, int] = {}
+    for rank, result in enumerate(results, start=1):
+        if result.get("content_type") != "narrative":
+            continue
+        chunk_id = result.get("chunk_id")
+        if chunk_id is not None:
+            ranks[int(chunk_id)] = rank
+    return ranks
+
+
+def _gap_entities(
+    gap_counts: Counter[int], character_names: Mapping[int, str]
+) -> list[Dict[str, Any]]:
+    """Render aggregate character gaps in retrieval_coverage_log style."""
+
+    return [
+        {
+            "kind": "character",
+            "id": character_id,
+            "name": character_names.get(character_id, f"character:{character_id}"),
+            "gap_queries": gap_count,
+        }
+        for character_id, gap_count in sorted(
+            gap_counts.items(), key=lambda item: (-item[1], item[0])
+        )
+    ]
+
+
+def measure_presence_boost(
+    chunks: Sequence[AcceptedChunk],
+    character_names: Mapping[int, str],
+    search_manager: SearchManager,
+    *,
+    top_k: int,
+) -> Dict[str, Any]:
+    """Run paired retrieval arms and return rank and gap counterfactuals."""
+
+    if top_k <= 0:
+        raise ValueError("top_k must be positive")
+
+    references_by_chunk = {
+        chunk.chunk_id: set(chunk.present_character_ids) for chunk in chunks
+    }
+    rank_stats: Dict[str, Counter[str]] = defaultdict(Counter)
+    rank_deltas: Dict[str, list[int]] = defaultdict(list)
+    baseline_gaps: Counter[int] = Counter()
+    boosted_gaps: Counter[int] = Counter()
+    resolved_gaps: Counter[int] = Counter()
+    introduced_gaps: Counter[int] = Counter()
+    entity_opportunities = 0
+
+    for chunk in chunks:
+        query_type = str(
+            search_manager.query_analyzer.analyze_query(chunk.raw_text).get(
+                "type", "general"
+            )
+        )
+        rank_stats[query_type]["queries"] += 1
+        baseline = search_manager.perform_hybrid_search(
+            query_text=chunk.raw_text,
+            top_k=top_k,
+            present_character_ids=chunk.present_character_ids,
+            presence_boost_enabled=False,
+        )
+        boosted = search_manager.perform_hybrid_search(
+            query_text=chunk.raw_text,
+            top_k=top_k,
+            present_character_ids=chunk.present_character_ids,
+            presence_boost_enabled=True,
+        )
+        if not baseline or not boosted:
+            raise RuntimeError(
+                "Hybrid search returned no results for accepted chunk "
+                f"{chunk.chunk_id}; baseline={len(baseline)}, boosted={len(boosted)}"
+            )
+        baseline_ranks = _narrative_rank_by_id(baseline)
+        boosted_ranks = _narrative_rank_by_id(boosted)
+        roster = set(chunk.present_character_ids)
+        presence_candidates = {
+            candidate_id
+            for candidate_id in baseline_ranks.keys() | boosted_ranks.keys()
+            if references_by_chunk.get(candidate_id, set()) & roster
+        }
+        missing_rank = top_k + 1
+        for candidate_id in presence_candidates:
+            delta = baseline_ranks.get(candidate_id, missing_rank) - boosted_ranks.get(
+                candidate_id, missing_rank
+            )
+            rank_deltas[query_type].append(delta)
+            rank_stats[query_type]["presence_candidates"] += 1
+            if delta > 0:
+                rank_stats[query_type]["improved"] += 1
+            elif delta < 0:
+                rank_stats[query_type]["regressed"] += 1
+            else:
+                rank_stats[query_type]["unchanged"] += 1
+
+        baseline_result_ids = set(baseline_ranks)
+        boosted_result_ids = set(boosted_ranks)
+        for character_id in chunk.present_character_ids:
+            entity_opportunities += 1
+            baseline_gap = not any(
+                character_id in references_by_chunk.get(result_id, set())
+                for result_id in baseline_result_ids
+            )
+            boosted_gap = not any(
+                character_id in references_by_chunk.get(result_id, set())
+                for result_id in boosted_result_ids
+            )
+            if baseline_gap:
+                baseline_gaps[character_id] += 1
+            if boosted_gap:
+                boosted_gaps[character_id] += 1
+            if baseline_gap and not boosted_gap:
+                resolved_gaps[character_id] += 1
+            if boosted_gap and not baseline_gap:
+                introduced_gaps[character_id] += 1
+
+    per_query_type: Dict[str, Dict[str, Any]] = {}
+    for query_type in sorted(rank_stats):
+        stats = rank_stats[query_type]
+        deltas = rank_deltas[query_type]
+        per_query_type[query_type] = {
+            "queries": stats["queries"],
+            "presence_candidates": stats["presence_candidates"],
+            "improved": stats["improved"],
+            "unchanged": stats["unchanged"],
+            "regressed": stats["regressed"],
+            "mean_rank_delta": (
+                round(sum(deltas) / len(deltas), 3) if deltas else None
+            ),
+            "rank_delta_distribution": dict(sorted(Counter(deltas).items())),
+        }
+
+    return {
+        "accepted_chunks": len(chunks),
+        "top_k": top_k,
+        "per_query_type": per_query_type,
+        "counterfactual_coverage": {
+            "entity_opportunities": entity_opportunities,
+            "baseline_gap_count": sum(baseline_gaps.values()),
+            "boosted_gap_count": sum(boosted_gaps.values()),
+            "baseline_gap_entities": _gap_entities(baseline_gaps, character_names),
+            "boosted_gap_entities": _gap_entities(boosted_gaps, character_names),
+            "resolved_gap_entities": _gap_entities(resolved_gaps, character_names),
+            "introduced_gap_entities": _gap_entities(introduced_gaps, character_names),
+        },
+    }
+
+
+def build_search_manager(db_url: str, *, top_k: int) -> SearchManager:
+    """Build the production hybrid-search entry point for measurement."""
+
+    memnon_settings = load_settings_as_dict()["Agent Settings"]["MEMNON"]
+    embedding_manager = CachingEmbeddingManager(EmbeddingManager(memnon_settings))
+    idf_dictionary = ReadOnlyIDFDictionary(db_url)
+    idf_dictionary.build_dictionary(force_rebuild=True)
+    model_weights = {
+        model_name: float(model_config["weight"])
+        for model_name, model_config in memnon_settings["models"].items()
+    }
+    return SearchManager(
+        db_url=db_url,
+        embedding_manager=embedding_manager,
+        idf_dictionary=idf_dictionary,
+        settings=memnon_settings,
+        retrieval_settings={
+            "default_top_k": top_k,
+            "model_weights": model_weights,
+        },
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the SELECT-only presence-boost measurement harness."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("database", help="Explicit PostgreSQL database name")
+    parser.add_argument("--top-k", type=int, default=15)
+    args = parser.parse_args(argv)
+    db_url = database_url(args.database)
+    with psycopg2.connect(db_url) as connection:
+        chunks, character_names = load_measurement_corpus(connection)
+    search_manager = build_search_manager(db_url, top_k=args.top_k)
+    report = measure_presence_boost(
+        chunks,
+        character_names,
+        search_manager,
+        top_k=args.top_k,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/config/test_settings_models.py
+++ b/tests/config/test_settings_models.py
@@ -27,6 +27,24 @@ def _nexus_toml_dict() -> dict:
         return tomllib.load(handle)
 
 
+@pytest.mark.parametrize(
+    "field",
+    [
+        "presence_boost_enabled",
+        "presence_boost_factor",
+        "presence_boost_factors",
+    ],
+)
+def test_presence_boost_settings_are_required(field: str) -> None:
+    """Deleting any presence arm key must fail full config validation."""
+
+    raw = _nexus_toml_dict()
+    del raw["memnon"]["retrieval"]["hybrid_search"][field]
+
+    with pytest.raises(ValidationError, match=field):
+        Settings(**raw)
+
+
 def test_model_config_rejects_unknown_default_model():
     """Legacy display defaults must stay anchored to registered model IDs."""
     with pytest.raises(ValidationError, match="default_model references unknown"):

--- a/tests/test_lore/test_entity_queries.py
+++ b/tests/test_lore/test_entity_queries.py
@@ -10,6 +10,7 @@ from nexus.agents.lore.utils.entity_queries import (
     fetch_all_characters_with_references,
     fetch_all_places_with_references,
     fetch_place_ids_by_names,
+    fetch_present_character_ids,
 )
 
 
@@ -176,6 +177,26 @@ class _PlaceQuerySession:
             return _Result(list(self.places.values()))
 
         raise AssertionError(f"Unexpected place query: {sql}")
+
+
+def test_present_character_ids_use_exact_chunk_roster() -> None:
+    """Presence retrieval carries only sorted present rows from its anchor."""
+
+    class PresenceSession:
+        def execute(
+            self, statement: Any, parameters: Optional[Dict[str, Any]] = None
+        ) -> _Result:
+            assert "reference::text = 'present'" in str(statement)
+            assert parameters == {"chunk_id": 42}
+            return _Result(
+                [
+                    _Row(character_id=9),
+                    _Row(character_id=3),
+                    _Row(character_id=9),
+                ]
+            )
+
+    assert fetch_present_character_ids(PresenceSession(), 42) == [3, 9]
 
 
 def test_user_character_does_not_consume_non_user_character_cap() -> None:

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -804,6 +804,46 @@ def test_deep_queries_use_raw_chunk_only(turn_manager: TurnCycleManager) -> None
     }
 
 
+def test_deep_queries_thread_present_character_roster(
+    turn_manager: TurnCycleManager,
+) -> None:
+    """The turn-cycle retrieval boundary passes its exact parent roster."""
+
+    class DummyMemnon:
+        def __init__(self) -> None:
+            self.present_character_ids: list[int] = []
+
+        def query_memory(
+            self,
+            query: str,
+            k: int,
+            use_hybrid: bool,
+            present_character_ids: list[int],
+        ) -> Dict[str, list[Dict[str, Any]]]:
+            self.present_character_ids = list(present_character_ids)
+            return {"results": []}
+
+    memnon = DummyMemnon()
+    turn_manager.lore.memnon = memnon
+    ctx = TurnContext(
+        turn_id="turn_presence_retrieval",
+        user_input="Continue.",
+        start_time=time.time(),
+        present_character_ids=[3, 9],
+        warm_slice=[
+            {
+                "id": 42,
+                "is_target": True,
+                "full_text": "Who is standing beside the protagonist?",
+            }
+        ],
+    )
+
+    asyncio.run(turn_manager.execute_deep_queries(ctx))
+
+    assert memnon.present_character_ids == [3, 9]
+
+
 def test_deep_queries_can_skip_without_raw_text(
     turn_manager: TurnCycleManager,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -31,7 +31,10 @@ class DummyLore:
                         "apex_context_window": 75_000,
                         "prompt_overhead_tokens": 0,
                     }
-                }
+                },
+                "MEMNON": {
+                    "retrieval": {"hybrid_search": {"presence_boost_enabled": False}}
+                },
             },
             "memory": {},
         }
@@ -804,44 +807,130 @@ def test_deep_queries_use_raw_chunk_only(turn_manager: TurnCycleManager) -> None
     }
 
 
-def test_deep_queries_thread_present_character_roster(
-    turn_manager: TurnCycleManager,
+@pytest.mark.parametrize("presence_boost_enabled", [False, True])
+def test_turn_phases_gate_and_thread_produced_presence_roster(
+    monkeypatch: pytest.MonkeyPatch,
+    presence_boost_enabled: bool,
 ) -> None:
-    """The turn-cycle retrieval boundary passes its exact parent roster."""
+    """The real entity phase produces the exact roster only for the enabled arm."""
+
+    roster_query_count = 0
+
+    class Row:
+        def __init__(self, character_id: int) -> None:
+            self.character_id = character_id
+
+    class Result:
+        def __init__(self, rows: list[Any] | None = None) -> None:
+            self.rows = rows or []
+
+        def fetchall(self) -> list[Any]:
+            return self.rows
+
+        def fetchone(self) -> Any | None:
+            return self.rows[0] if self.rows else None
+
+        def __iter__(self):
+            return iter(self.rows)
+
+    class ProductionSession:
+        def __enter__(self) -> "ProductionSession":
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            return None
+
+        def execute(
+            self, statement: Any, parameters: Dict[str, Any] | None = None
+        ) -> Result:
+            nonlocal roster_query_count
+            sql = " ".join(str(statement).split())
+            if (
+                "SELECT character_id FROM chunk_character_references" in sql
+                and "reference::text = 'present'" in sql
+            ):
+                if not presence_boost_enabled:
+                    raise AssertionError("disabled arm executed the roster query")
+                assert parameters == {"chunk_id": 42}
+                roster_query_count += 1
+                return Result([Row(9), Row(3)])
+            return Result()
 
     class DummyMemnon:
         def __init__(self) -> None:
-            self.present_character_ids: list[int] = []
+            self.threaded_present_ids: list[int] | None = None
+
+        Session = ProductionSession
 
         def query_memory(
             self,
             query: str,
             k: int,
             use_hybrid: bool,
-            present_character_ids: list[int],
+            **kwargs: Any,
         ) -> Dict[str, list[Dict[str, Any]]]:
-            self.present_character_ids = list(present_character_ids)
+            present_ids = kwargs.get("present_character_ids")
+            self.threaded_present_ids = (
+                list(present_ids) if present_ids is not None else None
+            )
             return {"results": []}
 
-    memnon = DummyMemnon()
-    turn_manager.lore.memnon = memnon
+    class PresenceLore:
+        def __init__(self) -> None:
+            self.settings = load_settings_as_dict()
+            self.settings["Agent Settings"]["MEMNON"]["retrieval"]["hybrid_search"][
+                "presence_boost_enabled"
+            ] = presence_boost_enabled
+            self.memnon = DummyMemnon()
+            self.memory_manager = None
+            self.token_manager = None
+            self.enable_logon = True
+
+    monkeypatch.setattr(
+        turn_cycle_module,
+        "fetch_all_characters_with_references",
+        lambda *_args, **_kwargs: {"baseline": [], "featured": []},
+    )
+    monkeypatch.setattr(
+        turn_cycle_module,
+        "fetch_all_places_with_references",
+        lambda *_args, **_kwargs: {"baseline": [], "featured": []},
+    )
+    monkeypatch.setattr(
+        turn_cycle_module,
+        "fetch_all_factions_with_references",
+        lambda *_args, **_kwargs: {"baseline": [], "featured": []},
+    )
+
+    lore = PresenceLore()
+    manager = TurnCycleManager(lore)
     ctx = TurnContext(
         turn_id="turn_presence_retrieval",
         user_input="Continue.",
         start_time=time.time(),
-        present_character_ids=[3, 9],
+        target_chunk_id=42,
+        provider_wire_type="local",
+        provider_name="local",
         warm_slice=[
             {
-                "id": 42,
+                "chunk_id": 42,
                 "is_target": True,
                 "full_text": "Who is standing beside the protagonist?",
             }
         ],
     )
 
-    asyncio.run(turn_manager.execute_deep_queries(ctx))
+    asyncio.run(manager.query_entity_states(ctx))
+    asyncio.run(manager.execute_deep_queries(ctx))
 
-    assert memnon.present_character_ids == [3, 9]
+    if presence_boost_enabled:
+        assert roster_query_count == 1
+        assert ctx.present_character_ids == [3, 9]
+        assert lore.memnon.threaded_present_ids == [3, 9]
+    else:
+        assert roster_query_count == 0
+        assert ctx.present_character_ids == []
+        assert lore.memnon.threaded_present_ids is None
 
 
 def test_deep_queries_can_skip_without_raw_text(

--- a/tests/test_presence_boost.py
+++ b/tests/test_presence_boost.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import psycopg2
 
 from nexus.agents.memnon.utils import continuous_temporal_search
 from nexus.agents.memnon.utils import db_access
+from scripts.measure_presence_boost import ReadOnlyIDFDictionary
 
 
 class _Cursor:
@@ -36,6 +38,51 @@ class _Connection:
 
     def close(self) -> None:
         self.closed = True
+
+
+class _IDFCursor:
+    def __init__(self) -> None:
+        self.statement = ""
+
+    def __enter__(self) -> "_IDFCursor":
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def execute(self, statement: str) -> None:
+        self.statement = statement
+
+    def fetchone(self) -> tuple[int]:
+        return (1,)
+
+    def fetchall(self) -> list[tuple[str, int]]:
+        return [("fixture", 0)]
+
+
+class _IDFConnection:
+    def __enter__(self) -> "_IDFConnection":
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def cursor(self) -> _IDFCursor:
+        return _IDFCursor()
+
+
+def test_measurement_idf_does_not_create_home_cache(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    """Harness IDF construction and build leave an empty HOME untouched."""
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(psycopg2, "connect", lambda *_args, **_kwargs: _IDFConnection())
+
+    dictionary = ReadOnlyIDFDictionary("postgresql://test@localhost/disposable")
+    assert dictionary.build_dictionary(force_rebuild=True) == {"fixture": 0.0}
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_time_aware_search_forwards_presence_boost(

--- a/tests/test_presence_boost.py
+++ b/tests/test_presence_boost.py
@@ -1,0 +1,85 @@
+"""Unit contracts for presence-weighted temporal retrieval plumbing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg2
+
+from nexus.agents.memnon.utils import continuous_temporal_search
+from nexus.agents.memnon.utils import db_access
+
+
+class _Cursor:
+    def __enter__(self) -> "_Cursor":
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def execute(self, statement: str) -> None:
+        assert "MAX(id)" in statement
+
+    def fetchone(self) -> tuple[int]:
+        return (10,)
+
+
+class _Connection:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def set_session(self, *, readonly: bool) -> None:
+        assert readonly
+
+    def cursor(self) -> _Cursor:
+        return _Cursor()
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_time_aware_search_forwards_presence_boost(
+    monkeypatch: Any,
+) -> None:
+    """Temporal reranking retains the same roster and configured bonus."""
+
+    captured: dict[str, Any] = {}
+
+    def fake_hybrid_search(**kwargs: Any) -> list[dict[str, Any]]:
+        captured.update(kwargs)
+        return [
+            {
+                "id": "4",
+                "chunk_id": "4",
+                "content_type": "narrative",
+                "score": 0.7,
+            }
+        ]
+
+    monkeypatch.setattr(psycopg2, "connect", lambda **_kwargs: _Connection())
+    monkeypatch.setattr(
+        continuous_temporal_search,
+        "analyze_temporal_intent",
+        lambda _query_text: 0.9,
+    )
+    monkeypatch.setattr(
+        db_access,
+        "execute_multi_model_hybrid_search",
+        fake_hybrid_search,
+    )
+
+    results = continuous_temporal_search.execute_multi_model_time_aware_search(
+        db_url="postgresql://test@localhost/disposable",
+        query_text="What happened recently?",
+        query_embeddings={"fixture": [1.0, 0.0, 0.0]},
+        model_weights={"fixture": 1.0},
+        temporal_boost_factor=0.4,
+        top_k=2,
+        present_character_ids=[9, 3],
+        presence_boost_factor=0.25,
+    )
+
+    assert captured["present_character_ids"] == [9, 3]
+    assert captured["presence_boost_factor"] == 0.25
+    assert captured["top_k"] == 4
+    assert results[0]["source"] == "multi_model_time_aware_search"

--- a/tests/test_presence_boost_pg.py
+++ b/tests/test_presence_boost_pg.py
@@ -1,0 +1,322 @@
+"""Disposable-PostgreSQL proofs for presence-weighted MEMNON retrieval."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Iterator
+import uuid
+
+import psycopg2
+from psycopg2 import sql
+import pytest
+
+from nexus.agents.memnon.utils.search import SearchManager
+from scripts.measure_presence_boost import (
+    load_measurement_corpus,
+    measure_presence_boost,
+)
+
+
+pytestmark = pytest.mark.requires_postgres
+
+
+class FixedEmbeddingManager:
+    """Return one deterministic embedding while exercising the real scorer."""
+
+    def get_available_models(self) -> list[str]:
+        """Return the fixture model key."""
+
+        return ["presence-fixture"]
+
+    def generate_embedding(self, _query_text: str, _model_key: str) -> list[float]:
+        """Return the fixture query vector."""
+
+        return [1.0, 0.0, 0.0]
+
+
+def _connect(dbname: str) -> Any:
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+def _database_url(dbname: str) -> str:
+    user = os.environ.get("PGUSER", "pythagor")
+    host = os.environ.get("PGHOST", "localhost")
+    port = os.environ.get("PGPORT", "5432")
+    return f"postgresql://{user}@{host}:{port}/{dbname}"
+
+
+def _insert_chunk(cursor: Any, raw_text: str, scene: int) -> int:
+    cursor.execute(
+        """
+        INSERT INTO narrative_chunks (
+            raw_text, storyteller_text, authorial_directives,
+            state, finalized_at
+        ) VALUES (%s, %s, '[]'::jsonb, 'finalized', now())
+        RETURNING id
+        """,
+        (raw_text, raw_text),
+    )
+    chunk_id = int(cursor.fetchone()[0])
+    cursor.execute(
+        """
+        INSERT INTO chunk_metadata (
+            chunk_id, season, episode, scene, world_layer,
+            time_delta, generation_date
+        ) VALUES (
+            %s, 1, 1, %s, 'primary', interval '0 seconds', now()
+        )
+        """,
+        (chunk_id, scene),
+    )
+    return chunk_id
+
+
+@pytest.fixture()
+def presence_database() -> Iterator[dict[str, Any]]:
+    """Clone the template and seed equal narrative/summary search candidates."""
+
+    dbname = f"qa683_presence_{uuid.uuid4().hex[:12]}"
+    admin = None
+    connection = None
+    try:
+        try:
+            admin = _connect("postgres")
+        except psycopg2.Error as exc:
+            pytest.skip(f"PostgreSQL admin connection unavailable: {exc}")
+        admin.autocommit = True
+        with admin.cursor() as cursor:
+            cursor.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier("NEXUS_template"),
+                )
+            )
+
+        connection = _connect(dbname)
+        with connection:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT to_regclass('public.retrograde_summaries')")
+                if cursor.fetchone()[0] is None:
+                    pytest.skip("NEXUS_template has not applied migration 078")
+                cursor.execute(
+                    """
+                    INSERT INTO global_variables (id, new_story, base_timestamp)
+                    VALUES (true, true, now())
+                    ON CONFLICT (id) DO UPDATE
+                    SET base_timestamp = EXCLUDED.base_timestamp
+                    """
+                )
+                cursor.execute(
+                    "INSERT INTO characters (name, summary) "
+                    "VALUES (%s, %s) RETURNING id",
+                    ("Zephyr Fixture", "Disposable presence character."),
+                )
+                character_id = int(cursor.fetchone()[0])
+                query_text = "Who is the zephyr fixture witness"
+                nonpresent_chunk_id = _insert_chunk(cursor, query_text, 1)
+                present_chunk_id = _insert_chunk(cursor, query_text, 2)
+                cursor.execute(
+                    """
+                    INSERT INTO chunk_character_references (
+                        chunk_id, character_id, reference
+                    ) VALUES (%s, %s, 'present')
+                    """,
+                    (present_chunk_id, character_id),
+                )
+                cursor.execute(
+                    """
+                    CREATE TABLE chunk_embeddings_0003d (
+                        chunk_id bigint NOT NULL REFERENCES narrative_chunks(id),
+                        model text NOT NULL,
+                        embedding vector(3) NOT NULL,
+                        PRIMARY KEY (chunk_id, model)
+                    )
+                    """
+                )
+                cursor.execute(
+                    """
+                    INSERT INTO chunk_embeddings_0003d (
+                        chunk_id, model, embedding
+                    ) VALUES
+                        (%s, 'presence-fixture', '[1,0,0]'),
+                        (%s, 'presence-fixture', '[1,0,0]')
+                    """,
+                    (nonpresent_chunk_id, present_chunk_id),
+                )
+                cursor.execute("SELECT type FROM event_types ORDER BY type LIMIT 1")
+                event_type = cursor.fetchone()[0]
+                cursor.execute(
+                    """
+                    INSERT INTO world_events (
+                        event_type, tick_chunk_id, world_layer, source,
+                        changed_fields, payload
+                    ) VALUES (
+                        %s, %s, 'primary', 'retrograde', '{}', %s::jsonb
+                    ) RETURNING id
+                    """,
+                    (
+                        event_type,
+                        nonpresent_chunk_id,
+                        json.dumps(
+                            {
+                                "retrograde_event_ref": "qa683_summary",
+                                "summary": query_text,
+                                "chronology": "deep_past",
+                            }
+                        ),
+                    ),
+                )
+                world_event_id = int(cursor.fetchone()[0])
+                cursor.execute(
+                    """
+                    INSERT INTO retrograde_summaries (
+                        world_event_id, recorded_at_chunk_id, chronology,
+                        summary_text, embedding_generated_at
+                    ) VALUES (%s, %s, 'deep_past', %s, now())
+                    RETURNING id
+                    """,
+                    (world_event_id, nonpresent_chunk_id, query_text),
+                )
+                summary_id = int(cursor.fetchone()[0])
+                cursor.execute(
+                    """
+                    CREATE TABLE retrograde_summary_embeddings_0003d (
+                        summary_id bigint NOT NULL
+                            REFERENCES retrograde_summaries(id),
+                        model text NOT NULL,
+                        embedding vector(3) NOT NULL,
+                        PRIMARY KEY (summary_id, model)
+                    )
+                    """
+                )
+                cursor.execute(
+                    """
+                    INSERT INTO retrograde_summary_embeddings_0003d (
+                        summary_id, model, embedding
+                    ) VALUES (%s, 'presence-fixture', '[1,0,0]')
+                    """,
+                    (summary_id,),
+                )
+
+        yield {
+            "dbname": dbname,
+            "db_url": _database_url(dbname),
+            "query_text": query_text,
+            "character_id": character_id,
+            "nonpresent_chunk_id": nonpresent_chunk_id,
+            "present_chunk_id": present_chunk_id,
+            "summary_id": summary_id,
+        }
+    finally:
+        if connection is not None:
+            connection.close()
+        if admin is not None:
+            with admin.cursor() as cursor:
+                cursor.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = %s AND pid <> pg_backend_pid()",
+                    (dbname,),
+                )
+                cursor.execute(
+                    sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+                )
+            admin.close()
+
+
+def _search_manager(db_url: str) -> SearchManager:
+    hybrid_config = {
+        "enabled": True,
+        "vector_weight_default": 0.6,
+        "text_weight_default": 0.4,
+        "weights_by_query_type": {"character": {"vector": 0.6, "text": 0.4}},
+        "use_query_type_weights": True,
+        "temporal_boost_factor": 0.0,
+        "temporal_boost_factors": {},
+        "use_query_type_temporal_factors": False,
+        "presence_boost_enabled": False,
+        "presence_boost_factor": 0.15,
+        "presence_boost_factors": {"character": 0.25},
+    }
+    return SearchManager(
+        db_url=db_url,
+        embedding_manager=FixedEmbeddingManager(),
+        idf_dictionary=None,
+        settings={"retrieval": {"hybrid_search": hybrid_config}},
+        retrieval_settings={
+            "default_top_k": 10,
+            "model_weights": {"presence-fixture": 1.0},
+        },
+    )
+
+
+def _result_by_id(results: list[dict[str, Any]], result_id: str) -> dict[str, Any]:
+    return next(result for result in results if result["id"] == result_id)
+
+
+def test_presence_boost_entry_point_and_summary_scope(
+    presence_database: dict[str, Any],
+) -> None:
+    """Off is identical; on lifts only the co-present narrative candidate."""
+
+    fixture = presence_database
+    manager = _search_manager(fixture["db_url"])
+    legacy = manager.perform_hybrid_search(
+        query_text=fixture["query_text"],
+        top_k=10,
+    )
+    disabled = manager.perform_hybrid_search(
+        query_text=fixture["query_text"],
+        top_k=10,
+        present_character_ids=[fixture["character_id"]],
+        presence_boost_enabled=False,
+    )
+    boosted = manager.perform_hybrid_search(
+        query_text=fixture["query_text"],
+        top_k=10,
+        present_character_ids=[fixture["character_id"]],
+        presence_boost_enabled=True,
+    )
+
+    assert disabled == legacy
+    present_id = str(fixture["present_chunk_id"])
+    nonpresent_id = str(fixture["nonpresent_chunk_id"])
+    summary_id = f"retrograde_summary:{fixture['summary_id']}"
+    assert boosted[0]["id"] == present_id
+    assert _result_by_id(boosted, present_id)["score"] == pytest.approx(
+        _result_by_id(disabled, present_id)["score"] + 0.25
+    )
+    assert _result_by_id(boosted, nonpresent_id) == _result_by_id(
+        disabled, nonpresent_id
+    )
+    assert _result_by_id(boosted, summary_id) == _result_by_id(disabled, summary_id)
+    assert "presence_boost" not in _result_by_id(boosted, summary_id)
+
+
+def test_measurement_harness_uses_ephemeral_corpus(
+    presence_database: dict[str, Any],
+) -> None:
+    """The harness loads real rosters and reports paired entry-point results."""
+
+    fixture = presence_database
+    with _connect(fixture["dbname"]) as connection:
+        chunks, character_names = load_measurement_corpus(connection)
+    source_chunks = [
+        chunk for chunk in chunks if chunk.chunk_id == fixture["present_chunk_id"]
+    ]
+    report = measure_presence_boost(
+        source_chunks,
+        character_names,
+        _search_manager(fixture["db_url"]),
+        top_k=3,
+    )
+
+    assert report["accepted_chunks"] == 1
+    assert report["per_query_type"]["character"]["queries"] == 1
+    assert report["counterfactual_coverage"]["entity_opportunities"] == 1
+    assert report["counterfactual_coverage"]["introduced_gap_entities"] == []


### PR DESCRIPTION
Closes #683.

The MGO review's highest value-to-effort port: SkyrimNet's actor-involvement retrieval weight (0.20, outranking recency — the "she remembers me" term), translated to MEMNON as an additive presence boost on the authorial hybrid search. Pure SQL; no migration; no LLM calls.

- Join on `chunk_character_references` (`reference = 'present'`) against the presence roster already computed per turn; applied once, post-fusion.
- Strictly narrative-corpus — follows the `_retrograde_summaries_allowed` scoping idiom so summaries never receive a presence signal they don't carry.
- **Ships disabled** per the `structured_data_enabled = false` precedent ("revisit only with bake-off-grade evidence"): `presence_boost_enabled = false`, factors configurable per query type (0.25 character/relationship, 0.15 general).
- `scripts/measure_presence_boost.py`: read-only counterfactual harness reporting rank deltas plus resolved/introduced `gap_entities`-style coverage. I'll run it against live slot data post-merge and flip the default in a follow-up if the numbers clear the bar.

134 passed + PG suite; regression arm proves boost-off is byte-identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG