### PR TITLE
Forward Per-Seat Prompt Cache Keys and Guard the Stable System Prefix

### DIFF
--- a/docs/prompt_block_stability.md
+++ b/docs/prompt_block_stability.md
@@ -1,0 +1,28 @@
+# Prompt Block Stability Audit
+Measured 2026-08-09; this documents the measured stable/volatile split for future cache work.
+
+| Block | Classification | Evidence |
+|---|---|---|
+| Skald core prompt | Turn-stable | `nexus/agents/lore/logon_utility.py:418-468` |
+| Cached SettingCard snapshot | Turn-stable | `nexus/agents/lore/logon_utility.py:465-482` |
+| Writer-pass doctrine | Turn-stable | `nexus/agents/lore/logon_utility.py:1158-1182` |
+| Gaia system doctrine + SettingCard | Turn-stable | `nexus/agents/lore/logon_utility.py:1333-1360` |
+| Writer schema declaration | Turn-stable | `nexus/agents/lore/logon_utility.py:1828-1927` |
+| Gaia schema declaration | Semi-stable when registry enums change; otherwise stable | `nexus/agents/lore/logon_utility.py:1828-1927` |
+| Intertitle/position telemetry | Volatile | `nexus/agents/lore/logon_utility.py:1951-1980` |
+| Scene conditions | Volatile | `nexus/agents/lore/logon_utility.py:1982-1995` |
+| Storyteller correspondence/letters | Volatile | `nexus/agents/lore/logon_utility.py:1997-2003` |
+| Warm narrative slice | Volatile | `nexus/agents/lore/logon_utility.py:2005-2013` |
+| Bootstrap context | Request-specific; not a consecutive two-pass block | `nexus/agents/lore/logon_utility.py:2015-2019` |
+| User input | Volatile | `nexus/agents/lore/logon_utility.py:2021-2023` |
+| Entity dossier/presence | Volatile | `nexus/agents/lore/logon_utility.py:2025-2152` |
+| Retrieved historical context | Volatile | `nexus/agents/lore/logon_utility.py:2154-2164` |
+| World knowledge | Volatile | `nexus/agents/lore/logon_utility.py:2166-2187` |
+| Contextual Orrery tag library | Semi-stable scene/registry boundary | `nexus/agents/lore/logon_utility.py:2189-2194` |
+| Imminent proposals | Volatile | `nexus/agents/lore/logon_utility.py:2215-2233` |
+| Scene pressure | Volatile | `nexus/agents/lore/logon_utility.py:2235-2253` |
+| Joint beats | Volatile | `nexus/agents/lore/logon_utility.py:2255-2279` |
+| Ambient peripherals | Volatile | `nexus/agents/lore/logon_utility.py:2281-2298` |
+| Author’s note | Volatile | `nexus/agents/lore/logon_utility.py:2300-2312` |
+| Final instructions | Turn-stable | `nexus/agents/lore/logon_utility.py:2314-2321` |
+| Gaia finished Writer narrative, choices, scene, presence, operations, and letter | Volatile | `nexus/agents/lore/logon_utility.py:1363-1403` |

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -380,9 +380,9 @@ class LogonUtility:
         )
         self._provider_type_name: Optional[str] = None
         self._validation_dbname: Optional[str] = None
-        # Keyed by schema type for single-pass entries and by
-        # (schema type, wire class) tuples for two-pass entries, because the
-        # pinned gaia seat can run a different wire class than the writer.
+        # Keyed by schema type for single-pass entries and by schema, wire, and
+        # slot-qualified cache affinity for two-pass entries, because gaia can
+        # run a different wire and cache affinity must never cross save slots.
         self._schema_format_cache: Dict[Any, Dict[str, Any]] = {}
         # Current prompt proposal bindings are read by the generation-time
         # replacement-delta validator. They are replaced atomically per turn.
@@ -1831,7 +1831,7 @@ class LogonUtility:
         *,
         wire_type: Optional[Literal["openai", "anthropic", "local"]] = None,
     ) -> Dict[str, Any]:
-        """Return the frozen transport schema arguments for one pass.
+        """Return the frozen transport request arguments for one pass.
 
         ``wire_type`` is the wire class of the provider EXECUTING the pass —
         the pinned gaia seat may run a different class than the writer.
@@ -1851,16 +1851,24 @@ class LogonUtility:
             raise RuntimeError(
                 "Two-pass schema formatting requires an active provider wire class"
             )
+        prompt_cache_key: Optional[str] = None
+        if effective_wire == "openai":
+            from nexus.api.slot_utils import require_slot_dbname
+
+            slot_dbname = require_slot_dbname(dbname=self.dbname)
+            usage_seat = "skald_writer" if is_writer else "gaia"
+            prompt_cache_key = f"nexus:{slot_dbname}:{usage_seat}"
         cache_key: tuple[Any, ...]
         if is_gaia:
             cache_key = (
                 SkaldGaiaWire,
                 effective_wire,
+                prompt_cache_key,
                 gaia_wire_registry_digest(gaia_schema_model),
                 schema_model,
             )
         else:
-            cache_key = (SkaldWriterWire, effective_wire)
+            cache_key = (SkaldWriterWire, effective_wire, prompt_cache_key)
         if cache_key in self._schema_format_cache:
             return self._schema_format_cache[cache_key]
 
@@ -1876,7 +1884,8 @@ class LogonUtility:
                     skald_writer_strict_text_format()
                     if is_writer
                     else skald_gaia_strict_text_format(gaia_schema_model)
-                )
+                ),
+                "prompt_cache_key": prompt_cache_key,
             }
         elif effective_wire == "local":
             lenient_schema = (

--- a/scripts/api_openai.py
+++ b/scripts/api_openai.py
@@ -436,6 +436,7 @@ class OpenAIProvider(LLMProvider):
         schema_model: Type,
         *,
         text_format: Optional[Dict[str, Any]] = None,
+        prompt_cache_key: Optional[str] = None,
     ) -> Tuple[Any, LLMResponse]:
         """
         Get a structured completion using OpenAI native strict schema output.
@@ -443,6 +444,7 @@ class OpenAIProvider(LLMProvider):
         Args:
             prompt: The input prompt
             schema_model: A Pydantic BaseModel class defining the output schema
+            prompt_cache_key: Optional stable routing key for OpenAI prompt caching
 
         Returns:
             A tuple of (parsed_object, LLMResponse)
@@ -472,7 +474,10 @@ class OpenAIProvider(LLMProvider):
             "get_structured_completion_async",
         )
         return self._get_structured_completion_native_sync(
-            prompt, schema_model, text_format=text_format
+            prompt,
+            schema_model,
+            text_format=text_format,
+            prompt_cache_key=prompt_cache_key,
         )
 
     async def get_structured_completion_async(
@@ -481,10 +486,14 @@ class OpenAIProvider(LLMProvider):
         schema_model: Type,
         *,
         text_format: Optional[Dict[str, Any]] = None,
+        prompt_cache_key: Optional[str] = None,
     ) -> Tuple[Any, LLMResponse]:
         """Get a structured completion without blocking an existing event loop."""
         return await self._get_structured_completion_native_async(
-            prompt, schema_model, text_format=text_format
+            prompt,
+            schema_model,
+            text_format=text_format,
+            prompt_cache_key=prompt_cache_key,
         )
 
     def _raise_if_running_loop(self, method_name: str, async_method_name: str) -> None:
@@ -539,6 +548,7 @@ class OpenAIProvider(LLMProvider):
         schema_model: Type,
         *,
         text_format: Optional[Dict[str, Any]] = None,
+        prompt_cache_key: Optional[str] = None,
     ) -> Tuple[Any, LLMResponse]:
         """Run a native strict-schema Responses request with bounded repair."""
 
@@ -558,7 +568,10 @@ class OpenAIProvider(LLMProvider):
                 try:
                     response = self.client.responses.parse(
                         **self._build_native_structured_request_params(
-                            active_prompt, schema_model, text_format=text_format
+                            active_prompt,
+                            schema_model,
+                            text_format=text_format,
+                            prompt_cache_key=prompt_cache_key,
                         )
                     )
                 except Exception as exc:
@@ -627,6 +640,7 @@ class OpenAIProvider(LLMProvider):
         schema_model: Type,
         *,
         text_format: Optional[Dict[str, Any]] = None,
+        prompt_cache_key: Optional[str] = None,
     ) -> Tuple[Any, LLMResponse]:
         """Dispatch structured output without blocking an existing event loop."""
 
@@ -639,6 +653,7 @@ class OpenAIProvider(LLMProvider):
             prompt,
             schema_model,
             text_format=text_format,
+            prompt_cache_key=prompt_cache_key,
         )
 
     def _should_fallback_to_chat_completions(self, exc: BaseException) -> bool:
@@ -754,6 +769,7 @@ class OpenAIProvider(LLMProvider):
         schema_model: Type,
         *,
         text_format: Optional[Dict[str, Any]] = None,
+        prompt_cache_key: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Build OpenAI Responses params for native strict structured output."""
 
@@ -774,6 +790,8 @@ class OpenAIProvider(LLMProvider):
             request_params["temperature"] = self.temperature
         if self.reasoning_effort:
             request_params["reasoning"] = {"effort": self.reasoning_effort}
+        if prompt_cache_key:
+            request_params["prompt_cache_key"] = prompt_cache_key
         return request_params
 
     def _build_chat_structured_request_params(

--- a/tests/test_lore/test_two_pass_pipeline.py
+++ b/tests/test_lore/test_two_pass_pipeline.py
@@ -48,6 +48,7 @@ from nexus.api.native_structured_output import (
     run_output_validator,
 )
 from nexus.api.presence_reconciliation import CharacterRosterRows
+from nexus.api.slot_utils import require_slot_dbname
 
 
 @pytest.fixture(autouse=True)
@@ -360,9 +361,16 @@ def _expected_schema_kwargs(
     anthropic_transport: str | None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     if provider_type == "openai":
+        slot_dbname = require_slot_dbname()
         return (
-            {"text_format": skald_writer_strict_text_format()},
-            {"text_format": skald_gaia_strict_text_format()},
+            {
+                "text_format": skald_writer_strict_text_format(),
+                "prompt_cache_key": f"nexus:{slot_dbname}:skald_writer",
+            },
+            {
+                "text_format": skald_gaia_strict_text_format(),
+                "prompt_cache_key": f"nexus:{slot_dbname}:gaia",
+            },
         )
     if provider_type == "local":
         return (
@@ -501,6 +509,58 @@ def test_sync_two_pass_pipeline_uses_provider_specific_transports(
     _assert_two_pass_calls(provider, provider_type, anthropic_transport)
     assert response.narrative == WRITER_PAYLOAD["narrative"]
     assert response.generation_model == provider.model
+
+
+def test_two_pass_system_messages_are_stable_across_consecutive_turns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Full Writer and Gaia builders keep volatile state out of system messages."""
+
+    monkeypatch.setenv("NEXUS_SLOT", "3")
+    utility, provider = _utility(
+        "openai",
+        [WRITER_PAYLOAD, GAIA_PAYLOAD, WRITER_PAYLOAD, GAIA_PAYLOAD],
+    )
+    utility._system_prompt = utility._load_system_prompt()
+    provider.system_prompt = utility._system_prompt
+    monkeypatch.setattr(
+        utility,
+        "_read_presence_baseline_for_context",
+        lambda _context_payload, _schema_model: BASELINE,
+    )
+    first_context = {
+        **_context(),
+        "warm_slice": {"chunks": [{"text": "The first turn's warm slice."}]},
+        "user_input": "Open the archive.",
+    }
+    second_context = {
+        **_context(),
+        "warm_slice": {
+            "chunks": [
+                {"text": "The first turn's warm slice."},
+                {"text": "The second turn changes the volatile suffix."},
+            ]
+        },
+        "user_input": "Follow the drowned bell.",
+    }
+
+    utility.generate_narrative(first_context, effective_context_window=75_000)
+    utility.generate_narrative(second_context, effective_context_window=75_000)
+
+    assert len(provider.calls) == 4
+    first_writer, first_gaia, second_writer, second_gaia = provider.calls
+    assert first_writer["usage_seat"] == second_writer["usage_seat"] == "skald_writer"
+    assert first_gaia["usage_seat"] == second_gaia["usage_seat"] == "gaia"
+    assert first_writer["system_prompt"].encode("utf-8") == second_writer[
+        "system_prompt"
+    ].encode("utf-8")
+    assert first_gaia["system_prompt"].encode("utf-8") == second_gaia[
+        "system_prompt"
+    ].encode("utf-8")
+    assert first_writer["prompt"] != second_writer["prompt"]
+    assert first_gaia["prompt"] != second_gaia["prompt"]
+    assert first_writer["kwargs"]["prompt_cache_key"] == ("nexus:save_03:skald_writer")
+    assert first_gaia["kwargs"]["prompt_cache_key"] == "nexus:save_03:gaia"
 
 
 @pytest.mark.asyncio
@@ -752,7 +812,8 @@ def test_openai_two_pass_injects_registry_model_and_coerces_at_boundary(
 
     assert provider.calls[1]["schema_model"] is schema_model
     assert provider.calls[1]["kwargs"] == {
-        "text_format": skald_gaia_strict_text_format(schema_model)
+        "text_format": skald_gaia_strict_text_format(schema_model),
+        "prompt_cache_key": f"nexus:{require_slot_dbname()}:gaia",
     }
     assert (
         response.new_entities == SkaldGaiaWire.model_validate(GAIA_PAYLOAD).new_entities
@@ -1126,7 +1187,10 @@ def test_sync_pinned_gaia_runs_fresh_openai_seat(
     assert provider.calls[0]["usage_seat"] == "skald_writer"
     assert gaia_call["usage_seat"] == "gaia"
     # Heterogeneous kwargs: strict OpenAI gaia schema under this writer wire.
-    assert gaia_call["kwargs"] == {"text_format": skald_gaia_strict_text_format()}
+    assert gaia_call["kwargs"] == {
+        "text_format": skald_gaia_strict_text_format(),
+        "prompt_cache_key": f"nexus:{require_slot_dbname()}:gaia",
+    }
     assert captured["route"][0] == "pinned-gaia-model"
     assert captured["route"][3] == "openai"
     assert captured["anthropic_transport"] is None
@@ -1166,7 +1230,8 @@ async def test_async_pinned_gaia_runs_fresh_openai_seat(
     assert len(provider.calls) == 1
     assert len(gaia_recorder.calls) == 1
     assert gaia_recorder.calls[0]["kwargs"] == {
-        "text_format": skald_gaia_strict_text_format()
+        "text_format": skald_gaia_strict_text_format(),
+        "prompt_cache_key": f"nexus:{require_slot_dbname()}:gaia",
     }
     assert captured["route"][3] == "openai"
     assert windows[-1] == 75_000
@@ -1220,7 +1285,28 @@ def test_two_pass_schema_kwargs_cache_is_wire_keyed() -> None:
         SkaldGaiaWire, wire_type="openai"
     )
     assert anthropic_kwargs == {}
-    assert openai_kwargs == {"text_format": skald_gaia_strict_text_format()}
+    assert openai_kwargs == {
+        "text_format": skald_gaia_strict_text_format(),
+        "prompt_cache_key": f"nexus:{require_slot_dbname()}:gaia",
+    }
+
+
+def test_two_pass_prompt_cache_keys_are_slot_and_seat_scoped() -> None:
+    """Changing slots cannot reuse either storyteller seat's cache affinity."""
+
+    utility, _provider = _utility("openai", [])
+    utility.dbname = "save_02"
+    first_writer = utility._two_pass_schema_format_kwargs(SkaldWriterWire)
+    first_gaia = utility._two_pass_schema_format_kwargs(SkaldGaiaWire)
+
+    utility.dbname = "save_04"
+    second_writer = utility._two_pass_schema_format_kwargs(SkaldWriterWire)
+    second_gaia = utility._two_pass_schema_format_kwargs(SkaldGaiaWire)
+
+    assert first_writer["prompt_cache_key"] == "nexus:save_02:skald_writer"
+    assert first_gaia["prompt_cache_key"] == "nexus:save_02:gaia"
+    assert second_writer["prompt_cache_key"] == "nexus:save_04:skald_writer"
+    assert second_gaia["prompt_cache_key"] == "nexus:save_04:gaia"
 
 
 def test_two_pass_gaia_schema_cache_is_registry_digest_keyed() -> None:

--- a/tests/test_native_structured_output.py
+++ b/tests/test_native_structured_output.py
@@ -1967,6 +1967,23 @@ def test_chat_request_params_ride_extra_body() -> None:
     assert provider.request_params == {"reasoning": {"effort": "low"}}
 
 
+def test_native_structured_request_forwards_prompt_cache_key() -> None:
+    """OpenAI Responses receives the slot-qualified storyteller seat key."""
+
+    provider = OpenAIProvider(
+        model="gpt-5.6",
+        api_key="test-key",
+    )
+
+    params = provider._build_native_structured_request_params(
+        "Prompt",
+        StorytellerResponseBootstrap,
+        prompt_cache_key="nexus:save_03:skald_writer",
+    )
+
+    assert params["prompt_cache_key"] == "nexus:save_03:skald_writer"
+
+
 def test_chat_request_without_request_params_omits_extra_body() -> None:
     """Models without registry params keep the pre-#580 request shape."""
 


### PR DESCRIPTION
Closes #684 — with scope honestly reduced by what the audit found.

**The stop-report that reshaped this PR:** the worker classified every prompt block (now shipped as `docs/prompt_block_stability.md`) and found absolute stable-first ordering collides with two deliberate semantic contracts — the intertitle must open the prompt (position carries meaning; test-enforced) and the author's note must sit immediately before the final instructions (recency by design). Ruling: those contracts are settled prompt doctrine and stand. Since the intertitle opens the user message, the user-message prefix is volatile from byte zero *by design* — the cache asset is the **system message**, which already explains the observed 21–24% auto-cache baseline.

What ships:
- **`prompt_cache_key = nexus:{slot_dbname}:{seat}`** on OpenAI structured requests (both seats), via `require_slot_dbname` — loud failure on invalid slot state; cache affinity never crosses save slots. Non-OpenAI providers untouched.
- **Contract test**: two consecutive turns through the genuine `generate_narrative` path must produce byte-identical Writer and Gaia system messages — the regression guard against SkyrimNet's diagnosed failure (74.9% stable prefix forfeited to interleaved volatile state).
- **`docs/prompt_block_stability.md`**: the full measured block classification, the map for any future measured message-role redesign.

Live cache-hit validation happens post-merge on the isolated lane; telemetry already records `cached_input_tokens` for the before/after. 272 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG