### PR TITLE
Persist the Pass-1/Pass-2 Baseline Across Turns via Incubator Staging

### DIFF
--- a/migrations/107_lore_pass_baselines.sql
+++ b/migrations/107_lore_pass_baselines.sql
@@ -1,0 +1,26 @@
+-- Migration 107: durable Pass-1/Pass-2 baselines staged with provisional prose.
+
+ALTER TABLE incubator
+    ADD COLUMN IF NOT EXISTS lore_pass_baseline JSONB;
+
+COMMENT ON COLUMN incubator.lore_pass_baseline IS
+    'Unbound versioned Pass-2 baseline staged atomically with provisional storyteller prose and discarded on rejection.';
+
+CREATE TABLE IF NOT EXISTS lore_pass_baselines (
+    chunk_id BIGINT PRIMARY KEY
+        REFERENCES narrative_chunks(id) ON DELETE CASCADE,
+    schema_version INTEGER NOT NULL CHECK (schema_version > 0),
+    payload JSONB NOT NULL CHECK (jsonb_typeof(payload) = 'object'),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE lore_pass_baselines IS
+    'Accepted versioned Pass-2 baselines, promoted in the same transaction as their narrative chunk.';
+COMMENT ON COLUMN lore_pass_baselines.chunk_id IS
+    'Actual accepted narrative_chunks id returned by insertion; also the parent identity required during next-turn hydration.';
+COMMENT ON COLUMN lore_pass_baselines.schema_version IS
+    'Validated baseline wire-schema version duplicated from payload for indexed administrative inspection.';
+COMMENT ON COLUMN lore_pass_baselines.payload IS
+    'Validated bound Pass-2 baseline containing exact typed memory identities, token accounting, and compatibility fingerprint.';
+COMMENT ON COLUMN lore_pass_baselines.created_at IS
+    'Database time at accepted-chunk promotion.';

--- a/nexus/agents/lore/lore.py
+++ b/nexus/agents/lore/lore.py
@@ -403,6 +403,13 @@ class LORE:
         )
 
         try:
+            if parent_chunk_id is not None:
+                if self.memory_manager is None:
+                    raise RuntimeError(
+                        "Pass-2 baseline hydration requires the memory manager"
+                    )
+                self.memory_manager.restore_pass2_baseline(parent_chunk_id)
+
             # Phase 1: User Input Processing
             self.current_phase = TurnPhase.USER_INPUT
             await self.turn_manager.process_user_input(self.turn_context)

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -1602,50 +1602,48 @@ class TurnCycleManager:
             ] = structured_response.model_dump()
 
         if getattr(self.lore, "memory_manager", None):
-            try:
-                warm_section = turn_context.context_payload.get("warm_slice")
-                retrieved_section = turn_context.context_payload.get(
-                    "retrieved_passages"
+            warm_section = turn_context.context_payload.get("warm_slice")
+            retrieved_section = turn_context.context_payload.get("retrieved_passages")
+            if not isinstance(warm_section, dict) or not isinstance(
+                warm_section.get("chunks"), list
+            ):
+                raise RuntimeError(
+                    "Integrated storyteller payload is missing warm_slice.chunks"
                 )
-                if not isinstance(warm_section, dict) or not isinstance(
-                    warm_section.get("chunks"), list
-                ):
-                    raise RuntimeError(
-                        "Integrated storyteller payload is missing warm_slice.chunks"
-                    )
-                if not isinstance(retrieved_section, dict) or not isinstance(
-                    retrieved_section.get("results"), list
-                ):
-                    raise RuntimeError(
-                        "Integrated storyteller payload is missing "
-                        "retrieved_passages.results"
-                    )
-                baseline = self.lore.memory_manager.handle_storyteller_response(
-                    narrative=narrative_text,
-                    warm_slice=warm_section["chunks"],
-                    retrieved_passages=retrieved_section["results"],
-                    token_usage=turn_context.token_counts,
-                    assembled_context=turn_context.context_payload,
+            if not isinstance(retrieved_section, dict) or not isinstance(
+                retrieved_section.get("results"), list
+            ):
+                raise RuntimeError(
+                    "Integrated storyteller payload is missing "
+                    "retrieved_passages.results"
                 )
-                transition = self.lore.memory_manager.context_state.transition
-                baseline_snapshot = {
-                    "baseline_chunks": _sorted_chunk_ids(baseline.baseline_chunks),
-                    "baseline_themes": baseline.baseline_themes,
-                    "expected_user_themes": (
-                        transition.expected_user_themes if transition else []
-                    ),
-                    "remaining_budget": (
-                        self.lore.memory_manager.context_state.get_remaining_budget()
-                    ),
-                    "structured_passages": baseline.structured_passages,
-                }
-                turn_context.memory_state["pass1"] = baseline_snapshot
-                turn_context.phase_states["integration"][
-                    "memory_baseline"
-                ] = baseline_snapshot
-            except Exception as exc:  # pragma: no cover - defensive logging
-                logger.error("Pass 1 baseline storage failed: %s", exc)
-                turn_context.memory_state.setdefault("errors", []).append(str(exc))
+            baseline = self.lore.memory_manager.handle_storyteller_response(
+                narrative=narrative_text,
+                warm_slice=warm_section["chunks"],
+                retrieved_passages=retrieved_section["results"],
+                token_usage=turn_context.token_counts,
+                assembled_context=turn_context.context_payload,
+            )
+            staged_baseline = self.lore.memory_manager.export_pass2_baseline()
+            transition = self.lore.memory_manager.context_state.transition
+            baseline_snapshot = {
+                "baseline_chunks": _sorted_chunk_ids(baseline.baseline_chunks),
+                "baseline_themes": baseline.baseline_themes,
+                "expected_user_themes": (
+                    transition.expected_user_themes if transition else []
+                ),
+                "remaining_budget": (
+                    self.lore.memory_manager.context_state.get_remaining_budget()
+                ),
+                "structured_passages": baseline.structured_passages,
+            }
+            turn_context.memory_state["pass1"] = baseline_snapshot
+            turn_context.memory_state["lore_pass_baseline"] = (
+                staged_baseline.model_dump(mode="json")
+            )
+            turn_context.phase_states["integration"][
+                "memory_baseline"
+            ] = baseline_snapshot
 
         # Store narrative chunk if MEMNON available
         if self.lore.memnon and narrative_text:

--- a/nexus/api/commit_handler.py
+++ b/nexus/api/commit_handler.py
@@ -49,6 +49,10 @@ from nexus.api.choice_handling import (
     selected_text_from_choice_object,
 )
 from nexus.api.lore_adapter import compute_raw_text, split_staged_orrery_payload
+from nexus.memory.context_state import (
+    bind_pass2_baseline,
+    validate_staged_pass2_baseline,
+)
 
 logger = logging.getLogger("nexus.api.commit_handler")
 
@@ -70,6 +74,7 @@ async def fetch_incubator_data(
                choice_object, choice_text, orrery_proposal,
                COALESCE(orrery_adjudications, '[]'::jsonb) AS orrery_adjudications,
                COALESCE(new_entities, '[]'::jsonb) AS new_entities,
+               lore_pass_baseline,
                metadata_updates, entity_updates, reference_updates,
                llm_response_id, generation_model, status
         FROM incubator
@@ -612,6 +617,7 @@ async def commit_incubator_to_database(
         try:
             # Step 1: Get incubator data
             incubator = await fetch_incubator_data(conn, session_id)
+            validate_staged_pass2_baseline(incubator["lore_pass_baseline"])
             logger.info("Processing incubator session %s", session_id)
 
             # Step 2: Get parent context
@@ -664,6 +670,18 @@ async def commit_incubator_to_database(
             )
             if chunk_id is None:
                 raise ValueError("Failed to obtain chunk_id after insert")
+            bound_baseline = bind_pass2_baseline(
+                incubator["lore_pass_baseline"], chunk_id
+            )
+            await conn.execute(
+                """
+                INSERT INTO lore_pass_baselines (chunk_id, schema_version, payload)
+                VALUES ($1, $2, $3::text::jsonb)
+                """,
+                chunk_id,
+                bound_baseline.schema_version,
+                json.dumps(bound_baseline.model_dump(mode="json")),
+            )
 
             # Step 5: Create declaration stubs before name-reference resolution.
             await create_declared_entity_stubs(

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -34,6 +34,10 @@ from nexus.agents.orrery.reconstruction import (
     set_commit_chunk_attribution_sync,
 )
 from nexus.agents.orrery.tag_writer import _row_value, apply_tag_bestowal
+from nexus.api.choice_handling import (
+    normalize_choice_object,
+    selected_text_from_choice_object,
+)
 from nexus.api.db_converters import chronology_to_db_values
 from nexus.api.summary_triggers import (
     SummaryTask,
@@ -48,9 +52,9 @@ from nexus.memory.correspondence import (
     persist_staged_correspondence,
     plan_correspondence_compaction,
 )
-from nexus.api.choice_handling import (
-    normalize_choice_object,
-    selected_text_from_choice_object,
+from nexus.memory.context_state import (
+    bind_pass2_baseline,
+    validate_staged_pass2_baseline,
 )
 
 logger = logging.getLogger("nexus.api.commit_handler_sync")
@@ -323,6 +327,7 @@ def commit_incubator_to_database_sync(
                            COALESCE(new_entities, '[]'::jsonb) AS new_entities,
                            correspondence_writer_letter,
                            correspondence_gaia_letter,
+                           lore_pass_baseline,
                            metadata_updates, entity_updates, reference_updates,
                            llm_response_id, generation_model, status
                     FROM incubator
@@ -337,6 +342,7 @@ def commit_incubator_to_database_sync(
                     raise ValueError(
                         f"No incubator data found for session {session_id}"
                     )
+                validate_staged_pass2_baseline(incubator["lore_pass_baseline"])
 
                 logger.info("Processing incubator session %s", session_id)
 
@@ -433,6 +439,21 @@ def commit_incubator_to_database_sync(
                 if chunk_id is None:
                     raise ValueError("Failed to obtain chunk_id after insert")
                 logger.info("Created narrative chunk %s", chunk_id)
+                bound_baseline = bind_pass2_baseline(
+                    incubator["lore_pass_baseline"], chunk_id
+                )
+                cur.execute(
+                    """
+                    INSERT INTO lore_pass_baselines (
+                        chunk_id, schema_version, payload
+                    ) VALUES (%s, %s, %s::jsonb)
+                    """,
+                    (
+                        chunk_id,
+                        bound_baseline.schema_version,
+                        json.dumps(bound_baseline.model_dump(mode="json")),
+                    ),
+                )
                 # Attribute trigger-versioned writes in this transaction
                 # (relationship_versions) to the committing chunk.
                 set_commit_chunk_attribution_sync(cur, chunk_id)

--- a/nexus/api/lore_adapter.py
+++ b/nexus/api/lore_adapter.py
@@ -16,6 +16,7 @@ from nexus.api.choice_handling import (
     selected_text_from_choice_object,
 )
 from nexus.memory.correspondence import GeneratedCorrespondence
+from nexus.memory.context_state import Pass2BaselineV1, validate_staged_pass2_baseline
 
 logger = logging.getLogger("nexus.api.lore_adapter")
 
@@ -128,6 +129,7 @@ def response_to_incubator(
     parent_chunk_id: int,
     user_text: str,
     session_id: str,
+    lore_pass_baseline: Pass2BaselineV1,
     orrery_proposal: Optional[Any] = None,
     bleed_offer_resolution_ids: Iterable[int] = (),
     correspondence: Optional[GeneratedCorrespondence] = None,
@@ -140,6 +142,7 @@ def response_to_incubator(
         parent_chunk_id: The parent chunk being continued from
         user_text: The user's input text
         session_id: Session ID for tracking
+        lore_pass_baseline: Unbound durable Pass-1 state for the generated prose
         orrery_proposal: Optional no-write Orrery proposal from TurnContext
         bleed_offer_resolution_ids: Resolutions offered to this exact draft
 
@@ -153,6 +156,7 @@ def response_to_incubator(
         raise ValueError("No narrative text in LORE response")
 
     generation_model = getattr(response, "generation_model", None)
+    staged_baseline = validate_staged_pass2_baseline(lore_pass_baseline)
 
     # Extract choice object (presented choices, no selection yet)
     choice_obj = extract_choice_object(response)
@@ -185,6 +189,7 @@ def response_to_incubator(
         "correspondence_gaia_letter": (
             correspondence.gaia_letter if correspondence is not None else None
         ),
+        "lore_pass_baseline": staged_baseline.model_dump(mode="json"),
         "session_id": session_id,
         "llm_response_id": getattr(response, "response_id", None),
         "status": "provisional",
@@ -381,6 +386,7 @@ def validate_incubator_data(incubator_data: Dict[str, Any]) -> bool:
         "metadata_updates",
         "entity_updates",
         "reference_updates",
+        "lore_pass_baseline",
         "session_id",
         "status",
     ]
@@ -391,6 +397,8 @@ def validate_incubator_data(incubator_data: Dict[str, Any]) -> bool:
 
     if not incubator_data["storyteller_text"]:
         raise ValueError("Storyteller text cannot be empty")
+
+    validate_staged_pass2_baseline(incubator_data["lore_pass_baseline"])
 
     if incubator_data["chunk_id"] <= incubator_data["parent_chunk_id"]:
         raise ValueError("Chunk ID must be greater than parent chunk ID")

--- a/nexus/api/narrative_generation.py
+++ b/nexus/api/narrative_generation.py
@@ -23,6 +23,8 @@ from nexus.api.lore_adapter import (
     validate_incubator_data,
 )
 from nexus.api.narrative_lease import finish_generation
+from nexus.memory.context_state import validate_staged_pass2_baseline
+from nexus.memory.manager import empty_pass2_baseline
 from nexus.telemetry.usage import usage_context
 
 logger = logging.getLogger("nexus.api.narrative_generation")
@@ -244,6 +246,9 @@ async def generate_narrative_async(
                     parent_chunk_id=parent_chunk_id,
                     user_text=user_text,
                     session_id=session_id,
+                    lore_pass_baseline=validate_staged_pass2_baseline(
+                        lore.turn_context.memory_state["lore_pass_baseline"]
+                    ),
                     orrery_proposal=(
                         lore.turn_context.orrery_proposal if lore.turn_context else None
                     ),
@@ -377,6 +382,7 @@ async def write_to_incubator(
     generation_model = data["generation_model"]
     if not isinstance(generation_model, str) or not generation_model.strip():
         raise ValueError("Generated incubator payload is missing its model id")
+    lore_pass_baseline = validate_staged_pass2_baseline(data["lore_pass_baseline"])
 
     values = (
         data["chunk_id"],
@@ -398,6 +404,7 @@ async def write_to_incubator(
         json.dumps(data.get("new_entities", [])),
         data.get("correspondence_writer_letter"),
         data.get("correspondence_gaia_letter"),
+        json.dumps(lore_pass_baseline.model_dump(mode="json")),
         data["session_id"],
         data["llm_response_id"],
         data["status"],
@@ -447,11 +454,11 @@ async def write_to_incubator(
                         metadata_updates, entity_updates, reference_updates,
                         orrery_proposal, orrery_adjudications,
                         new_entities, correspondence_writer_letter,
-                        correspondence_gaia_letter, session_id, llm_response_id,
-                        status
+                        correspondence_gaia_letter, lore_pass_baseline, session_id,
+                        llm_response_id, status
                     ) VALUES (
                         TRUE, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                        %s, %s, %s, %s, %s, %s, %s
+                        %s, %s, %s, %s, %s, %s, %s, %s
                     )
                     """,
                     values,
@@ -485,6 +492,7 @@ async def write_to_incubator(
                         new_entities = %s,
                         correspondence_writer_letter = %s,
                         correspondence_gaia_letter = %s,
+                        lore_pass_baseline = %s,
                         session_id = %s,
                         llm_response_id = %s,
                         status = %s,
@@ -710,6 +718,7 @@ async def generate_bootstrap_narrative(
             "factions": [],
         },
         "orrery_adjudications": [],
+        "lore_pass_baseline": empty_pass2_baseline(settings).model_dump(mode="json"),
         "session_id": session_id,
         "llm_response_id": f"bootstrap_{uuid.uuid4().hex[:8]}",
         "status": "provisional",

--- a/nexus/memory/__init__.py
+++ b/nexus/memory/__init__.py
@@ -1,10 +1,11 @@
 """Memory subsystem for LORE's two-pass narrative workflow."""
 
 from .manager import ContextMemoryManager
-from .context_state import ContextPackage, PassTransition
+from .context_state import ContextPackage, Pass2BaselineV1, PassTransition
 
 __all__ = [
     "ContextMemoryManager",
     "ContextPackage",
+    "Pass2BaselineV1",
     "PassTransition",
 ]

--- a/nexus/memory/context_state.py
+++ b/nexus/memory/context_state.py
@@ -4,7 +4,28 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Union
+from typing import (
+    Annotated,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Set,
+    Union,
+)
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    NonNegativeInt,
+    PositiveInt,
+    StrictInt,
+    model_validator,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +33,58 @@ logger = logging.getLogger(__name__)
 MemoryIdentity = Union[int, str]
 RETROGRADE_SUMMARY_CONTENT_TYPE = "retrograde_summary"
 RETROGRADE_SUMMARY_ID_PREFIX = "retrograde_summary:"
+PASS2_BASELINE_SCHEMA_VERSION = 1
+PASS2_BASELINE_PRODUCER = "nexus.memory.context_memory_manager"
+
+PersistedRetrogradeIdentity = Annotated[
+    str,
+    Field(pattern=r"^retrograde_summary:[1-9][0-9]*$"),
+]
+PersistedMemoryIdentity = Union[StrictInt, PersistedRetrogradeIdentity]
+
+
+class Pass2BaselineV1(BaseModel):
+    """Durable Pass-1 state required to run Pass 2 on the next turn."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    schema_version: Literal[1] = PASS2_BASELINE_SCHEMA_VERSION
+    producer: Literal["nexus.memory.context_memory_manager"] = PASS2_BASELINE_PRODUCER
+    config_fingerprint: Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
+    parent_chunk_id: Optional[PositiveInt] = None
+    memory_identities: List[PersistedMemoryIdentity]
+    prior_token_accounting: Dict[str, NonNegativeInt]
+    remaining_budget: NonNegativeInt
+
+    @model_validator(mode="after")
+    def validate_memory_identities(self) -> "Pass2BaselineV1":
+        """Reject booleans, non-positive chunk ids, and duplicate identities."""
+
+        identities: List[MemoryIdentity] = list(self.memory_identities)
+        for identity in identities:
+            if isinstance(identity, int) and identity <= 0:
+                raise ValueError("narrative memory identities must be positive")
+        if len(set(identities)) != len(identities):
+            raise ValueError("memory identities must be unique")
+        return self
+
+
+def validate_staged_pass2_baseline(payload: Any) -> Pass2BaselineV1:
+    """Validate an incubator baseline and require it to remain ID-unbound."""
+
+    baseline = Pass2BaselineV1.model_validate(payload)
+    if baseline.parent_chunk_id is not None:
+        raise ValueError("Staged Pass-2 baseline must not predict an accepted chunk id")
+    return baseline
+
+
+def bind_pass2_baseline(payload: Any, chunk_id: int) -> Pass2BaselineV1:
+    """Bind a validated staged baseline to the actual accepted chunk id."""
+
+    if isinstance(chunk_id, bool) or not isinstance(chunk_id, int) or chunk_id <= 0:
+        raise ValueError("Accepted Pass-2 baseline chunk id must be positive")
+    staged = validate_staged_pass2_baseline(payload)
+    return staged.model_copy(update={"parent_chunk_id": chunk_id})
 
 
 def is_retrograde_summary(memory: Dict[str, Any]) -> bool:

--- a/nexus/memory/manager.py
+++ b/nexus/memory/manager.py
@@ -516,11 +516,21 @@ class ContextMemoryManager:
                 identity if isinstance(identity, int) else str(identity),
             ),
         )
+        prior_token_accounting: Dict[str, int] = {}
+        for name, value in package.token_usage.items():
+            if name == "using_reasoning_model" and isinstance(value, bool):
+                continue
+            if not isinstance(value, int) or value < 0:
+                raise ValueError(
+                    "Pass-2 baseline token accounting values must be "
+                    f"nonnegative integers: {name}={value!r}"
+                )
+            prior_token_accounting[name] = value
         return Pass2BaselineV1(
             producer=PASS2_BASELINE_PRODUCER,
             config_fingerprint=pass2_baseline_config_fingerprint(self.settings),
             memory_identities=identities,
-            prior_token_accounting=package.token_usage,
+            prior_token_accounting=prior_token_accounting,
             remaining_budget=transition.remaining_budget,
         )
 

--- a/nexus/memory/manager.py
+++ b/nexus/memory/manager.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import re
 from collections import Counter
@@ -14,6 +16,9 @@ from .context_state import (
     ContextPackage,
     ContextStateManager,
     MemoryIdentity,
+    PASS2_BASELINE_PRODUCER,
+    RETROGRADE_SUMMARY_ID_PREFIX,
+    Pass2BaselineV1,
     PassTransition,
     is_retrograde_summary,
     memory_identity,
@@ -38,6 +43,53 @@ except ImportError:  # pragma: no cover - fallback if module unavailable
 logger = logging.getLogger(__name__)
 
 _STORYTELLER_WIRE_CLASSES = frozenset({"openai", "anthropic", "local"})
+
+
+class MissingPass2BaselineError(RuntimeError):
+    """An accepted parent chunk has no durable Pass-2 baseline."""
+
+
+def pass2_baseline_config_fingerprint(settings: Mapping[str, Any]) -> str:
+    """Fingerprint configuration that determines two-pass memory behavior."""
+
+    legacy_agent_settings = settings.get("Agent Settings")
+    legacy_lore_settings = (
+        legacy_agent_settings.get("LORE")
+        if isinstance(legacy_agent_settings, Mapping)
+        else None
+    )
+    lore_settings = (
+        legacy_lore_settings
+        if isinstance(legacy_lore_settings, Mapping)
+        else settings.get("lore", {})
+    )
+    payload = {
+        "memory": settings.get("memory", {}),
+        "lore_token_budget": (
+            lore_settings.get("token_budget", {})
+            if isinstance(lore_settings, Mapping)
+            else {}
+        ),
+    }
+    serialized = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def empty_pass2_baseline(settings: Mapping[str, Any]) -> Pass2BaselineV1:
+    """Build the explicit empty baseline staged by bootstrap/admin boundary tools."""
+
+    return Pass2BaselineV1(
+        producer=PASS2_BASELINE_PRODUCER,
+        config_fingerprint=pass2_baseline_config_fingerprint(settings),
+        memory_identities=[],
+        prior_token_accounting={},
+        remaining_budget=0,
+    )
 
 
 def _storyteller_token_budget(settings: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -433,6 +485,139 @@ class ContextMemoryManager:
             dbname,
             max_tokens=max_tokens,
         )
+
+    def export_pass2_baseline(self) -> Pass2BaselineV1:
+        """Export the current post-trimming Pass-1 state for incubator staging."""
+
+        package = self.context_state.context
+        transition = self.context_state.transition
+        if package is None or transition is None:
+            raise RuntimeError(
+                "Cannot export a Pass-2 baseline before Pass 1 completes"
+            )
+
+        normalized_identities: Set[MemoryIdentity] = set()
+        for identity in package.baseline_chunks:
+            if isinstance(identity, str) and not identity.startswith(
+                RETROGRADE_SUMMARY_ID_PREFIX
+            ):
+                try:
+                    identity = int(identity)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Unsupported Pass-2 baseline memory identity {identity!r}"
+                    ) from exc
+            normalized_identities.add(identity)
+
+        identities = sorted(
+            normalized_identities,
+            key=lambda identity: (
+                0 if isinstance(identity, int) else 1,
+                identity if isinstance(identity, int) else str(identity),
+            ),
+        )
+        return Pass2BaselineV1(
+            producer=PASS2_BASELINE_PRODUCER,
+            config_fingerprint=pass2_baseline_config_fingerprint(self.settings),
+            memory_identities=identities,
+            prior_token_accounting=package.token_usage,
+            remaining_budget=transition.remaining_budget,
+        )
+
+    def restore_pass2_baseline(self, parent_chunk_id: int) -> Pass2BaselineV1:
+        """Hydrate Pass-2 state from one accepted parent chunk or fail loudly."""
+
+        if (
+            isinstance(parent_chunk_id, bool)
+            or not isinstance(parent_chunk_id, int)
+            or parent_chunk_id <= 0
+        ):
+            raise ValueError("Pass-2 baseline parent_chunk_id must be positive")
+        engine = getattr(getattr(self.memnon, "db_manager", None), "engine", None)
+        if engine is None:
+            raise RuntimeError(
+                "Pass-2 baseline restoration requires MEMNON database access"
+            )
+
+        with engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        """
+                    SELECT b.schema_version, b.payload, n.storyteller_text
+                    FROM lore_pass_baselines AS b
+                    JOIN narrative_chunks AS n ON n.id = b.chunk_id
+                    WHERE b.chunk_id = :chunk_id
+                    """
+                    ),
+                    {"chunk_id": parent_chunk_id},
+                )
+                .mappings()
+                .one_or_none()
+            )
+            if row is None:
+                parent_exists = conn.execute(
+                    text(
+                        "SELECT EXISTS (SELECT 1 FROM narrative_chunks WHERE id = :id)"
+                    ),
+                    {"id": parent_chunk_id},
+                ).scalar_one()
+                if not parent_exists:
+                    raise ValueError(
+                        f"Cannot restore Pass-2 baseline: parent chunk "
+                        f"{parent_chunk_id} does not exist"
+                    )
+                raise MissingPass2BaselineError(
+                    "Accepted parent chunk "
+                    f"{parent_chunk_id} has no lore_pass_baselines row. Stamp the "
+                    "slot's current migration boundary with "
+                    "scripts/stamp_lore_pass_baseline.py --slot <1-5>, then retry."
+                )
+
+        baseline = Pass2BaselineV1.model_validate(row["payload"])
+        if row["schema_version"] != baseline.schema_version:
+            raise RuntimeError(
+                "Pass-2 baseline schema columns disagree for parent chunk "
+                f"{parent_chunk_id}: column={row['schema_version']}, "
+                f"payload={baseline.schema_version}"
+            )
+        if baseline.parent_chunk_id != parent_chunk_id:
+            raise RuntimeError(
+                "Pass-2 baseline parent identity mismatch: requested "
+                f"{parent_chunk_id}, payload={baseline.parent_chunk_id}"
+            )
+        expected_fingerprint = pass2_baseline_config_fingerprint(self.settings)
+        if baseline.config_fingerprint != expected_fingerprint:
+            raise RuntimeError(
+                "Pass-2 baseline config fingerprint is incompatible for parent "
+                f"chunk {parent_chunk_id}: stored={baseline.config_fingerprint}, "
+                f"current={expected_fingerprint}"
+            )
+
+        storyteller_output = row["storyteller_text"]
+        if not isinstance(storyteller_output, str) or not storyteller_output:
+            raise RuntimeError(
+                f"Accepted parent chunk {parent_chunk_id} has no storyteller output"
+            )
+        analysis = self._analyze_storyteller_output(storyteller_output)
+        package = ContextPackage(
+            baseline_chunks=set(baseline.memory_identities),
+            baseline_entities={
+                "characters": analysis.get("characters", []),
+                "locations": analysis.get("locations", []),
+                "keywords": analysis.get("keywords", []),
+            },
+            baseline_themes=analysis.get("themes", []),
+            token_usage=dict(baseline.prior_token_accounting),
+        )
+        transition = PassTransition(
+            storyteller_output=storyteller_output,
+            expected_user_themes=analysis.get("expected", []),
+            remaining_budget=baseline.remaining_budget,
+        )
+        self.context_state.store_baseline(package, transition)
+        self.query_memory.reset_pass("pass2")
+        return baseline
 
     def handle_storyteller_response(
         self,

--- a/scripts/stamp_lore_pass_baseline.py
+++ b/scripts/stamp_lore_pass_baseline.py
@@ -1,0 +1,81 @@
+"""Stamp an explicit empty Pass-2 baseline at a save's migration boundary.
+
+Usage:
+    python scripts/stamp_lore_pass_baseline.py --slot 2
+
+Run this once after migration 107 for an existing save whose accepted tail
+predates durable LORE baselines. It never infers a historical retrieval set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import psycopg2
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from nexus.api.slot_utils import get_slot_db_url  # noqa: E402
+from nexus.config import load_settings_as_dict  # noqa: E402
+from nexus.memory.context_state import bind_pass2_baseline  # noqa: E402
+from nexus.memory.manager import empty_pass2_baseline  # noqa: E402
+
+
+def stamp_slot_tail(slot: int) -> int:
+    """Stamp the slot's accepted tail and return its narrative chunk id."""
+
+    settings = load_settings_as_dict()
+    staged = empty_pass2_baseline(settings)
+    with psycopg2.connect(get_slot_db_url(slot=slot)) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT id FROM narrative_chunks ORDER BY id DESC LIMIT 1")
+            row = cur.fetchone()
+            if row is None:
+                raise RuntimeError(f"Slot {slot} has no accepted narrative tail")
+            chunk_id = int(row[0])
+
+            cur.execute(
+                "SELECT 1 FROM lore_pass_baselines WHERE chunk_id = %s",
+                (chunk_id,),
+            )
+            if cur.fetchone() is not None:
+                raise RuntimeError(
+                    f"Slot {slot} tail chunk {chunk_id} already has a Pass-2 baseline"
+                )
+
+            bound = bind_pass2_baseline(staged, chunk_id)
+            cur.execute(
+                """
+                INSERT INTO lore_pass_baselines (chunk_id, schema_version, payload)
+                VALUES (%s, %s, %s::jsonb)
+                """,
+                (
+                    chunk_id,
+                    bound.schema_version,
+                    json.dumps(bound.model_dump(mode="json")),
+                ),
+            )
+    return chunk_id
+
+
+def main(argv: Any = None) -> int:
+    """Parse CLI arguments and stamp one explicitly selected save slot."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slot", type=int, choices=range(1, 6), required=True)
+    args = parser.parse_args(argv)
+    chunk_id = stamp_slot_tail(args.slot)
+    print(
+        f"Stamped slot {args.slot} tail chunk {chunk_id} with an explicit empty "
+        "Pass-2 migration-boundary baseline."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_api/test_correspondence_pg.py
+++ b/tests/test_api/test_correspondence_pg.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import threading
 import time
@@ -24,10 +25,13 @@ from nexus.memory.correspondence import (
     plan_correspondence_compaction,
     read_accepted_correspondence,
 )
+from nexus.memory.manager import empty_pass2_baseline
 from scripts.replay_state import _verify_correspondence_provenance
 
 
 pytestmark = pytest.mark.requires_postgres
+
+TEST_BASELINE_PAYLOAD = empty_pass2_baseline({}).model_dump(mode="json")
 
 
 def _connect(dbname: str, *, dict_cursor: bool = False) -> Any:
@@ -65,6 +69,7 @@ def disposable_correspondence_db() -> Iterator[str]:
                 ).read_text()
                 cur.execute(migration)
                 cur.execute(migration)
+                cur.execute(Path("migrations/107_lore_pass_baselines.sql").read_text())
         yield dbname
     finally:
         with admin.cursor() as cur:
@@ -156,15 +161,20 @@ def test_parallel_approvals_claim_incubator_row_once(
                     id, chunk_id, parent_chunk_id, user_text, storyteller_text,
                     generation_model, metadata_updates, entity_updates,
                     reference_updates, orrery_adjudications, new_entities,
-                    session_id, llm_response_id, status
+                    lore_pass_baseline, session_id, llm_response_id, status
                 ) VALUES (
                     TRUE, 2, %s, 'continue', %s, 'TEST',
                     '{}'::jsonb, '{}'::jsonb, '{}'::jsonb,
-                    '[]'::jsonb, '[]'::jsonb, %s, 'parallel-approval',
+                    '[]'::jsonb, '[]'::jsonb, %s::jsonb, %s, 'parallel-approval',
                     'provisional'
                 )
                 """,
-                (parent_chunk_id, storyteller_text, session_id),
+                (
+                    parent_chunk_id,
+                    storyteller_text,
+                    json.dumps(TEST_BASELINE_PAYLOAD),
+                    session_id,
+                ),
             )
 
     first_conn = _connect(dbname)
@@ -349,6 +359,7 @@ def test_accept_reject_hysteresis_and_digest_undo(
                         "new_entities": [],
                         "correspondence_writer_letter": "rejected writer secret",
                         "correspondence_gaia_letter": "rejected gaia secret",
+                        "lore_pass_baseline": TEST_BASELINE_PAYLOAD,
                         "session_id": session_id,
                         "llm_response_id": "response-617",
                         "status": "provisional",
@@ -414,6 +425,7 @@ def test_accept_reject_hysteresis_and_digest_undo(
                     "new_entities": [],
                     "correspondence_writer_letter": "writer secret 11",
                     "correspondence_gaia_letter": "gaia secret 11",
+                    "lore_pass_baseline": TEST_BASELINE_PAYLOAD,
                     "session_id": session_id,
                     "llm_response_id": "response-accepted-617",
                     "status": "provisional",

--- a/tests/test_api/test_lore_adapter.py
+++ b/tests/test_api/test_lore_adapter.py
@@ -128,6 +128,7 @@ def test_response_to_incubator_stages_exact_draft_bleed_manifest() -> None:
         user_text="Continue.",
         session_id="draft-a",
         bleed_offer_resolution_ids=[501],
+        lore_pass_baseline=TEST_BASELINE,
     )
     draft_b = response_to_incubator(
         response=response,
@@ -135,6 +136,7 @@ def test_response_to_incubator_stages_exact_draft_bleed_manifest() -> None:
         user_text="Continue.",
         session_id="draft-b",
         bleed_offer_resolution_ids=[],
+        lore_pass_baseline=TEST_BASELINE,
     )
 
     assert split_staged_orrery_payload(draft_a["orrery_proposal"]) == (None, (501,))

--- a/tests/test_api/test_lore_adapter.py
+++ b/tests/test_api/test_lore_adapter.py
@@ -6,6 +6,10 @@ from nexus.agents.logon.apex_schema import (
     StorytellerResponseExtended,
 )
 from nexus.api.lore_adapter import response_to_incubator, split_staged_orrery_payload
+from nexus.memory.manager import empty_pass2_baseline
+
+
+TEST_BASELINE = empty_pass2_baseline({})
 
 
 def test_response_to_incubator_serializes_current_reference_schema() -> None:
@@ -72,6 +76,7 @@ def test_response_to_incubator_serializes_current_reference_schema() -> None:
         parent_chunk_id=1,
         user_text="I cross the street.",
         session_id="session-1",
+        lore_pass_baseline=TEST_BASELINE,
     )
 
     assert incubator["metadata_updates"]["chronology"]["time_delta_minutes"] == 1
@@ -174,6 +179,7 @@ def test_response_to_incubator_threads_generation_model_verbatim() -> None:
         parent_chunk_id=1,
         user_text="Continue.",
         session_id="session-missing-model",
+        lore_pass_baseline=TEST_BASELINE,
     )
     assert unstamped["generation_model"] is None
 
@@ -183,6 +189,7 @@ def test_response_to_incubator_threads_generation_model_verbatim() -> None:
         parent_chunk_id=1,
         user_text="Continue.",
         session_id="session-stamped-model",
+        lore_pass_baseline=TEST_BASELINE,
     )
     assert stamped["generation_model"] == "gpt-5.6-terra"
 
@@ -259,6 +266,7 @@ def test_response_to_incubator_preserves_full_canonical_state_updates() -> None:
         parent_chunk_id=9,
         user_text="Follow the sound.",
         session_id="rich-state-roundtrip",
+        lore_pass_baseline=TEST_BASELINE,
     )
     payload = incubator["entity_updates"]
 

--- a/tests/test_api/test_narrative_generation.py
+++ b/tests/test_api/test_narrative_generation.py
@@ -21,6 +21,7 @@ from nexus.api.narrative_schemas import (
     RegenerateNarrativeRequest,
 )
 from nexus.memory.correspondence import GeneratedCorrespondence
+from nexus.memory.manager import empty_pass2_baseline
 
 
 @pytest.fixture(autouse=True)
@@ -160,6 +161,11 @@ async def test_continuation_threads_logon_model_into_incubator(
                 error_log=[],
                 orrery_proposal=None,
                 bleed_menu=[SimpleNamespace(resolution_id=501)],
+                memory_state={
+                    "lore_pass_baseline": empty_pass2_baseline({}).model_dump(
+                        mode="json"
+                    )
+                },
                 private_correspondence=GeneratedCorrespondence(
                     writer_letter=self.secret,
                     gaia_letter="PRIVATE-GAIA-PROGRESS-SENTINEL",
@@ -316,6 +322,8 @@ async def test_bootstrap_threads_logon_model_into_incubator_payload(
     )
 
     assert payload["generation_model"] == "resolved-bootstrap-model"
+    assert payload["lore_pass_baseline"]["memory_identities"] == []
+    assert payload["lore_pass_baseline"]["parent_chunk_id"] is None
     assert payload["reference_updates"]["places"] == [
         {
             "place_id": 27,

--- a/tests/test_api/test_orrery_config_reuse_pg.py
+++ b/tests/test_api/test_orrery_config_reuse_pg.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import uuid
+from pathlib import Path
 from typing import Any, Iterator
 
 import asyncpg  # type: ignore[import-untyped]
@@ -14,9 +15,12 @@ from psycopg2 import sql
 
 import nexus.config as config_module
 from nexus.api import commit_handler, commit_handler_sync
+from nexus.memory.manager import empty_pass2_baseline
 
 
 pytestmark = pytest.mark.requires_postgres
+
+TEST_BASELINE_PAYLOAD = empty_pass2_baseline({}).model_dump(mode="json")
 
 
 def _connect(dbname: str) -> Any:
@@ -45,6 +49,9 @@ def qa654_db() -> Iterator[str]:
                     sql.Identifier("NEXUS_template"),
                 )
             )
+        with _connect(dbname) as conn:
+            with conn.cursor() as cur:
+                cur.execute(Path("migrations/107_lore_pass_baselines.sql").read_text())
         yield dbname
     finally:
         with admin.cursor() as cur:
@@ -87,14 +94,15 @@ def _seed_commit(dbname: str, session_id: str) -> int:
                     id, chunk_id, parent_chunk_id, user_text, storyteller_text,
                     generation_model, metadata_updates, entity_updates,
                     reference_updates, orrery_proposal, orrery_adjudications,
-                    new_entities, session_id, llm_response_id, status
+                    new_entities, lore_pass_baseline, session_id,
+                    llm_response_id, status
                 ) VALUES (
                     TRUE, 2, %s, 'continue', 'Accepted scene.', 'TEST',
                     '{}'::jsonb, NULL, '{}'::jsonb, NULL, '[]'::jsonb,
-                    '[]'::jsonb, %s, 'qa654-response', 'provisional'
+                    '[]'::jsonb, %s::jsonb, %s, 'qa654-response', 'provisional'
                 )
                 """,
-                (parent_chunk_id, session_id),
+                (parent_chunk_id, json.dumps(TEST_BASELINE_PAYLOAD), session_id),
             )
     return parent_chunk_id
 

--- a/tests/test_commit_handler.py
+++ b/tests/test_commit_handler.py
@@ -1,5 +1,6 @@
 """Unit tests for asynchronous narrative commit helpers."""
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -15,6 +16,11 @@ from nexus.api.commit_handler import (
 import nexus.api.commit_handler as commit_handler
 from nexus.api.lore_adapter import response_to_incubator
 from nexus.api.presence_reconciliation import CharacterRosterRows
+from nexus.memory.manager import empty_pass2_baseline
+
+
+TEST_BASELINE = empty_pass2_baseline({})
+TEST_BASELINE_PAYLOAD = TEST_BASELINE.model_dump(mode="json")
 
 
 class RecordingAsyncConnection:
@@ -86,6 +92,7 @@ class AsyncCommitConnection:
             },
             "llm_response_id": "response-2",
             "generation_model": "test-model",
+            "lore_pass_baseline": TEST_BASELINE_PAYLOAD,
             "status": "provisional",
         }
 
@@ -231,6 +238,13 @@ async def test_async_commit_links_same_turn_character_declaration(monkeypatch):
 
     assert chunk_id == conn.chunk_id
     assert conn.character_junctions == [(conn.chunk_id, 72, "present")]
+    baseline_writes = [
+        args
+        for sql, args in conn.statements
+        if sql.startswith("INSERT INTO lore_pass_baselines")
+    ]
+    assert baseline_writes[0][:2] == (conn.chunk_id, 1)
+    assert json.loads(baseline_writes[0][2])["parent_chunk_id"] == conn.chunk_id
 
 
 @pytest.mark.asyncio
@@ -316,6 +330,7 @@ async def test_async_reconciled_mentions_flow_through_adapter_and_commit(monkeyp
         parent_chunk_id=88,
         user_text="Continue.",
         session_id="async-655",
+        lore_pass_baseline=TEST_BASELINE,
     )
 
     async def no_op(*_args, **_kwargs):

--- a/tests/test_commit_handler_sync.py
+++ b/tests/test_commit_handler_sync.py
@@ -1,5 +1,6 @@
 """Unit tests for synchronous narrative commit helpers."""
 
+import json
 import logging
 from types import SimpleNamespace
 
@@ -22,6 +23,11 @@ from nexus.api.commit_handler_sync import (
 import nexus.api.commit_handler_sync as commit_handler_sync
 from nexus.api.lore_adapter import response_to_incubator
 from nexus.api.presence_reconciliation import CharacterRosterRows
+from nexus.memory.manager import empty_pass2_baseline
+
+
+TEST_BASELINE = empty_pass2_baseline({})
+TEST_BASELINE_PAYLOAD = TEST_BASELINE.model_dump(mode="json")
 
 
 class MissingLookupCursor:
@@ -200,6 +206,7 @@ class CommitConnection:
             },
             "llm_response_id": "response-1",
             "generation_model": "test-model",
+            "lore_pass_baseline": TEST_BASELINE_PAYLOAD,
             "status": "provisional",
         }
 
@@ -285,6 +292,13 @@ def test_sync_commit_links_same_turn_character_declaration(monkeypatch):
 
     assert chunk_id == conn.chunk_id
     assert conn.character_junctions == [(conn.chunk_id, 71, "present")]
+    baseline_writes = [
+        params
+        for sql, params in conn.statements
+        if sql.startswith("INSERT INTO lore_pass_baselines")
+    ]
+    assert baseline_writes[0][:2] == (conn.chunk_id, 1)
+    assert json.loads(baseline_writes[0][2])["parent_chunk_id"] == conn.chunk_id
     assert any(
         "FROM incubator" in sql and "FOR UPDATE" in sql
         for sql, _params in conn.statements
@@ -453,6 +467,7 @@ def test_sync_reconciled_mentions_flow_through_adapter_and_commit(monkeypatch):
         parent_chunk_id=44,
         user_text="Continue.",
         session_id="sync-655",
+        lore_pass_baseline=TEST_BASELINE,
     )
     _patch_sync_commit_runtime(monkeypatch)
 

--- a/tests/test_correspondence.py
+++ b/tests/test_correspondence.py
@@ -42,6 +42,7 @@ from nexus.memory.correspondence import (
     load_compaction_system_prompt,
     plan_correspondence_compaction,
 )
+from nexus.memory.manager import empty_pass2_baseline
 
 
 PROMPTS_DIR = Path(__file__).parents[1] / "prompts"
@@ -188,6 +189,7 @@ def test_private_artifacts_never_enter_public_response_or_raw_text() -> None:
         parent_chunk_id=4,
         user_text="Inspect the room.",
         session_id="private-test",
+        lore_pass_baseline=empty_pass2_baseline({}),
         correspondence=secrets,
     )
     raw_text = compute_raw_text(

--- a/tests/test_lore/test_memory_manager.py
+++ b/tests/test_lore/test_memory_manager.py
@@ -195,7 +195,10 @@ def test_pass1_baseline_tracks_chunks_and_budget(
         narrative=baseline_inputs["narrative"],
         warm_slice=baseline_inputs["warm_slice"],
         retrieved_passages=baseline_inputs["retrieved"],
-        token_usage=baseline_inputs["token_usage"],
+        token_usage={
+            **baseline_inputs["token_usage"],
+            "using_reasoning_model": False,
+        },
     )
 
     # Baseline chunk ids combine warm slice and retrieved passages
@@ -215,7 +218,11 @@ def test_pass1_baseline_tracks_chunks_and_budget(
     exported = manager.export_pass2_baseline()
     assert exported.parent_chunk_id is None
     assert exported.memory_identities == [101, 102, 201]
-    assert exported.prior_token_accounting == package.token_usage
+    assert exported.prior_token_accounting == {
+        name: value
+        for name, value in package.token_usage.items()
+        if name != "using_reasoning_model"
+    }
     assert exported.remaining_budget == transition.remaining_budget
     dumped = exported.model_dump(mode="json")
     assert "storyteller_output" not in dumped

--- a/tests/test_lore/test_memory_manager.py
+++ b/tests/test_lore/test_memory_manager.py
@@ -7,8 +7,10 @@ import logging
 from typing import Dict, List
 
 import pytest
+from pydantic import ValidationError
 
 from nexus.memory import ContextMemoryManager
+from nexus.memory.context_state import Pass2BaselineV1
 from nexus.memory.divergence import DivergenceResult
 from nexus.memory.entity_detector import HighSpecificityEntityDetector
 
@@ -209,6 +211,45 @@ def test_pass1_baseline_tracks_chunks_and_budget(
     # Expected themes populated from narrative analysis
     assert "Alex" in transition.expected_user_themes
     assert "Emilia" in package.baseline_entities.get("characters", [])
+
+    exported = manager.export_pass2_baseline()
+    assert exported.parent_chunk_id is None
+    assert exported.memory_identities == [101, 102, 201]
+    assert exported.prior_token_accounting == package.token_usage
+    assert exported.remaining_budget == transition.remaining_budget
+    dumped = exported.model_dump(mode="json")
+    assert "storyteller_output" not in dumped
+    assert "assembled_context" not in dumped
+    assert "baseline_entities" not in dumped
+
+
+@pytest.mark.parametrize(
+    ("update", "message"),
+    [
+        ({"schema_version": 2}, "Input should be 1"),
+        ({"memory_identities": [True]}, "valid integer"),
+        ({"memory_identities": [0]}, "must be positive"),
+        ({"prior_token_accounting": {"warm_slice": -1}}, "greater than or equal"),
+        ({"remaining_budget": -1}, "greater than or equal"),
+    ],
+)
+def test_pass2_baseline_rejects_unsupported_or_invalid_state(
+    update: Dict[str, object], message: str
+) -> None:
+    """The durable wire fails closed on versions, identities, and budgets."""
+
+    payload: Dict[str, object] = {
+        "schema_version": 1,
+        "producer": "nexus.memory.context_memory_manager",
+        "config_fingerprint": "0" * 64,
+        "parent_chunk_id": None,
+        "memory_identities": [1, "retrograde_summary:2"],
+        "prior_token_accounting": {"warm_slice": 1},
+        "remaining_budget": 10,
+    }
+    payload.update(update)
+    with pytest.raises(ValidationError, match=message):
+        Pass2BaselineV1.model_validate(payload)
 
 
 def test_pass1_records_reserve_shortfall(

--- a/tests/test_lore/test_pass2_baseline_pg.py
+++ b/tests/test_lore/test_pass2_baseline_pg.py
@@ -1,0 +1,482 @@
+"""Ephemeral-PostgreSQL lifecycle coverage for durable Pass-2 baselines."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2
+import pytest
+from psycopg2 import sql
+from sqlalchemy import create_engine, text
+
+from nexus.agents.logon.apex_schema import StorytellerResponseStandard
+from nexus.api import commit_handler_sync
+from nexus.api.commit_handler_sync import commit_incubator_to_database_sync
+from nexus.api.lore_adapter import response_to_incubator
+from nexus.api.narrative_generation import write_to_incubator
+from nexus.memory.manager import ContextMemoryManager, MissingPass2BaselineError
+from scripts import stamp_lore_pass_baseline
+
+
+pytestmark = pytest.mark.requires_postgres
+
+MIGRATION = Path("migrations/107_lore_pass_baselines.sql")
+
+
+def _connect(dbname: str) -> Any:
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+
+
+@pytest.fixture()
+def pass2_database() -> Iterator[str]:
+    """Clone the template, apply migration 107, and always drop the clone."""
+
+    dbname = f"nexus_test_pass2_{uuid4().hex[:12]}"
+    source_db = os.environ.get("NEXUS_TEST_TEMPLATE_DB", "NEXUS_template")
+    admin = _connect("postgres")
+    admin.autocommit = True
+    try:
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname),
+                    sql.Identifier(source_db),
+                )
+            )
+        migration = MIGRATION.read_text()
+        with _connect(dbname) as conn:
+            with conn.cursor() as cur:
+                cur.execute(migration)
+                cur.execute(migration)
+                cur.execute("DELETE FROM incubator")
+                cur.execute("DELETE FROM narrative_generation_lease")
+                cur.execute("DELETE FROM narrative_generation_sessions")
+        yield dbname
+    finally:
+        with admin.cursor() as cur:
+            cur.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (dbname,),
+            )
+            cur.execute(
+                sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+            )
+        admin.close()
+
+
+def _settings() -> dict[str, Any]:
+    return {
+        "Agent Settings": {
+            "LORE": {
+                "token_budget": {
+                    "apex_context_window": 1_000,
+                    "provider_overrides": {},
+                }
+            }
+        },
+        "memory": {
+            "phase2_fraction": 0.1,
+            "raw_search_k": 30,
+            "skip_simple_choices": False,
+            "pass2_budget_reserve": 0.25,
+            "divergence_threshold": 0.7,
+            "warm_slice_default": True,
+            "max_sql_iterations": 5,
+        },
+    }
+
+
+class _DatabaseMemnon:
+    """Minimal MEMNON surface backed by the disposable database engine."""
+
+    def __init__(self, engine: Any, results: list[dict[str, Any]] | None = None):
+        self.db_manager = SimpleNamespace(engine=engine)
+        self.idf_dictionary = None
+        self.results = results or []
+
+    def query_memory(
+        self, query: str, k: int = 5, use_hybrid: bool = True
+    ) -> dict[str, Any]:
+        del query, k, use_hybrid
+        return {"results": copy.deepcopy(self.results)}
+
+
+def _seed_parent(conn: Any, label: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO narrative_chunks (raw_text, storyteller_text)
+            VALUES (%s, %s)
+            RETURNING id
+            """,
+            (label, label),
+        )
+        chunk_id = int(cur.fetchone()[0])
+        cur.execute(
+            """
+            INSERT INTO chunk_metadata (
+                chunk_id, season, episode, scene, world_layer, slug
+            ) VALUES (%s, 1, 1, 1, 'primary', %s)
+            """,
+            (chunk_id, f"pass2-{chunk_id}"),
+        )
+    return chunk_id
+
+
+def _create_lease(conn: Any, session_id: str, parent_chunk_id: int) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO narrative_generation_sessions (
+                session_id, operation, parent_chunk_id, status
+            ) VALUES (%s, 'continue', %s, 'initiated')
+            """,
+            (session_id, parent_chunk_id),
+        )
+        cur.execute(
+            """
+            INSERT INTO narrative_generation_lease (
+                id, session_id, parent_chunk_id, operation, expires_at
+            ) VALUES (TRUE, %s, %s, 'continue', NOW() + INTERVAL '5 minutes')
+            """,
+            (session_id, parent_chunk_id),
+        )
+
+
+def _replace_lease(conn: Any, session_id: str, parent_chunk_id: int) -> None:
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM narrative_generation_lease")
+    _create_lease(conn, session_id, parent_chunk_id)
+
+
+def _response(narrative: str) -> StorytellerResponseStandard:
+    return StorytellerResponseStandard.model_validate(
+        {
+            "generation_model": "TEST",
+            "narrative": narrative,
+            "choices": ["Continue.", "Wait."],
+            "chunk_metadata": {
+                "chronology": {"episode_transition": "continue"},
+                "world_layer": "primary",
+            },
+            "referenced_entities": {
+                "characters": [],
+                "places": [],
+                "factions": [],
+            },
+            "state_updates": {
+                "characters": [],
+                "locations": [],
+                "factions": [],
+                "relationships": [],
+            },
+        }
+    )
+
+
+def _patch_unrelated_commit_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        commit_handler_sync,
+        "commit_orrery_tick_sync",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            resolution_count=0,
+            event_count=0,
+            tag_mutation_count=0,
+            cleared_tag_count=0,
+            skipped_existing_count=0,
+            adjudication_count=0,
+            deferred_count=0,
+            voided_count=0,
+            replaced_count=0,
+            scene_pressure_count=0,
+            prompt_exposure_count=0,
+            propagation_count=0,
+            reveal_count=0,
+        ),
+    )
+    monkeypatch.setattr(
+        commit_handler_sync, "_orrery_checkpoint_interval", lambda _settings: 0
+    )
+    monkeypatch.setattr(
+        "nexus.api.presence_audit.presence_audit_enabled", lambda: False
+    )
+
+
+def test_two_turn_regeneration_sparse_promotion_restore_and_cascade(
+    pass2_database: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accepted turn N restores exact exclusions in a fresh manager for N+1."""
+
+    _patch_unrelated_commit_work(monkeypatch)
+    database_url = f"postgresql://{os.environ.get('PGUSER', 'pythagor')}@"
+    database_url += (
+        f"{os.environ.get('PGHOST', 'localhost')}:"
+        f"{os.environ.get('PGPORT', '5432')}/{pass2_database}"
+    )
+    engine = create_engine(database_url, future=True)
+    conn = _connect(pass2_database)
+    try:
+        parent_chunk_id = _seed_parent(conn, "accepted parent")
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO narrative_chunks (raw_text, storyteller_text) "
+                "VALUES ('retired', 'retired') RETURNING id"
+            )
+            retired_id = int(cur.fetchone()[0])
+            cur.execute("DELETE FROM narrative_chunks WHERE id = %s", (retired_id,))
+
+        manager_n = ContextMemoryManager(_settings(), memnon=_DatabaseMemnon(engine))
+        manager_n.handle_storyteller_response(
+            narrative="Provisional first generation.",
+            warm_slice=[{"chunk_id": parent_chunk_id, "text": "accepted parent"}],
+            retrieved_passages=[
+                {
+                    "memory_id": "retrograde_summary:7",
+                    "content_type": "retrograde_summary",
+                    "text": "summary",
+                }
+            ],
+            token_usage={
+                "total_available": 100,
+                "warm_slice": 10,
+                "structured": 0,
+                "augmentation": 0,
+            },
+            assembled_context={
+                "warm_slice": {"chunks": []},
+                "retrieved_passages": {"results": []},
+            },
+        )
+        first_baseline = manager_n.export_pass2_baseline()
+
+        first_session = str(uuid4())
+        _create_lease(conn, first_session, parent_chunk_id)
+        conn.commit()
+        first_payload = response_to_incubator(
+            _response("Provisional first generation."),
+            parent_chunk_id=parent_chunk_id,
+            user_text="Continue.",
+            session_id=first_session,
+            lore_pass_baseline=first_baseline,
+        )
+        asyncio.run(write_to_incubator(conn, first_payload))
+
+        second_baseline = first_baseline.model_copy(
+            update={"memory_identities": [parent_chunk_id, 999_998]}
+        )
+        second_session = str(uuid4())
+        _replace_lease(conn, second_session, parent_chunk_id)
+        conn.commit()
+        second_payload = response_to_incubator(
+            _response("Replacement generation."),
+            parent_chunk_id=parent_chunk_id,
+            user_text="Continue.",
+            session_id=second_session,
+            lore_pass_baseline=second_baseline,
+        )
+        asyncio.run(
+            write_to_incubator(
+                conn,
+                second_payload,
+                expected_incubator_session=first_session,
+            )
+        )
+        with conn.cursor() as cur:
+            cur.execute("SELECT storyteller_text, lore_pass_baseline FROM incubator")
+            staged_text, staged_baseline = cur.fetchone()
+        assert staged_text == "Replacement generation."
+        assert staged_baseline["memory_identities"] == [parent_chunk_id, 999_998]
+
+        accepted_chunk_id = commit_incubator_to_database_sync(
+            conn, second_session, slot=5
+        )
+        assert accepted_chunk_id > parent_chunk_id + 1
+        with engine.connect() as read_conn:
+            rows = read_conn.execute(
+                text(
+                    "SELECT chunk_id, payload FROM lore_pass_baselines "
+                    "WHERE chunk_id >= :parent ORDER BY chunk_id"
+                ),
+                {"parent": parent_chunk_id},
+            ).all()
+        assert [row[0] for row in rows] == [accepted_chunk_id]
+        assert rows[0][1]["parent_chunk_id"] == accepted_chunk_id
+
+        fresh_memnon = _DatabaseMemnon(
+            engine,
+            results=[
+                {"chunk_id": parent_chunk_id, "text": "duplicate parent"},
+                {"chunk_id": 999_998, "text": "duplicate retrieval"},
+                {"chunk_id": 999_999, "text": "new memory"},
+            ],
+        )
+        manager_n_plus_one = ContextMemoryManager(_settings(), memnon=fresh_memnon)
+        restored = manager_n_plus_one.restore_pass2_baseline(accepted_chunk_id)
+        manager_n_plus_one.configure_base_storyteller_budget()
+        update = manager_n_plus_one.handle_user_input("Investigate Zyxonium")
+        assert restored.memory_identities == [parent_chunk_id, 999_998]
+        assert update.baseline_available is True
+        assert [row["chunk_id"] for row in update.retrieved_chunks] == [999_999]
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM narrative_chunks WHERE id = %s", (accepted_chunk_id,)
+            )
+        conn.commit()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM lore_pass_baselines WHERE chunk_id = %s",
+                (accepted_chunk_id,),
+            )
+            assert cur.fetchone()[0] == 0
+    finally:
+        conn.close()
+        engine.dispose()
+
+
+def test_acceptance_failure_rolls_back_chunk_baseline_and_incubator_delete(
+    pass2_database: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-baseline acceptance failure leaves only the provisional row."""
+
+    _patch_unrelated_commit_work(monkeypatch)
+    conn = _connect(pass2_database)
+    try:
+        parent_chunk_id = _seed_parent(conn, "rollback parent")
+        session_id = str(uuid4())
+        _create_lease(conn, session_id, parent_chunk_id)
+        conn.commit()
+        baseline = ContextMemoryManager(_settings()).handle_storyteller_response(
+            narrative="Rollback candidate.",
+            warm_slice=[{"chunk_id": parent_chunk_id, "text": "parent"}],
+            token_usage={"total_available": 50, "warm_slice": 10},
+        )
+        assert baseline.baseline_chunks == {parent_chunk_id}
+        staged = ContextMemoryManager(_settings())
+        staged.handle_storyteller_response(
+            narrative="Rollback candidate.",
+            warm_slice=[{"chunk_id": parent_chunk_id, "text": "parent"}],
+            token_usage={"total_available": 50, "warm_slice": 10},
+        )
+        payload = response_to_incubator(
+            _response("Rollback candidate."),
+            parent_chunk_id=parent_chunk_id,
+            user_text="Continue.",
+            session_id=session_id,
+            lore_pass_baseline=staged.export_pass2_baseline(),
+        )
+        asyncio.run(write_to_incubator(conn, payload))
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM narrative_chunks")
+            before_chunks = int(cur.fetchone()[0])
+
+        monkeypatch.setattr(
+            commit_handler_sync,
+            "insert_chunk_metadata_sync",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("forced metadata failure")
+            ),
+        )
+        with pytest.raises(RuntimeError, match="forced metadata failure"):
+            commit_incubator_to_database_sync(conn, session_id, slot=5)
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM narrative_chunks")
+            assert cur.fetchone()[0] == before_chunks
+            cur.execute("SELECT count(*) FROM lore_pass_baselines")
+            assert cur.fetchone()[0] == 0
+            cur.execute(
+                "SELECT count(*) FROM incubator WHERE session_id = %s", (session_id,)
+            )
+            assert cur.fetchone()[0] == 1
+
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM incubator WHERE session_id = %s", (session_id,))
+        conn.commit()
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM incubator")
+            assert cur.fetchone()[0] == 0
+            cur.execute("SELECT count(*) FROM lore_pass_baselines")
+            assert cur.fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_missing_tail_error_and_admin_stamp_boundary(
+    pass2_database: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Historical tails fail loudly until the explicit empty boundary is stamped."""
+
+    database_url = f"postgresql://{os.environ.get('PGUSER', 'pythagor')}@"
+    database_url += (
+        f"{os.environ.get('PGHOST', 'localhost')}:"
+        f"{os.environ.get('PGPORT', '5432')}/{pass2_database}"
+    )
+    engine = create_engine(database_url, future=True)
+    conn = _connect(pass2_database)
+    try:
+        tail_chunk_id = _seed_parent(conn, "historical tail")
+        conn.commit()
+        manager = ContextMemoryManager(_settings(), memnon=_DatabaseMemnon(engine))
+        with pytest.raises(
+            MissingPass2BaselineError,
+            match=r"scripts/stamp_lore_pass_baseline.py --slot <1-5>",
+        ):
+            manager.restore_pass2_baseline(tail_chunk_id)
+
+        monkeypatch.setattr(
+            stamp_lore_pass_baseline,
+            "get_slot_db_url",
+            lambda slot: database_url,
+        )
+        monkeypatch.setattr(
+            stamp_lore_pass_baseline,
+            "load_settings_as_dict",
+            _settings,
+        )
+        assert stamp_lore_pass_baseline.stamp_slot_tail(5) == tail_chunk_id
+
+        fresh = ContextMemoryManager(_settings(), memnon=_DatabaseMemnon(engine))
+        restored = fresh.restore_pass2_baseline(tail_chunk_id)
+        assert restored.parent_chunk_id == tail_chunk_id
+        assert restored.memory_identities == []
+        assert restored.prior_token_accounting == {}
+        assert restored.remaining_budget == 0
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE lore_pass_baselines
+                SET payload = jsonb_set(
+                    payload,
+                    '{config_fingerprint}',
+                    to_jsonb(%s::text)
+                )
+                WHERE chunk_id = %s
+                """,
+                ("0" * 64, tail_chunk_id),
+            )
+        conn.commit()
+        incompatible = ContextMemoryManager(_settings(), memnon=_DatabaseMemnon(engine))
+        with pytest.raises(RuntimeError, match="config fingerprint is incompatible"):
+            incompatible.restore_pass2_baseline(tail_chunk_id)
+    finally:
+        conn.close()
+        engine.dispose()

--- a/tests/test_lore/test_pass2_baseline_pg.py
+++ b/tests/test_lore/test_pass2_baseline_pg.py
@@ -4,23 +4,34 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import json
 import os
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Iterator
 from uuid import uuid4
 
+import asyncpg
 import psycopg2
 import pytest
 from psycopg2 import sql
 from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
 
+from nexus.agents.lore.logon_utility import LogonUtility
+from nexus.agents.lore.lore import LORE
 from nexus.agents.logon.apex_schema import StorytellerResponseStandard
-from nexus.api import commit_handler_sync
+from nexus.api import commit_handler, commit_handler_sync
 from nexus.api.commit_handler_sync import commit_incubator_to_database_sync
 from nexus.api.lore_adapter import response_to_incubator
-from nexus.api.narrative_generation import write_to_incubator
-from nexus.memory.manager import ContextMemoryManager, MissingPass2BaselineError
+from nexus.api.narrative_generation import generate_narrative_async, write_to_incubator
+from nexus.config import load_settings_as_dict
+from nexus.memory.context_state import bind_pass2_baseline
+from nexus.memory.manager import (
+    ContextMemoryManager,
+    MissingPass2BaselineError,
+    empty_pass2_baseline,
+)
 from scripts import stamp_lore_pass_baseline
 
 
@@ -103,6 +114,7 @@ class _DatabaseMemnon:
 
     def __init__(self, engine: Any, results: list[dict[str, Any]] | None = None):
         self.db_manager = SimpleNamespace(engine=engine)
+        self.Session = sessionmaker(bind=engine)
         self.idf_dictionary = None
         self.results = results or []
 
@@ -111,6 +123,125 @@ class _DatabaseMemnon:
     ) -> dict[str, Any]:
         del query, k, use_hybrid
         return {"results": copy.deepcopy(self.results)}
+
+    def get_chunk_by_id(self, chunk_id: int) -> dict[str, Any] | None:
+        """Load one real narrative row for LORE's warm-slice anchor."""
+
+        with self.db_manager.engine.connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        "SELECT id, raw_text, storyteller_text "
+                        "FROM narrative_chunks WHERE id = :chunk_id"
+                    ),
+                    {"chunk_id": chunk_id},
+                )
+                .mappings()
+                .one_or_none()
+            )
+        if row is None:
+            return None
+        prose = row["storyteller_text"] or row["raw_text"] or ""
+        return {
+            "id": row["id"],
+            "chunk_id": row["id"],
+            "text": prose,
+            "full_text": prose,
+        }
+
+    def get_recent_chunks(self, limit: int = 10) -> dict[str, Any]:
+        """Load real recent narrative rows for LORE's warm slice."""
+
+        with self.db_manager.engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT id, raw_text, storyteller_text FROM narrative_chunks "
+                    "ORDER BY id DESC LIMIT :limit"
+                ),
+                {"limit": limit},
+            ).mappings()
+            results = [
+                {
+                    "id": row["id"],
+                    "chunk_id": row["id"],
+                    "text": row["storyteller_text"] or row["raw_text"] or "",
+                }
+                for row in rows
+            ]
+        return {"results": results}
+
+    def close(self) -> None:
+        """Leave the test-owned shared engine alive across fresh LORE instances."""
+
+
+class _RouteProvider:
+    """Structured-output provider stub used beneath a real LogonUtility."""
+
+    def __init__(self, outputs: list[dict[str, Any]]) -> None:
+        self.model = "gpt-4o"
+        self.system_prompt = "Pass-2 lifecycle provider stub"
+        self.outputs = outputs
+        self.calls: list[dict[str, Any]] = []
+
+    async def get_structured_completion_async(
+        self,
+        prompt: str,
+        schema_model: type,
+        **kwargs: Any,
+    ) -> tuple[Any, object]:
+        """Validate the queued payload through LOGON's selected wire schema."""
+
+        self.calls.append(
+            {"prompt": prompt, "schema_model": schema_model, "kwargs": kwargs}
+        )
+        if not self.outputs:
+            raise AssertionError("Provider stub exhausted")
+        return schema_model.model_validate(self.outputs.pop(0)), object()
+
+
+class _ProgressRecorder:
+    """Record the real narrative route's progress notifications."""
+
+    def __init__(self) -> None:
+        self.statuses: list[str] = []
+
+    async def send_progress(
+        self,
+        session_id: str,
+        status: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        """Capture one route notification without an external WebSocket."""
+
+        del session_id, data
+        self.statuses.append(status)
+
+
+def _wire_payload(narrative: str) -> dict[str, Any]:
+    return {
+        "narrative": narrative,
+        "choices": ["Continue.", "Wait."],
+        "orrery_adjudications": [],
+        "new_entities": [],
+        "letter": "Preserve the current continuity while advancing the scene.",
+    }
+
+
+async def _connect_async(dbname: str) -> asyncpg.Connection:
+    conn = await asyncpg.connect(
+        database=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+    )
+    for type_name in ("json", "jsonb"):
+        await conn.set_type_codec(
+            type_name,
+            schema="pg_catalog",
+            encoder=json.dumps,
+            decoder=json.loads,
+        )
+    return conn
 
 
 def _seed_parent(conn: Any, label: str) -> int:
@@ -216,7 +347,183 @@ def _patch_unrelated_commit_work(
     )
 
 
-def test_two_turn_regeneration_sparse_promotion_restore_and_cascade(
+def test_real_continuation_route_restores_pass2_baseline_in_fresh_lore(
+    pass2_database: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production continuation route hydrates Pass 2 across fresh LOREs."""
+
+    _patch_unrelated_commit_work(monkeypatch)
+    route_settings = load_settings_as_dict()
+    route_settings["orrery"]["enabled"] = False
+    route_settings["API Settings"]["apex"]["turn_pipeline"] = "single_pass"
+    route_settings["apex"]["turn_pipeline"] = "single_pass"
+
+    database_url = f"postgresql://{os.environ.get('PGUSER', 'pythagor')}@"
+    database_url += (
+        f"{os.environ.get('PGHOST', 'localhost')}:"
+        f"{os.environ.get('PGPORT', '5432')}/{pass2_database}"
+    )
+    engine = create_engine(database_url, future=True)
+    conn = _connect(pass2_database)
+    lore_instances: list[LORE] = []
+    provider_outputs = [
+        _wire_payload("Turn N provider prose."),
+        _wire_payload("Turn N plus one provider prose."),
+    ]
+    providers: list[_RouteProvider] = []
+    retrieval_id = 999_998
+    new_retrieval_id = 999_999
+    retrieval_batches = [
+        [{"chunk_id": retrieval_id, "text": "turn N retrieved memory"}],
+        [
+            {"chunk_id": retrieval_id, "text": "duplicate turn N memory"},
+            {"chunk_id": new_retrieval_id, "text": "new turn N+1 memory"},
+        ],
+    ]
+    memnon_count = 0
+
+    original_init = LORE.__init__
+
+    def load_route_settings(
+        lore: LORE, settings_path: str | None = None
+    ) -> dict[str, Any]:
+        del settings_path
+        lore.settings_path = Path("nexus.toml").resolve()
+        return copy.deepcopy(route_settings)
+
+    def initialize_route_memnon(lore: LORE) -> None:
+        nonlocal memnon_count
+        if memnon_count >= len(retrieval_batches):
+            raise AssertionError("Unexpected extra LORE instance")
+        lore.memnon = _DatabaseMemnon(engine, retrieval_batches[memnon_count])
+        memnon_count += 1
+
+    def initialize_route_logon(lore: LORE) -> None:
+        utility = LogonUtility(
+            lore.settings,
+            dbname=pass2_database,
+            settings_path=lore.settings_path,
+            model_override="gpt-4o",
+        )
+        utility._setting_context_loaded = True
+        utility._setting_context = None
+        provider = _RouteProvider(provider_outputs)
+        utility.provider = provider
+        utility._provider_bootstrap_mode = False
+        utility._provider_wire_type = "openai"
+        utility._provider_type_name = "openai"
+        utility._system_prompt = provider.system_prompt
+        lore.logon = utility
+        lore._logon_initialized = True
+        providers.append(provider)
+
+    def record_lore_instance(lore: LORE, *args: Any, **kwargs: Any) -> None:
+        original_init(lore, *args, **kwargs)
+        lore_instances.append(lore)
+
+    monkeypatch.setattr(LORE, "_load_settings", load_route_settings)
+    monkeypatch.setattr(LORE, "_initialize_memnon", initialize_route_memnon)
+    monkeypatch.setattr(LORE, "_initialize_logon", initialize_route_logon)
+    monkeypatch.setattr(LORE, "__init__", record_lore_instance)
+    monkeypatch.setattr(
+        LogonUtility,
+        "_format_turn_tag_library",
+        lambda _self, _context, *, presence_baseline: "",
+    )
+
+    try:
+        parent_chunk_id = _seed_parent(conn, "route parent")
+        retrieval_batches[1].insert(
+            0,
+            {"chunk_id": parent_chunk_id, "text": "duplicate turn N parent"},
+        )
+        explicit_bootstrap_boundary = bind_pass2_baseline(
+            empty_pass2_baseline(route_settings), parent_chunk_id
+        )
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO lore_pass_baselines (chunk_id, schema_version, payload)
+                VALUES (%s, %s, %s::jsonb)
+                """,
+                (
+                    parent_chunk_id,
+                    explicit_bootstrap_boundary.schema_version,
+                    json.dumps(explicit_bootstrap_boundary.model_dump(mode="json")),
+                ),
+            )
+        first_session = str(uuid4())
+        _create_lease(conn, first_session, parent_chunk_id)
+        conn.commit()
+
+        first_progress = _ProgressRecorder()
+        asyncio.run(
+            generate_narrative_async(
+                first_session,
+                parent_chunk_id,
+                "Investigate Zyxonium.",
+                slot=5,
+                get_db_connection=lambda _slot: _connect(pass2_database),
+                load_settings=lambda: copy.deepcopy(route_settings),
+                manager=first_progress,
+                manage_generation_lease=False,
+            )
+        )
+        assert first_progress.statuses[-1] == "complete"
+        assert len(lore_instances) == 1
+        assert (
+            lore_instances[0].turn_context.memory_state["pass2"]["baseline_available"]
+            is True
+        )
+        staged_first = lore_instances[0].turn_context.memory_state["lore_pass_baseline"]
+        assert parent_chunk_id in staged_first["memory_identities"]
+        assert retrieval_id in staged_first["memory_identities"]
+
+        accepted_chunk_id = commit_incubator_to_database_sync(
+            conn, first_session, slot=5
+        )
+
+        second_session = str(uuid4())
+        _replace_lease(conn, second_session, accepted_chunk_id)
+        conn.commit()
+        second_progress = _ProgressRecorder()
+        asyncio.run(
+            generate_narrative_async(
+                second_session,
+                accepted_chunk_id,
+                "Investigate Zyxonium again.",
+                slot=5,
+                get_db_connection=lambda _slot: _connect(pass2_database),
+                load_settings=lambda: copy.deepcopy(route_settings),
+                manager=second_progress,
+                manage_generation_lease=False,
+            )
+        )
+
+        assert second_progress.statuses[-1] == "complete"
+        assert len(lore_instances) == 2
+        assert lore_instances[0] is not lore_instances[1]
+        pass2_state = lore_instances[1].turn_context.memory_state["pass2"]
+        assert pass2_state["baseline_available"] is True
+        assert pass2_state["retrieved_memory_ids"] == [new_retrieval_id]
+        assert parent_chunk_id not in pass2_state["retrieved_memory_ids"]
+        assert retrieval_id not in pass2_state["retrieved_memory_ids"]
+        assert sum(len(provider.calls) for provider in providers) == 2
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT lore_pass_baseline FROM incubator WHERE session_id = %s",
+                (second_session,),
+            )
+            second_staged = cur.fetchone()[0]
+        assert new_retrieval_id in second_staged["memory_identities"]
+    finally:
+        conn.close()
+        engine.dispose()
+
+
+def test_component_regeneration_sparse_promotion_restore_and_cascade(
     pass2_database: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -416,6 +723,107 @@ def test_acceptance_failure_rolls_back_chunk_baseline_and_incubator_delete(
             assert cur.fetchone()[0] == 0
     finally:
         conn.close()
+
+
+@pytest.mark.asyncio
+async def test_async_regeneration_replace_and_acceptance_failure_roll_back(
+    pass2_database: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Async promotion atomically preserves the replacement draft on failure."""
+
+    sync_conn = _connect(pass2_database)
+    async_conn: asyncpg.Connection | None = None
+    try:
+        parent_chunk_id = _seed_parent(sync_conn, "async rollback parent")
+        first_session = str(uuid4())
+        _create_lease(sync_conn, first_session, parent_chunk_id)
+        sync_conn.commit()
+
+        first_manager = ContextMemoryManager(_settings())
+        first_manager.handle_storyteller_response(
+            narrative="Async first candidate.",
+            warm_slice=[{"chunk_id": parent_chunk_id, "text": "parent"}],
+            token_usage={"total_available": 50, "warm_slice": 10},
+        )
+        first_payload = response_to_incubator(
+            _response("Async first candidate."),
+            parent_chunk_id=parent_chunk_id,
+            user_text="Continue.",
+            session_id=first_session,
+            lore_pass_baseline=first_manager.export_pass2_baseline(),
+        )
+        await write_to_incubator(sync_conn, first_payload)
+
+        replacement_memory_id = 999_997
+        replacement_manager = ContextMemoryManager(_settings())
+        replacement_manager.handle_storyteller_response(
+            narrative="Async replacement candidate.",
+            warm_slice=[
+                {"chunk_id": parent_chunk_id, "text": "parent"},
+                {"chunk_id": replacement_memory_id, "text": "replacement memory"},
+            ],
+            token_usage={"total_available": 50, "warm_slice": 12},
+        )
+        replacement_session = str(uuid4())
+        _replace_lease(sync_conn, replacement_session, parent_chunk_id)
+        sync_conn.commit()
+        replacement_payload = response_to_incubator(
+            _response("Async replacement candidate."),
+            parent_chunk_id=parent_chunk_id,
+            user_text="Continue again.",
+            session_id=replacement_session,
+            lore_pass_baseline=replacement_manager.export_pass2_baseline(),
+        )
+        await write_to_incubator(
+            sync_conn,
+            replacement_payload,
+            expected_incubator_session=first_session,
+        )
+
+        with sync_conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM narrative_chunks")
+            before_chunks = int(cur.fetchone()[0])
+            cur.execute(
+                "SELECT storyteller_text, session_id, lore_pass_baseline "
+                "FROM incubator"
+            )
+            staged_text, staged_session, staged_baseline = cur.fetchone()
+        assert staged_text == "Async replacement candidate."
+        assert staged_session == replacement_session
+        assert replacement_memory_id in staged_baseline["memory_identities"]
+
+        async def fail_metadata(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("forced async metadata failure")
+
+        monkeypatch.setattr(commit_handler, "insert_chunk_metadata", fail_metadata)
+        async_conn = await _connect_async(pass2_database)
+        with pytest.raises(RuntimeError, match="forced async metadata failure"):
+            await commit_handler.commit_incubator_to_database(
+                async_conn, replacement_session, slot=5
+            )
+
+        assert (
+            await async_conn.fetchval("SELECT count(*) FROM narrative_chunks")
+            == before_chunks
+        )
+        assert (
+            await async_conn.fetchval("SELECT count(*) FROM lore_pass_baselines") == 0
+        )
+        preserved = await async_conn.fetchrow(
+            "SELECT storyteller_text, session_id, lore_pass_baseline " "FROM incubator"
+        )
+        assert preserved is not None
+        assert preserved["storyteller_text"] == "Async replacement candidate."
+        assert str(preserved["session_id"]) == replacement_session
+        assert (
+            replacement_memory_id
+            in preserved["lore_pass_baseline"]["memory_identities"]
+        )
+    finally:
+        if async_conn is not None:
+            await async_conn.close()
+        sync_conn.close()
 
 
 def test_missing_tail_error_and_admin_stamp_boundary(

--- a/tests/test_orrery/test_events.py
+++ b/tests/test_orrery/test_events.py
@@ -18,6 +18,7 @@ from nexus.agents.orrery.resolver import (
 )
 from nexus.agents.logon.apex_schema import OrreryAdjudication
 from nexus.api.lore_adapter import response_to_incubator
+from nexus.memory.manager import empty_pass2_baseline
 
 
 def test_template_outbound_pair_writer_rejects_status_ladder() -> None:
@@ -669,6 +670,7 @@ def test_response_to_incubator_serializes_orrery_proposal() -> None:
         parent_chunk_id=99,
         user_text="Continue.",
         session_id="session-1",
+        lore_pass_baseline=empty_pass2_baseline({}),
         orrery_proposal=_proposal(),
     )
 
@@ -696,6 +698,7 @@ def test_response_to_incubator_serializes_orrery_adjudications() -> None:
         parent_chunk_id=99,
         user_text="Continue.",
         session_id="session-1",
+        lore_pass_baseline=empty_pass2_baseline({}),
         orrery_proposal=_proposal(),
     )
 

--- a/tests/test_orrery/test_generation_model_provenance_live.py
+++ b/tests/test_orrery/test_generation_model_provenance_live.py
@@ -17,6 +17,7 @@ from nexus.api.narrative_lease import (
     bind_generation_parent,
 )
 from nexus.api.slot_utils import get_slot_db_url
+from nexus.memory.manager import empty_pass2_baseline
 from tests.test_orrery.claim_accounts_test_support import (
     install_claim_accounts_shadow_sync,
 )
@@ -25,6 +26,7 @@ from tests.test_orrery.claim_accounts_test_support import (
 pytestmark = pytest.mark.requires_postgres
 
 LIVE_SLOT = 5
+TEST_BASELINE_PAYLOAD = empty_pass2_baseline({}).model_dump(mode="json")
 
 
 class _NonCommittingConnection:
@@ -63,10 +65,14 @@ def provenance_db() -> Iterator[dict[str, Any]]:
     lease_migration_sql = (
         Path(__file__).parents[2] / "migrations" / "098_narrative_generation_lease.sql"
     ).read_text()
+    baseline_migration_sql = (
+        Path(__file__).parents[2] / "migrations" / "107_lore_pass_baselines.sql"
+    ).read_text()
     try:
         with raw_connection.cursor() as cur:
             cur.execute(migration_sql)
             cur.execute(lease_migration_sql)
+            cur.execute(baseline_migration_sql)
             schema = f"provenance_reveal_{uuid4().hex[:12]}"
             cur.execute(f'CREATE SCHEMA "{schema}"')
             cur.execute(f'SET LOCAL search_path = "{schema}", public')
@@ -141,6 +147,7 @@ def _incubator_payload(
         "orrery_proposal": None,
         "orrery_adjudications": [],
         "new_entities": [],
+        "lore_pass_baseline": TEST_BASELINE_PAYLOAD,
         "session_id": session_id,
         "llm_response_id": f"rollback-{uuid4().hex[:12]}",
         "status": "provisional",
@@ -251,10 +258,11 @@ def test_sync_accept_allows_historical_null_generation_model(
                 id, chunk_id, parent_chunk_id, user_text, storyteller_text,
                 choice_object, choice_text, metadata_updates, entity_updates,
                 reference_updates, orrery_proposal, orrery_adjudications,
-                new_entities, session_id, llm_response_id, status
+                new_entities, lore_pass_baseline, session_id, llm_response_id,
+                status
             ) VALUES (
                 TRUE, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                %s, %s, %s
+                %s, %s, %s, %s
             )
             """,
             (
@@ -270,6 +278,7 @@ def test_sync_accept_allows_historical_null_generation_model(
                 None,
                 Json([]),
                 Json([]),
+                Json(TEST_BASELINE_PAYLOAD),
                 payload["session_id"],
                 payload["llm_response_id"],
                 payload["status"],


### PR DESCRIPTION
Closes #675.

Design settled by independent consult (Sol, read-only) with coordinator concurrence: **option 2 — incubator staging with promote-on-accept**. The consult also proved option 3 (deterministic reconstruction) impossible: the exact prior retrieval selection can't be reproduced later because the corpus itself changes as chunks become embedded/ironman.

- `Pass2BaselineV1` persists only the cross-turn operational contract: exact post-trim memory identities, token accounting/remaining budget, config fingerprint. Assembled context is never serialized; prose reloads from the accepted chunk.
- Staged baselines are **deliberately unbound** (`parent_chunk_id=None`); acceptance binds them to the actual `RETURNING id` inside the commit transaction — the consult's named sharpest failure mode (sparse ids under regeneration) is structurally excluded.
- One hydration path for restart and ordinary teardown; `baseline_available=True` from the first post-migration accepted turn.
- Fail-loud everywhere: invalid staged state raises; historical tails get an administrative error naming the explicit stamp helper (`scripts/stamp_lore_pass_baseline.py`) — no inferred retrieval sets, no silent bootstrap inference.
- Rollback invariants tested: rejection, regeneration replace, acceptance failure, FK cascade.

96 unit + 7 PG tests green through the genuine fresh-instance-per-turn lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG