### PR TITLE
Teach the Bleed Fake Connection the Recent-Rulings Query

### DIFF
--- a/tests/test_orrery/test_bleed.py
+++ b/tests/test_orrery/test_bleed.py
@@ -81,6 +81,9 @@ class FakeSession:
         if "SELECT max(nc.id) AS max_id" in sql:
             assert "orrery:retrograde_prologue_anchor" in sql
             return FakeResult([{"max_id": self.max_chunk_id}])
+        if "FROM orrery_adjudication_log" in sql:
+            assert "tick_chunk_id <= :through_tick" in sql
+            return FakeResult([])
         raise AssertionError(f"Unexpected Bleed query: {sql}")
 
     def commit(self):


### PR DESCRIPTION
Repairs main: #690 (adjudication outcomes in the payload) and #692 (strict fake-SQL router in the bleed tests) were each green in isolation but break together — the router raises on the new `orrery_adjudication_log` query, failing five payload tests on the merged tree. One routing entry (empty rulings, with the `through_tick` shape asserted) restores green while keeping the router strict.

Integration gap, not a logic defect in either PR. Merging directly under the straightforward-fix rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG