### PR TITLE
Add Actor-Owned Experiential Memory (character_experiences)

### DIFF
--- a/migrations/104_character_experiences.sql
+++ b/migrations/104_character_experiences.sql
@@ -1,0 +1,194 @@
+-- 104_character_experiences.sql
+-- Actor-owned deterministic experience seeds and fenced scene rendering jobs.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type WHERE typname = 'character_experience_basis'
+    ) THEN
+        CREATE TYPE character_experience_basis AS ENUM (
+            'participant', 'witness', 'acquisition'
+        );
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type
+        WHERE typname = 'character_experience_invalidation_status'
+    ) THEN
+        CREATE TYPE character_experience_invalidation_status AS ENUM (
+            'valid', 'invalidated'
+        );
+    END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS character_experiences (
+    id                      bigserial PRIMARY KEY,
+    character_entity_id     bigint NOT NULL REFERENCES entities(id),
+    anchor_chunk_id         bigint NOT NULL REFERENCES narrative_chunks(id),
+    world_event_ids         bigint[] NOT NULL,
+    claim_id                bigint REFERENCES claims(id),
+    claim_awareness_id      bigint REFERENCES claim_awareness(id),
+    basis                   character_experience_basis NOT NULL,
+    location_id             bigint REFERENCES places(id),
+    world_time              timestamptz,
+    seed_summary            text NOT NULL CHECK (btrim(seed_summary) <> ''),
+    experience_text         text,
+    emotion                 text REFERENCES tags(tag),
+    salience                double precision NOT NULL
+                                CHECK (salience >= 0.0 AND salience <= 1.0),
+    render_model            text,
+    renderer_version        text,
+    source_digest           text NOT NULL CHECK (btrim(source_digest) <> ''),
+    render_generation_id    uuid,
+    world_layer             world_layer_type NOT NULL,
+    invalidation_status     character_experience_invalidation_status
+                                NOT NULL DEFAULT 'valid',
+    invalidated_at          timestamptz,
+    embedding_generated_at timestamptz,
+    created_at              timestamptz NOT NULL DEFAULT now(),
+    CHECK (cardinality(world_event_ids) > 0),
+    CHECK (emotion IS NULL OR emotion IN ('elated', 'sour', 'restless', 'grim')),
+    CHECK (
+        (basis = 'acquisition' AND claim_id IS NOT NULL
+            AND claim_awareness_id IS NOT NULL)
+        OR
+        (basis <> 'acquisition' AND claim_id IS NULL
+            AND claim_awareness_id IS NULL)
+    ),
+    CHECK (
+        (invalidation_status = 'valid' AND invalidated_at IS NULL)
+        OR
+        (invalidation_status = 'invalidated' AND invalidated_at IS NOT NULL)
+    ),
+    CHECK (
+        (experience_text IS NULL AND render_model IS NULL
+            AND renderer_version IS NULL AND render_generation_id IS NULL)
+        OR
+        (experience_text IS NOT NULL AND btrim(experience_text) <> ''
+            AND render_model IS NOT NULL AND renderer_version IS NOT NULL
+            AND render_generation_id IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_character_experiences_seed_identity
+    ON character_experiences (
+        character_entity_id,
+        anchor_chunk_id,
+        basis,
+        COALESCE(claim_awareness_id, 0)
+    );
+CREATE INDEX IF NOT EXISTS ix_character_experiences_unrendered
+    ON character_experiences (anchor_chunk_id, character_entity_id)
+    WHERE experience_text IS NULL AND invalidation_status = 'valid';
+CREATE INDEX IF NOT EXISTS ix_character_experiences_world_event_ids
+    ON character_experiences USING GIN (world_event_ids);
+
+COMMENT ON TABLE character_experiences IS
+    'Actor-owned factual experience seeds and optional subjective first-person renderings; this corpus does not itself grant recall or disclosure.';
+COMMENT ON COLUMN character_experiences.id IS
+    'Monotonic identity used by rendering and dimension-specific embedding tables.';
+COMMENT ON COLUMN character_experiences.character_entity_id IS
+    'Entity-spine identity of the character who owns this private experience.';
+COMMENT ON COLUMN character_experiences.anchor_chunk_id IS
+    'Accepted narrative chunk whose durable events or delivered account formed the seed.';
+COMMENT ON COLUMN character_experiences.world_event_ids IS
+    'Canonical source event identities; acquisition rows include the delivery event and incident event.';
+COMMENT ON COLUMN character_experiences.claim_id IS
+    'Exact delivered claim account for an acquisition, never an inference that the character witnessed its incident.';
+COMMENT ON COLUMN character_experiences.claim_awareness_id IS
+    'Durable told or granted awareness row whose insertion caused an acquisition experience.';
+COMMENT ON COLUMN character_experiences.basis IS
+    'Participant, verified present witness, or acquisition by being told or granted an account.';
+COMMENT ON COLUMN character_experiences.location_id IS
+    'Canonical scene or source-event place when one is durably known.';
+COMMENT ON COLUMN character_experiences.world_time IS
+    'In-world formation time under the two-clocks doctrine.';
+COMMENT ON COLUMN character_experiences.seed_summary IS
+    'Deterministic factual seed text assembled only from accepted event, roster, and account data.';
+COMMENT ON COLUMN character_experiences.experience_text IS
+    'Subjective first-person rendering; NULL preserves an unrendered or failed seed for retry.';
+COMMENT ON COLUMN character_experiences.emotion IS
+    'Optional mechanical mood registered by migration 095; rendering never assigns this value.';
+COMMENT ON COLUMN character_experiences.salience IS
+    'Deterministic bounded score from branch magnitude, relationship-valence delta, and verified presence duration.';
+COMMENT ON COLUMN character_experiences.render_model IS
+    'Resolved registry model id used for the successful scene rendering call.';
+COMMENT ON COLUMN character_experiences.renderer_version IS
+    'Deterministic renderer contract version used to validate and persist the rendering.';
+COMMENT ON COLUMN character_experiences.source_digest IS
+    'SHA-256 digest of canonical seed inputs used for replay and stale-write fencing.';
+COMMENT ON COLUMN character_experiences.render_generation_id IS
+    'One UUID shared by every recollection accepted from the same scene-batch provider call.';
+COMMENT ON COLUMN character_experiences.world_layer IS
+    'Timeline layer copied from the accepted anchor chunk.';
+COMMENT ON COLUMN character_experiences.invalidation_status IS
+    'Replay-safe validity state; invalidated rows remain durable rather than being deleted.';
+COMMENT ON COLUMN character_experiences.invalidated_at IS
+    'Database time when replay or timeline repair invalidated this experience.';
+COMMENT ON COLUMN character_experiences.embedding_generated_at IS
+    'Ironman stamp set only after every active MEMNON model vector is stored successfully.';
+COMMENT ON COLUMN character_experiences.created_at IS
+    'Database wall-clock time when the deterministic seed was inserted.';
+
+CREATE TABLE IF NOT EXISTS character_experience_jobs (
+    id                  bigserial PRIMARY KEY,
+    boundary_chunk_id   bigint NOT NULL REFERENCES narrative_chunks(id),
+    scene_end_chunk_id  bigint NOT NULL REFERENCES narrative_chunks(id),
+    world_layer         world_layer_type NOT NULL,
+    experience_ids      bigint[] NOT NULL,
+    slot                text NOT NULL,
+    state               orrery_job_state NOT NULL DEFAULT 'queued',
+    attempts            integer NOT NULL DEFAULT 0,
+    available_at        timestamptz NOT NULL DEFAULT now(),
+    lease_until         timestamptz,
+    locked_by           text,
+    lease_nonce         uuid,
+    last_error          text,
+    model               text NOT NULL,
+    source_digest       text NOT NULL,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+    CHECK (cardinality(experience_ids) > 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_character_experience_jobs_boundary
+    ON character_experience_jobs (boundary_chunk_id, world_layer);
+CREATE INDEX IF NOT EXISTS ix_character_experience_jobs_available
+    ON character_experience_jobs (state, available_at);
+
+COMMENT ON TABLE character_experience_jobs IS
+    'Owner-fenced asynchronous scene-batch rendering queue for character experience seeds.';
+COMMENT ON COLUMN character_experience_jobs.id IS
+    'Monotonic scene rendering job identity.';
+COMMENT ON COLUMN character_experience_jobs.boundary_chunk_id IS
+    'Accepted chunk carrying the scene-reset boundary that made the prior scene renderable.';
+COMMENT ON COLUMN character_experience_jobs.scene_end_chunk_id IS
+    'Last accepted chunk included in the scene batch.';
+COMMENT ON COLUMN character_experience_jobs.world_layer IS
+    'Timeline layer fenced at enqueue and completion.';
+COMMENT ON COLUMN character_experience_jobs.experience_ids IS
+    'Immutable complete set of unrendered seed ids selected for this scene boundary.';
+COMMENT ON COLUMN character_experience_jobs.slot IS
+    'Save-slot label owning the job.';
+COMMENT ON COLUMN character_experience_jobs.state IS
+    'Shared Orrery queued, leased, succeeded, failed, or stale-rejected job state.';
+COMMENT ON COLUMN character_experience_jobs.attempts IS
+    'Number of owner leases acquired for this job.';
+COMMENT ON COLUMN character_experience_jobs.available_at IS
+    'Database time when a queued retry may be leased.';
+COMMENT ON COLUMN character_experience_jobs.lease_until IS
+    'Database-clock lease expiry checked by fenced completion and failure writes.';
+COMMENT ON COLUMN character_experience_jobs.locked_by IS
+    'Worker owner identifier required with lease_nonce for fenced writes.';
+COMMENT ON COLUMN character_experience_jobs.lease_nonce IS
+    'Fresh UUID stamped at each lease acquisition to reject stale workers.';
+COMMENT ON COLUMN character_experience_jobs.last_error IS
+    'Most recent rendering or validation failure retained for operational diagnosis.';
+COMMENT ON COLUMN character_experience_jobs.model IS
+    'Resolved registry model id frozen when the scene job is enqueued.';
+COMMENT ON COLUMN character_experience_jobs.source_digest IS
+    'SHA-256 digest of the ordered experience id and seed-digest batch.';
+COMMENT ON COLUMN character_experience_jobs.created_at IS
+    'Database wall-clock time when the boundary job was enqueued.';
+COMMENT ON COLUMN character_experience_jobs.updated_at IS
+    'Database wall-clock time of the most recent queue state transition.';

--- a/migrations/104_character_experiences.sql
+++ b/migrations/104_character_experiences.sql
@@ -98,13 +98,13 @@ COMMENT ON COLUMN character_experiences.claim_id IS
 COMMENT ON COLUMN character_experiences.claim_awareness_id IS
     'Durable told or granted awareness row whose insertion caused an acquisition experience.';
 COMMENT ON COLUMN character_experiences.basis IS
-    'Participant, verified present witness, or acquisition by being told or granted an account.';
+    'Canonical event-role participant, policy-authorized witness, or acquisition by being told or granted an account.';
 COMMENT ON COLUMN character_experiences.location_id IS
     'Canonical scene or source-event place when one is durably known.';
 COMMENT ON COLUMN character_experiences.world_time IS
     'In-world formation time under the two-clocks doctrine.';
 COMMENT ON COLUMN character_experiences.seed_summary IS
-    'Deterministic factual seed text assembled only from accepted event, roster, and account data.';
+    'Deterministic factual seed text assembled only from accepted event-role receipts and delivered-account data.';
 COMMENT ON COLUMN character_experiences.experience_text IS
     'Subjective first-person rendering; NULL preserves an unrendered or failed seed for retry.';
 COMMENT ON COLUMN character_experiences.emotion IS
@@ -135,6 +135,13 @@ CREATE TABLE IF NOT EXISTS character_experience_jobs (
     boundary_chunk_id   bigint NOT NULL REFERENCES narrative_chunks(id),
     scene_end_chunk_id  bigint NOT NULL REFERENCES narrative_chunks(id),
     world_layer         world_layer_type NOT NULL,
+    boundary_season     integer NOT NULL,
+    boundary_episode    integer NOT NULL,
+    boundary_scene      integer NOT NULL,
+    scene_end_season    integer NOT NULL,
+    scene_end_episode   integer NOT NULL,
+    scene_end_scene     integer NOT NULL,
+    batch_ordinal       integer NOT NULL CHECK (batch_ordinal >= 0),
     experience_ids      bigint[] NOT NULL,
     slot                text NOT NULL,
     state               orrery_job_state NOT NULL DEFAULT 'queued',
@@ -144,7 +151,7 @@ CREATE TABLE IF NOT EXISTS character_experience_jobs (
     locked_by           text,
     lease_nonce         uuid,
     last_error          text,
-    model               text NOT NULL,
+    requested_model     text NOT NULL,
     source_digest       text NOT NULL,
     created_at          timestamptz NOT NULL DEFAULT now(),
     updated_at          timestamptz NOT NULL DEFAULT now(),
@@ -152,7 +159,9 @@ CREATE TABLE IF NOT EXISTS character_experience_jobs (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_character_experience_jobs_boundary
-    ON character_experience_jobs (boundary_chunk_id, world_layer);
+    ON character_experience_jobs (
+        boundary_chunk_id, world_layer, batch_ordinal
+    );
 CREATE INDEX IF NOT EXISTS ix_character_experience_jobs_available
     ON character_experience_jobs (state, available_at);
 
@@ -165,9 +174,23 @@ COMMENT ON COLUMN character_experience_jobs.boundary_chunk_id IS
 COMMENT ON COLUMN character_experience_jobs.scene_end_chunk_id IS
     'Last accepted chunk included in the scene batch.';
 COMMENT ON COLUMN character_experience_jobs.world_layer IS
-    'Timeline layer fenced at enqueue and completion.';
+    'Timeline layer shared by the frozen boundary and scene-end anchor and revalidated at completion.';
+COMMENT ON COLUMN character_experience_jobs.boundary_season IS
+    'Season identity copied from the boundary chunk and revalidated under a shared lock at completion.';
+COMMENT ON COLUMN character_experience_jobs.boundary_episode IS
+    'Episode identity copied from the boundary chunk and revalidated under a shared lock at completion.';
+COMMENT ON COLUMN character_experience_jobs.boundary_scene IS
+    'Scene identity copied from the boundary chunk and revalidated under a shared lock at completion.';
+COMMENT ON COLUMN character_experience_jobs.scene_end_season IS
+    'Season identity copied from the prior-scene anchor and revalidated under a shared lock at completion.';
+COMMENT ON COLUMN character_experience_jobs.scene_end_episode IS
+    'Episode identity copied from the prior-scene anchor and revalidated under a shared lock at completion.';
+COMMENT ON COLUMN character_experience_jobs.scene_end_scene IS
+    'Scene identity copied from the prior-scene anchor and revalidated under a shared lock at completion.';
+COMMENT ON COLUMN character_experience_jobs.batch_ordinal IS
+    'Zero-based immutable batch number used to split one boundary roster within the configured seed budget.';
 COMMENT ON COLUMN character_experience_jobs.experience_ids IS
-    'Immutable complete set of unrendered seed ids selected for this scene boundary.';
+    'Immutable bounded partition of unrendered seed ids selected for this scene boundary.';
 COMMENT ON COLUMN character_experience_jobs.slot IS
     'Save-slot label owning the job.';
 COMMENT ON COLUMN character_experience_jobs.state IS
@@ -184,8 +207,8 @@ COMMENT ON COLUMN character_experience_jobs.lease_nonce IS
     'Fresh UUID stamped at each lease acquisition to reject stale workers.';
 COMMENT ON COLUMN character_experience_jobs.last_error IS
     'Most recent rendering or validation failure retained for operational diagnosis.';
-COMMENT ON COLUMN character_experience_jobs.model IS
-    'Resolved registry model id frozen when the scene job is enqueued.';
+COMMENT ON COLUMN character_experience_jobs.requested_model IS
+    'Resolved registry model id requested when the scene job was enqueued; successful experiences stamp the model resolved at call time.';
 COMMENT ON COLUMN character_experience_jobs.source_digest IS
     'SHA-256 digest of the ordered experience id and seed-digest batch.';
 COMMENT ON COLUMN character_experience_jobs.created_at IS

--- a/nexus.toml
+++ b/nexus.toml
@@ -392,6 +392,7 @@ max_attempts = 3
 retry_delay_seconds = 300
 lease_duration_seconds = 300
 max_jobs_per_drain = 2
+max_seeds_per_render = 12
 
 [orrery.selection]
 # Branch selection inside a fired package: "stochastic" softmax-samples all

--- a/nexus.toml
+++ b/nexus.toml
@@ -378,6 +378,21 @@ clear = "temperate"
 enabled = true
 duration_hours = 12
 
+[orrery.experiences]
+enabled = true
+model = "@openai.gaia"
+dossier_fields = ["summary", "background", "personality"]
+minimum_dossier_fields = 2
+magnitude_weight = 0.60
+valence_delta_weight = 0.25
+presence_duration_weight = 0.15
+presence_duration_cap_chunks = 8
+max_output_tokens = 2400
+max_attempts = 3
+retry_delay_seconds = 300
+lease_duration_seconds = 300
+max_jobs_per_drain = 2
+
 [orrery.selection]
 # Branch selection inside a fired package: "stochastic" softmax-samples all
 # passing branches by magnitude (PRNG seeded on per-resolution persisted

--- a/nexus/agents/logon/apex_schema.py
+++ b/nexus/agents/logon/apex_schema.py
@@ -358,6 +358,13 @@ class ChunkMetadataUpdate(BaseModel):
         default=None,
         description="Optional anchor-scene weather override.",
     )
+    scene_boundary: bool = Field(
+        default=False,
+        description=(
+            "Internal scene-reset marker carried through incubator staging; "
+            "never authored as a SkaldGaiaWire arm."
+        ),
+    )
 
     model_config = ConfigDict(extra="forbid")
 

--- a/nexus/agents/logon/skald_wire.py
+++ b/nexus/agents/logon/skald_wire.py
@@ -883,10 +883,14 @@ def hydrate_skald_turn(
     raises instead of inventing an empty prior scene.
     """
 
+    metadata = _hydrate_scene(wire.scene)
+    metadata.scene_boundary = bool(
+        wire.presence is not None and wire.presence.scene_reset is not None
+    )
     return StorytellerResponseExtended(
         narrative=wire.narrative,
         choices=wire.choices,
-        chunk_metadata=_hydrate_scene(wire.scene),
+        chunk_metadata=metadata,
         referenced_entities=_hydrate_references(
             wire.presence,
             presence_baseline,

--- a/nexus/agents/memnon/utils/embedding_tables.py
+++ b/nexus/agents/memnon/utils/embedding_tables.py
@@ -12,6 +12,9 @@ EMBEDDING_TABLE_PATTERN = re.compile(r"^chunk_embeddings_(?P<dimensions>\d+)d$")
 RETROGRADE_SUMMARY_EMBEDDING_TABLE_PATTERN = re.compile(
     r"^retrograde_summary_embeddings_(?P<dimensions>\d+)d$"
 )
+CHARACTER_EXPERIENCE_EMBEDDING_TABLE_PATTERN = re.compile(
+    r"^character_experience_embeddings_(?P<dimensions>\d+)d$"
+)
 
 # pgvector 0.8.x caps HNSW/IVFFlat indexes at 2000 dimensions in this local
 # deployment. Higher-dimensional tables still support exact vector search.
@@ -60,6 +63,13 @@ def retrograde_summary_table_name_for_dimensions(dimensions: int) -> str:
     return f"retrograde_summary_embeddings_{dimensions:04d}d"
 
 
+def character_experience_table_name_for_dimensions(dimensions: int) -> str:
+    """Return the dedicated character-experience table for ``dimensions``."""
+    if dimensions <= 0:
+        raise ValueError(f"Embedding dimensions must be positive, got {dimensions}")
+    return f"character_experience_embeddings_{dimensions:04d}d"
+
+
 def parse_embedding_table_dimensions(table_name: str) -> Optional[int]:
     """Return dimensions encoded in an embedding table name, if it matches."""
     match = EMBEDDING_TABLE_PATTERN.match(table_name)
@@ -73,6 +83,16 @@ def parse_retrograde_summary_embedding_table_dimensions(
 ) -> Optional[int]:
     """Return dimensions encoded in a Retrograde summary embedding table."""
     match = RETROGRADE_SUMMARY_EMBEDDING_TABLE_PATTERN.match(table_name)
+    if not match:
+        return None
+    return int(match.group("dimensions"))
+
+
+def parse_character_experience_embedding_table_dimensions(
+    table_name: str,
+) -> Optional[int]:
+    """Return dimensions encoded in a character-experience embedding table."""
+    match = CHARACTER_EXPERIENCE_EMBEDDING_TABLE_PATTERN.match(table_name)
     if not match:
         return None
     return int(match.group("dimensions"))
@@ -181,5 +201,53 @@ def ensure_retrograde_summary_embedding_table(
         CREATE INDEX IF NOT EXISTS {table_name}_model_idx
         ON {table_name} (model)
         """,
+    )
+    return table_name
+
+
+def ensure_character_experience_embedding_table(
+    connection: _DDLExecutor, dimensions: int
+) -> str:
+    """Ensure a dedicated actor-experience vector table exists lazily."""
+    table_name = character_experience_table_name_for_dimensions(dimensions)
+    _execute_ddl(
+        connection,
+        f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            experience_id BIGINT NOT NULL
+                REFERENCES character_experiences(id) ON DELETE CASCADE,
+            model TEXT NOT NULL,
+            embedding vector({dimensions}) NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (experience_id, model)
+        )
+        """,
+    )
+    _execute_ddl(
+        connection,
+        f"""
+        CREATE INDEX IF NOT EXISTS {table_name}_model_idx
+        ON {table_name} (model)
+        """,
+    )
+    _execute_ddl(
+        connection,
+        f"COMMENT ON COLUMN {table_name}.experience_id IS "
+        "'Actor-owned character_experiences.id bound to this vector row.'",
+    )
+    _execute_ddl(
+        connection,
+        f"COMMENT ON COLUMN {table_name}.model IS "
+        "'Active MEMNON embedding model that produced this vector.'",
+    )
+    _execute_ddl(
+        connection,
+        f"COMMENT ON COLUMN {table_name}.embedding IS "
+        f"'Exact {dimensions}-dimension embedding of experience_text.'",
+    )
+    _execute_ddl(
+        connection,
+        f"COMMENT ON COLUMN {table_name}.created_at IS "
+        "'Database time of the most recent successful vector upsert.'",
     )
     return table_name

--- a/nexus/agents/orrery/experience_embedding.py
+++ b/nexus/agents/orrery/experience_embedding.py
@@ -1,0 +1,159 @@
+"""All-or-nothing embeddings for rendered character experiences."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from nexus.agents.memnon.utils.embedding_tables import (
+    ensure_character_experience_embedding_table,
+)
+
+
+def _normalized_experience_ids(experience_ids: Sequence[int]) -> list[int]:
+    """Return unique positive ids while preserving caller order."""
+    normalized: list[int] = []
+    seen: set[int] = set()
+    for value in experience_ids:
+        experience_id = int(value)
+        if experience_id <= 0:
+            raise ValueError(f"experience_id must be positive, got {experience_id}")
+        if experience_id not in seen:
+            normalized.append(experience_id)
+            seen.add(experience_id)
+    return normalized
+
+
+def _memnon_settings() -> dict[str, Any]:
+    from nexus.config import load_settings_as_dict
+
+    settings = load_settings_as_dict().get("Agent Settings", {}).get("MEMNON", {})
+    if not settings:
+        raise RuntimeError("nexus.toml has no MEMNON embedding settings")
+    return settings
+
+
+def embed_character_experiences(
+    dbname: str,
+    experience_ids: Sequence[int],
+) -> list[dict[str, Any]]:
+    """Embed rendered recollections and stamp only after every vector upsert.
+
+    Every active-model embedding is generated before the write transaction.
+    Dimension tables, all model vectors, and every ironman timestamp then land
+    in one transaction. A generation or write failure leaves the entire input
+    set unstamped and retryable.
+    """
+    requested_ids = _normalized_experience_ids(experience_ids)
+    if not requested_ids:
+        return []
+
+    from nexus.agents.memnon.utils.embedding_manager import EmbeddingManager
+    from nexus.agents.orrery.retrograde_embedding import (
+        active_memnon_embedding_model_dimensions,
+    )
+    from nexus.api.db_pool import get_connection
+
+    with get_connection(dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT id, experience_text
+                FROM character_experiences
+                WHERE id = ANY(%s)
+                  AND invalidation_status = 'valid'
+                """,
+                (requested_ids,),
+            )
+            experiences = {
+                int(row["id"]): row["experience_text"] for row in cursor.fetchall()
+            }
+    missing = [item for item in requested_ids if item not in experiences]
+    if missing:
+        raise RuntimeError(f"Character experiences not found in {dbname}: {missing}")
+    unrendered = [item for item in requested_ids if not experiences[item]]
+    if unrendered:
+        raise RuntimeError(
+            f"Character experiences are not rendered in {dbname}: {unrendered}"
+        )
+
+    memnon_settings = _memnon_settings()
+    configured = list(active_memnon_embedding_model_dimensions())
+    manager = EmbeddingManager(settings=memnon_settings)
+    model_names = manager.get_available_models()
+    if set(model_names) != set(configured):
+        raise RuntimeError(
+            "Active MEMNON embedding model load did not match configuration; "
+            f"configured={sorted(configured)}, loaded={sorted(model_names)}"
+        )
+
+    generated: dict[int, list[tuple[str, list[float]]]] = {}
+    for experience_id in requested_ids:
+        model_embeddings: list[tuple[str, list[float]]] = []
+        for model_name in model_names:
+            embedding = manager.generate_embedding(
+                str(experiences[experience_id]), model_name
+            )
+            if not embedding:
+                raise RuntimeError(
+                    "Embedding generation failed for character experience "
+                    f"{experience_id} with model {model_name}; "
+                    "embedding_generated_at remains NULL for retry"
+                )
+            model_embeddings.append((model_name, embedding))
+        generated[experience_id] = model_embeddings
+
+    with get_connection(dbname, dict_cursor=True) as conn:
+        with conn.cursor() as cursor:
+            ensured: dict[int, str] = {}
+            for experience_id, model_embeddings in generated.items():
+                for model_name, embedding in model_embeddings:
+                    dimensions = len(embedding)
+                    table_name = ensured.get(dimensions)
+                    if table_name is None:
+                        table_name = ensure_character_experience_embedding_table(
+                            cursor, dimensions
+                        )
+                        ensured[dimensions] = table_name
+                    value = "[" + ",".join(str(number) for number in embedding) + "]"
+                    cursor.execute(
+                        f"""
+                        INSERT INTO {table_name}
+                            (experience_id, model, embedding, created_at)
+                        VALUES (%s, %s, %s::vector({dimensions}), NOW())
+                        ON CONFLICT (experience_id, model) DO UPDATE
+                        SET embedding = EXCLUDED.embedding,
+                            created_at = EXCLUDED.created_at
+                        """,
+                        (experience_id, model_name, value),
+                    )
+            cursor.execute(
+                """
+                UPDATE character_experiences
+                SET embedding_generated_at = NOW()
+                WHERE id = ANY(%s)
+                  AND experience_text IS NOT NULL
+                  AND invalidation_status = 'valid'
+                RETURNING id, embedding_generated_at
+                """,
+                (requested_ids,),
+            )
+            stamped = {
+                int(row["id"]): row["embedding_generated_at"]
+                for row in cursor.fetchall()
+            }
+            if len(stamped) != len(requested_ids):
+                raise RuntimeError(
+                    "Character experience embedding stamp count did not match "
+                    f"request ({len(stamped)} of {len(requested_ids)})"
+                )
+    return [
+        {
+            "experience_id": experience_id,
+            "models": [model for model, _embedding in generated[experience_id]],
+            "dimensions": sorted(
+                {len(embedding) for _model, embedding in generated[experience_id]}
+            ),
+            "embedding_generated_at": stamped[experience_id].isoformat(),
+        }
+        for experience_id in requested_ids
+    ]

--- a/nexus/agents/orrery/experiences.py
+++ b/nexus/agents/orrery/experiences.py
@@ -1,0 +1,981 @@
+"""Deterministic actor-owned experience formation and scene rendering."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+import re
+from typing import Any, Iterable, Mapping, Optional, Sequence
+from uuid import uuid4
+
+from psycopg2.extras import RealDictCursor
+from pydantic import BaseModel, ConfigDict, Field
+
+from nexus.config.settings_models import OrreryExperienceSettings
+from nexus.telemetry.usage import usage_context
+
+
+logger = logging.getLogger("nexus.orrery.experiences")
+
+RENDERER_VERSION = "experience-renderer-v1"
+_PROMPT_PATH = (
+    Path(__file__).resolve().parents[3] / "prompts" / "experience_renderer.md"
+)
+_PARTICIPANT_ROLES = frozenset({"actor", "target", "beneficiary"})
+_CAPITALIZED_NAME = re.compile(
+    r"(?<![.!?]\s)(?<!^)\b[A-Z][a-z]+(?:[ '-][A-Z][a-z]+)*\b"
+)
+_FIRST_PERSON = re.compile(r"\b(?:I|me|my|mine|we|us|our|ours)\b", re.IGNORECASE)
+_SENTENCE = re.compile(r"(?<=[.!?])(?:[\"']?\s+|$)")
+
+
+class ExperienceRecollection(BaseModel):
+    """One provider-rendered recollection keyed to its durable seed."""
+
+    experience_id: int = Field(gt=0)
+    experience_text: str = Field(min_length=1)
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
+class ExperienceRenderBatch(BaseModel):
+    """Complete structured response for one scene roster."""
+
+    recollections: list[ExperienceRecollection] = Field(min_length=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ExperienceLeaseLostError(RuntimeError):
+    """Raised when a stale scene worker attempts a fenced write."""
+
+
+class ExperienceSourceStaleError(RuntimeError):
+    """Raised when a scene job's immutable seed batch no longer matches."""
+
+
+def experience_settings(settings: Mapping[str, Any]) -> OrreryExperienceSettings:
+    """Validate the experience subsection from a full settings mapping."""
+
+    orrery = settings.get("orrery") if "orrery" in settings else settings
+    raw = (orrery or {}).get("experiences") or {}
+    if isinstance(raw, OrreryExperienceSettings):
+        return raw
+    return OrreryExperienceSettings.model_validate(raw)
+
+
+def _row_value(row: Any, key: str, index: int) -> Any:
+    if isinstance(row, Mapping):
+        return row[key]
+    return row[index]
+
+
+def _json_mapping(value: Any) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, str):
+        value = json.loads(value)
+    if not isinstance(value, Mapping):
+        raise ValueError(f"Expected JSON object, got {type(value).__name__}")
+    return value
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _eligible_character(row: Mapping[str, Any], cfg: OrreryExperienceSettings) -> bool:
+    return sum(
+        bool(str(row.get(field) or "").strip()) for field in cfg.dossier_fields
+    ) >= (cfg.minimum_dossier_fields)
+
+
+def _numeric_valences(value: Any, *, parent_key: str = "") -> Iterable[float]:
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            yield from _numeric_valences(nested, parent_key=str(key))
+        return
+    if isinstance(value, list):
+        for nested in value:
+            yield from _numeric_valences(nested, parent_key=parent_key)
+        return
+    if "valence" not in parent_key.casefold() or isinstance(value, bool):
+        return
+    match = re.match(r"\s*([+-]?\d+(?:\.\d+)?)", str(value))
+    if match:
+        numeric = abs(float(match.group(1)))
+        yield min(1.0, numeric if numeric <= 1.0 else numeric / 5.0)
+
+
+def _presence_duration(
+    cur: Any,
+    *,
+    character_entity_id: int,
+    anchor_chunk_id: int,
+    world_layer: str,
+    cap: int,
+) -> int:
+    cur.execute(
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM chunk_character_references ccr
+            JOIN characters c ON c.id = ccr.character_id
+            WHERE ccr.chunk_id = recent.chunk_id
+              AND ccr.reference::text = 'present'
+              AND c.entity_id = %s
+        ) AS present
+        FROM (
+            SELECT cm.chunk_id
+            FROM chunk_metadata cm
+            WHERE cm.chunk_id <= %s
+              AND cm.world_layer::text = %s
+            ORDER BY cm.chunk_id DESC
+            LIMIT %s
+        ) AS recent
+        ORDER BY recent.chunk_id DESC
+        """,
+        (character_entity_id, anchor_chunk_id, world_layer, cap),
+    )
+    duration = 0
+    for row in cur.fetchall():
+        if not bool(_row_value(row, "present", 0)):
+            break
+        duration += 1
+    return duration
+
+
+def _active_mood(cur: Any, character_entity_id: int) -> Optional[str]:
+    cur.execute(
+        """
+        SELECT t.tag
+        FROM entity_tags et
+        JOIN tags t ON t.id = et.tag_id
+        WHERE et.entity_id = %s
+          AND et.cleared_at IS NULL
+          AND t.category = 'mood'
+        ORDER BY et.applied_at DESC, et.id DESC
+        LIMIT 1
+        """,
+        (character_entity_id,),
+    )
+    row = cur.fetchone()
+    return str(_row_value(row, "tag", 0)) if row is not None else None
+
+
+def _salience(
+    *,
+    events: Sequence[Mapping[str, Any]],
+    presence_duration: int,
+    cfg: OrreryExperienceSettings,
+) -> float:
+    magnitude = max(
+        (abs(float(row.get("magnitude") or 0.0)) for row in events), default=0.0
+    )
+    valence = max(
+        (
+            candidate
+            for row in events
+            for candidate in _numeric_valences(_json_mapping(row.get("state_delta")))
+        ),
+        default=0.0,
+    )
+    presence = min(1.0, presence_duration / cfg.presence_duration_cap_chunks)
+    return round(
+        min(
+            1.0,
+            cfg.magnitude_weight * min(1.0, magnitude)
+            + cfg.valence_delta_weight * valence
+            + cfg.presence_duration_weight * presence,
+        ),
+        6,
+    )
+
+
+def _event_fact(row: Mapping[str, Any]) -> str:
+    actor = str(row.get("actor_name") or "an unnamed actor")
+    target = row.get("target_name")
+    location = row.get("location_name")
+    payload = _json_mapping(row.get("payload"))
+    detail = payload.get("narrative_stub") or payload.get("branch_label")
+    fact = f"{row['event_type']}: {actor}"
+    if target:
+        fact += f" affected {target}"
+    if location:
+        fact += f" at {location}"
+    if detail:
+        fact += f" ({str(detail).strip()})"
+    return fact + "."
+
+
+def _insert_experience(
+    cur: Any,
+    *,
+    character_entity_id: int,
+    anchor_chunk_id: int,
+    world_event_ids: Sequence[int],
+    claim_id: Optional[int],
+    claim_awareness_id: Optional[int],
+    basis: str,
+    location_id: Optional[int],
+    world_time: Any,
+    seed_summary: str,
+    emotion: Optional[str],
+    salience: float,
+    world_layer: str,
+) -> bool:
+    canonical_ids = sorted(set(int(value) for value in world_event_ids))
+    source_digest = _digest(
+        {
+            "character_entity_id": character_entity_id,
+            "anchor_chunk_id": anchor_chunk_id,
+            "world_event_ids": canonical_ids,
+            "claim_id": claim_id,
+            "claim_awareness_id": claim_awareness_id,
+            "basis": basis,
+            "location_id": location_id,
+            "world_time": world_time,
+            "seed_summary": seed_summary,
+            "emotion": emotion,
+            "salience": salience,
+            "world_layer": world_layer,
+        }
+    )
+    cur.execute(
+        """
+        INSERT INTO character_experiences (
+            character_entity_id, anchor_chunk_id, world_event_ids,
+            claim_id, claim_awareness_id, basis, location_id, world_time,
+            seed_summary, emotion, salience, source_digest, world_layer
+        ) VALUES (
+            %s, %s, %s, %s, %s, %s::character_experience_basis, %s, %s,
+            %s, %s, %s, %s, %s::world_layer_type
+        )
+        ON CONFLICT DO NOTHING
+        RETURNING id
+        """,
+        (
+            character_entity_id,
+            anchor_chunk_id,
+            canonical_ids,
+            claim_id,
+            claim_awareness_id,
+            basis,
+            location_id,
+            world_time,
+            seed_summary,
+            emotion,
+            salience,
+            source_digest,
+            world_layer,
+        ),
+    )
+    return cur.fetchone() is not None
+
+
+def seed_character_experiences_sync(
+    conn: Any,
+    *,
+    anchor_chunk_id: int,
+    settings: Mapping[str, Any],
+) -> int:
+    """Insert deterministic participant, witness, and acquisition seeds."""
+
+    cfg = experience_settings(settings)
+    if not cfg.enabled:
+        return 0
+    inserted = 0
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT cm.world_time, cm.world_layer::text AS world_layer,
+                   setting.place_id AS setting_place_id
+            FROM chunk_metadata cm
+            LEFT JOIN LATERAL (
+                SELECT pcr.place_id
+                FROM place_chunk_references pcr
+                WHERE pcr.chunk_id = cm.chunk_id
+                  AND pcr.reference_type::text = 'setting'
+                ORDER BY pcr.place_id
+                LIMIT 1
+            ) setting ON TRUE
+            WHERE cm.chunk_id = %s
+            """,
+            (anchor_chunk_id,),
+        )
+        metadata = cur.fetchone()
+        if metadata is None:
+            raise RuntimeError(
+                f"Experience anchor chunk {anchor_chunk_id} has no metadata"
+            )
+        world_time = metadata["world_time"]
+        world_layer = str(metadata["world_layer"])
+
+        cur.execute(
+            """
+            SELECT c.entity_id, c.name, c.summary, c.background, c.personality
+            FROM chunk_character_references ccr
+            JOIN characters c ON c.id = ccr.character_id
+            WHERE ccr.chunk_id = %s
+              AND ccr.reference::text = 'present'
+              AND c.entity_id IS NOT NULL
+            ORDER BY c.entity_id
+            """,
+            (anchor_chunk_id,),
+        )
+        present = [dict(row) for row in cur.fetchall()]
+        eligible = [row for row in present if _eligible_character(row, cfg)]
+
+        cur.execute(
+            """
+            SELECT e.id, e.event_type, e.actor_entity_id, e.target_entity_id,
+                   e.location_id, e.magnitude, e.payload,
+                   actor.name AS actor_name, target.name AS target_name,
+                   place.name AS location_name, r.state_delta,
+                   COALESCE(array_agg(wee.entity_id) FILTER (
+                       WHERE wee.role::text IN ('actor', 'target', 'beneficiary')
+                   ), '{}') AS participant_entity_ids
+            FROM world_events e
+            LEFT JOIN entity_names_v actor ON actor.id = e.actor_entity_id
+            LEFT JOIN entity_names_v target ON target.id = e.target_entity_id
+            LEFT JOIN places place ON place.id = e.location_id
+            LEFT JOIN orrery_resolutions r ON r.id = e.resolution_id
+            LEFT JOIN world_event_entities wee ON wee.event_id = e.id
+            WHERE e.tick_chunk_id = %s
+              AND e.superseded_by_event_id IS NULL
+            GROUP BY e.id, actor.name, target.name, place.name, r.state_delta
+            ORDER BY e.id
+            """,
+            (anchor_chunk_id,),
+        )
+        events = [dict(row) for row in cur.fetchall()]
+        event_ids = [int(row["id"]) for row in events]
+        facts = " ".join(_event_fact(row) for row in events)
+        for character in eligible:
+            if not events:
+                break
+            character_id = int(character["entity_id"])
+            participant = any(
+                character_id in set(row["participant_entity_ids"] or [])
+                for row in events
+            )
+            basis = "participant" if participant else "witness"
+            duration = _presence_duration(
+                cur,
+                character_entity_id=character_id,
+                anchor_chunk_id=anchor_chunk_id,
+                world_layer=world_layer,
+                cap=cfg.presence_duration_cap_chunks,
+            )
+            location_id = next(
+                (int(row["location_id"]) for row in events if row.get("location_id")),
+                metadata.get("setting_place_id"),
+            )
+            basis_phrase = "participated in" if participant else "witnessed"
+            seed_summary = (
+                f"{character['name']} {basis_phrase} the accepted scene at "
+                f"{world_time.isoformat() if world_time else 'an unknown world time'}. "
+                f"{facts}"
+            )
+            inserted += int(
+                _insert_experience(
+                    cur,
+                    character_entity_id=character_id,
+                    anchor_chunk_id=anchor_chunk_id,
+                    world_event_ids=event_ids,
+                    claim_id=None,
+                    claim_awareness_id=None,
+                    basis=basis,
+                    location_id=location_id,
+                    world_time=world_time,
+                    seed_summary=seed_summary,
+                    emotion=_active_mood(cur, character_id),
+                    salience=_salience(
+                        events=events,
+                        presence_duration=duration,
+                        cfg=cfg,
+                    ),
+                    world_layer=world_layer,
+                )
+            )
+
+        cur.execute(
+            """
+            SELECT ca.id AS awareness_id, ca.claim_id, ca.knower_entity_id,
+                   ca.source_tier, ca.acquired_at_world_time,
+                   c.summary AS claim_summary, c.account_label,
+                   c.world_event_id AS incident_event_id,
+                   character.name, character.summary, character.background,
+                   character.personality,
+                   delivery.id AS delivery_event_id,
+                   incident.location_id
+            FROM claim_awareness ca
+            JOIN claims c ON c.id = ca.claim_id
+            JOIN characters character ON character.entity_id = ca.knower_entity_id
+            JOIN world_events incident ON incident.id = c.world_event_id
+            LEFT JOIN world_events delivery
+              ON delivery.tick_chunk_id = ca.source_chunk_id
+             AND delivery.payload ->> 'awareness_id' = ca.id::text
+            WHERE ca.source_chunk_id = %s
+              AND ca.source_tier IN ('told', 'granted')
+            ORDER BY ca.id
+            """,
+            (anchor_chunk_id,),
+        )
+        for acquisition in (dict(row) for row in cur.fetchall()):
+            if not _eligible_character(acquisition, cfg):
+                continue
+            source_ids = [int(acquisition["incident_event_id"])]
+            if acquisition.get("delivery_event_id") is not None:
+                source_ids.append(int(acquisition["delivery_event_id"]))
+            seed_summary = (
+                f"{acquisition['name']} acquired the "
+                f"{acquisition['account_label']} account by being "
+                f"{acquisition['source_tier']}: {acquisition['claim_summary']}"
+            )
+            character_id = int(acquisition["knower_entity_id"])
+            inserted += int(
+                _insert_experience(
+                    cur,
+                    character_entity_id=character_id,
+                    anchor_chunk_id=anchor_chunk_id,
+                    world_event_ids=source_ids,
+                    claim_id=int(acquisition["claim_id"]),
+                    claim_awareness_id=int(acquisition["awareness_id"]),
+                    basis="acquisition",
+                    location_id=acquisition.get("location_id"),
+                    world_time=acquisition.get("acquired_at_world_time") or world_time,
+                    seed_summary=seed_summary,
+                    emotion=_active_mood(cur, character_id),
+                    salience=_salience(
+                        events=[{"magnitude": 0.0, "state_delta": {}}],
+                        presence_duration=0,
+                        cfg=cfg,
+                    ),
+                    world_layer=world_layer,
+                )
+            )
+    return inserted
+
+
+def _batch_digest(rows: Sequence[Mapping[str, Any]]) -> str:
+    return _digest(
+        [
+            {"id": int(row["id"]), "source_digest": str(row["source_digest"])}
+            for row in sorted(rows, key=lambda item: int(item["id"]))
+        ]
+    )
+
+
+def enqueue_scene_experience_job_sync(
+    conn: Any,
+    *,
+    boundary_chunk_id: int,
+    scene_end_chunk_id: int,
+    world_layer: str,
+    slot: Optional[int],
+    settings: Mapping[str, Any],
+) -> bool:
+    """Enqueue one immutable prior-scene seed batch at a scene reset."""
+
+    cfg = experience_settings(settings)
+    if not cfg.enabled or scene_end_chunk_id <= 0:
+        return False
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT max(boundary_chunk_id) AS previous_boundary
+            FROM character_experience_jobs
+            WHERE world_layer::text = %s
+              AND boundary_chunk_id < %s
+            """,
+            (world_layer, boundary_chunk_id),
+        )
+        previous = cur.fetchone()["previous_boundary"]
+        lower_bound = int(previous) if previous is not None else 0
+        cur.execute(
+            """
+            SELECT id, source_digest
+            FROM character_experiences
+            WHERE anchor_chunk_id >= %s
+              AND anchor_chunk_id <= %s
+              AND world_layer::text = %s
+              AND invalidation_status = 'valid'
+              AND experience_text IS NULL
+            ORDER BY id
+            """,
+            (lower_bound, scene_end_chunk_id, world_layer),
+        )
+        rows = [dict(row) for row in cur.fetchall()]
+        if not rows:
+            return False
+        cur.execute(
+            """
+            INSERT INTO character_experience_jobs (
+                boundary_chunk_id, scene_end_chunk_id, world_layer,
+                experience_ids, slot, model, source_digest
+            ) VALUES (%s, %s, %s::world_layer_type, %s, %s, %s, %s)
+            ON CONFLICT (boundary_chunk_id, world_layer) DO NOTHING
+            RETURNING id
+            """,
+            (
+                boundary_chunk_id,
+                scene_end_chunk_id,
+                world_layer,
+                [int(row["id"]) for row in rows],
+                str(slot) if slot is not None else "default",
+                cfg.model,
+                _batch_digest(rows),
+            ),
+        )
+        return cur.fetchone() is not None
+
+
+def _known_and_allowed_names(
+    cur: Any, row: Mapping[str, Any]
+) -> tuple[set[str], set[str]]:
+    cur.execute("SELECT name FROM entity_names_v WHERE name IS NOT NULL")
+    known = {str(item["name"]) for item in cur.fetchall() if str(item["name"]).strip()}
+    cur.execute(
+        """
+        SELECT DISTINCT names.name
+        FROM (
+            SELECT owner.name
+            FROM characters owner
+            WHERE owner.entity_id = %s
+            UNION ALL
+            SELECT entity_name.name
+            FROM world_event_entities wee
+            JOIN entity_names_v entity_name ON entity_name.id = wee.entity_id
+            WHERE wee.event_id = ANY(%s)
+            UNION ALL
+            SELECT actor.name
+            FROM world_events event
+            JOIN entity_names_v actor ON actor.id = event.actor_entity_id
+            WHERE event.id = ANY(%s)
+            UNION ALL
+            SELECT target.name
+            FROM world_events event
+            JOIN entity_names_v target ON target.id = event.target_entity_id
+            WHERE event.id = ANY(%s)
+            UNION ALL
+            SELECT place.name
+            FROM places place
+            WHERE place.id = %s
+        ) names
+        WHERE names.name IS NOT NULL
+        """,
+        (
+            row["character_entity_id"],
+            row["world_event_ids"],
+            row["world_event_ids"],
+            row["world_event_ids"],
+            row.get("location_id"),
+        ),
+    )
+    allowed = {str(item["name"]) for item in cur.fetchall()}
+    return known, allowed
+
+
+def validate_render_batch(
+    rows: Sequence[Mapping[str, Any]],
+    batch: ExperienceRenderBatch,
+    *,
+    names_by_experience: Optional[Mapping[int, tuple[set[str], set[str]]]] = None,
+) -> dict[int, str]:
+    """Validate completeness, perspective, length, and source-scene entities."""
+
+    expected = {int(row["id"]) for row in rows}
+    actual = [item.experience_id for item in batch.recollections]
+    if len(actual) != len(set(actual)):
+        raise ValueError("Experience renderer returned duplicate experience ids")
+    if set(actual) != expected:
+        raise ValueError(
+            f"Experience renderer ids mismatch; expected={sorted(expected)}, "
+            f"actual={sorted(actual)}"
+        )
+    validated: dict[int, str] = {}
+    for recollection in batch.recollections:
+        text = recollection.experience_text.strip()
+        sentences = [part.strip() for part in _SENTENCE.split(text) if part.strip()]
+        if not 2 <= len(sentences) <= 4:
+            raise ValueError(
+                f"Experience {recollection.experience_id} must contain 2-4 sentences"
+            )
+        if _FIRST_PERSON.search(text) is None:
+            raise ValueError(
+                f"Experience {recollection.experience_id} is not first person"
+            )
+        known, allowed = (
+            names_by_experience.get(recollection.experience_id, (set(), set()))
+            if names_by_experience is not None
+            else (set(), set())
+        )
+        disallowed_known = sorted(
+            name
+            for name in known - allowed
+            if re.search(rf"\b{re.escape(name)}\b", text)
+        )
+        capitalized = {
+            match.group(0)
+            for match in _CAPITALIZED_NAME.finditer(text)
+            if match.group(0) not in {"I"}
+        }
+        invented = sorted(
+            name
+            for name in capitalized
+            if not any(name in allowed_name for allowed_name in allowed)
+        )
+        if disallowed_known or invented:
+            offenders = sorted(set(disallowed_known + invented))
+            raise ValueError(
+                f"Experience {recollection.experience_id} names entities absent "
+                f"from its source scene: {offenders}"
+            )
+        validated[recollection.experience_id] = text
+    return validated
+
+
+def _render_prompt(rows: Sequence[Mapping[str, Any]]) -> str:
+    prompt = _PROMPT_PATH.read_text(encoding="utf-8").strip()
+    records = [
+        {
+            "experience_id": int(row["id"]),
+            "character": row["character_name"],
+            "basis": row["basis"],
+            "world_time": row["world_time"],
+            "location": row.get("location_name"),
+            "seed": row["seed_summary"],
+        }
+        for row in rows
+    ]
+    return (
+        prompt
+        + "\n\nScene seed records:\n"
+        + json.dumps(records, ensure_ascii=False, sort_keys=True, default=str)
+    )
+
+
+def _experience_provider(cfg: OrreryExperienceSettings) -> Any:
+    from nexus.api.config_utils import get_wizard_retry_budget
+    from nexus.api.native_structured_output import build_native_structured_provider
+
+    prompt = _PROMPT_PATH.read_text(encoding="utf-8").strip()
+    return build_native_structured_provider(
+        model=cfg.model,
+        max_tokens=cfg.max_output_tokens,
+        system_prompt=prompt,
+        structured_output_retries=get_wizard_retry_budget(),
+        seat="experience_renderer",
+    )
+
+
+def _lease_matches(
+    current: Optional[Mapping[str, Any]], leased: Mapping[str, Any]
+) -> bool:
+    return bool(
+        current
+        and current.get("state") == "leased"
+        and current.get("locked_by") == leased.get("locked_by")
+        and str(current.get("lease_nonce")) == str(leased.get("lease_nonce"))
+        and bool(current.get("lease_live"))
+    )
+
+
+def _complete_render(
+    cur: Any,
+    *,
+    job: Mapping[str, Any],
+    rows: Sequence[Mapping[str, Any]],
+    rendered: Mapping[int, str],
+) -> None:
+    cur.execute(
+        """
+        SELECT state::text AS state, locked_by, lease_nonce,
+               lease_until >= clock_timestamp() AS lease_live,
+               source_digest, world_layer::text AS world_layer
+        FROM character_experience_jobs
+        WHERE id = %s
+        FOR UPDATE
+        """,
+        (job["job_id"],),
+    )
+    current = cur.fetchone()
+    if not _lease_matches(current, job):
+        raise ExperienceLeaseLostError(
+            f"Experience job {job['job_id']} no longer owns its live lease"
+        )
+    if current["source_digest"] != job["source_digest"]:
+        raise ExperienceSourceStaleError(
+            f"Experience job {job['job_id']} source digest changed"
+        )
+    cur.execute(
+        """
+        SELECT id, source_digest, experience_text,
+               invalidation_status::text AS invalidation_status,
+               world_layer::text AS world_layer
+        FROM character_experiences
+        WHERE id = ANY(%s)
+        ORDER BY id
+        FOR UPDATE
+        """,
+        (job["experience_ids"],),
+    )
+    current_rows = [dict(row) for row in cur.fetchall()]
+    if (
+        len(current_rows) != len(rows)
+        or _batch_digest(current_rows) != job["source_digest"]
+        or any(row["experience_text"] is not None for row in current_rows)
+        or any(row["invalidation_status"] != "valid" for row in current_rows)
+        or any(row["world_layer"] != job["world_layer"] for row in current_rows)
+    ):
+        raise ExperienceSourceStaleError(
+            f"Experience job {job['job_id']} seed batch is stale"
+        )
+    generation_id = str(uuid4())
+    for row in current_rows:
+        experience_id = int(row["id"])
+        cur.execute(
+            """
+            UPDATE character_experiences
+            SET experience_text = %s,
+                render_model = %s,
+                renderer_version = %s,
+                render_generation_id = %s
+            WHERE id = %s
+              AND source_digest = %s
+              AND experience_text IS NULL
+              AND invalidation_status = 'valid'
+            """,
+            (
+                rendered[experience_id],
+                job["model"],
+                RENDERER_VERSION,
+                generation_id,
+                experience_id,
+                row["source_digest"],
+            ),
+        )
+        if cur.rowcount != 1:
+            raise ExperienceSourceStaleError(
+                f"Experience {experience_id} changed during fenced completion"
+            )
+    cur.execute(
+        """
+        UPDATE character_experience_jobs
+        SET state = 'succeeded', lease_until = NULL, locked_by = NULL,
+            lease_nonce = NULL, last_error = NULL, updated_at = now()
+        WHERE id = %s AND state = 'leased' AND locked_by = %s
+          AND lease_nonce = %s AND lease_until >= clock_timestamp()
+        """,
+        (job["job_id"], job["locked_by"], job["lease_nonce"]),
+    )
+    if cur.rowcount != 1:
+        raise ExperienceLeaseLostError(
+            f"Experience job {job['job_id']} lost its lease at completion"
+        )
+
+
+def _fail_render(
+    cur: Any,
+    *,
+    job: Mapping[str, Any],
+    error: str,
+    cfg: OrreryExperienceSettings,
+) -> None:
+    next_state = "failed" if int(job["attempts"]) + 1 >= cfg.max_attempts else "queued"
+    cur.execute(
+        """
+        UPDATE character_experience_jobs
+        SET state = %s::orrery_job_state,
+            available_at = CASE WHEN %s = 'queued'
+                THEN clock_timestamp() + (%s * interval '1 second')
+                ELSE available_at END,
+            lease_until = NULL, locked_by = NULL, lease_nonce = NULL,
+            last_error = %s, updated_at = now()
+        WHERE id = %s AND state = 'leased' AND locked_by = %s
+          AND lease_nonce = %s AND lease_until >= clock_timestamp()
+        """,
+        (
+            next_state,
+            next_state,
+            cfg.retry_delay_seconds,
+            error,
+            job["job_id"],
+            job["locked_by"],
+            job["lease_nonce"],
+        ),
+    )
+    if cur.rowcount != 1:
+        raise ExperienceLeaseLostError(
+            f"Experience job {job['job_id']} lost its lease before failure write"
+        )
+
+
+def _reject_stale_source(
+    cur: Any,
+    *,
+    job: Mapping[str, Any],
+    error: str,
+) -> None:
+    cur.execute(
+        """
+        UPDATE character_experience_jobs
+        SET state = 'stale_rejected', lease_until = NULL, locked_by = NULL,
+            lease_nonce = NULL, last_error = %s, updated_at = now()
+        WHERE id = %s AND state = 'leased' AND locked_by = %s
+          AND lease_nonce = %s AND lease_until >= clock_timestamp()
+        """,
+        (error, job["job_id"], job["locked_by"], job["lease_nonce"]),
+    )
+    if cur.rowcount != 1:
+        raise ExperienceLeaseLostError(
+            f"Experience job {job['job_id']} lost its lease before stale rejection"
+        )
+
+
+def drain_experience_render_jobs_sync(
+    *,
+    slot: Optional[int],
+    settings: Mapping[str, Any],
+    conn: Any,
+    provider: Optional[Any] = None,
+    limit: Optional[int] = None,
+) -> tuple[int, int]:
+    """Lease, render, validate, and fence scene-batch experience jobs."""
+
+    cfg = experience_settings(settings)
+    if not cfg.enabled:
+        return (0, 0)
+    job_limit = (
+        cfg.max_jobs_per_drain if limit is None else min(limit, cfg.max_jobs_per_drain)
+    )
+    if job_limit < 0:
+        raise ValueError("Experience render job limit must be non-negative")
+    if job_limit == 0:
+        return (0, 0)
+    owner = f"experience:{slot if slot is not None else 'default'}:{uuid4()}"
+    renderer: Any = None
+    with conn:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT id AS job_id, experience_ids, attempts, model,
+                       source_digest, world_layer::text AS world_layer, slot
+                FROM character_experience_jobs
+                WHERE (
+                    (state = 'queued' AND available_at <= clock_timestamp())
+                    OR
+                    (state = 'leased' AND lease_until < clock_timestamp())
+                )
+                ORDER BY CASE
+                    WHEN state = 'leased' THEN lease_until ELSE available_at
+                END,
+                         id
+                LIMIT %s
+                FOR UPDATE SKIP LOCKED
+                """,
+                (job_limit,),
+            )
+            selected_jobs = cur.fetchall()
+            if selected_jobs:
+                # Match the hardened narration queue: provider construction
+                # must succeed before any durable lease is acquired.
+                renderer = provider or _experience_provider(cfg)
+            jobs = []
+            for selected in selected_jobs:
+                job = dict(selected)
+                nonce = str(uuid4())
+                cur.execute(
+                    """
+                    UPDATE character_experience_jobs
+                    SET state = 'leased',
+                        lease_until = clock_timestamp() + (%s * interval '1 second'),
+                        locked_by = %s, lease_nonce = %s,
+                        attempts = attempts + 1, updated_at = now()
+                    WHERE id = %s
+                    """,
+                    (cfg.lease_duration_seconds, owner, nonce, job["job_id"]),
+                )
+                job["locked_by"] = owner
+                job["lease_nonce"] = nonce
+                jobs.append(job)
+    rendered_count = 0
+    failed_count = 0
+    for job in jobs:
+        try:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT experience.id, experience.character_entity_id,
+                           experience.world_event_ids, experience.basis::text AS basis,
+                           experience.location_id, experience.world_time,
+                           experience.seed_summary, experience.source_digest,
+                           character.name AS character_name, place.name AS location_name
+                    FROM character_experiences experience
+                    JOIN characters character
+                      ON character.entity_id = experience.character_entity_id
+                    LEFT JOIN places place ON place.id = experience.location_id
+                    WHERE experience.id = ANY(%s)
+                    ORDER BY experience.id
+                    """,
+                    (job["experience_ids"],),
+                )
+                rows = [dict(row) for row in cur.fetchall()]
+                names = {
+                    int(row["id"]): _known_and_allowed_names(cur, row) for row in rows
+                }
+            prompt = _render_prompt(rows)
+            with usage_context(
+                seat="experience_renderer",
+                slot=(int(job["slot"]) if str(job["slot"]).isdigit() else slot),
+                run_id=str(job["job_id"]),
+            ):
+                response = renderer.get_structured_completion(
+                    prompt, ExperienceRenderBatch
+                )
+            batch = response[0] if isinstance(response, tuple) else response
+            if not isinstance(batch, ExperienceRenderBatch):
+                batch = ExperienceRenderBatch.model_validate(batch)
+            validated = validate_render_batch(rows, batch, names_by_experience=names)
+            with conn:
+                with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                    _complete_render(cur, job=job, rows=rows, rendered=validated)
+            rendered_count += len(rows)
+        except ExperienceLeaseLostError:
+            failed_count += 1
+            logger.exception("Rejected stale experience render job %s", job["job_id"])
+        except ExperienceSourceStaleError as exc:
+            failed_count += 1
+            try:
+                with conn:
+                    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                        _reject_stale_source(cur, job=job, error=str(exc))
+            except ExperienceLeaseLostError:
+                logger.exception(
+                    "Rejected stale-source write for experience render job %s",
+                    job["job_id"],
+                )
+            logger.exception("Rejected stale experience source %s", job["job_id"])
+        except Exception as exc:
+            failed_count += 1
+            try:
+                with conn:
+                    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                        _fail_render(cur, job=job, error=str(exc), cfg=cfg)
+            except ExperienceLeaseLostError:
+                logger.exception(
+                    "Rejected failure write for experience render job %s",
+                    job["job_id"],
+                )
+            logger.exception("Failed experience render job %s", job["job_id"])
+    return rendered_count, failed_count

--- a/nexus/agents/orrery/experiences.py
+++ b/nexus/agents/orrery/experiences.py
@@ -13,6 +13,11 @@ from uuid import uuid4
 from psycopg2.extras import RealDictCursor
 from pydantic import BaseModel, ConfigDict, Field
 
+from nexus.agents.orrery.epistemics import (
+    CLAIM_BIRTH_ROLE_POLICY,
+    PARTICIPANT_ROLES,
+    WITNESS_ROLES,
+)
 from nexus.config.settings_models import OrreryExperienceSettings
 from nexus.telemetry.usage import usage_context
 
@@ -23,12 +28,54 @@ RENDERER_VERSION = "experience-renderer-v1"
 _PROMPT_PATH = (
     Path(__file__).resolve().parents[3] / "prompts" / "experience_renderer.md"
 )
-_PARTICIPANT_ROLES = frozenset({"actor", "target", "beneficiary"})
-_CAPITALIZED_NAME = re.compile(
-    r"(?<![.!?]\s)(?<!^)\b[A-Z][a-z]+(?:[ '-][A-Z][a-z]+)*\b"
+_CAPITALIZED_SEQUENCE = re.compile(r"\b[A-Z][A-Za-z0-9]*(?:[ '-][A-Z][A-Za-z0-9]*)*\b")
+_SENTENCE_INITIAL_ALLOWLIST = frozenset(
+    {
+        "a",
+        "after",
+        "an",
+        "and",
+        "as",
+        "at",
+        "before",
+        "but",
+        "by",
+        "for",
+        "from",
+        "he",
+        "i",
+        "in",
+        "it",
+        "my",
+        "once",
+        "our",
+        "she",
+        "so",
+        "that",
+        "the",
+        "then",
+        "they",
+        "this",
+        "through",
+        "to",
+        "until",
+        "we",
+        "when",
+        "while",
+        "with",
+        "without",
+    }
 )
 _FIRST_PERSON = re.compile(r"\b(?:I|me|my|mine|we|us|our|ours)\b", re.IGNORECASE)
 _SENTENCE = re.compile(r"(?<=[.!?])(?:[\"']?\s+|$)")
+_ACQUISITION_RECEIPT = re.compile(
+    r"\b(?:told|heard|learned|informed|received|read|listened|account|message|report)\b",
+    re.IGNORECASE,
+)
+_ACQUISITION_WITNESS = re.compile(
+    r"\b(?:saw|watched|witnessed|observed|looked on|was there)\b",
+    re.IGNORECASE,
+)
 
 
 class ExperienceRecollection(BaseModel):
@@ -217,6 +264,48 @@ def _event_fact(row: Mapping[str, Any]) -> str:
     return fact + "."
 
 
+def _public_audience_entity_ids(row: Mapping[str, Any]) -> frozenset[int]:
+    """Return an emitter-declared audience only for explicitly public events."""
+
+    payload = _json_mapping(row.get("payload"))
+    if payload.get("on_screen_public") is not True:
+        return frozenset()
+    raw_audience = payload.get("audience_entity_ids")
+    if not isinstance(raw_audience, list):
+        raise ValueError(
+            f"Public event {row['id']} must declare audience_entity_ids as a list"
+        )
+    audience: set[int] = set()
+    for raw_id in raw_audience:
+        if isinstance(raw_id, bool):
+            raise ValueError(f"Public event {row['id']} has an invalid audience id")
+        entity_id = int(raw_id)
+        if entity_id <= 0:
+            raise ValueError(f"Public event {row['id']} has an invalid audience id")
+        audience.add(entity_id)
+    return frozenset(audience)
+
+
+def _event_receipts(row: Mapping[str, Any]) -> dict[int, str]:
+    """Derive actor-owned receipt bases from canonical event roles and policy."""
+
+    event_type = str(row["event_type"])
+    birth_roles = CLAIM_BIRTH_ROLE_POLICY.get(event_type)
+    receipts: dict[int, str] = {}
+    for participant in row.get("participants") or []:
+        if not isinstance(participant, Mapping):
+            raise ValueError(f"Event {row['id']} has a malformed participant receipt")
+        entity_id = int(participant["entity_id"])
+        role = str(participant["role"])
+        if role in PARTICIPANT_ROLES and (birth_roles is None or role in birth_roles):
+            receipts[entity_id] = "participant"
+        elif role in WITNESS_ROLES and birth_roles is not None and role in birth_roles:
+            receipts.setdefault(entity_id, "witness")
+    for entity_id in _public_audience_entity_ids(row):
+        receipts.setdefault(entity_id, "witness")
+    return receipts
+
+
 def _insert_experience(
     cur: Any,
     *,
@@ -322,28 +411,20 @@ def seed_character_experiences_sync(
 
         cur.execute(
             """
-            SELECT c.entity_id, c.name, c.summary, c.background, c.personality
-            FROM chunk_character_references ccr
-            JOIN characters c ON c.id = ccr.character_id
-            WHERE ccr.chunk_id = %s
-              AND ccr.reference::text = 'present'
-              AND c.entity_id IS NOT NULL
-            ORDER BY c.entity_id
-            """,
-            (anchor_chunk_id,),
-        )
-        present = [dict(row) for row in cur.fetchall()]
-        eligible = [row for row in present if _eligible_character(row, cfg)]
-
-        cur.execute(
-            """
             SELECT e.id, e.event_type, e.actor_entity_id, e.target_entity_id,
                    e.location_id, e.magnitude, e.payload,
                    actor.name AS actor_name, target.name AS target_name,
                    place.name AS location_name, r.state_delta,
-                   COALESCE(array_agg(wee.entity_id) FILTER (
-                       WHERE wee.role::text IN ('actor', 'target', 'beneficiary')
-                   ), '{}') AS participant_entity_ids
+                   COALESCE(
+                       jsonb_agg(
+                           jsonb_build_object(
+                               'entity_id', wee.entity_id,
+                               'role', wee.role::text
+                           )
+                           ORDER BY wee.entity_id, wee.role::text
+                       ) FILTER (WHERE wee.entity_id IS NOT NULL),
+                       '[]'::jsonb
+                   ) AS participants
             FROM world_events e
             LEFT JOIN entity_names_v actor ON actor.id = e.actor_entity_id
             LEFT JOIN entity_names_v target ON target.id = e.target_entity_id
@@ -358,17 +439,31 @@ def seed_character_experiences_sync(
             (anchor_chunk_id,),
         )
         events = [dict(row) for row in cur.fetchall()]
-        event_ids = [int(row["id"]) for row in events]
-        facts = " ".join(_event_fact(row) for row in events)
-        for character in eligible:
-            if not events:
-                break
-            character_id = int(character["entity_id"])
-            participant = any(
-                character_id in set(row["participant_entity_ids"] or [])
-                for row in events
+        receipts: dict[tuple[int, str], list[dict[str, Any]]] = {}
+        for event in events:
+            for entity_id, basis in _event_receipts(event).items():
+                receipts.setdefault((entity_id, basis), []).append(event)
+        receipt_entity_ids = sorted({entity_id for entity_id, _basis in receipts})
+        eligible_by_id: dict[int, dict[str, Any]] = {}
+        if receipt_entity_ids:
+            cur.execute(
+                """
+                SELECT entity_id, name, summary, background, personality
+                FROM characters
+                WHERE entity_id = ANY(%s)
+                ORDER BY entity_id
+                """,
+                (receipt_entity_ids,),
             )
-            basis = "participant" if participant else "witness"
+            eligible_by_id = {
+                int(row["entity_id"]): dict(row)
+                for row in cur.fetchall()
+                if _eligible_character(row, cfg)
+            }
+        for (character_id, basis), owned_events in sorted(receipts.items()):
+            character = eligible_by_id.get(character_id)
+            if character is None:
+                continue
             duration = _presence_duration(
                 cur,
                 character_entity_id=character_id,
@@ -377,10 +472,15 @@ def seed_character_experiences_sync(
                 cap=cfg.presence_duration_cap_chunks,
             )
             location_id = next(
-                (int(row["location_id"]) for row in events if row.get("location_id")),
+                (
+                    int(row["location_id"])
+                    for row in owned_events
+                    if row.get("location_id")
+                ),
                 metadata.get("setting_place_id"),
             )
-            basis_phrase = "participated in" if participant else "witnessed"
+            basis_phrase = "participated in" if basis == "participant" else "witnessed"
+            facts = " ".join(_event_fact(row) for row in owned_events)
             seed_summary = (
                 f"{character['name']} {basis_phrase} the accepted scene at "
                 f"{world_time.isoformat() if world_time else 'an unknown world time'}. "
@@ -391,7 +491,7 @@ def seed_character_experiences_sync(
                     cur,
                     character_entity_id=character_id,
                     anchor_chunk_id=anchor_chunk_id,
-                    world_event_ids=event_ids,
+                    world_event_ids=[int(row["id"]) for row in owned_events],
                     claim_id=None,
                     claim_awareness_id=None,
                     basis=basis,
@@ -400,7 +500,7 @@ def seed_character_experiences_sync(
                     seed_summary=seed_summary,
                     emotion=_active_mood(cur, character_id),
                     salience=_salience(
-                        events=events,
+                        events=owned_events,
                         presence_duration=duration,
                         cfg=cfg,
                     ),
@@ -484,13 +584,56 @@ def enqueue_scene_experience_job_sync(
     world_layer: str,
     slot: Optional[int],
     settings: Mapping[str, Any],
-) -> bool:
-    """Enqueue one immutable prior-scene seed batch at a scene reset."""
+) -> int:
+    """Enqueue bounded immutable prior-scene seed batches at a scene reset."""
 
     cfg = experience_settings(settings)
     if not cfg.enabled or scene_end_chunk_id <= 0:
-        return False
+        return 0
     with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT boundary.season AS boundary_season,
+                   boundary.episode AS boundary_episode,
+                   boundary.scene AS boundary_scene,
+                   boundary.world_layer::text AS boundary_world_layer,
+                   scene_end.season AS scene_end_season,
+                   scene_end.episode AS scene_end_episode,
+                   scene_end.scene AS scene_end_scene,
+                   scene_end.world_layer::text AS scene_end_world_layer
+            FROM chunk_metadata boundary
+            JOIN chunk_metadata scene_end ON scene_end.chunk_id = %s
+            WHERE boundary.chunk_id = %s
+            FOR SHARE OF boundary, scene_end
+            """,
+            (scene_end_chunk_id, boundary_chunk_id),
+        )
+        timeline = cur.fetchone()
+        if timeline is None:
+            raise RuntimeError(
+                "Experience boundary or scene-end anchor lacks timeline metadata"
+            )
+        if (
+            timeline["boundary_world_layer"] != world_layer
+            or timeline["scene_end_world_layer"] != world_layer
+        ):
+            raise ValueError(
+                "Experience boundary and scene-end anchor must match the requested "
+                f"world layer {world_layer!r}"
+            )
+        cur.execute(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM character_experience_jobs
+                WHERE boundary_chunk_id = %s
+                  AND world_layer::text = %s
+            ) AS already_enqueued
+            """,
+            (boundary_chunk_id, world_layer),
+        )
+        if bool(cur.fetchone()["already_enqueued"]):
+            return 0
         cur.execute(
             """
             SELECT max(boundary_chunk_id) AS previous_boundary
@@ -517,27 +660,48 @@ def enqueue_scene_experience_job_sync(
         )
         rows = [dict(row) for row in cur.fetchall()]
         if not rows:
-            return False
-        cur.execute(
-            """
-            INSERT INTO character_experience_jobs (
-                boundary_chunk_id, scene_end_chunk_id, world_layer,
-                experience_ids, slot, model, source_digest
-            ) VALUES (%s, %s, %s::world_layer_type, %s, %s, %s, %s)
-            ON CONFLICT (boundary_chunk_id, world_layer) DO NOTHING
-            RETURNING id
-            """,
-            (
-                boundary_chunk_id,
-                scene_end_chunk_id,
-                world_layer,
-                [int(row["id"]) for row in rows],
-                str(slot) if slot is not None else "default",
-                cfg.model,
-                _batch_digest(rows),
-            ),
-        )
-        return cur.fetchone() is not None
+            return 0
+        inserted = 0
+        for batch_ordinal, start in enumerate(
+            range(0, len(rows), cfg.max_seeds_per_render)
+        ):
+            batch_rows = rows[start : start + cfg.max_seeds_per_render]
+            cur.execute(
+                """
+                INSERT INTO character_experience_jobs (
+                    boundary_chunk_id, scene_end_chunk_id, world_layer,
+                    boundary_season, boundary_episode, boundary_scene,
+                    scene_end_season, scene_end_episode, scene_end_scene,
+                    batch_ordinal, experience_ids, slot, requested_model,
+                    source_digest
+                ) VALUES (
+                    %s, %s, %s::world_layer_type, %s, %s, %s,
+                    %s, %s, %s, %s, %s, %s, %s, %s
+                )
+                ON CONFLICT (
+                    boundary_chunk_id, world_layer, batch_ordinal
+                ) DO NOTHING
+                RETURNING id
+                """,
+                (
+                    boundary_chunk_id,
+                    scene_end_chunk_id,
+                    world_layer,
+                    timeline["boundary_season"],
+                    timeline["boundary_episode"],
+                    timeline["boundary_scene"],
+                    timeline["scene_end_season"],
+                    timeline["scene_end_episode"],
+                    timeline["scene_end_scene"],
+                    batch_ordinal,
+                    [int(row["id"]) for row in batch_rows],
+                    str(slot) if slot is not None else "default",
+                    cfg.model,
+                    _batch_digest(batch_rows),
+                ),
+            )
+            inserted += int(cur.fetchone() is not None)
+        return inserted
 
 
 def _known_and_allowed_names(
@@ -545,6 +709,55 @@ def _known_and_allowed_names(
 ) -> tuple[set[str], set[str]]:
     cur.execute("SELECT name FROM entity_names_v WHERE name IS NOT NULL")
     known = {str(item["name"]) for item in cur.fetchall() if str(item["name"]).strip()}
+    if row["basis"] == "acquisition":
+        cur.execute(
+            """
+            SELECT claim.summary, claim.account_payload, claim.account_label,
+                   owner.name AS owner_name,
+                   immediate.name AS immediate_source_name,
+                   root.name AS root_source_name
+            FROM claims claim
+            JOIN claim_awareness awareness ON awareness.id = %s
+            JOIN entity_names_v owner ON owner.id = %s
+            LEFT JOIN entity_names_v immediate
+              ON immediate.id = awareness.immediate_source_entity_id
+            LEFT JOIN entity_names_v root
+              ON root.id = awareness.root_source_entity_id
+            WHERE claim.id = %s
+            """,
+            (
+                row["claim_awareness_id"],
+                row["character_entity_id"],
+                row["claim_id"],
+            ),
+        )
+        account = cur.fetchone()
+        if account is None:
+            raise ExperienceSourceStaleError(
+                f"Acquisition experience {row['id']} lost its delivered account"
+            )
+        scope = " ".join(
+            (
+                str(account.get("summary") or ""),
+                json.dumps(account.get("account_payload"), default=str),
+                str(account.get("account_label") or ""),
+            )
+        )
+        allowed = {
+            str(name)
+            for name in (
+                account.get("owner_name"),
+                account.get("immediate_source_name"),
+                account.get("root_source_name"),
+            )
+            if name
+        }
+        allowed.update(
+            name
+            for name in known
+            if re.search(rf"\b{re.escape(name)}\b", scope, re.IGNORECASE)
+        )
+        return known, allowed
     cur.execute(
         """
         SELECT DISTINCT names.name
@@ -586,6 +799,22 @@ def _known_and_allowed_names(
     return known, allowed
 
 
+def _proper_noun_candidates(text: str) -> set[str]:
+    candidates: set[str] = set()
+    for match in _CAPITALIZED_SEQUENCE.finditer(text):
+        candidate = match.group(0).strip()
+        while candidate:
+            first = re.match(r"^[A-Za-z0-9]+", candidate)
+            if first is None or first.group(0).casefold() not in (
+                _SENTENCE_INITIAL_ALLOWLIST
+            ):
+                break
+            candidate = candidate[first.end() :].lstrip(" '-")
+        if candidate:
+            candidates.add(candidate)
+    return candidates
+
+
 def validate_render_batch(
     rows: Sequence[Mapping[str, Any]],
     batch: ExperienceRenderBatch,
@@ -615,6 +844,20 @@ def validate_render_batch(
             raise ValueError(
                 f"Experience {recollection.experience_id} is not first person"
             )
+        source_row = next(
+            row for row in rows if int(row["id"]) == recollection.experience_id
+        )
+        if source_row.get("basis") == "acquisition":
+            if _ACQUISITION_RECEIPT.search(text) is None:
+                raise ValueError(
+                    f"Acquisition experience {recollection.experience_id} must "
+                    "describe receiving or learning the account"
+                )
+            if _ACQUISITION_WITNESS.search(text) is not None:
+                raise ValueError(
+                    f"Acquisition experience {recollection.experience_id} "
+                    "must not describe witnessing the underlying event"
+                )
         known, allowed = (
             names_by_experience.get(recollection.experience_id, (set(), set()))
             if names_by_experience is not None
@@ -623,17 +866,12 @@ def validate_render_batch(
         disallowed_known = sorted(
             name
             for name in known - allowed
-            if re.search(rf"\b{re.escape(name)}\b", text)
+            if re.search(rf"\b{re.escape(name)}\b", text, re.IGNORECASE)
         )
-        capitalized = {
-            match.group(0)
-            for match in _CAPITALIZED_NAME.finditer(text)
-            if match.group(0) not in {"I"}
-        }
+        allowed_casefold = {name.casefold() for name in allowed}
+        capitalized = _proper_noun_candidates(text)
         invented = sorted(
-            name
-            for name in capitalized
-            if not any(name in allowed_name for allowed_name in allowed)
+            name for name in capitalized if name.casefold() not in allowed_casefold
         )
         if disallowed_known or invented:
             offenders = sorted(set(disallowed_known + invented))
@@ -697,12 +935,17 @@ def _complete_render(
     job: Mapping[str, Any],
     rows: Sequence[Mapping[str, Any]],
     rendered: Mapping[int, str],
+    render_model: str,
 ) -> None:
     cur.execute(
         """
         SELECT state::text AS state, locked_by, lease_nonce,
                lease_until >= clock_timestamp() AS lease_live,
-               source_digest, world_layer::text AS world_layer
+               source_digest, world_layer::text AS world_layer,
+               boundary_chunk_id, scene_end_chunk_id,
+               boundary_season, boundary_episode, boundary_scene,
+               scene_end_season, scene_end_episode, scene_end_scene,
+               requested_model
         FROM character_experience_jobs
         WHERE id = %s
         FOR UPDATE
@@ -717,6 +960,55 @@ def _complete_render(
     if current["source_digest"] != job["source_digest"]:
         raise ExperienceSourceStaleError(
             f"Experience job {job['job_id']} source digest changed"
+        )
+    frozen_fields = (
+        "world_layer",
+        "boundary_chunk_id",
+        "scene_end_chunk_id",
+        "boundary_season",
+        "boundary_episode",
+        "boundary_scene",
+        "scene_end_season",
+        "scene_end_episode",
+        "scene_end_scene",
+        "requested_model",
+    )
+    if any(current[field] != job[field] for field in frozen_fields):
+        raise ExperienceSourceStaleError(
+            f"Experience job {job['job_id']} frozen timeline identity changed"
+        )
+    cur.execute(
+        """
+        SELECT boundary.season AS boundary_season,
+               boundary.episode AS boundary_episode,
+               boundary.scene AS boundary_scene,
+               boundary.world_layer::text AS boundary_world_layer,
+               scene_end.season AS scene_end_season,
+               scene_end.episode AS scene_end_episode,
+               scene_end.scene AS scene_end_scene,
+               scene_end.world_layer::text AS scene_end_world_layer
+        FROM chunk_metadata boundary
+        JOIN chunk_metadata scene_end ON scene_end.chunk_id = %s
+        WHERE boundary.chunk_id = %s
+        FOR SHARE OF boundary, scene_end
+        """,
+        (job["scene_end_chunk_id"], job["boundary_chunk_id"]),
+    )
+    timeline = cur.fetchone()
+    if timeline is None or any(
+        (
+            timeline.get("boundary_world_layer") != job["world_layer"],
+            timeline.get("scene_end_world_layer") != job["world_layer"],
+            timeline.get("boundary_season") != job["boundary_season"],
+            timeline.get("boundary_episode") != job["boundary_episode"],
+            timeline.get("boundary_scene") != job["boundary_scene"],
+            timeline.get("scene_end_season") != job["scene_end_season"],
+            timeline.get("scene_end_episode") != job["scene_end_episode"],
+            timeline.get("scene_end_scene") != job["scene_end_scene"],
+        )
+    ):
+        raise ExperienceSourceStaleError(
+            f"Experience job {job['job_id']} boundary timeline is stale"
         )
     cur.execute(
         """
@@ -758,7 +1050,7 @@ def _complete_render(
             """,
             (
                 rendered[experience_id],
-                job["model"],
+                render_model,
                 RENDERER_VERSION,
                 generation_id,
                 experience_id,
@@ -869,8 +1161,11 @@ def drain_experience_render_jobs_sync(
         with conn.cursor(cursor_factory=RealDictCursor) as cur:
             cur.execute(
                 """
-                SELECT id AS job_id, experience_ids, attempts, model,
-                       source_digest, world_layer::text AS world_layer, slot
+                SELECT id AS job_id, experience_ids, attempts, requested_model,
+                       source_digest, world_layer::text AS world_layer, slot,
+                       boundary_chunk_id, scene_end_chunk_id,
+                       boundary_season, boundary_episode, boundary_scene,
+                       scene_end_season, scene_end_episode, scene_end_scene
                 FROM character_experience_jobs
                 WHERE (
                     (state = 'queued' AND available_at <= clock_timestamp())
@@ -913,27 +1208,33 @@ def drain_experience_render_jobs_sync(
     failed_count = 0
     for job in jobs:
         try:
-            with conn.cursor(cursor_factory=RealDictCursor) as cur:
-                cur.execute(
-                    """
-                    SELECT experience.id, experience.character_entity_id,
-                           experience.world_event_ids, experience.basis::text AS basis,
-                           experience.location_id, experience.world_time,
-                           experience.seed_summary, experience.source_digest,
-                           character.name AS character_name, place.name AS location_name
-                    FROM character_experiences experience
-                    JOIN characters character
-                      ON character.entity_id = experience.character_entity_id
-                    LEFT JOIN places place ON place.id = experience.location_id
-                    WHERE experience.id = ANY(%s)
-                    ORDER BY experience.id
-                    """,
-                    (job["experience_ids"],),
-                )
-                rows = [dict(row) for row in cur.fetchall()]
-                names = {
-                    int(row["id"]): _known_and_allowed_names(cur, row) for row in rows
-                }
+            with conn:
+                with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                    cur.execute(
+                        """
+                        SELECT experience.id, experience.character_entity_id,
+                               experience.world_event_ids,
+                               experience.claim_id,
+                               experience.claim_awareness_id,
+                               experience.basis::text AS basis,
+                               experience.location_id, experience.world_time,
+                               experience.seed_summary, experience.source_digest,
+                               character.name AS character_name,
+                               place.name AS location_name
+                        FROM character_experiences experience
+                        JOIN characters character
+                          ON character.entity_id = experience.character_entity_id
+                        LEFT JOIN places place ON place.id = experience.location_id
+                        WHERE experience.id = ANY(%s)
+                        ORDER BY experience.id
+                        """,
+                        (job["experience_ids"],),
+                    )
+                    rows = [dict(row) for row in cur.fetchall()]
+                    names = {
+                        int(row["id"]): _known_and_allowed_names(cur, row)
+                        for row in rows
+                    }
             prompt = _render_prompt(rows)
             with usage_context(
                 seat="experience_renderer",
@@ -949,7 +1250,13 @@ def drain_experience_render_jobs_sync(
             validated = validate_render_batch(rows, batch, names_by_experience=names)
             with conn:
                 with conn.cursor(cursor_factory=RealDictCursor) as cur:
-                    _complete_render(cur, job=job, rows=rows, rendered=validated)
+                    _complete_render(
+                        cur,
+                        job=job,
+                        rows=rows,
+                        rendered=validated,
+                        render_model=cfg.model,
+                    )
             rendered_count += len(rows)
         except ExperienceLeaseLostError:
             failed_count += 1

--- a/nexus/agents/orrery/worker.py
+++ b/nexus/agents/orrery/worker.py
@@ -17,6 +17,7 @@ from nexus.agents.orrery.retrograde_maturation import (
     drain_maturation_jobs_sync,
     load_maturation_status_sync,
 )
+from nexus.agents.orrery.experiences import drain_experience_render_jobs_sync
 from nexus.config import load_settings_as_dict
 from nexus.config.settings_models import OrreryNarrationSettings, OrreryPromoteSettings
 from nexus.telemetry.usage import usage_context
@@ -61,6 +62,8 @@ class OrreryWorkerResult(BaseModel):
     semantically_cleared: int = 0
     matured: int = 0
     maturation_failed: int = 0
+    experiences_rendered: int = 0
+    experience_render_failed: int = 0
 
 
 class NarrationCompletionRejectedError(RuntimeError):
@@ -110,6 +113,8 @@ def process_orrery_outbox_sync(
     settings: Optional[Mapping[str, Any]] = None,
     narration_provider: Optional[Any] = None,
     maturation_limit: Optional[int] = None,
+    experience_limit: Optional[int] = None,
+    experience_provider: Optional[Any] = None,
 ) -> OrreryWorkerResult:
     """Drain pending Orrery background work."""
 
@@ -137,6 +142,12 @@ def process_orrery_outbox_sync(
         limit=maturation_limit,
         settings=settings,
     )
+    experiences_rendered, experience_render_failed = drain_experience_outbox_sync(
+        slot=slot,
+        settings=settings,
+        provider=experience_provider,
+        limit=experience_limit,
+    )
     return OrreryWorkerResult(
         promoted=promoted,
         skipped=skipped,
@@ -145,7 +156,33 @@ def process_orrery_outbox_sync(
         semantically_cleared=semantically_cleared,
         matured=matured,
         maturation_failed=maturation_failed,
+        experiences_rendered=experiences_rendered,
+        experience_render_failed=experience_render_failed,
     )
+
+
+def drain_experience_outbox_sync(
+    slot: Optional[int] = None,
+    *,
+    settings: Optional[Mapping[str, Any]] = None,
+    provider: Optional[Any] = None,
+    limit: Optional[int] = None,
+    conn: Optional[Any] = None,
+) -> tuple[int, int]:
+    """Drain actor-experience scene jobs with the worker's slot connection."""
+    owns_conn = conn is None
+    connection = conn or _connect_for_slot(slot)
+    try:
+        return drain_experience_render_jobs_sync(
+            slot=slot,
+            settings=dict(settings or load_settings_as_dict()),
+            conn=connection,
+            provider=provider,
+            limit=limit,
+        )
+    finally:
+        if owns_conn:
+            connection.close()
 
 
 def promote_pending_resolutions_sync(

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -684,7 +684,7 @@ def commit_incubator_to_database_sync(
                     chunk_id,
                 )
             if metadata_update.scene_boundary and not is_bootstrap:
-                enqueued = enqueue_scene_experience_job_sync(
+                enqueued_jobs = enqueue_scene_experience_job_sync(
                     conn,
                     boundary_chunk_id=chunk_id,
                     scene_end_chunk_id=int(incubator["parent_chunk_id"]),
@@ -692,9 +692,10 @@ def commit_incubator_to_database_sync(
                     slot=slot,
                     settings=orrery_settings,
                 )
-                if enqueued:
+                if enqueued_jobs:
                     logger.info(
-                        "Enqueued character experience scene batch at chunk %s",
+                        "Enqueued %s character experience scene batches at chunk %s",
+                        enqueued_jobs,
                         chunk_id,
                     )
 

--- a/nexus/api/commit_handler_sync.py
+++ b/nexus/api/commit_handler_sync.py
@@ -23,6 +23,10 @@ from nexus.agents.logon.apex_schema import (
 )
 from nexus.agents.orrery.bleed import record_bleed_uptake_sync
 from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.agents.orrery.experiences import (
+    enqueue_scene_experience_job_sync,
+    seed_character_experiences_sync,
+)
 from nexus.agents.orrery.retrograde_maturation import (
     enqueue_declared_entity_maturations,
 )
@@ -664,6 +668,35 @@ def commit_incubator_to_database_sync(
                     orrery_result.propagation_count,
                     orrery_result.reveal_count,
                 )
+
+            # Step 9.52: deterministic actor-owned experience formation. The
+            # provider is deliberately absent from this accepted transaction;
+            # a scene reset only enqueues the prior scene's immutable seed set.
+            experience_count = seed_character_experiences_sync(
+                conn,
+                anchor_chunk_id=chunk_id,
+                settings=orrery_settings,
+            )
+            if experience_count:
+                logger.info(
+                    "Inserted %s character experience seeds for chunk %s",
+                    experience_count,
+                    chunk_id,
+                )
+            if metadata_update.scene_boundary and not is_bootstrap:
+                enqueued = enqueue_scene_experience_job_sync(
+                    conn,
+                    boundary_chunk_id=chunk_id,
+                    scene_end_chunk_id=int(incubator["parent_chunk_id"]),
+                    world_layer=world_layer,
+                    slot=slot,
+                    settings=orrery_settings,
+                )
+                if enqueued:
+                    logger.info(
+                        "Enqueued character experience scene batch at chunk %s",
+                        chunk_id,
+                    )
 
             # Step 9.55: interval state checkpoint (reconstruction bar 7c).
             # Fresh cursor: the earlier `with conn.cursor()` blocks have

--- a/nexus/api/lore_adapter.py
+++ b/nexus/api/lore_adapter.py
@@ -321,6 +321,9 @@ def extract_metadata_updates(response: StoryTurnResponse) -> Dict[str, Any]:
         if scene_weather is not None:
             metadata_updates["scene_weather"] = scene_weather
 
+        if bool(getattr(metadata, "scene_boundary", False)):
+            metadata_updates["scene_boundary"] = True
+
     return metadata_updates
 
 

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1310,6 +1310,11 @@ class OrreryExperienceSettings(BaseModel):
     retry_delay_seconds: int = Field(default=300, ge=0)
     lease_duration_seconds: int = Field(default=300, ge=1)
     max_jobs_per_drain: int = Field(default=2, ge=1)
+    max_seeds_per_render: int = Field(
+        default=12,
+        ge=1,
+        description="Maximum experience seeds included in one provider call",
+    )
 
     @model_validator(mode="after")
     def _validate_eligibility_and_salience(self) -> "OrreryExperienceSettings":

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1283,6 +1283,52 @@ class OrreryNarrationSettings(BaseModel):
     )
 
 
+class OrreryExperienceSettings(BaseModel):
+    """Actor-owned experiential memory settings for ``[orrery.experiences]``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    model: str = Field(..., description="Model ID or @provider.role reference")
+    dossier_fields: List[Literal["summary", "background", "personality"]] = Field(
+        default_factory=lambda: ["summary", "background", "personality"],
+        min_length=1,
+        description="Character dossier fields counted by the eligibility gate",
+    )
+    minimum_dossier_fields: int = Field(
+        default=2,
+        ge=1,
+        le=3,
+        description="Non-empty configured dossier fields required for eligibility",
+    )
+    magnitude_weight: float = Field(default=0.60, ge=0.0, le=1.0)
+    valence_delta_weight: float = Field(default=0.25, ge=0.0, le=1.0)
+    presence_duration_weight: float = Field(default=0.15, ge=0.0, le=1.0)
+    presence_duration_cap_chunks: int = Field(default=8, ge=1)
+    max_output_tokens: int = Field(default=2400, ge=1)
+    max_attempts: int = Field(default=3, ge=1)
+    retry_delay_seconds: int = Field(default=300, ge=0)
+    lease_duration_seconds: int = Field(default=300, ge=1)
+    max_jobs_per_drain: int = Field(default=2, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_eligibility_and_salience(self) -> "OrreryExperienceSettings":
+        if self.minimum_dossier_fields > len(self.dossier_fields):
+            raise ValueError(
+                "minimum_dossier_fields cannot exceed configured dossier_fields"
+            )
+        if len(set(self.dossier_fields)) != len(self.dossier_fields):
+            raise ValueError("dossier_fields must be unique")
+        total = (
+            self.magnitude_weight
+            + self.valence_delta_weight
+            + self.presence_duration_weight
+        )
+        if abs(total - 1.0) > 1e-9:
+            raise ValueError("experience salience weights must sum to 1.0")
+        return self
+
+
 class OrreryBleedSettings(BaseModel):
     """Bleed selector settings for storyteller-time ambient candidates."""
 
@@ -2470,6 +2516,7 @@ class OrrerySettings(BaseModel):
         default_factory=OrreryRouteGraphSettings
     )
     narration: OrreryNarrationSettings
+    experiences: OrreryExperienceSettings
     bleed: OrreryBleedSettings = Field(default_factory=OrreryBleedSettings)
     ambient: OrreryAmbientSettings = Field(default_factory=OrreryAmbientSettings)
     promote: OrreryPromoteSettings = Field(default_factory=OrreryPromoteSettings)
@@ -3402,6 +3449,7 @@ class Settings(BaseModel):
         ]
         if self.orrery is not None:
             targets.append((self.orrery.narration, "model_ref", False))
+            targets.append((self.orrery.experiences, "model", False))
             targets.append((self.orrery.retrograde.maturation, "model_ref", True))
         if self.ir_eval is not None and self.ir_eval.judgment is not None:
             targets.append((self.ir_eval.judgment, "model", False))

--- a/prompts/experience_renderer.md
+++ b/prompts/experience_renderer.md
@@ -1,0 +1,21 @@
+# Experience Renderer
+
+The renderer receives one scene's factual seed records for several characters.
+
+Each seed names its character, the events that character took part in or witnessed, and the scene's time and place.
+
+The renderer writes each character's private recollection of the scene.
+
+A recollection is two to four sentences of first-person past-tense memory in that character's interior voice.
+
+A recollection states what happened from that character's vantage: what they did, saw, heard, felt, and concluded.
+
+A recollection may carry emotion and judgment; it may not introduce people, places, objects, or events absent from its seed.
+
+A participant describes events from within; a witness describes them from the outside.
+
+Divergence between characters' recollections of the same scene is expected and desirable.
+
+People and places are named exactly as the seed names them.
+
+The output carries one recollection per seed, keyed by that seed's experience id.

--- a/prompts/experience_renderer.md
+++ b/prompts/experience_renderer.md
@@ -14,6 +14,8 @@ A recollection may carry emotion and judgment; it may not introduce people, plac
 
 A participant describes events from within; a witness describes them from the outside.
 
+An acquisition seed records being told an account; its recollection describes hearing the account, in the teller's framing, and never describes witnessing the underlying events.
+
 Divergence between characters' recollections of the same scene is expected and desirable.
 
 People and places are named exactly as the seed names them.

--- a/tests/test_commit_handler_sync.py
+++ b/tests/test_commit_handler_sync.py
@@ -287,6 +287,16 @@ def test_sync_commit_links_same_turn_character_declaration(monkeypatch):
     monkeypatch.setattr(
         commit_handler_sync, "_orrery_checkpoint_interval", lambda _settings: 0
     )
+    monkeypatch.setattr(
+        commit_handler_sync,
+        "seed_character_experiences_sync",
+        lambda *_args, **_kwargs: 0,
+    )
+    monkeypatch.setattr(
+        commit_handler_sync,
+        "enqueue_scene_experience_job_sync",
+        lambda *_args, **_kwargs: False,
+    )
 
     chunk_id = commit_incubator_to_database_sync(conn, "session-1", slot=5)
 
@@ -526,6 +536,16 @@ def _patch_sync_commit_runtime(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         commit_handler_sync, "_orrery_checkpoint_interval", lambda _settings: 0
+    )
+    monkeypatch.setattr(
+        commit_handler_sync,
+        "seed_character_experiences_sync",
+        lambda *_args, **_kwargs: 0,
+    )
+    monkeypatch.setattr(
+        commit_handler_sync,
+        "enqueue_scene_experience_job_sync",
+        lambda *_args, **_kwargs: False,
     )
 
 

--- a/tests/test_orrery/test_character_experiences_pg.py
+++ b/tests/test_orrery/test_character_experiences_pg.py
@@ -1,0 +1,589 @@
+"""Real accepted-commit and queue proofs for character experiences."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import re
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2
+from psycopg2 import sql
+from psycopg2.extras import Json, RealDictCursor
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.engine import URL
+from sqlalchemy.orm import Session
+
+from nexus.agents.orrery.experiences import (
+    ExperienceRecollection,
+    ExperienceRenderBatch,
+    drain_experience_render_jobs_sync,
+    enqueue_scene_experience_job_sync,
+    seed_character_experiences_sync,
+)
+from nexus.agents.orrery.resolver import resolve_dry_run
+from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+from nexus.api.commit_handler_sync import commit_incubator_to_database_sync
+from nexus.config import load_settings_as_dict
+
+
+pytestmark = pytest.mark.requires_postgres
+
+ROOT = Path(__file__).parents[2]
+MIGRATION_SQL = (ROOT / "migrations" / "104_character_experiences.sql").read_text()
+
+
+def _connect(dbname: str) -> Any:
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+        connect_timeout=2,
+    )
+
+
+@contextmanager
+def _disposable_database() -> Iterator[str]:
+    """Yield one migrated template clone and drop it even after failure."""
+    dbname = f"qa677_{uuid4().hex[:12]}"
+    source = os.environ.get("NEXUS_TEST_TEMPLATE_DB", "NEXUS_template")
+    assert source == "NEXUS_template" or source.startswith("qa677_")
+    admin: Any = None
+    try:
+        try:
+            admin = _connect("postgres")
+        except psycopg2.Error as exc:
+            pytest.skip(f"PostgreSQL admin connection unavailable: {exc}")
+        admin.autocommit = True
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname), sql.Identifier(source)
+                )
+            )
+        conn = _connect(dbname)
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(MIGRATION_SQL)
+        finally:
+            conn.close()
+        yield dbname
+    finally:
+        if admin is not None:
+            with admin.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = %s AND pid <> pg_backend_pid()",
+                    (dbname,),
+                )
+                cur.execute(
+                    sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+                )
+            admin.close()
+
+
+def _insert_chunk(cur: Any, label: str) -> int:
+    cur.execute(
+        "INSERT INTO narrative_chunks (raw_text, storyteller_text) "
+        "VALUES (%s, %s) RETURNING id",
+        (label, label),
+    )
+    chunk_id = int(cur.fetchone()[0])
+    cur.execute(
+        "INSERT INTO chunk_metadata "
+        "(chunk_id, season, episode, scene, world_layer, slug) "
+        "VALUES (%s, 1, 1, %s, 'primary', %s)",
+        (chunk_id, chunk_id, f"qa677_{chunk_id}"),
+    )
+    cur.execute(
+        "UPDATE chunk_metadata SET world_time = %s WHERE chunk_id = %s",
+        (datetime(2196, 7, 6, 23, 0, tzinfo=timezone.utc), chunk_id),
+    )
+    return chunk_id
+
+
+def _insert_character(
+    cur: Any,
+    name: str,
+    *,
+    summary: str | None,
+    background: str | None,
+) -> tuple[int, int]:
+    cur.execute("INSERT INTO entities (kind) VALUES ('character') RETURNING id")
+    entity_id = int(cur.fetchone()[0])
+    cur.execute(
+        """
+        INSERT INTO characters (name, entity_id, summary, background)
+        VALUES (%s, %s, %s, %s)
+        RETURNING id
+        """,
+        (name, entity_id, summary, background),
+    )
+    return int(cur.fetchone()[0]), entity_id
+
+
+def _resolve_sleep(dbname: str, parent_chunk_id: int) -> Any:
+    engine = create_engine(
+        URL.create(
+            "postgresql+psycopg2",
+            username=os.environ.get("PGUSER", "pythagor"),
+            host=os.environ.get("PGHOST", "localhost"),
+            port=int(os.environ.get("PGPORT", "5432")),
+            database=dbname,
+        ),
+        future=True,
+    )
+    try:
+        with Session(engine) as session:
+            return resolve_dry_run(
+                session,
+                BUILTIN_TEMPLATES,
+                anchor_chunk_id=parent_chunk_id,
+                window_chunks=30,
+                epistemics_settings={"enabled": False},
+            )
+    finally:
+        engine.dispose()
+
+
+def _stage_incubator(
+    cur: Any,
+    *,
+    session_id: str,
+    parent_chunk_id: int,
+    proposal: Any,
+    character_ids: list[int],
+    scene_boundary: bool,
+) -> None:
+    metadata = {
+        "chronology": {"episode_transition": "continue"},
+        "world_layer": "primary",
+    }
+    if scene_boundary:
+        metadata["scene_boundary"] = True
+    references = {
+        "characters": [
+            {"character_id": character_id, "reference_type": "present"}
+            for character_id in character_ids
+        ],
+        "places": [],
+        "factions": [],
+    }
+    cur.execute(
+        """
+        INSERT INTO incubator (
+            id, chunk_id, parent_chunk_id, user_text, storyteller_text,
+            generation_model, choice_object, choice_text,
+            metadata_updates, entity_updates, reference_updates,
+            orrery_proposal, orrery_adjudications, new_entities,
+            correspondence_writer_letter, correspondence_gaia_letter,
+            session_id, llm_response_id, status
+        ) VALUES (
+            TRUE, %s, %s, 'Continue.', 'The accepted scene advances.',
+            'TEST', NULL, NULL, %s, %s, %s, %s, %s, %s,
+            NULL, NULL, %s, %s, 'provisional'
+        )
+        """,
+        (
+            parent_chunk_id + 1,
+            parent_chunk_id,
+            Json(metadata),
+            Json({}),
+            Json(references),
+            Json(proposal.to_dict()) if proposal is not None else None,
+            Json([]),
+            Json([]),
+            session_id,
+            f"response-{session_id}",
+        ),
+    )
+
+
+class _SceneProvider:
+    """Structured provider double invoked only after a genuine durable lease."""
+
+    def get_structured_completion(
+        self, prompt: str, _schema: type[ExperienceRenderBatch]
+    ) -> tuple[ExperienceRenderBatch, None]:
+        ids = [int(value) for value in re.findall(r'"experience_id": (\d+)', prompt)]
+        return (
+            ExperienceRenderBatch(
+                recollections=[
+                    ExperienceRecollection(
+                        experience_id=experience_id,
+                        experience_text=(
+                            "I remembered the accepted event clearly. "
+                            "I felt watchful after it ended."
+                        ),
+                    )
+                    for experience_id in ids
+                ]
+            ),
+            None,
+        )
+
+
+class _FailingSceneProvider:
+    """Provider double proving failures leave deterministic seeds untouched."""
+
+    def get_structured_completion(self, *_args: Any) -> Any:
+        raise RuntimeError("synthetic experience render failure")
+
+
+class _LeaseStealingProvider(_SceneProvider):
+    """Replace the durable owner/nonce before returning a late valid batch."""
+
+    def __init__(self, dbname: str) -> None:
+        self.dbname = dbname
+
+    def get_structured_completion(
+        self, prompt: str, schema: type[ExperienceRenderBatch]
+    ) -> tuple[ExperienceRenderBatch, None]:
+        conn = _connect(self.dbname)
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        UPDATE character_experience_jobs
+                        SET locked_by = 'replacement-worker',
+                            lease_nonce = %s,
+                            lease_until = clock_timestamp() + interval '5 minutes'
+                        WHERE state = 'leased'
+                        """,
+                        (str(uuid4()),),
+                    )
+                    assert cur.rowcount == 1
+        finally:
+            conn.close()
+        return super().get_structured_completion(prompt, schema)
+
+
+def test_real_commit_forms_verified_seeds_and_boundary_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolve, accept, seed, boundary-enqueue, lease, and render end to end."""
+    monkeypatch.setattr(
+        "nexus.api.presence_audit.presence_audit_enabled", lambda: False
+    )
+    settings = load_settings_as_dict()
+    with _disposable_database() as dbname:
+        conn = _connect(dbname)
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    parent_chunk_id = _insert_chunk(cur, "Issue 677 parent")
+                    actor_character_id, actor_entity_id = _insert_character(
+                        cur,
+                        "Aster Vale",
+                        summary="A courier who keeps moving.",
+                        background="Raised among the night trains.",
+                    )
+                    witness_character_id, witness_entity_id = _insert_character(
+                        cur,
+                        "Beren Quill",
+                        summary="A station observer.",
+                        background="Records arrivals for the archive.",
+                    )
+                    extra_character_id, extra_entity_id = _insert_character(
+                        cur,
+                        "Passing Extra",
+                        summary="A one-scene passerby.",
+                        background=None,
+                    )
+                    _absent_character_id, absent_entity_id = _insert_character(
+                        cur,
+                        "Absent Dossier",
+                        summary="A known investigator.",
+                        background="Working elsewhere tonight.",
+                    )
+                    _proximity_character_id, proximity_entity_id = _insert_character(
+                        cur,
+                        "Nearby Dossier",
+                        summary="A nearby resident.",
+                        background="Lives beside the station.",
+                    )
+                    cur.execute(
+                        """
+                        UPDATE character_need_states
+                        SET debt_score = 60, last_evaluated_at = %s
+                        WHERE character_entity_id = %s AND need_type = 'sleep'
+                        """,
+                        (
+                            datetime(2196, 7, 6, 23, 0, tzinfo=timezone.utc),
+                            actor_entity_id,
+                        ),
+                    )
+                    assert cur.rowcount == 1
+                    cur.execute(
+                        """
+                        INSERT INTO world_events (
+                            event_type, tick_chunk_id, actor_entity_id,
+                            world_layer, source, changed_fields, payload
+                        ) VALUES (
+                            'slept', %s, %s, 'primary', 'resolver', '{}', '{}'::jsonb
+                        )
+                        """,
+                        (parent_chunk_id, actor_entity_id),
+                    )
+            proposal = _resolve_sleep(dbname, parent_chunk_id)
+            assert proposal.resolutions
+            assert any(draft.template_id == "sleep" for draft in proposal.resolutions)
+            formation_session = str(uuid4())
+            with conn:
+                with conn.cursor() as cur:
+                    _stage_incubator(
+                        cur,
+                        session_id=formation_session,
+                        parent_chunk_id=parent_chunk_id,
+                        proposal=proposal,
+                        character_ids=[
+                            actor_character_id,
+                            witness_character_id,
+                            extra_character_id,
+                        ],
+                        scene_boundary=False,
+                    )
+            accepted_chunk_id = commit_incubator_to_database_sync(
+                conn, formation_session, slot=677
+            )
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT character_entity_id, basis::text AS basis,
+                           experience_text
+                    FROM character_experiences
+                    WHERE anchor_chunk_id = %s
+                    ORDER BY character_entity_id
+                    """,
+                    (accepted_chunk_id,),
+                )
+                formation = [dict(row) for row in cur.fetchall()]
+            assert [
+                (row["character_entity_id"], row["basis"]) for row in formation
+            ] == [
+                (actor_entity_id, "participant"),
+                (witness_entity_id, "witness"),
+            ]
+            assert all(row["experience_text"] is None for row in formation)
+            assert absent_entity_id not in {
+                row["character_entity_id"] for row in formation
+            }
+            assert proximity_entity_id not in {
+                row["character_entity_id"] for row in formation
+            }
+            assert extra_entity_id not in {
+                row["character_entity_id"] for row in formation
+            }
+
+            boundary_session = str(uuid4())
+            with conn:
+                with conn.cursor() as cur:
+                    _stage_incubator(
+                        cur,
+                        session_id=boundary_session,
+                        parent_chunk_id=accepted_chunk_id,
+                        proposal=None,
+                        character_ids=[actor_character_id],
+                        scene_boundary=True,
+                    )
+            boundary_chunk_id = commit_incubator_to_database_sync(
+                conn, boundary_session, slot=677
+            )
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT state::text AS state, experience_ids,
+                           boundary_chunk_id, lease_nonce
+                    FROM character_experience_jobs
+                    """
+                )
+                job = dict(cur.fetchone())
+            assert job["state"] == "queued"
+            assert job["boundary_chunk_id"] == boundary_chunk_id
+            assert len(job["experience_ids"]) == 2
+            assert job["lease_nonce"] is None
+
+            rendered, failed = drain_experience_render_jobs_sync(
+                slot=677,
+                settings=settings,
+                conn=conn,
+                provider=_SceneProvider(),
+            )
+            assert (rendered, failed) == (2, 0)
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT experience_text, render_model, renderer_version,
+                           render_generation_id
+                    FROM character_experiences
+                    WHERE id = ANY(%s)
+                    ORDER BY id
+                    """,
+                    (job["experience_ids"],),
+                )
+                rendered_rows = [dict(row) for row in cur.fetchall()]
+                cur.execute(
+                    "SELECT state::text AS state, locked_by, lease_nonce "
+                    "FROM character_experience_jobs"
+                )
+                completed_job = dict(cur.fetchone())
+            assert all(row["experience_text"] for row in rendered_rows)
+            assert all(
+                row["render_model"] == settings["orrery"]["experiences"]["model"]
+                for row in rendered_rows
+            )
+            assert all(
+                row["renderer_version"] == "experience-renderer-v1"
+                for row in rendered_rows
+            )
+            assert len({row["render_generation_id"] for row in rendered_rows}) == 1
+            assert completed_job == {
+                "state": "succeeded",
+                "locked_by": None,
+                "lease_nonce": None,
+            }
+        finally:
+            conn.close()
+
+
+def test_acquisition_requires_told_or_granted_delivered_account() -> None:
+    """Only durable delivered-account awareness mints acquisition experiences."""
+    settings = load_settings_as_dict()
+    with _disposable_database() as dbname:
+        conn = _connect(dbname)
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    chunk_id = _insert_chunk(cur, "Issue 677 acquisition")
+                    _character_id, entity_id = _insert_character(
+                        cur,
+                        "Cora Flint",
+                        summary="A careful listener.",
+                        background="Keeps an indexed private journal.",
+                    )
+                    cur.execute(
+                        """
+                        INSERT INTO world_events (
+                            event_type, tick_chunk_id, actor_entity_id,
+                            world_layer, source, changed_fields, payload
+                        ) VALUES (
+                            'slept', %s, %s, 'primary', 'resolver', '{}', '{}'::jsonb
+                        ) RETURNING id
+                        """,
+                        (chunk_id, entity_id),
+                    )
+                    incident_id = int(cur.fetchone()[0])
+                    cur.execute(
+                        """
+                        INSERT INTO claims (
+                            world_event_id, summary, scope, source_chunk_id,
+                            account_label
+                        ) VALUES (%s, %s, 'bounded', %s, 'reported')
+                        RETURNING id
+                        """,
+                        (incident_id, "The north gate was opened.", chunk_id),
+                    )
+                    claim_id = int(cur.fetchone()[0])
+                    cur.execute(
+                        """
+                        INSERT INTO claim_awareness (
+                            claim_id, knower_entity_id, source_tier,
+                            immediate_source_entity_id, source_chunk_id
+                        ) VALUES (%s, %s, 'told', %s, %s)
+                        RETURNING id
+                        """,
+                        (claim_id, entity_id, entity_id, chunk_id),
+                    )
+                    awareness_id = int(cur.fetchone()[0])
+                assert (
+                    seed_character_experiences_sync(
+                        conn,
+                        anchor_chunk_id=chunk_id,
+                        settings=settings,
+                    )
+                    == 1
+                )
+                with conn.cursor() as cur:
+                    boundary_chunk_id = _insert_chunk(cur, "Acquisition boundary")
+                assert enqueue_scene_experience_job_sync(
+                    conn,
+                    boundary_chunk_id=boundary_chunk_id,
+                    scene_end_chunk_id=chunk_id,
+                    world_layer="primary",
+                    slot=677,
+                    settings=settings,
+                )
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT basis::text AS basis, claim_id, claim_awareness_id,
+                           world_event_ids, seed_summary
+                    FROM character_experiences
+                    """
+                )
+                row = dict(cur.fetchone())
+            assert row["basis"] == "acquisition"
+            assert row["claim_id"] == claim_id
+            assert row["claim_awareness_id"] == awareness_id
+            assert row["world_event_ids"] == [incident_id]
+            assert "by being told" in row["seed_summary"]
+            rendered, failed = drain_experience_render_jobs_sync(
+                slot=677,
+                settings=settings,
+                conn=conn,
+                provider=_FailingSceneProvider(),
+            )
+            assert (rendered, failed) == (0, 1)
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    "SELECT experience_text FROM character_experiences "
+                    "WHERE claim_awareness_id = %s",
+                    (awareness_id,),
+                )
+                assert cur.fetchone()["experience_text"] is None
+                cur.execute(
+                    "SELECT state::text AS state, attempts, last_error "
+                    "FROM character_experience_jobs"
+                )
+                failed_job = dict(cur.fetchone())
+            assert failed_job["state"] == "queued"
+            assert failed_job["attempts"] == 1
+            assert failed_job["last_error"] == "synthetic experience render failure"
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE character_experience_jobs "
+                        "SET available_at = clock_timestamp()"
+                    )
+            rendered, failed = drain_experience_render_jobs_sync(
+                slot=677,
+                settings=settings,
+                conn=conn,
+                provider=_LeaseStealingProvider(dbname),
+            )
+            assert (rendered, failed) == (0, 1)
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    "SELECT experience_text FROM character_experiences "
+                    "WHERE claim_awareness_id = %s",
+                    (awareness_id,),
+                )
+                assert cur.fetchone()["experience_text"] is None
+                cur.execute(
+                    "SELECT state::text AS state, locked_by "
+                    "FROM character_experience_jobs"
+                )
+                stolen_job = dict(cur.fetchone())
+            assert stolen_job == {
+                "state": "leased",
+                "locked_by": "replacement-worker",
+            }
+        finally:
+            conn.close()

--- a/tests/test_orrery/test_character_experiences_pg.py
+++ b/tests/test_orrery/test_character_experiences_pg.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from contextlib import contextmanager
 from datetime import datetime, timezone
 import os
@@ -12,6 +13,7 @@ from uuid import uuid4
 
 import psycopg2
 from psycopg2 import sql
+from psycopg2.extensions import TRANSACTION_STATUS_IDLE
 from psycopg2.extras import Json, RealDictCursor
 import pytest
 from sqlalchemy import create_engine
@@ -21,13 +23,25 @@ from sqlalchemy.orm import Session
 from nexus.agents.orrery.experiences import (
     ExperienceRecollection,
     ExperienceRenderBatch,
+    _known_and_allowed_names,
     drain_experience_render_jobs_sync,
     enqueue_scene_experience_job_sync,
     seed_character_experiences_sync,
+    validate_render_batch,
 )
 from nexus.agents.orrery.resolver import resolve_dry_run
 from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+from nexus.agents.logon.skald_wire import (
+    CharacterRef,
+    PlaceRef,
+    PresenceBaseline,
+    PresenceDelta,
+    SceneReset,
+    SkaldTurnWire,
+    hydrate_skald_turn,
+)
 from nexus.api.commit_handler_sync import commit_incubator_to_database_sync
+from nexus.api.lore_adapter import response_to_incubator
 from nexus.config import load_settings_as_dict
 
 
@@ -128,6 +142,20 @@ def _insert_character(
     return int(cur.fetchone()[0]), entity_id
 
 
+def _insert_place(cur: Any, name: str) -> int:
+    cur.execute("INSERT INTO entities (kind) VALUES ('place') RETURNING id")
+    entity_id = int(cur.fetchone()[0])
+    cur.execute(
+        """
+        INSERT INTO places (name, type, entity_id)
+        VALUES (%s, 'fixed_location', %s)
+        RETURNING id
+        """,
+        (name, entity_id),
+    )
+    return int(cur.fetchone()[0])
+
+
 def _resolve_sleep(dbname: str, parent_chunk_id: int) -> Any:
     engine = create_engine(
         URL.create(
@@ -158,23 +186,40 @@ def _stage_incubator(
     session_id: str,
     parent_chunk_id: int,
     proposal: Any,
-    character_ids: list[int],
+    characters: list[tuple[int, str]],
     scene_boundary: bool,
+    place: tuple[int, str] | None = None,
 ) -> None:
-    metadata = {
-        "chronology": {"episode_transition": "continue"},
-        "world_layer": "primary",
-    }
+    refs = [
+        CharacterRef(kind="character", id=character_id, name=name)
+        for character_id, name in characters
+    ]
     if scene_boundary:
-        metadata["scene_boundary"] = True
-    references = {
-        "characters": [
-            {"character_id": character_id, "reference_type": "present"}
-            for character_id in character_ids
-        ],
-        "places": [],
-        "factions": [],
-    }
+        assert place is not None
+        presence = PresenceDelta(
+            scene_reset=SceneReset(
+                place=PlaceRef(kind="place", id=place[0], name=place[1]),
+                present=refs,
+            )
+        )
+    else:
+        presence = PresenceDelta(enter=refs)
+    wire = SkaldTurnWire(
+        narrative="The accepted scene advances.",
+        choices=["Continue.", "Wait."],
+        presence=presence,
+        letter="Record the accepted scene.",
+    )
+    hydrated = hydrate_skald_turn(wire, presence_baseline=PresenceBaseline())
+    staged = response_to_incubator(
+        hydrated,
+        parent_chunk_id=parent_chunk_id,
+        user_text="Continue.",
+        session_id=session_id,
+        orrery_proposal=proposal,
+    )
+    staged["generation_model"] = "TEST"
+    staged["llm_response_id"] = f"response-{session_id}"
     cur.execute(
         """
         INSERT INTO incubator (
@@ -191,16 +236,16 @@ def _stage_incubator(
         )
         """,
         (
-            parent_chunk_id + 1,
-            parent_chunk_id,
-            Json(metadata),
-            Json({}),
-            Json(references),
-            Json(proposal.to_dict()) if proposal is not None else None,
-            Json([]),
-            Json([]),
-            session_id,
-            f"response-{session_id}",
+            staged["chunk_id"],
+            staged["parent_chunk_id"],
+            Json(staged["metadata_updates"]),
+            Json(staged["entity_updates"]),
+            Json(staged["reference_updates"]),
+            Json(staged["orrery_proposal"]),
+            Json(staged["orrery_adjudications"]),
+            Json(staged["new_entities"]),
+            staged["session_id"],
+            staged["llm_response_id"],
         ),
     )
 
@@ -236,6 +281,19 @@ class _FailingSceneProvider:
         raise RuntimeError("synthetic experience render failure")
 
 
+class _IdleTransactionProvider(_SceneProvider):
+    """Assert that the queue connection is idle during the provider call."""
+
+    def __init__(self, conn: Any) -> None:
+        self.conn = conn
+
+    def get_structured_completion(
+        self, prompt: str, schema: type[ExperienceRenderBatch]
+    ) -> tuple[ExperienceRenderBatch, None]:
+        assert self.conn.get_transaction_status() == TRANSACTION_STATUS_IDLE
+        return super().get_structured_completion(prompt, schema)
+
+
 class _LeaseStealingProvider(_SceneProvider):
     """Replace the durable owner/nonce before returning a late valid batch."""
 
@@ -258,6 +316,38 @@ class _LeaseStealingProvider(_SceneProvider):
                         WHERE state = 'leased'
                         """,
                         (str(uuid4()),),
+                    )
+                    assert cur.rowcount == 1
+        finally:
+            conn.close()
+        return super().get_structured_completion(prompt, schema)
+
+
+class _TimelineDriftingProvider(_SceneProvider):
+    """Mutate the frozen boundary timeline while the provider call is active."""
+
+    def __init__(self, dbname: str) -> None:
+        self.dbname = dbname
+
+    def get_structured_completion(
+        self, prompt: str, schema: type[ExperienceRenderBatch]
+    ) -> tuple[ExperienceRenderBatch, None]:
+        conn = _connect(self.dbname)
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        UPDATE chunk_metadata
+                        SET scene = scene + 1
+                        WHERE chunk_id = (
+                            SELECT boundary_chunk_id
+                            FROM character_experience_jobs
+                            WHERE state = 'leased'
+                            ORDER BY id
+                            LIMIT 1
+                        )
+                        """
                     )
                     assert cur.rowcount == 1
         finally:
@@ -309,6 +399,7 @@ def test_real_commit_forms_verified_seeds_and_boundary_batch(
                         summary="A nearby resident.",
                         background="Lives beside the station.",
                     )
+                    boundary_place_id = _insert_place(cur, "Departure Platform")
                     cur.execute(
                         """
                         UPDATE character_need_states
@@ -343,10 +434,10 @@ def test_real_commit_forms_verified_seeds_and_boundary_batch(
                         session_id=formation_session,
                         parent_chunk_id=parent_chunk_id,
                         proposal=proposal,
-                        character_ids=[
-                            actor_character_id,
-                            witness_character_id,
-                            extra_character_id,
+                        characters=[
+                            (actor_character_id, "Aster Vale"),
+                            (witness_character_id, "Beren Quill"),
+                            (extra_character_id, "Passing Extra"),
                         ],
                         scene_boundary=False,
                     )
@@ -367,10 +458,7 @@ def test_real_commit_forms_verified_seeds_and_boundary_batch(
                 formation = [dict(row) for row in cur.fetchall()]
             assert [
                 (row["character_entity_id"], row["basis"]) for row in formation
-            ] == [
-                (actor_entity_id, "participant"),
-                (witness_entity_id, "witness"),
-            ]
+            ] == [(actor_entity_id, "participant")]
             assert all(row["experience_text"] is None for row in formation)
             assert absent_entity_id not in {
                 row["character_entity_id"] for row in formation
@@ -379,6 +467,9 @@ def test_real_commit_forms_verified_seeds_and_boundary_batch(
                 row["character_entity_id"] for row in formation
             }
             assert extra_entity_id not in {
+                row["character_entity_id"] for row in formation
+            }
+            assert witness_entity_id not in {
                 row["character_entity_id"] for row in formation
             }
 
@@ -390,8 +481,9 @@ def test_real_commit_forms_verified_seeds_and_boundary_batch(
                         session_id=boundary_session,
                         parent_chunk_id=accepted_chunk_id,
                         proposal=None,
-                        character_ids=[actor_character_id],
+                        characters=[(actor_character_id, "Aster Vale")],
                         scene_boundary=True,
+                        place=(boundary_place_id, "Departure Platform"),
                     )
             boundary_chunk_id = commit_incubator_to_database_sync(
                 conn, boundary_session, slot=677
@@ -400,23 +492,26 @@ def test_real_commit_forms_verified_seeds_and_boundary_batch(
                 cur.execute(
                     """
                     SELECT state::text AS state, experience_ids,
-                           boundary_chunk_id, lease_nonce
+                           boundary_chunk_id, lease_nonce, requested_model
                     FROM character_experience_jobs
                     """
                 )
                 job = dict(cur.fetchone())
             assert job["state"] == "queued"
             assert job["boundary_chunk_id"] == boundary_chunk_id
-            assert len(job["experience_ids"]) == 2
+            assert len(job["experience_ids"]) == 1
             assert job["lease_nonce"] is None
+            assert job["requested_model"] == settings["orrery"]["experiences"]["model"]
 
+            render_settings = deepcopy(settings)
+            render_settings["orrery"]["experiences"]["model"] = "render-time-model"
             rendered, failed = drain_experience_render_jobs_sync(
                 slot=677,
-                settings=settings,
+                settings=render_settings,
                 conn=conn,
-                provider=_SceneProvider(),
+                provider=_IdleTransactionProvider(conn),
             )
-            assert (rendered, failed) == (2, 0)
+            assert (rendered, failed) == (1, 0)
             with conn.cursor(cursor_factory=RealDictCursor) as cur:
                 cur.execute(
                     """
@@ -436,8 +531,7 @@ def test_real_commit_forms_verified_seeds_and_boundary_batch(
                 completed_job = dict(cur.fetchone())
             assert all(row["experience_text"] for row in rendered_rows)
             assert all(
-                row["render_model"] == settings["orrery"]["experiences"]["model"]
-                for row in rendered_rows
+                row["render_model"] == "render-time-model" for row in rendered_rows
             )
             assert all(
                 row["renderer_version"] == "experience-renderer-v1"
@@ -449,6 +543,204 @@ def test_real_commit_forms_verified_seeds_and_boundary_batch(
                 "locked_by": None,
                 "lease_nonce": None,
             }
+        finally:
+            conn.close()
+
+
+def test_private_hunt_seeds_only_verified_actor_receipt() -> None:
+    """Present bystanders and a hidden target do not witness a private hunt."""
+    settings = load_settings_as_dict()
+    with _disposable_database() as dbname:
+        conn = _connect(dbname)
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    chunk_id = _insert_chunk(cur, "Issue 677 private hunt")
+                    actor_character_id, actor_entity_id = _insert_character(
+                        cur,
+                        "Hidden Hunter",
+                        summary="A patient tracker.",
+                        background="Trained beyond the city walls.",
+                    )
+                    target_character_id, target_entity_id = _insert_character(
+                        cur,
+                        "Unaware Quarry",
+                        summary="A guarded traveler.",
+                        background="Knows the old roads.",
+                    )
+                    bystander_character_id, bystander_entity_id = _insert_character(
+                        cur,
+                        "Nearby Bystander",
+                        summary="A diligent clerk.",
+                        background="Works beside the square.",
+                    )
+                    cur.executemany(
+                        """
+                        INSERT INTO chunk_character_references (
+                            chunk_id, character_id, reference
+                        ) VALUES (%s, %s, 'present')
+                        """,
+                        [
+                            (chunk_id, actor_character_id),
+                            (chunk_id, target_character_id),
+                            (chunk_id, bystander_character_id),
+                        ],
+                    )
+                    cur.execute(
+                        """
+                        INSERT INTO world_events (
+                            event_type, tick_chunk_id, actor_entity_id,
+                            target_entity_id, world_layer, source,
+                            changed_fields, payload
+                        ) VALUES (
+                            'hunt_declared', %s, %s, %s, 'primary', 'resolver',
+                            '{}', '{"hidden": true}'::jsonb
+                        ) RETURNING id
+                        """,
+                        (chunk_id, actor_entity_id, target_entity_id),
+                    )
+                    event_id = int(cur.fetchone()[0])
+                    cur.executemany(
+                        """
+                        INSERT INTO world_event_entities (event_id, entity_id, role)
+                        VALUES (%s, %s, %s)
+                        """,
+                        [
+                            (event_id, actor_entity_id, "actor"),
+                            (event_id, target_entity_id, "target"),
+                        ],
+                    )
+                assert (
+                    seed_character_experiences_sync(
+                        conn,
+                        anchor_chunk_id=chunk_id,
+                        settings=settings,
+                    )
+                    == 1
+                )
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT character_entity_id, basis::text AS basis,
+                           world_event_ids, seed_summary
+                    FROM character_experiences
+                    ORDER BY id
+                    """
+                )
+                rows = [dict(row) for row in cur.fetchall()]
+            assert len(rows) == 1
+            assert rows[0]["character_entity_id"] == actor_entity_id
+            assert rows[0]["basis"] == "participant"
+            assert rows[0]["world_event_ids"] == [event_id]
+            assert "hunt_declared" in rows[0]["seed_summary"]
+            assert target_entity_id not in {row["character_entity_id"] for row in rows}
+            assert bystander_entity_id not in {
+                row["character_entity_id"] for row in rows
+            }
+        finally:
+            conn.close()
+
+
+def test_boundary_batches_are_bounded_and_timeline_drift_is_rejected() -> None:
+    """Boundary overflow splits, and locked completion rejects timeline drift."""
+    settings = load_settings_as_dict()
+    settings["orrery"]["experiences"]["max_seeds_per_render"] = 2
+    with _disposable_database() as dbname:
+        conn = _connect(dbname)
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    scene_end_chunk_id = _insert_chunk(cur, "Bounded scene")
+                    for ordinal in range(3):
+                        _character_id, entity_id = _insert_character(
+                            cur,
+                            f"Batch Actor {ordinal}",
+                            summary=f"Actor {ordinal} has a complete dossier.",
+                            background="Present for a verified event role.",
+                        )
+                        cur.execute(
+                            """
+                            INSERT INTO world_events (
+                                event_type, tick_chunk_id, actor_entity_id,
+                                world_layer, source, changed_fields, payload
+                            ) VALUES (
+                                'slept', %s, %s, 'primary', 'resolver',
+                                '{}', '{}'::jsonb
+                            ) RETURNING id
+                            """,
+                            (scene_end_chunk_id, entity_id),
+                        )
+                        event_id = int(cur.fetchone()[0])
+                        cur.execute(
+                            """
+                            INSERT INTO world_event_entities (
+                                event_id, entity_id, role
+                            ) VALUES (%s, %s, 'actor')
+                            """,
+                            (event_id, entity_id),
+                        )
+                assert (
+                    seed_character_experiences_sync(
+                        conn,
+                        anchor_chunk_id=scene_end_chunk_id,
+                        settings=settings,
+                    )
+                    == 3
+                )
+                with conn.cursor() as cur:
+                    boundary_chunk_id = _insert_chunk(cur, "Bounded boundary")
+                assert (
+                    enqueue_scene_experience_job_sync(
+                        conn,
+                        boundary_chunk_id=boundary_chunk_id,
+                        scene_end_chunk_id=scene_end_chunk_id,
+                        world_layer="primary",
+                        slot=677,
+                        settings=settings,
+                    )
+                    == 2
+                )
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT batch_ordinal, cardinality(experience_ids) AS seed_count
+                    FROM character_experience_jobs
+                    ORDER BY batch_ordinal
+                    """
+                )
+                assert [dict(row) for row in cur.fetchall()] == [
+                    {"batch_ordinal": 0, "seed_count": 2},
+                    {"batch_ordinal": 1, "seed_count": 1},
+                ]
+            rendered, failed = drain_experience_render_jobs_sync(
+                slot=677,
+                settings=settings,
+                conn=conn,
+                provider=_TimelineDriftingProvider(dbname),
+                limit=1,
+            )
+            assert (rendered, failed) == (0, 1)
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT state::text AS state, last_error
+                    FROM character_experience_jobs
+                    ORDER BY id
+                    """
+                )
+                jobs = [dict(row) for row in cur.fetchall()]
+                cur.execute(
+                    """
+                    SELECT count(*) FILTER (WHERE experience_text IS NOT NULL)
+                           AS rendered_count
+                    FROM character_experiences
+                    """
+                )
+                rendered_count = int(cur.fetchone()["rendered_count"])
+            assert jobs[0]["state"] == "stale_rejected"
+            assert "boundary timeline is stale" in jobs[0]["last_error"]
+            assert jobs[1]["state"] == "queued"
+            assert rendered_count == 0
         finally:
             conn.close()
 
@@ -468,6 +760,12 @@ def test_acquisition_requires_told_or_granted_delivered_account() -> None:
                         summary="A careful listener.",
                         background="Keeps an indexed private journal.",
                     )
+                    _incident_character_id, incident_actor_id = _insert_character(
+                        cur,
+                        "Dorian Pike",
+                        summary=None,
+                        background=None,
+                    )
                     cur.execute(
                         """
                         INSERT INTO world_events (
@@ -477,7 +775,7 @@ def test_acquisition_requires_told_or_granted_delivered_account() -> None:
                             'slept', %s, %s, 'primary', 'resolver', '{}', '{}'::jsonb
                         ) RETURNING id
                         """,
-                        (chunk_id, entity_id),
+                        (chunk_id, incident_actor_id),
                     )
                     incident_id = int(cur.fetchone()[0])
                     cur.execute(
@@ -510,6 +808,44 @@ def test_acquisition_requires_told_or_granted_delivered_account() -> None:
                     )
                     == 1
                 )
+                with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                    cur.execute(
+                        """
+                        SELECT id, character_entity_id, world_event_ids,
+                               claim_id, claim_awareness_id,
+                               basis::text AS basis, location_id
+                        FROM character_experiences
+                        WHERE claim_awareness_id = %s
+                        """,
+                        (awareness_id,),
+                    )
+                    acquisition_scope_row = dict(cur.fetchone())
+                    known, allowed = _known_and_allowed_names(
+                        cur, acquisition_scope_row
+                    )
+                assert "Dorian Pike" in known
+                assert "Dorian Pike" not in allowed
+                invented_incident_witnessing = ExperienceRenderBatch(
+                    recollections=[
+                        ExperienceRecollection(
+                            experience_id=int(acquisition_scope_row["id"]),
+                            experience_text=(
+                                "I heard the account from Cora Flint. "
+                                "Dorian Pike opened the gate before me."
+                            ),
+                        )
+                    ]
+                )
+                with pytest.raises(
+                    ValueError, match="absent from its source scene.*Dorian Pike"
+                ):
+                    validate_render_batch(
+                        [acquisition_scope_row],
+                        invented_incident_witnessing,
+                        names_by_experience={
+                            int(acquisition_scope_row["id"]): (known, allowed)
+                        },
+                    )
                 with conn.cursor() as cur:
                     boundary_chunk_id = _insert_chunk(cur, "Acquisition boundary")
                 assert enqueue_scene_experience_job_sync(

--- a/tests/test_orrery/test_character_experiences_pg.py
+++ b/tests/test_orrery/test_character_experiences_pg.py
@@ -41,6 +41,7 @@ from nexus.agents.logon.skald_wire import (
     hydrate_skald_turn,
 )
 from nexus.api.commit_handler_sync import commit_incubator_to_database_sync
+from nexus.memory.manager import empty_pass2_baseline
 from nexus.api.lore_adapter import response_to_incubator
 from nexus.config import load_settings_as_dict
 
@@ -217,6 +218,7 @@ def _stage_incubator(
         user_text="Continue.",
         session_id=session_id,
         orrery_proposal=proposal,
+        lore_pass_baseline=empty_pass2_baseline({}),
     )
     staged["generation_model"] = "TEST"
     staged["llm_response_id"] = f"response-{session_id}"
@@ -228,11 +230,11 @@ def _stage_incubator(
             metadata_updates, entity_updates, reference_updates,
             orrery_proposal, orrery_adjudications, new_entities,
             correspondence_writer_letter, correspondence_gaia_letter,
-            session_id, llm_response_id, status
+            session_id, llm_response_id, status, lore_pass_baseline
         ) VALUES (
             TRUE, %s, %s, 'Continue.', 'The accepted scene advances.',
             'TEST', NULL, NULL, %s, %s, %s, %s, %s, %s,
-            NULL, NULL, %s, %s, 'provisional'
+            NULL, NULL, %s, %s, 'provisional', %s
         )
         """,
         (
@@ -246,6 +248,7 @@ def _stage_incubator(
             Json(staged["new_entities"]),
             staged["session_id"],
             staged["llm_response_id"],
+            Json(staged["lore_pass_baseline"]),
         ),
     )
 

--- a/tests/test_orrery/test_experiences.py
+++ b/tests/test_orrery/test_experiences.py
@@ -1,0 +1,219 @@
+"""Focused actor-owned experiential memory unit contracts."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any, Iterator
+
+import pytest
+
+from nexus.agents.logon.skald_wire import (
+    CharacterRef,
+    PlaceRef,
+    PresenceBaseline,
+    PresenceDelta,
+    SceneReset,
+    SkaldTurnWire,
+    hydrate_skald_turn,
+)
+from nexus.agents.orrery import experience_embedding
+from nexus.agents.orrery.experiences import (
+    ExperienceRecollection,
+    ExperienceRenderBatch,
+    validate_render_batch,
+)
+from nexus.api.lore_adapter import response_to_incubator
+from nexus.config import load_settings
+
+
+def test_scene_reset_survives_internal_incubator_staging() -> None:
+    """The real wire hydration path retains a queue boundary without a new arm."""
+    wire = SkaldTurnWire(
+        narrative="Mara entered the observatory.",
+        choices=["Wait.", "Follow."],
+        presence=PresenceDelta(
+            scene_reset=SceneReset(
+                place=PlaceRef(kind="place", id=9, name="Copper Observatory"),
+                present=[CharacterRef(kind="character", id=7, name="Mara")],
+            )
+        ),
+        letter="Begin the observatory scene.",
+    )
+    hydrated = hydrate_skald_turn(wire, presence_baseline=PresenceBaseline())
+    staged = response_to_incubator(
+        hydrated,
+        parent_chunk_id=4,
+        user_text="Go inside.",
+        session_id="experience-boundary",
+    )
+
+    assert staged["metadata_updates"]["scene_boundary"] is True
+    assert "experiences" not in wire.model_dump(mode="json")
+
+
+def test_experience_config_resolves_model_and_eligibility() -> None:
+    """Shipped tuning is validated and its provider role is resolved."""
+    settings = load_settings("nexus.toml")
+
+    assert settings.orrery.experiences.enabled is True
+    assert settings.orrery.experiences.model == (
+        settings.global_.model.api_models["openai"].roles["gaia"]
+    )
+    assert settings.orrery.experiences.minimum_dossier_fields == 2
+    assert sum(
+        (
+            settings.orrery.experiences.magnitude_weight,
+            settings.orrery.experiences.valence_delta_weight,
+            settings.orrery.experiences.presence_duration_weight,
+        )
+    ) == pytest.approx(1.0)
+
+
+def _seed_row() -> dict[str, Any]:
+    return {
+        "id": 41,
+        "character_entity_id": 7,
+        "world_event_ids": [12],
+        "location_id": 9,
+        "seed_summary": ("Mara witnessed Orrin open the Copper Observatory door."),
+    }
+
+
+def test_renderer_validator_rejects_entity_invention() -> None:
+    """A structured response cannot name a person absent from its source scene."""
+    batch = ExperienceRenderBatch(
+        recollections=[
+            ExperienceRecollection(
+                experience_id=41,
+                experience_text=(
+                    "I watched Orrin open the door. Then Selene warned me to run."
+                ),
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="absent from its source scene.*Selene"):
+        validate_render_batch(
+            [_seed_row()],
+            batch,
+            names_by_experience={41: ({"Mara", "Orrin", "Selene"}, {"Mara", "Orrin"})},
+        )
+
+
+def test_renderer_validator_accepts_complete_first_person_batch() -> None:
+    """Every seed is returned exactly once in bounded first-person prose."""
+    batch = ExperienceRenderBatch(
+        recollections=[
+            ExperienceRecollection(
+                experience_id=41,
+                experience_text=(
+                    "I watched Orrin open the door. I felt the cold air reach me."
+                ),
+            )
+        ]
+    )
+
+    assert validate_render_batch(
+        [_seed_row()],
+        batch,
+        names_by_experience={41: ({"Mara", "Orrin"}, {"Mara", "Orrin"})},
+    ) == {41: "I watched Orrin open the door. I felt the cold air reach me."}
+
+
+class _EmbeddingCursor:
+    def __init__(self, *, read: bool) -> None:
+        self.read = read
+        self.executions: list[tuple[str, Any]] = []
+        self._rows: list[dict[str, Any]] = []
+
+    def __enter__(self) -> "_EmbeddingCursor":
+        return self
+
+    def __exit__(self, *_args: Any) -> bool:
+        return False
+
+    def execute(self, statement: str, params: Any = None) -> None:
+        normalized = " ".join(statement.split())
+        self.executions.append((normalized, params))
+        if self.read:
+            self._rows = [
+                {"id": 11, "experience_text": "I remembered eleven."},
+                {"id": 22, "experience_text": "I remembered twenty-two."},
+            ]
+        elif normalized.startswith("UPDATE character_experiences"):
+            stamp = datetime(2196, 1, 1, tzinfo=timezone.utc)
+            self._rows = [
+                {"id": 11, "embedding_generated_at": stamp},
+                {"id": 22, "embedding_generated_at": stamp},
+            ]
+        else:
+            self._rows = []
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class _EmbeddingConnection:
+    def __init__(self, cursor: _EmbeddingCursor) -> None:
+        self._cursor = cursor
+
+    def cursor(self) -> _EmbeddingCursor:
+        return self._cursor
+
+
+def test_embedding_upsert_binds_each_correct_experience_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the stale-loop-id bug class fixed in PR #671."""
+    read_cursor = _EmbeddingCursor(read=True)
+    write_cursor = _EmbeddingCursor(read=False)
+    connections = iter(
+        [_EmbeddingConnection(read_cursor), _EmbeddingConnection(write_cursor)]
+    )
+
+    @contextmanager
+    def fake_connection(*_args: Any, **_kwargs: Any) -> Iterator[Any]:
+        yield next(connections)
+
+    class FakeManager:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def get_available_models(self) -> list[str]:
+            return ["test-embed"]
+
+        def generate_embedding(self, text: str, _model: str) -> list[float]:
+            return [float(len(text)), 1.0]
+
+    monkeypatch.setattr(
+        "nexus.api.db_pool.get_connection",
+        fake_connection,
+    )
+    monkeypatch.setattr(
+        "nexus.agents.memnon.utils.embedding_manager.EmbeddingManager",
+        FakeManager,
+    )
+    monkeypatch.setattr(
+        "nexus.agents.orrery.retrograde_embedding."
+        "active_memnon_embedding_model_dimensions",
+        lambda: {"test-embed": 2},
+    )
+    monkeypatch.setattr(
+        experience_embedding, "_memnon_settings", lambda: {"models": {}}
+    )
+    monkeypatch.setattr(
+        experience_embedding,
+        "ensure_character_experience_embedding_table",
+        lambda _cursor, _dimensions: "character_experience_embeddings_0002d",
+    )
+
+    result = experience_embedding.embed_character_experiences("qa677", [11, 22])
+
+    inserts = [
+        params
+        for sql, params in write_cursor.executions
+        if sql.startswith("INSERT INTO character_experience_embeddings_0002d")
+    ]
+    assert [params[0] for params in inserts] == [11, 22]
+    assert [row["experience_id"] for row in result] == [11, 22]

--- a/tests/test_orrery/test_experiences.py
+++ b/tests/test_orrery/test_experiences.py
@@ -23,6 +23,7 @@ from nexus.agents.orrery.experiences import (
     ExperienceRenderBatch,
     validate_render_batch,
 )
+from nexus.memory.manager import empty_pass2_baseline
 from nexus.api.lore_adapter import response_to_incubator
 from nexus.config import load_settings
 
@@ -46,6 +47,7 @@ def test_scene_reset_survives_internal_incubator_staging() -> None:
         parent_chunk_id=4,
         user_text="Go inside.",
         session_id="experience-boundary",
+        lore_pass_baseline=empty_pass2_baseline({}),
     )
 
     assert staged["metadata_updates"]["scene_boundary"] is True

--- a/tests/test_orrery/test_experiences.py
+++ b/tests/test_orrery/test_experiences.py
@@ -61,6 +61,7 @@ def test_experience_config_resolves_model_and_eligibility() -> None:
         settings.global_.model.api_models["openai"].roles["gaia"]
     )
     assert settings.orrery.experiences.minimum_dossier_fields == 2
+    assert settings.orrery.experiences.max_seeds_per_render == 12
     assert sum(
         (
             settings.orrery.experiences.magnitude_weight,
@@ -75,6 +76,7 @@ def _seed_row() -> dict[str, Any]:
         "id": 41,
         "character_entity_id": 7,
         "world_event_ids": [12],
+        "basis": "witness",
         "location_id": 9,
         "seed_summary": ("Mara witnessed Orrin open the Copper Observatory door."),
     }
@@ -99,6 +101,78 @@ def test_renderer_validator_rejects_entity_invention() -> None:
             batch,
             names_by_experience={41: ({"Mara", "Orrin", "Selene"}, {"Mara", "Orrin"})},
         )
+
+
+def test_renderer_validator_rejects_sentence_initial_novel_name() -> None:
+    """Sentence-initial proper nouns are validated instead of skipped."""
+    batch = ExperienceRenderBatch(
+        recollections=[
+            ExperienceRecollection(
+                experience_id=41,
+                experience_text=(
+                    "Zorblax warned me to leave. I remembered Orrin at the door."
+                ),
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="absent from its source scene.*Zorblax"):
+        validate_render_batch(
+            [_seed_row()],
+            batch,
+            names_by_experience={41: ({"Mara", "Orrin"}, {"Mara", "Orrin"})},
+        )
+
+
+def test_acquisition_validator_requires_telling_perspective() -> None:
+    """Acquisitions remember receiving an account, never seeing its incident."""
+    row = {**_seed_row(), "basis": "acquisition"}
+    witnessing = ExperienceRenderBatch(
+        recollections=[
+            ExperienceRecollection(
+                experience_id=41,
+                experience_text=(
+                    "I witnessed Orrin open the door. I learned why it mattered."
+                ),
+            )
+        ]
+    )
+    no_receipt = ExperienceRenderBatch(
+        recollections=[
+            ExperienceRecollection(
+                experience_id=41,
+                experience_text=(
+                    "I considered Orrin's choice. I distrusted the conclusion."
+                ),
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="must not describe witnessing"):
+        validate_render_batch([row], witnessing)
+    with pytest.raises(ValueError, match="receiving or learning"):
+        validate_render_batch([row], no_receipt)
+
+
+def test_acquisition_validator_accepts_delivered_account_perspective() -> None:
+    """A first-person memory of hearing the delivered account is valid."""
+    row = {**_seed_row(), "basis": "acquisition"}
+    batch = ExperienceRenderBatch(
+        recollections=[
+            ExperienceRecollection(
+                experience_id=41,
+                experience_text=(
+                    "I heard Orrin tell me about the door. I doubted his account."
+                ),
+            )
+        ]
+    )
+
+    assert validate_render_batch(
+        [row],
+        batch,
+        names_by_experience={41: ({"Mara", "Orrin"}, {"Mara", "Orrin"})},
+    ) == {41: "I heard Orrin tell me about the door. I doubted his account."}
 
 
 def test_renderer_validator_accepts_complete_first_person_batch() -> None:

--- a/tests/test_orrery/test_worker.py
+++ b/tests/test_orrery/test_worker.py
@@ -500,6 +500,15 @@ def test_process_orrery_outbox_includes_semantic_clearance(monkeypatch) -> None:
         fake_maturation,
     )
 
+    def fake_experiences(*_args, **kwargs):
+        calls.append(("experiences", kwargs["limit"]))
+        return (8, 9)
+
+    monkeypatch.setattr(
+        "nexus.agents.orrery.worker.drain_experience_outbox_sync",
+        fake_experiences,
+    )
+
     result = process_orrery_outbox_sync(
         slot=5,
         promotion_limit=6,
@@ -518,11 +527,14 @@ def test_process_orrery_outbox_includes_semantic_clearance(monkeypatch) -> None:
     assert result.semantically_cleared == 5
     assert result.matured == 6
     assert result.maturation_failed == 7
+    assert result.experiences_rendered == 8
+    assert result.experience_render_failed == 9
     assert calls == [
         ("promote", 6),
         ("drain", 7),
         ("clear", 8, 9, 10, 11),
         ("mature", 12),
+        ("experiences", None),
     ]
 
 


### PR DESCRIPTION
Closes #677. Loom-ruled: FULL LAYER (Arachne seq 24).

The third corpus, built to the formation synthesis frozen on the issue:

- **Migration 104**: `character_experiences` — basis enum (`participant`/`witness`/`acquisition`), deterministic NOT-NULL `seed_summary`, nullable `experience_text` until rendered, mood-vocabulary-validated emotion, deterministic `salience`, render provenance (model/version/digest), timeline identity, ironman stamp. Every column commented. Lazy embedding dimension tables via the retrograde pattern (PR #671's upsert-binding bug class explicitly guarded).
- **Seeds at commit, deterministically**: participants/witnesses from verified rosters only; told/granted → acquisition rows linked to the delivered account — SkyrimNet's four-divergent-accounts property without its per-actor frontier-call cost structure.
- **Rendering at scene boundaries, batched**: one structured call per scene roster on the #676-hardened queue idioms; renderer may characterize perception and emotion but cannot mint facts (output validated against seed-named entities); failed renders preserve seeds. Prompt at `prompts/experience_renderer.md` (coordinator-authored).
- **Cost bounded by config**: `[orrery.experiences]` eligibility gate (the MemoryFilter lesson), `@provider.role` model reference, all weights tunable.
- **Discoveries honored**: `chunk_metadata.scene` increments every chunk in this checkout, so scene boundaries derive from the existing `presence.scene_reset` wire signal as an internal post-hydration marker — the wire schema is untouched (no new Gaia arm; the schema-weight campaign stays closed).

2,248 passed at build (five pre-existing failures were the main breakage fixed in #698/#699); 56 green on the rebased combination. Surfacing into prompts is deliberately absent — that is #678's recall pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG