### PR TITLE
Add Typed Ambient Scene Seeds, Current Turn Only

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -547,6 +547,13 @@ reserved_remote_slots = 1
 # Upper bound on eligible candidates fetched per anchored menu selection.
 scan_limit = 24
 
+[orrery.ambient]
+max_seeds = 2
+per_dyad_cooldown_turns = 3
+expiry_turns = 1
+line_budget = 4
+turn_budget = 2
+
 [orrery.promote]
 # Calibrated against the 106-resolution corpus on save_05 (39 ticks, 2026-06).
 # Template priorities seam cleanly: mundane needs band tops out at 26

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -113,6 +113,12 @@ def _render_letter_budget(
     return text.replace(placeholder, str(int(max_letter_tokens)))
 
 
+def _prompt_one_line(value: Any) -> str:
+    """Collapse a prompt data value to one whitespace-normalized line."""
+
+    return " ".join(str(value).split())
+
+
 _PROPOSAL_TAG_DELTA_KEYS = frozenset(
     {
         "entity_tags.add",
@@ -551,6 +557,17 @@ class LogonUtility:
         return note
 
     @staticmethod
+    def _load_ambient_scene_instruction() -> str:
+        """Load the coordinator-authored ambient-scene instruction."""
+
+        prompts_dir = Path(__file__).parent.parent.parent.parent / "prompts"
+        instruction_path = prompts_dir / "ambient_scene_seeds.md"
+        instruction = instruction_path.read_text().strip()
+        if not instruction:
+            raise ValueError(f"Ambient-scene instruction is empty: {instruction_path}")
+        return instruction
+
+    @staticmethod
     def _format_setting_context(setting_data: Any) -> str:
         """Render persisted SettingCard JSON into system-prompt context."""
 
@@ -933,8 +950,14 @@ class LogonUtility:
         # This returns a tuple of (parsed_object, llm_response)
         try:
             if self._is_two_pass_turn(schema_model):
+                gaia_turn_prompt = self._format_context_prompt(
+                    context_payload,
+                    presence_baseline=presence_baseline,
+                    include_ambient_scene_seeds=False,
+                )
                 response = self._generate_narrative_two_pass(
                     prompt,
+                    gaia_turn_prompt=gaia_turn_prompt,
                     presence_baseline=presence_baseline,
                     character_roster=character_roster,
                     effective_context_window=effective_context_window,
@@ -1010,8 +1033,14 @@ class LogonUtility:
 
         try:
             if self._is_two_pass_turn(schema_model):
+                gaia_turn_prompt = self._format_context_prompt(
+                    context_payload,
+                    presence_baseline=presence_baseline,
+                    include_ambient_scene_seeds=False,
+                )
                 response = await self._generate_narrative_two_pass_async(
                     prompt,
+                    gaia_turn_prompt=gaia_turn_prompt,
                     presence_baseline=presence_baseline,
                     character_roster=character_roster,
                     effective_context_window=effective_context_window,
@@ -1406,6 +1435,7 @@ class LogonUtility:
         self,
         turn_prompt: str,
         *,
+        gaia_turn_prompt: str,
         presence_baseline: Optional[PresenceBaseline],
         character_roster: Optional[CharacterRosterRows],
         effective_context_window: Optional[int],
@@ -1439,7 +1469,7 @@ class LogonUtility:
         if not isinstance(writer, SkaldWriterWire):
             raise TypeError("LOGON writer pass returned a non-SkaldWriterWire response")
 
-        gaia_prompt = self._format_gaia_user_prompt(turn_prompt, writer)
+        gaia_prompt = self._format_gaia_user_prompt(gaia_turn_prompt, writer)
         gaia_window = (
             self._gaia_effective_window(gaia_route)
             if gaia_route is not None
@@ -1498,6 +1528,7 @@ class LogonUtility:
         self,
         turn_prompt: str,
         *,
+        gaia_turn_prompt: str,
         presence_baseline: Optional[PresenceBaseline],
         character_roster: Optional[CharacterRosterRows],
         effective_context_window: Optional[int],
@@ -1533,7 +1564,7 @@ class LogonUtility:
         if not isinstance(writer, SkaldWriterWire):
             raise TypeError("LOGON writer pass returned a non-SkaldWriterWire response")
 
-        gaia_prompt = self._format_gaia_user_prompt(turn_prompt, writer)
+        gaia_prompt = self._format_gaia_user_prompt(gaia_turn_prompt, writer)
         gaia_window = (
             self._gaia_effective_window(gaia_route)
             if gaia_route is not None
@@ -2033,6 +2064,7 @@ class LogonUtility:
         context: Dict,
         *,
         presence_baseline: Optional[PresenceBaseline] = None,
+        include_ambient_scene_seeds: bool = True,
     ) -> str:
         """Format context payload into a prompt for the Apex AI"""
         sections = []
@@ -2350,6 +2382,44 @@ class LogonUtility:
                 )
                 if prompt_text:
                     sections.append(f"- {label}: {prompt_text}")
+
+        ambient_scene_seeds = context.get("orrery_ambient_scene_seeds") or []
+        if ambient_scene_seeds and include_ambient_scene_seeds:
+            sections.append("\n=== ORRERY AMBIENT SCENE SEEDS ===")
+            sections.append(self._load_ambient_scene_instruction())
+            for seed in ambient_scene_seeds:
+                if not isinstance(seed, dict):
+                    continue
+                participants = seed.get("participants") or []
+                participant_bits = []
+                for item in participants:
+                    if not isinstance(item, dict):
+                        continue
+                    fallback_name = f"entity {item.get('entity_id')}"
+                    name = _prompt_one_line(item.get("name") or fallback_name)
+                    speaking = str(bool(item.get("speaking_eligible"))).lower()
+                    participant_bits.append(
+                        f"{name}#{item.get('entity_id')}[speak={speaking}]"
+                    )
+                participant_summary = ", ".join(participant_bits)
+                entitlement_summary = "; ".join(
+                    f"{item.get('participant_entity_id')}:"
+                    f"claims={item.get('claim_ids') or []},"
+                    f"experiences={item.get('character_experience_ids') or []}"
+                    for item in seed.get("entitlements") or []
+                    if isinstance(item, dict)
+                )
+                location = seed.get("location_constraint") or {}
+                sections.append(
+                    f"- {seed.get('seed_id')} participants={participant_summary}; "
+                    f"topic={_prompt_one_line(seed.get('topic'))}; "
+                    f"tension={_prompt_one_line(seed.get('tension'))}; "
+                    f"why_now={_prompt_one_line(seed.get('why_now'))}; "
+                    f"entitlements={entitlement_summary}; "
+                    f"location={location.get('kind')}:{location.get('place_id')}; "
+                    f"budget={seed.get('turn_budget')} turns/"
+                    f"{seed.get('line_budget')} lines; silence_ok=true"
+                )
 
         joint_beats = context.get("orrery_joint_beats") or []
         if joint_beats:

--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -52,6 +52,7 @@ class TurnContext:
     # Soft author's note / suggestion for the storyteller.
     note: Optional[str] = None
     orrery_proposal: Optional["OrreryTickProposal"] = None
+    ambient_pacing_allowed: Optional[bool] = None
     bleed_menu: List[Any] = field(default_factory=list)
     # Headline state at the anchor chunk (world time, time of day, season/
     # episode/scene, world layer, protagonist location) — the runtime

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -33,8 +33,7 @@ try:
         StorytellerResponseStandard,
         extract_narrative_text,
     )
-    from nexus.agents.orrery.resolver import resolve_dry_run
-    from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+    from nexus.agents.orrery.ambient import shared_ambient_pacing_allows
     from nexus.agents.orrery.bleed import (
         load_bleed_anchor_entity_ids,
         record_bleed_offers,
@@ -43,6 +42,8 @@ try:
     from nexus.agents.orrery.knowledge_surfacing import (
         build_knowledge_digest_sync,
     )
+    from nexus.agents.orrery.resolver import resolve_dry_run
+    from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
     from nexus.config.settings_models import (
         LORERetrievalSettings,
         OrreryBleedSettings,
@@ -67,8 +68,7 @@ except ImportError:
         StorytellerResponseStandard,
         extract_narrative_text,
     )
-    from nexus.agents.orrery.resolver import resolve_dry_run
-    from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
+    from nexus.agents.orrery.ambient import shared_ambient_pacing_allows
     from nexus.agents.orrery.bleed import (
         load_bleed_anchor_entity_ids,
         record_bleed_offers,
@@ -77,6 +77,8 @@ except ImportError:
     from nexus.agents.orrery.knowledge_surfacing import (
         build_knowledge_digest_sync,
     )
+    from nexus.agents.orrery.resolver import resolve_dry_run
+    from nexus.agents.orrery.templates import BUILTIN_TEMPLATES
     from nexus.config.settings_models import (
         LORERetrievalSettings,
         OrreryBleedSettings,
@@ -847,8 +849,19 @@ class TurnCycleManager:
 
         binding_settings = orrery_settings.get("binding", {})
         window_chunks = int(binding_settings.get("window_chunks", 30))
+        bleed_settings = OrreryBleedSettings.model_validate(
+            orrery_settings.get("bleed", {})
+        )
         with self.lore.memnon.Session() as session:
             anchor_chunk_id = self._orrery_anchor_chunk_id(session, turn_context)
+            turn_context.ambient_pacing_allowed = (
+                shared_ambient_pacing_allows(
+                    anchor_chunk_id,
+                    bleed_settings.density,
+                )
+                if anchor_chunk_id is not None
+                else False
+            )
             proposal = resolve_dry_run(
                 session,
                 BUILTIN_TEMPLATES,
@@ -865,6 +878,8 @@ class TurnCycleManager:
                 weather_settings=orrery_settings.get("weather"),
                 mood_settings=orrery_settings.get("mood"),
                 composition_settings=orrery_settings.get("composition"),
+                ambient_settings=orrery_settings.get("ambient"),
+                ambient_pacing_allowed=turn_context.ambient_pacing_allowed,
             )
 
         turn_context.orrery_proposal = proposal
@@ -874,19 +889,22 @@ class TurnCycleManager:
             "actor_count": proposal.actor_count,
             "resolution_count": proposal.resolution_count,
             "pressure_count": proposal.pressure_count,
+            "ambient_seed_count": proposal.ambient_seed_count,
             "template_ids": [
                 resolution.template_id for resolution in proposal.resolutions
             ],
             "pressure_template_ids": [
                 pressure.template_id for pressure in proposal.scene_pressures
             ],
+            "ambient_seed_ids": [seed.seed_id for seed in proposal.ambient_scene_seeds],
         }
         logger.info(
             "Orrery dry-run resolved %d actors into %d draft resolutions "
-            "and %d scene pressures",
+            "and %d scene pressures and %d ambient seeds",
             proposal.actor_count,
             proposal.resolution_count,
             proposal.pressure_count,
+            proposal.ambient_seed_count,
         )
 
     @staticmethod
@@ -1064,6 +1082,11 @@ class TurnCycleManager:
             turn_context.context_payload["orrery_scene_pressures"] = [
                 pressure.to_dict()
                 for pressure in turn_context.orrery_proposal.scene_pressures
+            ]
+
+        if proposal and getattr(proposal, "ambient_scene_seeds", ()):
+            turn_context.context_payload["orrery_ambient_scene_seeds"] = [
+                seed.model_dump(mode="json") for seed in proposal.ambient_scene_seeds
             ]
 
         if proposal and getattr(proposal, "joint_beats", ()):
@@ -1425,6 +1448,7 @@ class TurnCycleManager:
                 near_distance_max=bleed_settings.near_distance_max,
                 reserved_remote_slots=bleed_settings.reserved_remote_slots,
                 scan_limit=bleed_settings.scan_limit,
+                pacing_allowed=turn_context.ambient_pacing_allowed,
             )
 
         turn_context.bleed_menu = result.selected

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -6,6 +6,7 @@ Handles the execution of individual turn cycle phases.
 
 import json
 import logging
+from dataclasses import replace
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Union
 
@@ -33,7 +34,10 @@ try:
         StorytellerResponseStandard,
         extract_narrative_text,
     )
-    from nexus.agents.orrery.ambient import shared_ambient_pacing_allows
+    from nexus.agents.orrery.ambient import (
+        arbitrate_background_texture_channel,
+        shared_ambient_pacing_allows,
+    )
     from nexus.agents.orrery.bleed import (
         load_bleed_anchor_entity_ids,
         record_bleed_offers,
@@ -68,7 +72,10 @@ except ImportError:
         StorytellerResponseStandard,
         extract_narrative_text,
     )
-    from nexus.agents.orrery.ambient import shared_ambient_pacing_allows
+    from nexus.agents.orrery.ambient import (
+        arbitrate_background_texture_channel,
+        shared_ambient_pacing_allows,
+    )
     from nexus.agents.orrery.bleed import (
         load_bleed_anchor_entity_ids,
         record_bleed_offers,
@@ -1024,6 +1031,7 @@ class TurnCycleManager:
         logger.debug("Assembling context payload...")
 
         await self.select_orrery_bleed(turn_context)
+        self._arbitrate_background_texture(turn_context)
         world_knowledge = self._build_world_knowledge(turn_context)
         recent_rulings_section = self._build_recent_orrery_rulings_section(turn_context)
 
@@ -1460,6 +1468,40 @@ class TurnCycleManager:
             "near_count": result.near_count,
             "remote_count": result.remote_count,
             "offers_recorded": 0,
+        }
+
+    @staticmethod
+    def _arbitrate_background_texture(turn_context: TurnContext) -> None:
+        """Retain at most one paced background-texture channel for this turn."""
+
+        proposal = turn_context.orrery_proposal
+        ambient_seeds = tuple(getattr(proposal, "ambient_scene_seeds", ()))
+        bleed_candidates = list(turn_context.bleed_menu)
+        anchor_chunk_id = getattr(proposal, "anchor_chunk_id", None)
+        selected_channel = arbitrate_background_texture_channel(
+            anchor_chunk_id,
+            ambient_eligible=bool(ambient_seeds),
+            bleed_eligible=bool(bleed_candidates),
+        )
+
+        if selected_channel == "bleed" and ambient_seeds:
+            if proposal is None:
+                raise RuntimeError(
+                    "Ambient arbitration found seeds without an Orrery proposal"
+                )
+            turn_context.orrery_proposal = replace(
+                proposal,
+                ambient_scene_seeds=(),
+            )
+        elif selected_channel == "ambient_scene" and bleed_candidates:
+            turn_context.bleed_menu = []
+
+        turn_context.phase_states["orrery_background_texture"] = {
+            "anchor_chunk_id": anchor_chunk_id,
+            "pacing_allowed": bool(turn_context.ambient_pacing_allowed),
+            "ambient_candidate_count": len(ambient_seeds),
+            "bleed_candidate_count": len(bleed_candidates),
+            "selected_channel": selected_channel,
         }
 
     def record_orrery_bleed_offers(self, turn_context: TurnContext) -> None:

--- a/nexus/agents/orrery/ambient.py
+++ b/nexus/agents/orrery/ambient.py
@@ -15,6 +15,7 @@ from nexus.config.settings_models import OrreryAmbientSettings
 
 
 AMBIENT_EXPOSURE_TEMPLATE_ID = "ambient_scene_seed"
+BackgroundTextureChannel = Literal["ambient_scene", "bleed"]
 
 
 class AmbientParticipant(BaseModel):
@@ -124,6 +125,28 @@ def shared_ambient_pacing_allows(anchor_chunk_id: int, density: float) -> bool:
     return rng.random() < density
 
 
+def arbitrate_background_texture_channel(
+    anchor_chunk_id: Optional[int],
+    *,
+    ambient_eligible: bool,
+    bleed_eligible: bool,
+) -> Optional[BackgroundTextureChannel]:
+    """Choose the sole offered background-texture channel for one anchor."""
+
+    if not ambient_eligible and not bleed_eligible:
+        return None
+    if ambient_eligible and not bleed_eligible:
+        return "ambient_scene"
+    if bleed_eligible and not ambient_eligible:
+        return "bleed"
+    if anchor_chunk_id is None:
+        raise ValueError(
+            "Background-texture channel arbitration requires an anchor chunk"
+        )
+    rng = seeded_stochastic_rng("bleed", anchor_chunk_id, "channel_arbitration")
+    return ("ambient_scene", "bleed")[rng.randrange(2)]
+
+
 def build_ambient_scene_seeds(
     session: Any,
     *,
@@ -219,7 +242,11 @@ def build_ambient_scene_seeds(
     participant_ids = sorted(
         {entity_id for item in selected for entity_id in item.participant_ids}
     )
-    possessed_claims = _load_possessed_claim_ids(session, participant_ids)
+    possessed_claims = _load_possessed_claim_ids(
+        session,
+        participant_ids,
+        anchor_chunk_id=anchor_chunk_id,
+    )
     return tuple(
         _seed_from_candidate(
             candidate,
@@ -464,7 +491,10 @@ def _load_suppressed_dedup_keys(
 
 
 def _load_possessed_claim_ids(
-    session: Any, participant_ids: Sequence[int]
+    session: Any,
+    participant_ids: Sequence[int],
+    *,
+    anchor_chunk_id: int,
 ) -> dict[int, Tuple[int, ...]]:
     if not participant_ids:
         return {}
@@ -472,13 +502,28 @@ def _load_possessed_claim_ids(
         text(
             """
             /* orrery:ambient_possessed_claims */
-            SELECT knower_entity_id, claim_id
-            FROM claim_awareness
-            WHERE knower_entity_id = ANY(:participant_ids)
-            ORDER BY knower_entity_id, claim_id
+            WITH anchor AS (
+                SELECT created_at
+                FROM narrative_chunks
+                WHERE id = :anchor_chunk_id
+            )
+            SELECT ca.knower_entity_id, ca.claim_id
+            FROM claim_awareness ca
+            WHERE ca.knower_entity_id = ANY(:participant_ids)
+              -- Mirror replay.py's claim-awareness readmission visibility.
+              AND (
+                  (ca.source_chunk_id IS NOT NULL
+                   AND ca.source_chunk_id <= :anchor_chunk_id)
+                  OR (ca.source_chunk_id IS NULL
+                      AND ca.created_at <= (SELECT created_at FROM anchor))
+              )
+            ORDER BY ca.knower_entity_id, ca.claim_id
             """
         ),
-        {"participant_ids": list(participant_ids)},
+        {
+            "participant_ids": list(participant_ids),
+            "anchor_chunk_id": anchor_chunk_id,
+        },
     ).mappings()
     claims: dict[int, list[int]] = {}
     for row in rows:

--- a/nexus/agents/orrery/ambient.py
+++ b/nexus/agents/orrery/ambient.py
@@ -1,0 +1,566 @@
+"""Typed, deterministic ambient-scene seeds for the current Storyteller turn."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Any, Iterable, Literal, Mapping, Optional, Sequence, Tuple
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from sqlalchemy import text
+
+from nexus.agents.orrery.reciprocal import OrreryJointBeat
+from nexus.agents.orrery.substrate import WorldState, seeded_stochastic_rng
+from nexus.config.settings_models import OrreryAmbientSettings
+
+
+AMBIENT_EXPOSURE_TEMPLATE_ID = "ambient_scene_seed"
+
+
+class AmbientParticipant(BaseModel):
+    """One NPC admitted to an ambient-scene seed."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    entity_id: int = Field(ge=1)
+    name: str = Field(min_length=1)
+    speaking_eligible: bool
+
+
+class AmbientEntitlement(BaseModel):
+    """Exact actor-owned records one participant may draw on when speaking."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    participant_entity_id: int = Field(ge=1)
+    claim_ids: Tuple[int, ...] = ()
+    character_experience_ids: Tuple[int, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_owned_ids(self) -> "AmbientEntitlement":
+        """Entitlement identifiers must be positive, sorted, and unique."""
+
+        for label, values in (
+            ("claim_ids", self.claim_ids),
+            ("character_experience_ids", self.character_experience_ids),
+        ):
+            if any(value <= 0 for value in values):
+                raise ValueError(f"{label} must contain only positive identifiers")
+            if tuple(sorted(set(values))) != values:
+                raise ValueError(f"{label} must be sorted and unique")
+        return self
+
+
+class AmbientLocationConstraint(BaseModel):
+    """Where the current-turn ambient exchange is allowed to occur."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    kind: Literal["current_scene"] = "current_scene"
+    place_id: Optional[int] = Field(default=None, ge=1)
+
+
+class AmbientSceneSeed(BaseModel):
+    """Advisory, state-free direction for one bounded ambient exchange."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    seed_id: str = Field(min_length=1)
+    participants: Tuple[AmbientParticipant, ...]
+    topic: str = Field(min_length=1)
+    tension: str = Field(min_length=1)
+    why_now: str = Field(min_length=1)
+    entitlements: Tuple[AmbientEntitlement, ...]
+    location_constraint: AmbientLocationConstraint
+    dedup_key: str = Field(min_length=1)
+    cooldown_turns: int = Field(ge=0)
+    expiry_turns: int = Field(ge=1)
+    source_turn: int = Field(ge=1)
+    line_budget: int = Field(ge=1)
+    turn_budget: int = Field(ge=1)
+    silence_ok: Literal[True] = True
+
+    @model_validator(mode="after")
+    def _validate_participant_boundary(self) -> "AmbientSceneSeed":
+        """Require one entitlement record for each distinct participant."""
+
+        participant_ids = tuple(item.entity_id for item in self.participants)
+        if len(participant_ids) < 2:
+            raise ValueError("ambient scene seeds require at least two participants")
+        if len(set(participant_ids)) != len(participant_ids):
+            raise ValueError("ambient scene participants must be unique")
+        entitlement_ids = tuple(
+            item.participant_entity_id for item in self.entitlements
+        )
+        if entitlement_ids != participant_ids:
+            raise ValueError(
+                "ambient entitlements must match participants in participant order"
+            )
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class _AmbientCandidate:
+    """One deterministic signal-derived candidate before entitlement hydration."""
+
+    participant_ids: Tuple[int, int]
+    topic: str
+    tension: str
+    why_now: str
+    source_turn: int
+    source_rank: int
+
+
+def shared_ambient_pacing_allows(anchor_chunk_id: int, density: float) -> bool:
+    """Return the replay-safe pacing decision shared by Bleed and ambient seeds."""
+
+    if not 0.0 <= density <= 1.0:
+        raise ValueError(f"Bleed density must be between 0.0 and 1.0, got {density}")
+    if density == 0.0:
+        return False
+    if density == 1.0:
+        return True
+    rng = seeded_stochastic_rng("bleed", anchor_chunk_id, "density")
+    return rng.random() < density
+
+
+def build_ambient_scene_seeds(
+    session: Any,
+    *,
+    anchor_chunk_id: Optional[int],
+    state: WorldState,
+    present_actor_ids: Iterable[int],
+    joint_beats: Iterable[OrreryJointBeat],
+    entity_names: Mapping[int, str],
+    settings: Any,
+    pacing_allowed: bool,
+) -> Tuple[AmbientSceneSeed, ...]:
+    """Build bounded current-turn seeds using read-only Orrery state and ledgers."""
+
+    ambient_settings = OrreryAmbientSettings.model_validate(settings)
+    if anchor_chunk_id is None or ambient_settings.max_seeds == 0 or not pacing_allowed:
+        return ()
+
+    present_ids = frozenset(int(value) for value in present_actor_ids)
+    protagonist_id = _load_protagonist_entity_id(session)
+    eligible_ids = present_ids - ({protagonist_id} if protagonist_id else set())
+    if len(eligible_ids) < 2:
+        return ()
+
+    candidates = _joint_beat_candidates(
+        joint_beats,
+        anchor_chunk_id=anchor_chunk_id,
+        eligible_ids=eligible_ids,
+    )
+    candidates.extend(
+        _relationship_candidates(
+            state,
+            anchor_chunk_id=anchor_chunk_id,
+            eligible_ids=eligible_ids,
+        )
+    )
+    candidates.extend(
+        _claim_acquisition_candidates(
+            session,
+            anchor_chunk_id=anchor_chunk_id,
+            expiry_turns=ambient_settings.expiry_turns,
+            eligible_ids=eligible_ids,
+        )
+    )
+    candidates.extend(
+        _committed_resolution_candidates(
+            session,
+            anchor_chunk_id=anchor_chunk_id,
+            expiry_turns=ambient_settings.expiry_turns,
+            eligible_ids=eligible_ids,
+        )
+    )
+
+    unexpired = [
+        candidate
+        for candidate in candidates
+        if anchor_chunk_id - candidate.source_turn < ambient_settings.expiry_turns
+        and _shares_current_location(state, candidate.participant_ids)
+    ]
+    by_dyad: dict[Tuple[int, int], _AmbientCandidate] = {}
+    for candidate in sorted(
+        unexpired,
+        key=lambda item: (
+            item.participant_ids,
+            -item.source_turn,
+            item.source_rank,
+            item.why_now,
+        ),
+    ):
+        by_dyad.setdefault(candidate.participant_ids, candidate)
+
+    suppressed_keys = _load_suppressed_dedup_keys(
+        session,
+        anchor_chunk_id=anchor_chunk_id,
+        cooldown_turns=ambient_settings.per_dyad_cooldown_turns,
+    )
+    selectable = [
+        candidate
+        for candidate in by_dyad.values()
+        if _dyad_dedup_key(candidate.participant_ids) not in suppressed_keys
+    ]
+    selectable.sort(
+        key=lambda item: (
+            item.participant_ids,
+            -item.source_turn,
+            item.source_rank,
+            item.why_now,
+        )
+    )
+    rng = seeded_stochastic_rng("ambient_scene", anchor_chunk_id, "seed_selection")
+    rng.shuffle(selectable)
+    selected = selectable[: ambient_settings.max_seeds]
+
+    participant_ids = sorted(
+        {entity_id for item in selected for entity_id in item.participant_ids}
+    )
+    possessed_claims = _load_possessed_claim_ids(session, participant_ids)
+    return tuple(
+        _seed_from_candidate(
+            candidate,
+            state=state,
+            entity_names=entity_names,
+            possessed_claims=possessed_claims,
+            settings=ambient_settings,
+        )
+        for candidate in selected
+    )
+
+
+def _load_protagonist_entity_id(session: Any) -> Optional[int]:
+    row = (
+        session.execute(
+            text(
+                """
+                /* orrery:ambient_protagonist */
+                SELECT c.entity_id
+                FROM global_variables gv
+                JOIN characters c ON c.id = gv.user_character
+                WHERE gv.id = true
+                """
+            )
+        )
+        .mappings()
+        .first()
+    )
+    if row is None or row.get("entity_id") is None:
+        return None
+    return int(row["entity_id"])
+
+
+def _joint_beat_candidates(
+    joint_beats: Iterable[OrreryJointBeat],
+    *,
+    anchor_chunk_id: int,
+    eligible_ids: frozenset[int],
+) -> list[_AmbientCandidate]:
+    candidates: list[_AmbientCandidate] = []
+    for beat in joint_beats:
+        participants = _ordered_dyad(beat.entity_a, beat.entity_b)
+        if not set(participants).issubset(eligible_ids):
+            continue
+        candidates.append(
+            _AmbientCandidate(
+                participant_ids=participants,
+                topic=(f"{beat.forward_template_id} / {beat.reverse_template_id}"),
+                tension=f"{beat.kind} intent at magnitude {beat.magnitude:.3f}",
+                why_now=(
+                    "joint beat "
+                    f"{beat.forward_proposal_id} + {beat.reverse_proposal_id}"
+                ),
+                source_turn=anchor_chunk_id,
+                source_rank=0,
+            )
+        )
+    return candidates
+
+
+def _relationship_candidates(
+    state: WorldState,
+    *,
+    anchor_chunk_id: int,
+    eligible_ids: frozenset[int],
+) -> list[_AmbientCandidate]:
+    dyads = {
+        _ordered_dyad(source, target)
+        for source, target in state.relationship_types
+        if source != target and {source, target}.issubset(eligible_ids)
+    }
+    candidates: list[_AmbientCandidate] = []
+    for participants in sorted(dyads):
+        entity_a, entity_b = participants
+        forward = sorted(state.relationship_types.get((entity_a, entity_b), ()))
+        reverse = sorted(state.relationship_types.get((entity_b, entity_a), ()))
+        relationship_bits = []
+        if forward:
+            relationship_bits.append(f"{entity_a}->{entity_b}:{','.join(forward)}")
+        if reverse:
+            relationship_bits.append(f"{entity_b}->{entity_a}:{','.join(reverse)}")
+        trust_values = [
+            value
+            for value in (
+                state.trust.get((entity_a, entity_b)),
+                state.trust.get((entity_b, entity_a)),
+            )
+            if value is not None
+        ]
+        tension = (
+            "relationship valence " + "/".join(str(value) for value in trust_values)
+            if trust_values
+            else "active relationship state"
+        )
+        relationship_state = "; ".join(relationship_bits)
+        candidates.append(
+            _AmbientCandidate(
+                participant_ids=participants,
+                topic=relationship_state,
+                tension=tension,
+                why_now=f"relationship state {relationship_state}",
+                source_turn=anchor_chunk_id,
+                source_rank=3,
+            )
+        )
+    return candidates
+
+
+def _claim_acquisition_candidates(
+    session: Any,
+    *,
+    anchor_chunk_id: int,
+    expiry_turns: int,
+    eligible_ids: frozenset[int],
+) -> list[_AmbientCandidate]:
+    lower_bound = max(0, anchor_chunk_id - expiry_turns + 1)
+    rows = session.execute(
+        text(
+            """
+            /* orrery:ambient_claim_acquisitions */
+            SELECT awareness.id AS acquisition_id,
+                   awareness.claim_id,
+                   awareness.knower_entity_id,
+                   awareness.immediate_source_entity_id,
+                   awareness.source_chunk_id,
+                   claim.summary,
+                   claim.scope
+            FROM claim_awareness awareness
+            JOIN claims claim ON claim.id = awareness.claim_id
+            WHERE awareness.source_chunk_id BETWEEN :lower_bound AND :anchor
+              AND awareness.immediate_source_entity_id IS NOT NULL
+            ORDER BY awareness.source_chunk_id DESC, awareness.id
+            """
+        ),
+        {"lower_bound": lower_bound, "anchor": anchor_chunk_id},
+    ).mappings()
+    candidates: list[_AmbientCandidate] = []
+    for row in rows:
+        participants = _ordered_dyad(
+            int(row["knower_entity_id"]),
+            int(row["immediate_source_entity_id"]),
+        )
+        if not set(participants).issubset(eligible_ids):
+            continue
+        candidates.append(
+            _AmbientCandidate(
+                participant_ids=participants,
+                topic=str(row["summary"]),
+                tension=f"new {row['scope']} claim {int(row['claim_id'])}",
+                why_now=f"claim acquisition {int(row['acquisition_id'])}",
+                source_turn=int(row["source_chunk_id"]),
+                source_rank=1,
+            )
+        )
+    return candidates
+
+
+def _committed_resolution_candidates(
+    session: Any,
+    *,
+    anchor_chunk_id: int,
+    expiry_turns: int,
+    eligible_ids: frozenset[int],
+) -> list[_AmbientCandidate]:
+    lower_bound = max(0, anchor_chunk_id - expiry_turns + 1)
+    rows = session.execute(
+        text(
+            """
+            /* orrery:ambient_committed_resolutions */
+            SELECT resolution.id AS resolution_id,
+                   resolution.tick_chunk_id,
+                   resolution.template_id,
+                   resolution.brief,
+                   resolution.magnitude,
+                   event.id AS event_id,
+                   event.event_type,
+                   event.actor_entity_id,
+                   event.target_entity_id
+            FROM orrery_resolutions resolution
+            JOIN world_events event ON event.resolution_id = resolution.id
+            WHERE resolution.tick_chunk_id BETWEEN :lower_bound AND :anchor
+              AND event.actor_entity_id IS NOT NULL
+              AND event.target_entity_id IS NOT NULL
+              AND event.superseded_by_event_id IS NULL
+            ORDER BY resolution.tick_chunk_id DESC, event.id
+            """
+        ),
+        {"lower_bound": lower_bound, "anchor": anchor_chunk_id},
+    ).mappings()
+    candidates: list[_AmbientCandidate] = []
+    for row in rows:
+        participants = _ordered_dyad(
+            int(row["actor_entity_id"]), int(row["target_entity_id"])
+        )
+        if not set(participants).issubset(eligible_ids):
+            continue
+        topic = str(row.get("brief") or row["template_id"])
+        magnitude = float(row.get("magnitude") or 0.0)
+        candidates.append(
+            _AmbientCandidate(
+                participant_ids=participants,
+                topic=topic,
+                tension=f"{row['event_type']} at magnitude {magnitude:.3f}",
+                why_now=(
+                    f"event {int(row['event_id'])} from committed resolution "
+                    f"{int(row['resolution_id'])}"
+                ),
+                source_turn=int(row["tick_chunk_id"]),
+                source_rank=2,
+            )
+        )
+    return candidates
+
+
+def _load_suppressed_dedup_keys(
+    session: Any,
+    *,
+    anchor_chunk_id: int,
+    cooldown_turns: int,
+) -> frozenset[str]:
+    if cooldown_turns <= 0:
+        return frozenset()
+    cutoff = max(0, anchor_chunk_id - cooldown_turns)
+    rows = session.execute(
+        text(
+            """
+            /* orrery:ambient_exposure_cooldown */
+            SELECT DISTINCT binding_hash
+            FROM orrery_prompt_exposures
+            WHERE kind = 'scene_pressure'
+              AND template_id = :template_id
+              AND tick_chunk_id BETWEEN :cutoff AND :anchor
+            """
+        ),
+        {
+            "template_id": AMBIENT_EXPOSURE_TEMPLATE_ID,
+            "cutoff": cutoff,
+            "anchor": anchor_chunk_id,
+        },
+    ).mappings()
+    return frozenset(str(row["binding_hash"]) for row in rows)
+
+
+def _load_possessed_claim_ids(
+    session: Any, participant_ids: Sequence[int]
+) -> dict[int, Tuple[int, ...]]:
+    if not participant_ids:
+        return {}
+    rows = session.execute(
+        text(
+            """
+            /* orrery:ambient_possessed_claims */
+            SELECT knower_entity_id, claim_id
+            FROM claim_awareness
+            WHERE knower_entity_id = ANY(:participant_ids)
+            ORDER BY knower_entity_id, claim_id
+            """
+        ),
+        {"participant_ids": list(participant_ids)},
+    ).mappings()
+    claims: dict[int, list[int]] = {}
+    for row in rows:
+        claims.setdefault(int(row["knower_entity_id"]), []).append(int(row["claim_id"]))
+    return {
+        entity_id: tuple(sorted(set(claim_ids)))
+        for entity_id, claim_ids in claims.items()
+    }
+
+
+def _seed_from_candidate(
+    candidate: _AmbientCandidate,
+    *,
+    state: WorldState,
+    entity_names: Mapping[int, str],
+    possessed_claims: Mapping[int, Tuple[int, ...]],
+    settings: OrreryAmbientSettings,
+) -> AmbientSceneSeed:
+    dedup_key = _dyad_dedup_key(candidate.participant_ids)
+    seed_material = f"{dedup_key}:{candidate.why_now}"
+    return AmbientSceneSeed(
+        seed_id=sha256(seed_material.encode("utf-8")).hexdigest(),
+        participants=tuple(
+            AmbientParticipant(
+                entity_id=entity_id,
+                name=entity_names.get(entity_id, f"entity {entity_id}"),
+                speaking_eligible=True,
+            )
+            for entity_id in candidate.participant_ids
+        ),
+        topic=candidate.topic,
+        tension=candidate.tension,
+        why_now=candidate.why_now,
+        entitlements=tuple(
+            AmbientEntitlement(
+                participant_entity_id=entity_id,
+                claim_ids=possessed_claims.get(entity_id, ()),
+            )
+            for entity_id in candidate.participant_ids
+        ),
+        location_constraint=AmbientLocationConstraint(
+            place_id=_shared_place_id(state, candidate.participant_ids)
+        ),
+        dedup_key=dedup_key,
+        cooldown_turns=settings.per_dyad_cooldown_turns,
+        expiry_turns=settings.expiry_turns,
+        source_turn=candidate.source_turn,
+        line_budget=settings.line_budget,
+        turn_budget=settings.turn_budget,
+        silence_ok=True,
+    )
+
+
+def _ordered_dyad(entity_a: int, entity_b: int) -> Tuple[int, int]:
+    if entity_a == entity_b:
+        raise ValueError("ambient scene dyads require distinct participants")
+    first, second = sorted((int(entity_a), int(entity_b)))
+    return first, second
+
+
+def _dyad_dedup_key(participant_ids: Tuple[int, int]) -> str:
+    entity_a, entity_b = participant_ids
+    return sha256(f"ambient_scene:{entity_a}:{entity_b}".encode("utf-8")).hexdigest()
+
+
+def _shared_place_id(
+    state: WorldState, participant_ids: Tuple[int, int]
+) -> Optional[int]:
+    entity_a, entity_b = participant_ids
+    place_a = state.locations.get(entity_a)
+    place_b = state.locations.get(entity_b)
+    if place_a is None or place_b is None:
+        return None
+    if place_a != place_b:
+        return None
+    return int(place_a)
+
+
+def _shares_current_location(
+    state: WorldState, participant_ids: Tuple[int, int]
+) -> bool:
+    entity_a, entity_b = participant_ids
+    place_a = state.locations.get(entity_a)
+    place_b = state.locations.get(entity_b)
+    return place_a is None or place_b is None or place_a == place_b

--- a/nexus/agents/orrery/bleed.py
+++ b/nexus/agents/orrery/bleed.py
@@ -13,7 +13,7 @@ from typing import Any, Iterable, Mapping, Optional, Tuple
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 
-from nexus.agents.orrery.substrate import seeded_stochastic_rng
+from nexus.agents.orrery.ambient import shared_ambient_pacing_allows
 
 logger = logging.getLogger("nexus.orrery.bleed")
 
@@ -222,19 +222,20 @@ def load_bleed_candidates(
     anchor_chunk_id: int,
     density: float,
     limit: Optional[int],
+    pacing_allowed: Optional[bool] = None,
 ) -> list[BleedCandidate]:
     """Load narrated Orrery candidates that are eligible before the anchor."""
 
     if limit is not None and limit <= 0:
         return []
-    if not 0.0 <= density <= 1.0:
+    if pacing_allowed is not None and not isinstance(pacing_allowed, bool):
+        raise TypeError("pacing_allowed must be a bool when supplied")
+    if pacing_allowed is None:
+        pacing_allowed = shared_ambient_pacing_allows(anchor_chunk_id, density)
+    elif not 0.0 <= density <= 1.0:
         raise ValueError(f"Bleed density must be between 0.0 and 1.0, got {density}")
-    if density == 0.0:
+    if not pacing_allowed:
         return []
-    if density < 1.0:
-        rng = seeded_stochastic_rng("bleed", anchor_chunk_id, "density")
-        if rng.random() >= density:
-            return []
 
     limit_clause = "LIMIT :limit" if limit is not None else ""
     rows = session.execute(
@@ -308,6 +309,7 @@ def select_bleed_menu(
     near_distance_max: int,
     reserved_remote_slots: int,
     scan_limit: int,
+    pacing_allowed: Optional[bool] = None,
 ) -> BleedSelectorResult:
     """Select a proximity-balanced ambient menu from eligible candidates."""
 
@@ -324,6 +326,7 @@ def select_bleed_menu(
         # The empty-anchor fallback needs only the top of the pure ordering;
         # the proximity path partitions a bounded scan window (scan_limit).
         limit=max_candidates if not anchors else scan_limit,
+        pacing_allowed=pacing_allowed,
     )
     if not candidate_pool:
         return BleedSelectorResult()

--- a/nexus/agents/orrery/events.py
+++ b/nexus/agents/orrery/events.py
@@ -14,6 +14,7 @@ from hashlib import sha256
 import json
 from typing import Any, Mapping, Optional
 
+from nexus.agents.orrery.ambient import AMBIENT_EXPOSURE_TEMPLATE_ID
 from nexus.agents.orrery.db_rows import row_get as _row_get
 from nexus.agents.orrery.drift import (
     drain_relationship_drift_async,
@@ -1499,7 +1500,7 @@ def _prompt_exposure_rows(
     """(kind, template_id, binding_hash, position) for the rendered slice.
 
     Mirrors the render slices in logon_utility's storyteller prompt: the
-    first N proposals and first N pressures in proposal order.
+    first N proposals and pressures, plus every already-bounded ambient seed.
     """
 
     rows: list[tuple[str, str, str, int]] = []
@@ -1508,6 +1509,15 @@ def _prompt_exposure_rows(
     for position, pressure in enumerate(proposal.scene_pressures[:max_pressures]):
         rows.append(
             ("scene_pressure", pressure.template_id, pressure.binding_hash, position)
+        )
+    for position, seed in enumerate(proposal.ambient_scene_seeds):
+        rows.append(
+            (
+                "scene_pressure",
+                AMBIENT_EXPOSURE_TEMPLATE_ID,
+                seed.dedup_key,
+                position,
+            )
         )
     return rows
 

--- a/nexus/agents/orrery/resolver.py
+++ b/nexus/agents/orrery/resolver.py
@@ -11,6 +11,7 @@ from typing import Any, Iterable, Mapping, Optional, Protocol, Sequence, Tuple, 
 
 from sqlalchemy import text
 
+from nexus.agents.orrery.ambient import AmbientSceneSeed, build_ambient_scene_seeds
 from nexus.agents.orrery.communication import (
     CommunicationGraph,
     communication_graph_for_settings,
@@ -217,6 +218,7 @@ class OrreryTickProposal:
     actor_count: int
     resolutions: Tuple[OrreryResolutionDraft, ...]
     scene_pressures: Tuple[OrreryScenePressureDraft, ...] = ()
+    ambient_scene_seeds: Tuple[AmbientSceneSeed, ...] = ()
     joint_beats: Tuple[OrreryJointBeat, ...] = ()
     # Transient read-side projection. Intentionally omitted from to_dict():
     # incubator persistence stores decisions, not a hydration-time graph.
@@ -243,6 +245,12 @@ class OrreryTickProposal:
 
         return len(self.scene_pressures)
 
+    @property
+    def ambient_seed_count(self) -> int:
+        """Return the number of current-turn ambient-scene seeds."""
+
+        return len(self.ambient_scene_seeds)
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable representation of this proposal."""
 
@@ -253,6 +261,9 @@ class OrreryTickProposal:
             "resolutions": [draft.to_dict() for draft in self.resolutions],
             "scene_pressures": [
                 pressure.to_dict() for pressure in self.scene_pressures
+            ],
+            "ambient_scene_seeds": [
+                seed.model_dump(mode="json") for seed in self.ambient_scene_seeds
             ],
             "joint_beats": [beat.to_dict() for beat in self.joint_beats],
             "epistemics_settings": dict(self.epistemics_settings),
@@ -274,6 +285,10 @@ class OrreryTickProposal:
             scene_pressures=tuple(
                 OrreryScenePressureDraft.from_dict(item)
                 for item in data.get("scene_pressures", ())
+            ),
+            ambient_scene_seeds=tuple(
+                AmbientSceneSeed.model_validate(item)
+                for item in data.get("ambient_scene_seeds", ())
             ),
             joint_beats=coerce_joint_beats(data.get("joint_beats")),
             epistemics_settings=dict(
@@ -2341,6 +2356,8 @@ def resolve_dry_run(
     weather_settings: Optional[Any] = None,
     mood_settings: Optional[Any] = None,
     composition_settings: Optional[Any] = None,
+    ambient_settings: Optional[Any] = None,
+    ambient_pacing_allowed: Optional[bool] = None,
 ) -> OrreryTickProposal:
     """Hydrate, bind, and evaluate Orrery packages without database writes."""
 
@@ -2600,6 +2617,8 @@ def resolve_dry_run(
         spec["actor_entity_id"] for spec in present_need_pressure_specs
     }
     name_entity_ids = draft_entity_ids | pressure_entity_ids
+    if ambient_settings is not None and ambient_pacing_allowed:
+        name_entity_ids.update(composition_cache.present_actor_ids)
     if state.mood_enabled:
         name_entity_ids.update(composition_cache.present_actor_ids)
     entity_names = _load_entity_names(session, name_entity_ids)
@@ -2661,12 +2680,32 @@ def resolve_dry_run(
         ]
         if moods:
             scene_conditions["moods"] = moods
+    joint_beats = detect_joint_beats(drafts, entity_names)
+    if ambient_settings is not None and ambient_pacing_allowed is None:
+        raise ValueError(
+            "ambient_pacing_allowed is required when ambient_settings are supplied"
+        )
+    ambient_scene_seeds = (
+        build_ambient_scene_seeds(
+            session,
+            anchor_chunk_id=anchor_chunk_id,
+            state=state,
+            present_actor_ids=composition_cache.present_actor_ids,
+            joint_beats=joint_beats,
+            entity_names=entity_names,
+            settings=ambient_settings,
+            pacing_allowed=bool(ambient_pacing_allowed),
+        )
+        if ambient_settings is not None
+        else ()
+    )
     return OrreryTickProposal(
         anchor_chunk_id=anchor_chunk_id,
         actor_count=len(unique_actors),
         resolutions=tuple(drafts),
         scene_pressures=scene_pressures,
-        joint_beats=detect_joint_beats(drafts, entity_names),
+        ambient_scene_seeds=ambient_scene_seeds,
+        joint_beats=joint_beats,
         communication_graph=state.communication_graph,
         epistemics_settings={
             "enabled": epistemics_policy.enabled,

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1354,6 +1354,38 @@ class OrreryBleedSettings(BaseModel):
         return self
 
 
+class OrreryAmbientSettings(BaseModel):
+    """Bounds for current-turn typed ambient-scene seeds."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_seeds: int = Field(
+        default=2,
+        ge=0,
+        description="Maximum ambient-scene seeds offered in one turn.",
+    )
+    per_dyad_cooldown_turns: int = Field(
+        default=3,
+        ge=0,
+        description="Accepted turns suppressing a previously offered NPC dyad.",
+    )
+    expiry_turns: int = Field(
+        default=1,
+        ge=1,
+        description="Maximum age in accepted turns of a seed-triggering signal.",
+    )
+    line_budget: int = Field(
+        default=4,
+        ge=1,
+        description="Maximum visible dialogue lines an ambient seed may suggest.",
+    )
+    turn_budget: int = Field(
+        default=2,
+        ge=1,
+        description="Maximum speaker turns an ambient seed may suggest.",
+    )
+
+
 class OrreryPromoteSettings(BaseModel):
     """Deterministic promotion discriminator settings for Orrery resolutions."""
 
@@ -2439,6 +2471,7 @@ class OrrerySettings(BaseModel):
     )
     narration: OrreryNarrationSettings
     bleed: OrreryBleedSettings = Field(default_factory=OrreryBleedSettings)
+    ambient: OrreryAmbientSettings = Field(default_factory=OrreryAmbientSettings)
     promote: OrreryPromoteSettings = Field(default_factory=OrreryPromoteSettings)
     sunhelm: OrrerySunhelmSettings = Field(default_factory=OrrerySunhelmSettings)
     selection: OrrerySelectionSettings = Field(default_factory=OrrerySelectionSettings)

--- a/prompts/ambient_scene_seeds.md
+++ b/prompts/ambient_scene_seeds.md
@@ -1,0 +1,1 @@
+Ambient cues are optional; adapt, delay, or ignore them freely, and let silence stand when the scene wants it.

--- a/tests/test_orrery/test_ambient.py
+++ b/tests/test_orrery/test_ambient.py
@@ -2,21 +2,30 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
 import nexus.agents.orrery.events as orrery_events
 from nexus.agents.lore.logon_utility import LogonUtility
+from nexus.agents.lore.utils.turn_context import TurnContext
+from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
 from nexus.agents.orrery.ambient import (
     AMBIENT_EXPOSURE_TEMPLATE_ID,
     AmbientSceneSeed,
+    shared_ambient_pacing_allows,
 )
 from nexus.agents.orrery.events import commit_orrery_tick_sync
 from nexus.agents.orrery.propagation import PropagationDrainResult
 from nexus.agents.orrery.resolver import OrreryTickProposal, resolve_dry_run
 from nexus.agents.orrery.reveal import RevealDrainResult
 from nexus.config.settings_models import OrreryAmbientSettings
+from test_orrery.test_bleed import (
+    FakeLore as BleedFakeLore,
+    FakeSession as BleedFakeSession,
+    _candidate_row as bleed_candidate_row,
+    _settings as bleed_settings,
+)
 from test_orrery.test_resolver import FakeResult, FakeSession
 
 
@@ -86,7 +95,16 @@ class AmbientFakeSession(FakeSession):
             return FakeResult(self.exposure_rows)
         if "/* orrery:ambient_possessed_claims */" in sql:
             self.executed_sql.append(sql)
-            return FakeResult(self.possessed_claim_rows)
+            assert "ca.source_chunk_id <= :anchor_chunk_id" in sql
+            assert "ca.created_at <= (SELECT created_at FROM anchor)" in sql
+            anchor_chunk_id = int(params["anchor_chunk_id"])
+            visible_rows = [
+                row
+                for row in self.possessed_claim_rows
+                if row.get("source_chunk_id") is None
+                or int(row["source_chunk_id"]) <= anchor_chunk_id
+            ]
+            return FakeResult(visible_rows)
         return super().execute(statement, params)
 
 
@@ -130,6 +148,7 @@ def _resolve(
     *,
     anchor_chunk_id: int = 100,
     settings: dict[str, int] | None = None,
+    pacing_allowed: bool = True,
 ) -> OrreryTickProposal:
     return resolve_dry_run(
         session,
@@ -137,7 +156,7 @@ def _resolve(
         anchor_chunk_id=anchor_chunk_id,
         window_chunks=30,
         ambient_settings=settings or AMBIENT_SETTINGS,
-        ambient_pacing_allowed=True,
+        ambient_pacing_allowed=pacing_allowed,
     )
 
 
@@ -244,6 +263,177 @@ def test_entitlements_include_only_each_participant_possessed_claim_ids() -> Non
     }
 
 
+def test_entitlement_hydration_is_anchor_bounded_and_replay_identical() -> None:
+    """A claim acquired after the seed anchor cannot alter replayed seed bytes."""
+
+    at_anchor = [
+        {"knower_entity_id": 1, "claim_id": 10, "source_chunk_id": 100},
+        {"knower_entity_id": 2, "claim_id": 20, "source_chunk_id": 99},
+    ]
+    before_acquisition = _resolve(
+        AmbientFakeSession(
+            relationship_rows=_relationship_rows()[:2],
+            possessed_claim_rows=at_anchor,
+        ),
+        anchor_chunk_id=100,
+    ).ambient_scene_seeds[0]
+    after_acquisition = _resolve(
+        AmbientFakeSession(
+            relationship_rows=_relationship_rows()[:2],
+            possessed_claim_rows=[
+                *at_anchor,
+                {"knower_entity_id": 1, "claim_id": 99, "source_chunk_id": 105},
+            ],
+        ),
+        anchor_chunk_id=100,
+    ).ambient_scene_seeds[0]
+
+    assert all(
+        99 not in entitlement.claim_ids
+        for entitlement in after_acquisition.entitlements
+    )
+    assert after_acquisition.model_dump_json() == before_acquisition.model_dump_json()
+
+
+async def _assemble_background_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    ambient: bool,
+    bleed: bool,
+    pacing_allowed: bool = True,
+    density: float = 1.0,
+    anchor_chunk_id: int = 100,
+) -> TurnContext:
+    proposal = _resolve(
+        AmbientFakeSession(
+            relationship_rows=_relationship_rows()[:2] if ambient else [],
+        ),
+        anchor_chunk_id=anchor_chunk_id,
+        pacing_allowed=pacing_allowed,
+    )
+    settings = bleed_settings()
+    settings["orrery"]["bleed"]["density"] = density
+    manager = TurnCycleManager(
+        BleedFakeLore(
+            settings,
+            BleedFakeSession(
+                candidate_rows=[bleed_candidate_row()] if bleed else [],
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        manager,
+        "_build_recent_orrery_rulings_section",
+        lambda _context: [],
+    )
+    context = TurnContext(
+        turn_id="ambient-arbitration", user_input="Continue.", start_time=0
+    )
+    context.orrery_proposal = proposal
+    context.ambient_pacing_allowed = pacing_allowed
+    context.token_counts = {"total_available": 75_000}
+    await manager.assemble_context_payload(context)
+    return context
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("anchor_chunk_id", "expected_channel"),
+    [(100, "ambient_scene"), (101, "bleed")],
+)
+async def test_both_eligible_renders_exactly_one_background_channel(
+    monkeypatch: pytest.MonkeyPatch,
+    anchor_chunk_id: int,
+    expected_channel: str,
+) -> None:
+    """Real selection and rendering expose one replay-stable arbitration winner."""
+
+    context = await _assemble_background_payload(
+        monkeypatch,
+        ambient=True,
+        bleed=True,
+        anchor_chunk_id=anchor_chunk_id,
+    )
+    replay = await _assemble_background_payload(
+        monkeypatch,
+        ambient=True,
+        bleed=True,
+        anchor_chunk_id=anchor_chunk_id,
+    )
+
+    has_ambient = "orrery_ambient_scene_seeds" in context.context_payload
+    has_bleed = "orrery_bleed_menu" in context.context_payload
+    writer_prompt = LogonUtility({})._format_context_prompt(context.context_payload)
+    assert has_ambient ^ has_bleed
+    assert context.phase_states["orrery_background_texture"]["selected_channel"] == (
+        replay.phase_states["orrery_background_texture"]["selected_channel"]
+    )
+    assert (
+        context.phase_states["orrery_background_texture"]["selected_channel"]
+        == expected_channel
+    )
+    assert context.orrery_proposal is not None
+    assert bool(context.orrery_proposal.ambient_scene_seeds) is (
+        expected_channel == "ambient_scene"
+    )
+    assert bool(context.bleed_menu) is (expected_channel == "bleed")
+    assert set(context.context_payload).intersection(
+        {"orrery_ambient_scene_seeds", "orrery_bleed_menu"}
+    ) == set(replay.context_payload).intersection(
+        {"orrery_ambient_scene_seeds", "orrery_bleed_menu"}
+    )
+    assert ("=== ORRERY AMBIENT SCENE SEEDS ===" in writer_prompt) is has_ambient
+    assert ("=== ORRERY AMBIENT PERIPHERALS ===" in writer_prompt) is has_bleed
+
+
+@pytest.mark.parametrize(
+    ("ambient", "bleed", "expected_channel"),
+    [(True, False, "ambient_scene"), (False, True, "bleed")],
+)
+@pytest.mark.asyncio
+async def test_background_texture_single_eligible_channel_is_unaffected(
+    monkeypatch: pytest.MonkeyPatch,
+    ambient: bool,
+    bleed: bool,
+    expected_channel: str,
+) -> None:
+    """Real selection and rendering preserve the sole eligible channel."""
+
+    context = await _assemble_background_payload(
+        monkeypatch,
+        ambient=ambient,
+        bleed=bleed,
+    )
+
+    assert context.phase_states["orrery_background_texture"]["selected_channel"] == (
+        expected_channel
+    )
+    assert ("orrery_ambient_scene_seeds" in context.context_payload) is ambient
+    assert ("orrery_bleed_menu" in context.context_payload) is bleed
+
+
+@pytest.mark.asyncio
+async def test_failed_shared_density_draw_renders_neither_background_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production payload path renders neither channel after a failed draw."""
+
+    assert shared_ambient_pacing_allows(100, 0.0) is False
+    context = await _assemble_background_payload(
+        monkeypatch,
+        ambient=True,
+        bleed=True,
+        pacing_allowed=False,
+        density=0.0,
+    )
+
+    writer_prompt = LogonUtility({})._format_context_prompt(context.context_payload)
+    assert "orrery_ambient_scene_seeds" not in context.context_payload
+    assert "orrery_bleed_menu" not in context.context_payload
+    assert "=== ORRERY AMBIENT SCENE SEEDS ===" not in writer_prompt
+    assert "=== ORRERY AMBIENT PERIPHERALS ===" not in writer_prompt
+
+
 def test_writer_render_is_compact_optional_and_absent_from_gaia_context() -> None:
     """Ambient seeds render one line for the writer and never enter pass two."""
 
@@ -281,7 +471,7 @@ class _ExposureCursor:
     def __enter__(self) -> "_ExposureCursor":
         return self
 
-    def __exit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> bool:
+    def __exit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> Literal[False]:
         return False
 
     def execute(self, sql: str, params: Any = None) -> None:

--- a/tests/test_orrery/test_ambient.py
+++ b/tests/test_orrery/test_ambient.py
@@ -1,0 +1,374 @@
+"""Current-turn typed ambient-scene seed acceptance tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import nexus.agents.orrery.events as orrery_events
+from nexus.agents.lore.logon_utility import LogonUtility
+from nexus.agents.orrery.ambient import (
+    AMBIENT_EXPOSURE_TEMPLATE_ID,
+    AmbientSceneSeed,
+)
+from nexus.agents.orrery.events import commit_orrery_tick_sync
+from nexus.agents.orrery.propagation import PropagationDrainResult
+from nexus.agents.orrery.resolver import OrreryTickProposal, resolve_dry_run
+from nexus.agents.orrery.reveal import RevealDrainResult
+from nexus.config.settings_models import OrreryAmbientSettings
+from test_orrery.test_resolver import FakeResult, FakeSession
+
+
+AMBIENT_SETTINGS = {
+    "max_seeds": 2,
+    "per_dyad_cooldown_turns": 3,
+    "expiry_turns": 2,
+    "line_budget": 4,
+    "turn_budget": 2,
+}
+
+
+class AmbientFakeSession(FakeSession):
+    """Resolver fake extended only for the ambient read-side ledgers."""
+
+    def __init__(
+        self,
+        *,
+        claim_acquisition_rows: list[dict[str, Any]] | None = None,
+        committed_resolution_rows: list[dict[str, Any]] | None = None,
+        exposure_rows: list[dict[str, Any]] | None = None,
+        possessed_claim_rows: list[dict[str, Any]] | None = None,
+        relationship_rows: list[dict[str, Any]] | None = None,
+        present_actor_rows: list[dict[str, Any]] | None = None,
+        location_rows: list[dict[str, Any]] | None = None,
+    ) -> None:
+        active_rows = [{"id": value} for value in (1, 2, 3, 99)]
+        super().__init__(
+            active_entity_rows=active_rows,
+            relationship_rows=relationship_rows or [],
+            present_actor_rows=present_actor_rows
+            or [{"entity_id": value} for value in (1, 2, 3, 99)],
+            location_rows=location_rows
+            or [
+                {"entity_id": value, "current_location": 10} for value in (1, 2, 3, 99)
+            ],
+            activity_rows=[
+                {"entity_id": value, "current_activity": "idle"}
+                for value in (1, 2, 3, 99)
+            ],
+            chunk_ref_actor_rows=[],
+            entity_name_rows=[
+                {"id": 1, "name": "Mara"},
+                {"id": 2, "name": "Vale"},
+                {"id": 3, "name": "Iris"},
+                {"id": 99, "name": "Protagonist"},
+            ],
+        )
+        self.claim_acquisition_rows = claim_acquisition_rows or []
+        self.committed_resolution_rows = committed_resolution_rows or []
+        self.exposure_rows = exposure_rows or []
+        self.possessed_claim_rows = possessed_claim_rows or []
+
+    def execute(self, statement: Any, params: Any = None) -> FakeResult:
+        sql = str(statement)
+        if "/* orrery:ambient_protagonist */" in sql:
+            self.executed_sql.append(sql)
+            return FakeResult([{"entity_id": 99}])
+        if "/* orrery:ambient_claim_acquisitions */" in sql:
+            self.executed_sql.append(sql)
+            return FakeResult(self.claim_acquisition_rows)
+        if "/* orrery:ambient_committed_resolutions */" in sql:
+            self.executed_sql.append(sql)
+            return FakeResult(self.committed_resolution_rows)
+        if "/* orrery:ambient_exposure_cooldown */" in sql:
+            self.executed_sql.append(sql)
+            return FakeResult(self.exposure_rows)
+        if "/* orrery:ambient_possessed_claims */" in sql:
+            self.executed_sql.append(sql)
+            return FakeResult(self.possessed_claim_rows)
+        return super().execute(statement, params)
+
+
+def _relationship_rows() -> list[dict[str, Any]]:
+    return [
+        {
+            "source_entity_id": 1,
+            "target_entity_id": 2,
+            "relationship_type": "rival",
+            "valence_magnitude": -2,
+        },
+        {
+            "source_entity_id": 2,
+            "target_entity_id": 1,
+            "relationship_type": "colleague",
+            "valence_magnitude": 1,
+        },
+        {
+            "source_entity_id": 1,
+            "target_entity_id": 3,
+            "relationship_type": "friend",
+            "valence_magnitude": 2,
+        },
+        {
+            "source_entity_id": 2,
+            "target_entity_id": 3,
+            "relationship_type": "neighbor",
+            "valence_magnitude": 0,
+        },
+        {
+            "source_entity_id": 99,
+            "target_entity_id": 1,
+            "relationship_type": "ally",
+            "valence_magnitude": 3,
+        },
+    ]
+
+
+def _resolve(
+    session: AmbientFakeSession,
+    *,
+    anchor_chunk_id: int = 100,
+    settings: dict[str, int] | None = None,
+) -> OrreryTickProposal:
+    return resolve_dry_run(
+        session,
+        (),
+        anchor_chunk_id=anchor_chunk_id,
+        window_chunks=30,
+        ambient_settings=settings or AMBIENT_SETTINGS,
+        ambient_pacing_allowed=True,
+    )
+
+
+def test_resolver_builds_deterministic_bounded_state_free_seeds() -> None:
+    """The genuine resolver returns replay-identical seeds and performs no writes."""
+
+    first_session = AmbientFakeSession(relationship_rows=_relationship_rows())
+    second_session = AmbientFakeSession(relationship_rows=_relationship_rows())
+
+    first = _resolve(first_session)
+    second = _resolve(second_session)
+
+    assert first.ambient_scene_seeds == second.ambient_scene_seeds
+    assert len(first.ambient_scene_seeds) == 2
+    assert all(seed.silence_ok is True for seed in first.ambient_scene_seeds)
+    assert all(seed.line_budget == 4 for seed in first.ambient_scene_seeds)
+    assert all(seed.turn_budget == 2 for seed in first.ambient_scene_seeds)
+    assert all(
+        99 not in {participant.entity_id for participant in seed.participants}
+        for seed in first.ambient_scene_seeds
+    )
+    for sql in first_session.executed_sql:
+        normalized = sql.lstrip().upper()
+        assert normalized.startswith(("SELECT", "WITH", "/*"))
+        assert "INSERT INTO" not in normalized
+        assert "UPDATE " not in normalized
+        assert "DELETE FROM" not in normalized
+
+
+def test_proposal_round_trip_preserves_typed_ambient_seed() -> None:
+    """Incubator JSON retains the complete seed contract without state authority."""
+
+    proposal = _resolve(AmbientFakeSession(relationship_rows=_relationship_rows()[:2]))
+
+    payload = proposal.to_dict()
+    hydrated = OrreryTickProposal.from_dict(payload)
+
+    assert hydrated == proposal
+    assert "state_delta" not in payload["ambient_scene_seeds"][0]
+    assert payload["ambient_scene_seeds"][0]["silence_ok"] is True
+
+
+def test_per_dyad_exposure_cooldown_suppresses_repeat_offer() -> None:
+    """An exposure inside the configured cooldown prevents the dyad re-offer."""
+
+    first = _resolve(AmbientFakeSession(relationship_rows=_relationship_rows()[:2]))
+    dedup_key = first.ambient_scene_seeds[0].dedup_key
+    repeated = _resolve(
+        AmbientFakeSession(
+            relationship_rows=_relationship_rows()[:2],
+            exposure_rows=[{"binding_hash": dedup_key}],
+        ),
+        anchor_chunk_id=101,
+    )
+
+    assert repeated.ambient_scene_seeds == ()
+
+
+def test_expired_signal_does_not_become_current_turn_seed() -> None:
+    """A claim-acquisition signal at the expiry boundary is not eligible."""
+
+    proposal = _resolve(
+        AmbientFakeSession(
+            claim_acquisition_rows=[
+                {
+                    "acquisition_id": 501,
+                    "claim_id": 601,
+                    "knower_entity_id": 1,
+                    "immediate_source_entity_id": 2,
+                    "source_chunk_id": 98,
+                    "summary": "The archive door was opened.",
+                    "scope": "bounded",
+                }
+            ]
+        ),
+        anchor_chunk_id=100,
+    )
+
+    assert proposal.ambient_scene_seeds == ()
+
+
+def test_entitlements_include_only_each_participant_possessed_claim_ids() -> None:
+    """Sibling and other actors' accounts cannot cross the ownership boundary."""
+
+    proposal = _resolve(
+        AmbientFakeSession(
+            relationship_rows=_relationship_rows()[:2],
+            possessed_claim_rows=[
+                {"knower_entity_id": 1, "claim_id": 10},
+                {"knower_entity_id": 1, "claim_id": 11},
+                {"knower_entity_id": 2, "claim_id": 20},
+                {"knower_entity_id": 3, "claim_id": 30},
+            ],
+        )
+    )
+    seed = proposal.ambient_scene_seeds[0]
+    entitlements = {
+        item.participant_entity_id: item.claim_ids for item in seed.entitlements
+    }
+
+    assert entitlements == {1: (10, 11), 2: (20,)}
+    assert 30 not in {
+        claim_id for values in entitlements.values() for claim_id in values
+    }
+
+
+def test_writer_render_is_compact_optional_and_absent_from_gaia_context() -> None:
+    """Ambient seeds render one line for the writer and never enter pass two."""
+
+    seed = _resolve(
+        AmbientFakeSession(relationship_rows=_relationship_rows()[:2])
+    ).ambient_scene_seeds[0]
+    context = {
+        "user_input": "Continue.",
+        "orrery_ambient_scene_seeds": [seed.model_dump(mode="json")],
+    }
+
+    writer_prompt = LogonUtility({})._format_context_prompt(context)
+    gaia_prompt = LogonUtility({})._format_context_prompt(
+        context, include_ambient_scene_seeds=False
+    )
+
+    assert "=== ORRERY AMBIENT SCENE SEEDS ===" in writer_prompt
+    assert (
+        "Ambient cues are optional; adapt, delay, or ignore them freely, and let "
+        "silence stand when the scene wants it."
+    ) in writer_prompt
+    assert writer_prompt.count(f"- {seed.seed_id} ") == 1
+    assert "claims=" in writer_prompt
+    assert seed.seed_id not in gaia_prompt
+    assert "Ambient cues are optional" not in gaia_prompt
+
+
+class _ExposureCursor:
+    """Record the isolated ambient commit surface."""
+
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self._fetchone: Any = None
+
+    def __enter__(self) -> "_ExposureCursor":
+        return self
+
+    def __exit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> bool:
+        return False
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+        self._fetchone = (
+            {"id": len(self.executed)}
+            if "INSERT INTO orrery_prompt_exposures" in sql
+            else None
+        )
+
+    def fetchone(self) -> Any:
+        return self._fetchone
+
+
+class _ExposureConnection:
+    def __init__(self, cursor: _ExposureCursor) -> None:
+        self.cursor_obj = cursor
+
+    def cursor(self) -> _ExposureCursor:
+        return self.cursor_obj
+
+
+def test_commit_logs_seed_exposure_without_seed_state_writes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolve-to-commit materializes only the seed's existing exposure idiom."""
+
+    proposal = _resolve(AmbientFakeSession(relationship_rows=_relationship_rows()[:2]))
+    monkeypatch.setattr(
+        orrery_events, "_sweep_expired_entity_tags_sync", lambda *_args, **_kwargs: 0
+    )
+    monkeypatch.setattr(
+        orrery_events,
+        "drain_claim_propagation_sync",
+        lambda *_args, **_kwargs: PropagationDrainResult(),
+    )
+    monkeypatch.setattr(
+        orrery_events,
+        "drain_relationship_drift_sync",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        orrery_events,
+        "drain_backstory_reveals_sync",
+        lambda *_args, **_kwargs: RevealDrainResult(),
+    )
+    cursor = _ExposureCursor()
+
+    result = commit_orrery_tick_sync(
+        _ExposureConnection(cursor),
+        proposal,
+        tick_chunk_id=101,
+    )
+
+    assert result.prompt_exposure_count == 1
+    assert result.resolution_count == 0
+    assert result.event_count == 0
+    assert len(cursor.executed) == 1
+    sql, params = cursor.executed[0]
+    assert "INSERT INTO orrery_prompt_exposures" in sql
+    assert params[1] == "scene_pressure"
+    assert params[2].startswith(f"{AMBIENT_EXPOSURE_TEMPLATE_ID}:")
+    assert params[3] == AMBIENT_EXPOSURE_TEMPLATE_ID
+    assert params[4] == proposal.ambient_scene_seeds[0].dedup_key
+
+
+def test_ambient_settings_reject_unbounded_or_invalid_values() -> None:
+    """All adjustable ambient limits are validated by the config model."""
+
+    with pytest.raises(ValueError, match="max_seeds"):
+        OrreryAmbientSettings(max_seeds=-1)
+    with pytest.raises(ValueError, match="expiry_turns"):
+        OrreryAmbientSettings(expiry_turns=0)
+    with pytest.raises(ValueError, match="line_budget"):
+        OrreryAmbientSettings(line_budget=0)
+    with pytest.raises(ValueError, match="turn_budget"):
+        OrreryAmbientSettings(turn_budget=0)
+
+
+def test_seed_contract_rejects_silence_false() -> None:
+    """The typed contract cannot authorize compulsive non-silent output."""
+
+    seed = _resolve(
+        AmbientFakeSession(relationship_rows=_relationship_rows()[:2])
+    ).ambient_scene_seeds[0]
+    payload = seed.model_dump(mode="json")
+    payload["silence_ok"] = False
+
+    with pytest.raises(ValueError, match="silence_ok"):
+        AmbientSceneSeed.model_validate(payload)


### PR DESCRIPTION
Closes #681. Loom-ruled: current-turn seeds only — the async draft route was rejected and is not built.

- **Deterministic construction**: seeds derive from existing Orrery signals via the seeded-RNG discipline keyed to tick identity (replay-safe), and share **one** pacing draw per turn with the bleed channel's `[orrery.bleed] density` gate — ambient texture and bleed cannot double-fire.
- **The typed contract**: participants + speaking eligibility, topic, tension, `why_now` with deterministic provenance, entitlement lists containing only genuinely possessed claim ids (ownership-boundary tested), location constraint, per-dyad cooldown, expiry, budget, `silence_ok` always true.
- **State discipline**: zero writes outside the exposure log (asserted in tests); nothing a seed causes exists until the normal accepted commit; entitlement is advisory pointers, never new grants.
- **Writer-seat only**, one optional section; the single instruction line ships in `prompts/ambient_scene_seeds.md` (coordinator-authored).

126 green on the rebased combination (incl. the full bleed suite against the repaired fake router).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG