### PR TITLE
Add Entitlement-First Recall and a Mechanical Disclosure Gate

### DIFF
--- a/migrations/106_recall_trace.sql
+++ b/migrations/106_recall_trace.sql
@@ -1,0 +1,55 @@
+-- 106_recall_trace.sql
+-- Per-turn entitlement-first recall and disclosure decisions.
+
+CREATE TABLE IF NOT EXISTS orrery_recall_trace (
+    id                    bigserial PRIMARY KEY,
+    turn_id               text NOT NULL CHECK (btrim(turn_id) <> ''),
+    anchor_chunk_id       bigint NOT NULL REFERENCES narrative_chunks(id),
+    character_entity_id   bigint NOT NULL REFERENCES entities(id),
+    candidate_kind        text NOT NULL
+                              CHECK (candidate_kind IN ('claim', 'experience')),
+    candidate_id          bigint NOT NULL CHECK (candidate_id > 0),
+    claim_id              bigint,
+    decision              text NOT NULL
+                              CHECK (decision IN (
+                                  'included', 'excluded', 'suppressed'
+                              )),
+    reason                text NOT NULL CHECK (btrim(reason) <> ''),
+    mandatory             boolean NOT NULL,
+    score                 double precision NOT NULL,
+    score_components      jsonb NOT NULL,
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (turn_id, character_entity_id, candidate_kind, candidate_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_orrery_recall_trace_character_fifo
+    ON orrery_recall_trace (character_entity_id, id DESC);
+
+COMMENT ON TABLE orrery_recall_trace IS
+    'Compact per-turn audit of every eligible actor-owned recall candidate and its post-ranking disclosure decision; rows are retention-bounded per character by [orrery.recall] trace_rows_per_character and pruned oldest-id-first after each turn.';
+COMMENT ON COLUMN orrery_recall_trace.id IS
+    'Monotonic identity and FIFO ordering key for retention pruning.';
+COMMENT ON COLUMN orrery_recall_trace.turn_id IS
+    'LORE turn identity; retries upsert the same candidate decision.';
+COMMENT ON COLUMN orrery_recall_trace.anchor_chunk_id IS
+    'Accepted narrative anchor whose world clock, timeline, place, and audience governed the decision.';
+COMMENT ON COLUMN orrery_recall_trace.character_entity_id IS
+    'Speaking-eligible present character who owns the candidate material.';
+COMMENT ON COLUMN orrery_recall_trace.candidate_kind IS
+    'Eligible source corpus: possessed claim account or actor-owned character experience.';
+COMMENT ON COLUMN orrery_recall_trace.candidate_id IS
+    'Claim-awareness id for claim candidates or character_experiences.id for experience candidates.';
+COMMENT ON COLUMN orrery_recall_trace.claim_id IS
+    'Exact possessed account identity when the candidate is a claim or claim-backed acquisition experience; audit retention does not constrain claim replay or test-shadow lifecycle with a foreign key.';
+COMMENT ON COLUMN orrery_recall_trace.decision IS
+    'Included in WORLD KNOWLEDGE, excluded by ranking/budget, or suppressed by the separate disclosure gate.';
+COMMENT ON COLUMN orrery_recall_trace.reason IS
+    'Stable machine-readable explanation for the decision.';
+COMMENT ON COLUMN orrery_recall_trace.mandatory IS
+    'True only for a critical account acquired inside the current anchor scene.';
+COMMENT ON COLUMN orrery_recall_trace.score IS
+    'Weighted deterministic recall score after world-clock decay.';
+COMMENT ON COLUMN orrery_recall_trace.score_components IS
+    'Named recall and disclosure components, including raw score and decay modifier.';
+COMMENT ON COLUMN orrery_recall_trace.created_at IS
+    'Database time of the most recent decision upsert; retention pruning keeps the configured newest rows per character.';

--- a/nexus.toml
+++ b/nexus.toml
@@ -452,6 +452,41 @@ enabled = true
 max_entries = 12
 recent_reveal_window_chunks = 5
 
+[orrery.recall]
+# Weighted deterministic ranking over actor-owned eligible material only.
+semantic_fit_weight = 0.35
+event_severity_weight = 0.15
+actor_involvement_weight = 0.15
+emotional_salience_weight = 0.10
+recency_weight = 0.15
+place_match_weight = 0.10
+decay_half_life_hours = 720.0
+recency_horizon_hours = 2160.0
+missing_embedding_score = 0.0
+per_character_max_entries = 4
+mandatory_reserved_entries = 2
+trace_rows_per_character = 500
+
+[orrery.recall.severity_scores]
+minor = 0.25
+moderate = 0.50
+major = 0.75
+critical = 1.0
+
+[orrery.recall.involvement_scores]
+participant = 1.0
+witness = 0.67
+acquisition = 0.33
+
+[orrery.disclosure]
+minimum_score = 0.0
+private_claim_minimum_score = 0.20
+secrecy_penalty = 0.40
+relationship_valence_weight = 0.50
+shared_status_bonus = 0.20
+role_obligation_penalty = 0.50
+missing_relationship_valence = 0.0
+
 [orrery.epistemics]
 enabled = true
 # Event types that mint a bounded claim at birth. Types absent from this list

--- a/nexus.toml
+++ b/nexus.toml
@@ -454,6 +454,8 @@ recent_reveal_window_chunks = 5
 
 [orrery.recall]
 # Weighted deterministic ranking over actor-owned eligible material only.
+# Semantic fit applies only to character experiences and their own vectors.
+# Claim-text embeddings are future work if semantic claim recall is wanted.
 semantic_fit_weight = 0.35
 event_severity_weight = 0.15
 actor_involvement_weight = 0.15

--- a/nexus/agents/lore/logon_utility.py
+++ b/nexus/agents/lore/logon_utility.py
@@ -2297,6 +2297,9 @@ class LogonUtility:
                 qualifiers = [str(acquisition_kind)]
                 if item.get("freshly_revealed"):
                     qualifiers.append("freshly revealed")
+                source = item.get("source") or {}
+                if source.get("kind") == "experience":
+                    qualifiers.append(f"Character experience {source.get('id')}")
                 character_name = item.get("character_name") or (
                     f"entity {item.get('character_entity_id')}"
                 )

--- a/nexus/agents/lore/utils/turn_context.py
+++ b/nexus/agents/lore/utils/turn_context.py
@@ -39,6 +39,7 @@ class TurnContext:
     entity_data: Dict[str, Any] = field(default_factory=dict)
     present_character_ids: List[int] = field(default_factory=list)
     retrieved_passages: List[Dict] = field(default_factory=list)
+    recall_query_embeddings: Optional[Dict[str, List[float]]] = None
     context_payload: Dict[str, Any] = field(default_factory=dict)
     apex_response: Optional[str] = None
     private_correspondence: Optional["GeneratedCorrespondence"] = None

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -51,8 +51,10 @@ try:
     from nexus.config.settings_models import (
         LORERetrievalSettings,
         OrreryBleedSettings,
+        OrreryDisclosureSettings,
         OrreryKnowledgeSettings,
         OrreryPromptSettings,
+        OrreryRecallSettings,
     )
 except ImportError:
     # If relative import fails, try absolute
@@ -89,8 +91,10 @@ except ImportError:
     from nexus.config.settings_models import (
         LORERetrievalSettings,
         OrreryBleedSettings,
+        OrreryDisclosureSettings,
         OrreryKnowledgeSettings,
         OrreryPromptSettings,
+        OrreryRecallSettings,
     )
 
 try:
@@ -1362,6 +1366,12 @@ class TurnCycleManager:
         knowledge_settings = OrreryKnowledgeSettings.model_validate(
             orrery_settings.get("knowledge", {})
         )
+        recall_settings = OrreryRecallSettings.model_validate(
+            orrery_settings.get("recall", {})
+        )
+        disclosure_settings = OrreryDisclosureSettings.model_validate(
+            orrery_settings.get("disclosure", {})
+        )
         if not orrery_settings.get("enabled", False) or not knowledge_settings.enabled:
             turn_context.phase_states["world_knowledge"] = {
                 "enabled": False,
@@ -1393,7 +1403,12 @@ class TurnCycleManager:
                 present_entity_ids=present_entity_ids,
                 anchor_chunk_id=anchor_chunk_id,
                 settings=knowledge_settings,
+                recall_settings=recall_settings,
+                disclosure_settings=disclosure_settings,
+                turn_id=turn_context.turn_id,
+                current_turn_chunk_id=(turn_context.target_chunk_id or anchor_chunk_id),
             )
+            session.commit()
 
         turn_context.phase_states["world_knowledge"] = {
             "enabled": True,

--- a/nexus/agents/lore/utils/turn_cycle.py
+++ b/nexus/agents/lore/utils/turn_cycle.py
@@ -278,13 +278,16 @@ class TurnCycleManager:
         return enabled
 
     def _raw_chunk_retrieval_query(self, turn_context: TurnContext) -> Optional[str]:
-        """Resolve the current/parent chunk text to use as a baseline query."""
+        """Build one raw scene-and-input representation for retrieval."""
 
         for chunk in turn_context.warm_slice:
             if chunk.get("is_target"):
-                text = _chunk_text(chunk)
-                if text:
-                    return text
+                scene_text = _chunk_text(chunk)
+                if scene_text:
+                    user_input = turn_context.user_input.strip()
+                    if user_input and user_input != scene_text:
+                        return f"{scene_text}\n\nCURRENT TURN INPUT:\n{user_input}"
+                    return scene_text
         return None
 
     def _classify_query_type(self, query_text: str) -> str:
@@ -738,10 +741,12 @@ class TurnCycleManager:
         """
         Phase 4: Execute deep memory queries.
 
-        Retrieval uses the full current/parent chunk as the baseline query.
-        MEMNON's QueryAnalyzer classifies raw chunk text for optimal search.
+        Retrieval uses one raw representation containing the full current/parent
+        chunk and the current user input. MEMNON's QueryAnalyzer classifies that
+        exact representation for optimal search.
         """
         logger.debug("Executing deep queries...")
+        turn_context.recall_query_embeddings = None
 
         if not self.lore.memnon:
             logger.warning("MEMNON not available for deep queries")
@@ -750,7 +755,7 @@ class TurnCycleManager:
         if getattr(self.lore, "memory_manager", None):
             self.lore.memory_manager.reset_pass1_queries()
 
-        # Full chunk text is the retrieval baseline.
+        # The full scene plus raw current input is the retrieval baseline.
         queries = []
         raw_chunk_query = self._raw_chunk_retrieval_query(turn_context)
         if raw_chunk_query:
@@ -792,6 +797,13 @@ class TurnCycleManager:
                     "k": 15,  # Get more results since we'll deduplicate
                     "use_hybrid": True,
                 }
+                query_embeddings: Dict[str, List[float]] | None = None
+                orrery_settings = self.settings.get("orrery", {})
+                if orrery_settings.get("enabled", False) and orrery_settings.get(
+                    "knowledge", {}
+                ).get("enabled", False):
+                    query_embeddings = {}
+                    search_kwargs["query_embeddings"] = query_embeddings
                 if (
                     self._presence_boost_enabled()
                     and turn_context.present_character_ids
@@ -800,6 +812,8 @@ class TurnCycleManager:
                         turn_context.present_character_ids
                     )
                 results = self.lore.memnon.query_memory(**search_kwargs)
+                if query_embeddings:
+                    turn_context.recall_query_embeddings = query_embeddings
 
                 # Track query types for logging
                 query_type = query_obj["type"]
@@ -1406,7 +1420,7 @@ class TurnCycleManager:
                 recall_settings=recall_settings,
                 disclosure_settings=disclosure_settings,
                 turn_id=turn_context.turn_id,
-                current_turn_chunk_id=(turn_context.target_chunk_id or anchor_chunk_id),
+                query_embeddings=turn_context.recall_query_embeddings,
             )
             session.commit()
 

--- a/nexus/agents/memnon/memnon.py
+++ b/nexus/agents/memnon/memnon.py
@@ -1759,6 +1759,7 @@ class MEMNON:
         k: Optional[int] = None,
         use_hybrid: bool = True,
         present_character_ids: Optional[Sequence[int]] = None,
+        query_embeddings: Optional[Dict[str, List[float]]] = None,
     ) -> Dict[str, Any]:
         """
         Execute a query against memory and return matching results.
@@ -1770,6 +1771,8 @@ class MEMNON:
             k: Maximum number of results to return
             use_hybrid: Whether to use hybrid search
             present_character_ids: Character IDs present in the retrieval anchor
+            query_embeddings: Caller-owned mapping populated with the exact vectors
+                used by hybrid retrieval
 
         Returns:
             Dictionary containing query results and metadata
@@ -1859,6 +1862,7 @@ class MEMNON:
                         filters=strategy.get("filters"),
                         top_k=strategy.get("limit", k),
                         present_character_ids=present_character_ids,
+                        query_embeddings=query_embeddings,
                     )
                     all_results.extend(results)
 

--- a/nexus/agents/memnon/utils/search.py
+++ b/nexus/agents/memnon/utils/search.py
@@ -77,6 +77,7 @@ class SearchManager:
         top_k: Optional[int] = None,
         present_character_ids: Optional[Sequence[int]] = None,
         presence_boost_enabled: Optional[bool] = None,
+        query_embeddings: Optional[Dict[str, List[float]]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Perform hybrid search using both vector embeddings and text search.
@@ -88,6 +89,8 @@ class SearchManager:
             top_k: Maximum number of results to return
             present_character_ids: Character IDs present in the retrieval anchor
             presence_boost_enabled: Optional measurement override for the config flag
+            query_embeddings: Caller-owned mapping populated with the exact vectors
+                used by hybrid retrieval
 
         Returns:
             List of matching chunks with scores and metadata
@@ -173,12 +176,17 @@ class SearchManager:
             )
 
             # Generate embeddings for all active models
-            query_embeddings = {}
+            if query_embeddings is None:
+                query_embeddings = {}
+            else:
+                query_embeddings.clear()
             for model_key in active_models:
                 try:
-                    query_embeddings[model_key] = (
-                        self.embedding_manager.generate_embedding(query_text, model_key)
+                    embedding = self.embedding_manager.generate_embedding(
+                        query_text, model_key
                     )
+                    if embedding is not None:
+                        query_embeddings[model_key] = embedding
                 except Exception as e:
                     logger.error(
                         f"Error generating embedding for model {model_key}: {e}"

--- a/nexus/agents/orrery/knowledge_surfacing.py
+++ b/nexus/agents/orrery/knowledge_surfacing.py
@@ -14,7 +14,6 @@ from sqlalchemy import text
 
 from nexus.agents.memnon.utils.embedding_tables import (
     parse_character_experience_embedding_table_dimensions,
-    parse_embedding_table_dimensions,
 )
 from nexus.agents.orrery.reconstruction import playable_narrative_predicate
 from nexus.config.settings_models import (
@@ -61,7 +60,7 @@ class _Candidate:
     salience: float
     freshly_revealed: bool
     current_scene_acquisition: bool
-    semantic_fit: float = 0.0
+    semantic_fit: float | None = None
     score: float = 0.0
     mandatory: bool = False
     score_components: dict[str, Any] = field(default_factory=dict)
@@ -375,17 +374,14 @@ def _candidate(row: Mapping[str, Any]) -> _Candidate:
     )
 
 
-def _embedding_tables(session_or_cur: Any) -> list[str]:
+def _experience_embedding_tables(session_or_cur: Any) -> list[str]:
     result = _execute(
         session_or_cur,
         """
         SELECT table_name
         FROM information_schema.tables
         WHERE table_schema = current_schema()
-          AND (
-              table_name ~ '^chunk_embeddings_[0-9]+d$'
-              OR table_name ~ '^character_experience_embeddings_[0-9]+d$'
-          )
+          AND table_name ~ '^character_experience_embeddings_[0-9]+d$'
         ORDER BY table_name
         """,
         {},
@@ -397,17 +393,26 @@ def _semantic_scores(
     session_or_cur: Any,
     *,
     candidates: Sequence[_Candidate],
-    current_turn_chunk_id: int,
+    query_embeddings: Mapping[str, Sequence[float]] | None,
     missing_score: float,
-) -> dict[tuple[str, int], float]:
-    """Compare eligible corpus vectors with the stored raw-turn chunk vector."""
+) -> dict[int, tuple[float | None, str]]:
+    """Compare actor-owned experience vectors with current-turn query vectors."""
 
-    tables = _embedding_tables(session_or_cur)
-    chunk_tables = {
-        dimensions: table_name
-        for table_name in tables
-        if (dimensions := parse_embedding_table_dimensions(table_name)) is not None
-    }
+    experience_ids = sorted(
+        candidate.candidate_id
+        for candidate in candidates
+        if candidate.kind == "experience"
+    )
+    if not experience_ids:
+        return {}
+    usable_embeddings = dict(query_embeddings or {})
+    if not usable_embeddings:
+        return {
+            experience_id: (None, "skipped_no_query_embedding")
+            for experience_id in experience_ids
+        }
+
+    tables = _experience_embedding_tables(session_or_cur)
     experience_tables = {
         dimensions: table_name
         for table_name in tables
@@ -418,94 +423,58 @@ def _semantic_scores(
         )
         is not None
     }
-    accumulated: dict[tuple[str, int], list[float]] = {}
-    source_chunk_ids = sorted(
-        {
-            candidate.source_chunk_id
-            for candidate in candidates
-            if candidate.kind == "claim"
-        }
-    )
-    experience_ids = sorted(
-        {
-            candidate.candidate_id
-            for candidate in candidates
-            if candidate.kind == "experience"
-        }
-    )
-    for dimensions, chunk_table in sorted(chunk_tables.items()):
-        if source_chunk_ids:
-            result = _execute(
-                session_or_cur,
-                f"""
-                SELECT source.chunk_id AS candidate_id,
-                       avg(1 - (source.embedding <=> query.embedding)) AS score
-                FROM {chunk_table} source
-                JOIN {chunk_table} query
-                  ON query.chunk_id = :current_turn_chunk_id
-                 AND query.model = source.model
-                WHERE source.chunk_id = ANY(:candidate_ids)
-                GROUP BY source.chunk_id
-                """,
-                {
-                    "current_turn_chunk_id": current_turn_chunk_id,
-                    "candidate_ids": source_chunk_ids,
-                },
-            )
-            for row in _rows(result):
-                accumulated.setdefault(("claim", int(row["candidate_id"])), []).append(
-                    float(row["score"])
-                )
+    accumulated: dict[int, list[float]] = {}
+    for model, embedding in sorted(usable_embeddings.items()):
+        dimensions = len(embedding)
         experience_table = experience_tables.get(dimensions)
-        if experience_ids and experience_table is not None:
-            result = _execute(
-                session_or_cur,
-                f"""
-                SELECT source.experience_id AS candidate_id,
-                       avg(1 - (source.embedding <=> query.embedding)) AS score
-                FROM {experience_table} source
-                JOIN {chunk_table} query
-                  ON query.chunk_id = :current_turn_chunk_id
-                 AND query.model = source.model
-                WHERE source.experience_id = ANY(:candidate_ids)
-                GROUP BY source.experience_id
-                """,
-                {
-                    "current_turn_chunk_id": current_turn_chunk_id,
-                    "candidate_ids": experience_ids,
-                },
+        if experience_table is None:
+            continue
+        embedding_value = "[" + ",".join(str(value) for value in embedding) + "]"
+        result = _execute(
+            session_or_cur,
+            f"""
+            SELECT source.experience_id AS candidate_id,
+                   1 - (
+                       source.embedding <=>
+                       CAST(:query_embedding AS vector({dimensions}))
+                   ) AS score
+            FROM {experience_table} source
+            WHERE source.model = :model
+              AND source.experience_id = ANY(:candidate_ids)
+            """,
+            {
+                "query_embedding": embedding_value,
+                "model": model,
+                "candidate_ids": experience_ids,
+            },
+        )
+        for row in _rows(result):
+            accumulated.setdefault(int(row["candidate_id"]), []).append(
+                float(row["score"])
             )
-            for row in _rows(result):
-                accumulated.setdefault(
-                    ("experience", int(row["candidate_id"])), []
-                ).append(float(row["score"]))
 
-    scores: dict[tuple[str, int], float] = {}
-    for candidate in candidates:
-        identity = (
-            ("claim", candidate.source_chunk_id)
-            if candidate.kind == "claim"
-            else ("experience", candidate.candidate_id)
+    return {
+        experience_id: (
+            (sum(values) / len(values), "scored")
+            if (values := accumulated.get(experience_id))
+            else (missing_score, "missing_experience_embedding")
         )
-        values = accumulated.get(identity)
-        scores[(candidate.kind, candidate.candidate_id)] = (
-            sum(values) / len(values) if values else missing_score
-        )
-    return scores
+        for experience_id in experience_ids
+    }
 
 
 def _score_candidates(
     rows: Sequence[Mapping[str, Any]],
     *,
     session_or_cur: Any,
-    current_turn_chunk_id: int,
+    query_embeddings: Mapping[str, Sequence[float]] | None,
     settings: OrreryRecallSettings,
 ) -> list[_Candidate]:
     candidates = [_candidate(row) for row in rows]
     semantics = _semantic_scores(
         session_or_cur,
         candidates=candidates,
-        current_turn_chunk_id=current_turn_chunk_id,
+        query_embeddings=query_embeddings,
         missing_score=settings.missing_embedding_score,
     )
     for candidate, row in zip(candidates, rows, strict=True):
@@ -532,9 +501,17 @@ def _score_candidates(
             and candidate.location_id is not None
             and int(setting_place_id) == candidate.location_id
         )
-        semantic = semantics[(candidate.kind, candidate.candidate_id)]
+        if candidate.kind == "experience":
+            semantic, semantic_status = semantics[candidate.candidate_id]
+            semantic_contribution = (
+                settings.semantic_fit_weight * semantic if semantic is not None else 0.0
+            )
+        else:
+            semantic = None
+            semantic_status = "not_applicable_claim"
+            semantic_contribution = 0.0
         raw_score = (
-            settings.semantic_fit_weight * semantic
+            semantic_contribution
             + settings.event_severity_weight * severity
             + settings.actor_involvement_weight * involvement
             + settings.emotional_salience_weight * candidate.salience
@@ -549,7 +526,8 @@ def _score_candidates(
             and candidate.current_scene_acquisition
         )
         candidate.score_components = {
-            "semantic_fit": round(semantic, 8),
+            "semantic_fit": round(semantic, 8) if semantic is not None else None,
+            "semantic_status": semantic_status,
             "event_severity": round(severity, 8),
             "actor_involvement": round(involvement, 8),
             "emotional_salience": round(candidate.salience, 8),
@@ -974,7 +952,7 @@ def build_knowledge_digest_sync(
     recall_settings: Any = None,
     disclosure_settings: Any = None,
     turn_id: str | None = None,
-    current_turn_chunk_id: int | None = None,
+    query_embeddings: Mapping[str, Sequence[float]] | None = None,
 ) -> list[dict[str, Any]]:
     """Build ranked, audience-filtered knowledge for present characters.
 
@@ -1001,8 +979,6 @@ def build_knowledge_digest_sync(
     trace_turn_id = turn_id or f"anchor:{anchor}"
     if not trace_turn_id.strip():
         raise ValueError("turn_id must be nonempty")
-    raw_turn_chunk_id = int(current_turn_chunk_id or anchor)
-
     eligible = _eligible_rows(
         session_or_cur,
         present_entity_ids=present_ids,
@@ -1012,7 +988,7 @@ def build_knowledge_digest_sync(
     candidates = _score_candidates(
         eligible,
         session_or_cur=session_or_cur,
-        current_turn_chunk_id=raw_turn_chunk_id,
+        query_embeddings=query_embeddings,
         settings=recall,
     )
     ranked, excluded = _select_ranked(

--- a/nexus/agents/orrery/knowledge_surfacing.py
+++ b/nexus/agents/orrery/knowledge_surfacing.py
@@ -1,16 +1,27 @@
-"""Spoiler-limited Storyteller context for knowledge held in the scene."""
+"""Entitlement-first recall and disclosure for Storyteller world knowledge."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
 from datetime import datetime
+import json
 import logging
+import math
 from typing import Any
 
 from sqlalchemy import text
 
+from nexus.agents.memnon.utils.embedding_tables import (
+    parse_character_experience_embedding_table_dimensions,
+    parse_embedding_table_dimensions,
+)
 from nexus.agents.orrery.reconstruction import playable_narrative_predicate
-from nexus.config.settings_models import OrreryKnowledgeSettings
+from nexus.config.settings_models import (
+    OrreryDisclosureSettings,
+    OrreryKnowledgeSettings,
+    OrreryRecallSettings,
+)
 
 
 logger = logging.getLogger("nexus.orrery.knowledge_surfacing")
@@ -29,51 +40,123 @@ class KnowledgeDigest(list[dict[str, Any]]):
         self.truncated = truncated
 
 
-def _coerce_settings(settings: Any) -> OrreryKnowledgeSettings:
+@dataclass(slots=True)
+class _Candidate:
+    """One actor-owned item that crossed the hard eligibility boundary."""
+
+    kind: str
+    candidate_id: int
+    character_entity_id: int
+    character_name: str
+    summary: str
+    source_chunk_id: int
+    claim_id: int | None
+    claim_scope: str | None
+    source_tier: str
+    immediate_source_entity_id: int | None
+    immediate_source_name: str | None
+    acquired_at_world_time: datetime | None
+    location_id: int | None
+    severity: str | None
+    salience: float
+    freshly_revealed: bool
+    current_scene_acquisition: bool
+    semantic_fit: float = 0.0
+    score: float = 0.0
+    mandatory: bool = False
+    score_components: dict[str, Any] = field(default_factory=dict)
+
+
+def _coerce_model(settings: Any, model_type: type[Any], label: str) -> Any:
     """Normalize a settings mapping or Pydantic model."""
 
-    if isinstance(settings, OrreryKnowledgeSettings):
+    if isinstance(settings, model_type):
         return settings
     if hasattr(settings, "model_dump"):
         settings = settings.model_dump()
     if settings is None:
         settings = {}
     if isinstance(settings, Mapping):
-        return OrreryKnowledgeSettings.model_validate(dict(settings))
-    raise TypeError("Orrery knowledge settings must be a mapping or Pydantic model")
+        return model_type.model_validate(dict(settings))
+    raise TypeError(f"Orrery {label} settings must be a mapping or Pydantic model")
 
 
-def _query_rows(
+def _is_sqlalchemy(session_or_cur: Any) -> bool:
+    return type(session_or_cur).__module__.startswith("sqlalchemy")
+
+
+def _execute(session_or_cur: Any, statement: str, parameters: Mapping[str, Any]) -> Any:
+    """Execute named SQL through SQLAlchemy or a psycopg-compatible cursor."""
+
+    if _is_sqlalchemy(session_or_cur):
+        return session_or_cur.execute(text(statement), dict(parameters))
+    cursor_statement = statement.replace("%", "%%")
+    for name in sorted(parameters, key=len, reverse=True):
+        cursor_statement = cursor_statement.replace(f":{name}", f"%({name})s")
+    session_or_cur.execute(cursor_statement, dict(parameters))
+    return session_or_cur
+
+
+def _rows(result: Any) -> list[dict[str, Any]]:
+    """Return result rows as dictionaries for either supported database API."""
+
+    mappings = getattr(result, "mappings", None)
+    if callable(mappings):
+        return [dict(row) for row in mappings()]
+    fetched = result.fetchall()
+    if fetched and isinstance(fetched[0], Mapping):
+        return [dict(row) for row in fetched]
+    description = getattr(result, "description", None)
+    if description is None:
+        raise TypeError("Database result did not expose column metadata")
+    names = [column[0] for column in description]
+    return [dict(zip(names, row, strict=True)) for row in fetched]
+
+
+def _eligible_rows(
     session_or_cur: Any,
     *,
     present_entity_ids: Sequence[int],
     anchor_chunk_id: int,
     recent_reveal_window_chunks: int,
-    limit: int,
 ) -> list[dict[str, Any]]:
-    """Load possessed delivered accounts through SQLAlchemy or a DB-API cursor."""
+    """Load only possessed claims and actor-owned, timeline-valid experiences."""
 
-    recent_predicate = playable_narrative_predicate("recent_nc")
-    sql = f"""
-        /* orrery:world_knowledge */
-        WITH recent_chunks AS (
+    playable_source = playable_narrative_predicate("source_nc")
+    statement = f"""
+        /* orrery:entitlement_first_recall */
+        WITH current_meta AS (
+            SELECT cm.chunk_id, cm.world_time, cm.world_layer::text AS world_layer,
+                   cm.season, cm.episode, cm.scene,
+                   setting.place_id AS setting_place_id
+            FROM chunk_metadata cm
+            LEFT JOIN LATERAL (
+                SELECT pcr.place_id
+                FROM place_chunk_references pcr
+                WHERE pcr.chunk_id = cm.chunk_id
+                  AND pcr.reference_type::text = 'setting'
+                ORDER BY pcr.place_id
+                LIMIT 1
+            ) setting ON TRUE
+            WHERE cm.chunk_id = :anchor_chunk_id
+        ),
+        recent_chunks AS (
             SELECT recent_nc.id
             FROM narrative_chunks recent_nc
-            WHERE recent_nc.id <= {{anchor}}
-              AND {recent_predicate}
+            WHERE recent_nc.id <= :anchor_chunk_id
+              AND {playable_narrative_predicate('recent_nc')}
             ORDER BY recent_nc.id DESC
-            LIMIT {{window}}
-        ),
-        anchor_clock AS (
-            SELECT world_time
-            FROM chunk_metadata
-            WHERE chunk_id = {{anchor}}
+            LIMIT :window_chunks
         )
-        SELECT awareness.id AS awareness_id,
+        SELECT 'claim'::text AS candidate_kind,
+               awareness.id AS candidate_id,
                awareness.knower_entity_id AS character_entity_id,
                present_character.name AS character_name,
-               claim.id AS claim_id,
                claim.summary,
+               COALESCE(awareness.source_chunk_id, claim.source_chunk_id)
+                   AS source_chunk_id,
+               claim.id AS claim_id,
+               claim.scope AS claim_scope,
                awareness.source_tier,
                awareness.immediate_source_entity_id,
                COALESCE(
@@ -82,13 +165,14 @@ def _query_rows(
                    source_place.name
                ) AS immediate_source_name,
                awareness.acquired_at_world_time,
+               incident.location_id,
+               event_type.severity::text AS severity,
+               0.0::double precision AS salience,
                EXISTS (
                    SELECT 1
                    FROM world_events reveal
                    WHERE reveal.event_type = 'backstory_revealed'
-                     AND reveal.tick_chunk_id IN (
-                         SELECT id FROM recent_chunks
-                     )
+                     AND reveal.tick_chunk_id IN (SELECT id FROM recent_chunks)
                      AND (reveal.payload ->> 'claim_id')::bigint = claim.id
                      AND (
                          reveal.actor_entity_id = awareness.knower_entity_id
@@ -105,142 +189,780 @@ def _query_rows(
                                    awareness.knower_entity_id
                          )
                      )
-               ) AS freshly_revealed
+               ) AS freshly_revealed,
+               source_meta.season = current_meta.season
+                   AND source_meta.episode = current_meta.episode
+                   AND source_meta.scene = current_meta.scene
+                   AS current_scene_acquisition,
+               current_meta.world_time AS current_world_time,
+               current_meta.setting_place_id
         FROM claim_awareness awareness
         JOIN claims claim ON claim.id = awareness.claim_id
+        JOIN world_events incident ON incident.id = claim.world_event_id
+        JOIN event_types event_type ON event_type.type = incident.event_type
         JOIN characters present_character
           ON present_character.entity_id = awareness.knower_entity_id
+        JOIN entities present_entity
+          ON present_entity.id = present_character.entity_id
+         AND present_entity.is_active = true
+        JOIN chunk_metadata source_meta
+          ON source_meta.chunk_id = COALESCE(
+              awareness.source_chunk_id, claim.source_chunk_id
+          )
+        JOIN narrative_chunks source_nc ON source_nc.id = source_meta.chunk_id
+        CROSS JOIN current_meta
         LEFT JOIN characters source_character
           ON source_character.entity_id = awareness.immediate_source_entity_id
         LEFT JOIN factions source_faction
           ON source_faction.entity_id = awareness.immediate_source_entity_id
         LEFT JOIN places source_place
           ON source_place.entity_id = awareness.immediate_source_entity_id
-        WHERE awareness.knower_entity_id = ANY({{present_ids}})
-          AND (
-              awareness.source_chunk_id IS NULL
-              OR awareness.source_chunk_id <= {{anchor}}
-          )
+        WHERE awareness.knower_entity_id = ANY(:present_entity_ids)
+          AND source_meta.chunk_id <= :anchor_chunk_id
+          AND source_meta.world_layer::text IS NOT DISTINCT FROM
+              current_meta.world_layer
+          AND {playable_source}
           AND (
               awareness.acquired_at_world_time IS NULL
-              OR awareness.acquired_at_world_time <= (
-                  SELECT world_time FROM anchor_clock
+              OR awareness.acquired_at_world_time <= current_meta.world_time
+          )
+          AND NOT EXISTS (
+              SELECT 1
+              FROM backstory_secrets secret
+              WHERE secret.claim_id = claim.id AND secret.status = 'latent'
+          )
+
+        UNION ALL
+
+        SELECT 'experience'::text AS candidate_kind,
+               experience.id AS candidate_id,
+               experience.character_entity_id,
+               present_character.name AS character_name,
+               COALESCE(experience.experience_text, experience.seed_summary)
+                   AS summary,
+               experience.anchor_chunk_id AS source_chunk_id,
+               experience.claim_id,
+               claim.scope AS claim_scope,
+               experience.basis::text AS source_tier,
+               awareness.immediate_source_entity_id,
+               COALESCE(
+                   source_character.name,
+                   source_faction.name,
+                   source_place.name
+               ) AS immediate_source_name,
+               experience.world_time AS acquired_at_world_time,
+               experience.location_id,
+               experience_severity.severity,
+               experience.salience,
+               false AS freshly_revealed,
+               false AS current_scene_acquisition,
+               current_meta.world_time AS current_world_time,
+               current_meta.setting_place_id
+        FROM character_experiences experience
+        JOIN characters present_character
+          ON present_character.entity_id = experience.character_entity_id
+        JOIN entities present_entity
+          ON present_entity.id = present_character.entity_id
+         AND present_entity.is_active = true
+        JOIN chunk_metadata source_meta
+          ON source_meta.chunk_id = experience.anchor_chunk_id
+        JOIN narrative_chunks source_nc ON source_nc.id = source_meta.chunk_id
+        CROSS JOIN current_meta
+        LEFT JOIN claims claim ON claim.id = experience.claim_id
+        LEFT JOIN claim_awareness awareness
+          ON awareness.id = experience.claim_awareness_id
+        LEFT JOIN characters source_character
+          ON source_character.entity_id = awareness.immediate_source_entity_id
+        LEFT JOIN factions source_faction
+          ON source_faction.entity_id = awareness.immediate_source_entity_id
+        LEFT JOIN places source_place
+          ON source_place.entity_id = awareness.immediate_source_entity_id
+        LEFT JOIN LATERAL (
+            SELECT event_type.severity::text AS severity
+            FROM unnest(experience.world_event_ids) event_identity(event_id)
+            JOIN world_events event ON event.id = event_identity.event_id
+            JOIN event_types event_type ON event_type.type = event.event_type
+            ORDER BY CASE event_type.severity::text
+                WHEN 'critical' THEN 4
+                WHEN 'major' THEN 3
+                WHEN 'moderate' THEN 2
+                WHEN 'minor' THEN 1
+                ELSE 0
+            END DESC
+            LIMIT 1
+        ) experience_severity ON TRUE
+        WHERE experience.character_entity_id = ANY(:present_entity_ids)
+          AND experience.invalidation_status = 'valid'
+          AND experience.anchor_chunk_id <= :anchor_chunk_id
+          AND experience.world_layer::text IS NOT DISTINCT FROM
+              current_meta.world_layer
+          AND source_meta.world_layer::text IS NOT DISTINCT FROM
+              current_meta.world_layer
+          AND {playable_source}
+          AND (
+              experience.world_time IS NULL
+              OR experience.world_time <= current_meta.world_time
+          )
+          AND (
+              experience.claim_awareness_id IS NULL
+              OR (
+                  awareness.knower_entity_id = experience.character_entity_id
+                  AND awareness.claim_id = experience.claim_id
               )
           )
           AND NOT EXISTS (
               SELECT 1
               FROM backstory_secrets secret
-              WHERE secret.claim_id = claim.id
+              WHERE secret.claim_id = experience.claim_id
                 AND secret.status = 'latent'
           )
-        ORDER BY awareness.acquired_at_world_time DESC NULLS LAST,
-                 awareness.claim_id DESC,
-                 awareness.knower_entity_id DESC,
-                 awareness.id DESC
-        LIMIT {{limit}}
+        ORDER BY character_entity_id, candidate_kind, candidate_id
     """
+    result = _execute(
+        session_or_cur,
+        statement,
+        {
+            "anchor_chunk_id": anchor_chunk_id,
+            "window_chunks": recent_reveal_window_chunks,
+            "present_entity_ids": list(present_entity_ids),
+        },
+    )
+    return _rows(result)
 
-    is_sqlalchemy = type(session_or_cur).__module__.startswith("sqlalchemy")
-    if is_sqlalchemy:
-        sqlalchemy_statement = text(
-            sql.format(
-                anchor=":anchor_chunk_id",
-                window=":window_chunks",
-                present_ids=":present_entity_ids",
-                limit=":limit",
+
+def _candidate(row: Mapping[str, Any]) -> _Candidate:
+    """Validate and normalize one SQL candidate row."""
+
+    acquired = row.get("acquired_at_world_time")
+    if acquired is not None and not isinstance(acquired, datetime):
+        raise TypeError("Recall acquisition time must be a datetime or NULL")
+    kind = str(row["candidate_kind"])
+    source_tier = str(row["source_tier"])
+    involvement = (
+        source_tier if source_tier in {"participant", "witness"} else ("acquisition")
+    )
+    severity = row.get("severity")
+    return _Candidate(
+        kind=kind,
+        candidate_id=int(row["candidate_id"]),
+        character_entity_id=int(row["character_entity_id"]),
+        character_name=str(row["character_name"]),
+        summary=str(row["summary"]),
+        source_chunk_id=int(row["source_chunk_id"]),
+        claim_id=int(row["claim_id"]) if row.get("claim_id") is not None else None,
+        claim_scope=(
+            str(row["claim_scope"]) if row.get("claim_scope") is not None else None
+        ),
+        source_tier=involvement,
+        immediate_source_entity_id=(
+            int(row["immediate_source_entity_id"])
+            if row.get("immediate_source_entity_id") is not None
+            else None
+        ),
+        immediate_source_name=(
+            str(row["immediate_source_name"])
+            if row.get("immediate_source_name") is not None
+            else None
+        ),
+        acquired_at_world_time=acquired,
+        location_id=(
+            int(row["location_id"]) if row.get("location_id") is not None else None
+        ),
+        severity=str(severity) if severity is not None else None,
+        salience=float(row.get("salience") or 0.0),
+        freshly_revealed=bool(row.get("freshly_revealed")),
+        current_scene_acquisition=bool(row.get("current_scene_acquisition")),
+    )
+
+
+def _embedding_tables(session_or_cur: Any) -> list[str]:
+    result = _execute(
+        session_or_cur,
+        """
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = current_schema()
+          AND (
+              table_name ~ '^chunk_embeddings_[0-9]+d$'
+              OR table_name ~ '^character_experience_embeddings_[0-9]+d$'
+          )
+        ORDER BY table_name
+        """,
+        {},
+    )
+    return [str(row["table_name"]) for row in _rows(result)]
+
+
+def _semantic_scores(
+    session_or_cur: Any,
+    *,
+    candidates: Sequence[_Candidate],
+    current_turn_chunk_id: int,
+    missing_score: float,
+) -> dict[tuple[str, int], float]:
+    """Compare eligible corpus vectors with the stored raw-turn chunk vector."""
+
+    tables = _embedding_tables(session_or_cur)
+    chunk_tables = {
+        dimensions: table_name
+        for table_name in tables
+        if (dimensions := parse_embedding_table_dimensions(table_name)) is not None
+    }
+    experience_tables = {
+        dimensions: table_name
+        for table_name in tables
+        if (
+            dimensions := parse_character_experience_embedding_table_dimensions(
+                table_name
             )
         )
-        result = session_or_cur.execute(
-            sqlalchemy_statement,
+        is not None
+    }
+    accumulated: dict[tuple[str, int], list[float]] = {}
+    source_chunk_ids = sorted(
+        {
+            candidate.source_chunk_id
+            for candidate in candidates
+            if candidate.kind == "claim"
+        }
+    )
+    experience_ids = sorted(
+        {
+            candidate.candidate_id
+            for candidate in candidates
+            if candidate.kind == "experience"
+        }
+    )
+    for dimensions, chunk_table in sorted(chunk_tables.items()):
+        if source_chunk_ids:
+            result = _execute(
+                session_or_cur,
+                f"""
+                SELECT source.chunk_id AS candidate_id,
+                       avg(1 - (source.embedding <=> query.embedding)) AS score
+                FROM {chunk_table} source
+                JOIN {chunk_table} query
+                  ON query.chunk_id = :current_turn_chunk_id
+                 AND query.model = source.model
+                WHERE source.chunk_id = ANY(:candidate_ids)
+                GROUP BY source.chunk_id
+                """,
+                {
+                    "current_turn_chunk_id": current_turn_chunk_id,
+                    "candidate_ids": source_chunk_ids,
+                },
+            )
+            for row in _rows(result):
+                accumulated.setdefault(("claim", int(row["candidate_id"])), []).append(
+                    float(row["score"])
+                )
+        experience_table = experience_tables.get(dimensions)
+        if experience_ids and experience_table is not None:
+            result = _execute(
+                session_or_cur,
+                f"""
+                SELECT source.experience_id AS candidate_id,
+                       avg(1 - (source.embedding <=> query.embedding)) AS score
+                FROM {experience_table} source
+                JOIN {chunk_table} query
+                  ON query.chunk_id = :current_turn_chunk_id
+                 AND query.model = source.model
+                WHERE source.experience_id = ANY(:candidate_ids)
+                GROUP BY source.experience_id
+                """,
+                {
+                    "current_turn_chunk_id": current_turn_chunk_id,
+                    "candidate_ids": experience_ids,
+                },
+            )
+            for row in _rows(result):
+                accumulated.setdefault(
+                    ("experience", int(row["candidate_id"])), []
+                ).append(float(row["score"]))
+
+    scores: dict[tuple[str, int], float] = {}
+    for candidate in candidates:
+        identity = (
+            ("claim", candidate.source_chunk_id)
+            if candidate.kind == "claim"
+            else ("experience", candidate.candidate_id)
+        )
+        values = accumulated.get(identity)
+        scores[(candidate.kind, candidate.candidate_id)] = (
+            sum(values) / len(values) if values else missing_score
+        )
+    return scores
+
+
+def _score_candidates(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    session_or_cur: Any,
+    current_turn_chunk_id: int,
+    settings: OrreryRecallSettings,
+) -> list[_Candidate]:
+    candidates = [_candidate(row) for row in rows]
+    semantics = _semantic_scores(
+        session_or_cur,
+        candidates=candidates,
+        current_turn_chunk_id=current_turn_chunk_id,
+        missing_score=settings.missing_embedding_score,
+    )
+    for candidate, row in zip(candidates, rows, strict=True):
+        current_time = row.get("current_world_time")
+        if current_time is not None and not isinstance(current_time, datetime):
+            raise TypeError("Recall anchor world time must be a datetime or NULL")
+        if current_time is not None and candidate.acquired_at_world_time is not None:
+            age_hours = max(
+                0.0,
+                (current_time - candidate.acquired_at_world_time).total_seconds()
+                / 3600.0,
+            )
+            recency = max(0.0, 1.0 - age_hours / settings.recency_horizon_hours)
+            decay = math.pow(0.5, age_hours / settings.decay_half_life_hours)
+        else:
+            age_hours = None
+            recency = 0.0
+            decay = 1.0
+        severity = settings.severity_scores.get(candidate.severity or "", 0.0)
+        involvement = settings.involvement_scores[candidate.source_tier]
+        setting_place_id = row.get("setting_place_id")
+        place_match = float(
+            setting_place_id is not None
+            and candidate.location_id is not None
+            and int(setting_place_id) == candidate.location_id
+        )
+        semantic = semantics[(candidate.kind, candidate.candidate_id)]
+        raw_score = (
+            settings.semantic_fit_weight * semantic
+            + settings.event_severity_weight * severity
+            + settings.actor_involvement_weight * involvement
+            + settings.emotional_salience_weight * candidate.salience
+            + settings.recency_weight * recency
+            + settings.place_match_weight * place_match
+        )
+        candidate.semantic_fit = semantic
+        candidate.score = round(raw_score * decay, 8)
+        candidate.mandatory = bool(
+            candidate.kind == "claim"
+            and candidate.severity == "critical"
+            and candidate.current_scene_acquisition
+        )
+        candidate.score_components = {
+            "semantic_fit": round(semantic, 8),
+            "event_severity": round(severity, 8),
+            "actor_involvement": round(involvement, 8),
+            "emotional_salience": round(candidate.salience, 8),
+            "recency": round(recency, 8),
+            "place_match": round(place_match, 8),
+            "age_world_hours": round(age_hours, 8) if age_hours is not None else None,
+            "raw_score": round(raw_score, 8),
+            "decay_modifier": round(decay, 8),
+        }
+    return candidates
+
+
+def _rank_key(candidate: _Candidate) -> tuple[Any, ...]:
+    acquired = candidate.acquired_at_world_time
+    return (
+        -candidate.score,
+        -(acquired.timestamp() if acquired is not None else float("-inf")),
+        candidate.kind,
+        -candidate.candidate_id,
+    )
+
+
+def _round_robin(
+    candidates: Sequence[_Candidate],
+    *,
+    limit: int,
+    per_character_limit: int,
+    initial_counts: Mapping[int, int] | None = None,
+) -> list[_Candidate]:
+    """Select fairly across characters while respecting per-character caps."""
+
+    grouped: dict[int, list[_Candidate]] = {}
+    for candidate in candidates:
+        grouped.setdefault(candidate.character_entity_id, []).append(candidate)
+    for values in grouped.values():
+        values.sort(key=_rank_key)
+    counts = dict(initial_counts or {})
+    selected: list[_Candidate] = []
+    while len(selected) < limit:
+        progressed = False
+        for character_id in sorted(grouped):
+            if len(selected) >= limit:
+                break
+            if counts.get(character_id, 0) >= per_character_limit:
+                continue
+            values = grouped[character_id]
+            if not values:
+                continue
+            selected.append(values.pop(0))
+            counts[character_id] = counts.get(character_id, 0) + 1
+            progressed = True
+        if not progressed:
+            break
+    return selected
+
+
+def _select_ranked(
+    candidates: Sequence[_Candidate],
+    *,
+    shared_limit: int,
+    settings: OrreryRecallSettings,
+) -> tuple[list[_Candidate], dict[tuple[str, int], str]]:
+    mandatory = [candidate for candidate in candidates if candidate.mandatory]
+    reserved = _round_robin(
+        mandatory,
+        limit=min(shared_limit, settings.mandatory_reserved_entries),
+        per_character_limit=settings.per_character_max_entries,
+    )
+    selected_ids = {(item.kind, item.candidate_id) for item in reserved}
+    counts: dict[int, int] = {}
+    for item in reserved:
+        counts[item.character_entity_id] = counts.get(item.character_entity_id, 0) + 1
+    remaining = [
+        candidate
+        for candidate in candidates
+        if (candidate.kind, candidate.candidate_id) not in selected_ids
+    ]
+    ranked = _round_robin(
+        remaining,
+        limit=shared_limit - len(reserved),
+        per_character_limit=settings.per_character_max_entries,
+        initial_counts=counts,
+    )
+    selected = reserved + ranked
+    for item in ranked:
+        counts[item.character_entity_id] = counts.get(item.character_entity_id, 0) + 1
+    selected_ids = {(item.kind, item.candidate_id) for item in selected}
+    excluded: dict[tuple[str, int], str] = {}
+    for candidate in candidates:
+        identity = (candidate.kind, candidate.candidate_id)
+        if identity in selected_ids:
+            continue
+        reason = (
+            "per_character_cap"
+            if counts.get(candidate.character_entity_id, 0)
+            >= settings.per_character_max_entries
+            else "shared_budget"
+        )
+        excluded[identity] = reason
+    return selected, excluded
+
+
+def _present_character_ids(
+    session_or_cur: Any, present_entity_ids: Sequence[int]
+) -> tuple[int, ...]:
+    result = _execute(
+        session_or_cur,
+        """
+        SELECT character.entity_id
+        FROM characters character
+        JOIN entities entity ON entity.id = character.entity_id
+        WHERE character.entity_id = ANY(:present_entity_ids)
+          AND entity.is_active = true
+        ORDER BY character.entity_id
+        """,
+        {"present_entity_ids": list(present_entity_ids)},
+    )
+    return tuple(int(row["entity_id"]) for row in _rows(result))
+
+
+def _disclosure_context(
+    session_or_cur: Any,
+    *,
+    character_ids: Sequence[int],
+) -> tuple[
+    dict[tuple[int, int], float],
+    dict[int, set[int]],
+    dict[int, set[int]],
+    set[tuple[int, int]],
+]:
+    if not character_ids:
+        return {}, {}, {}, set()
+    relationship_result = _execute(
+        session_or_cur,
+        """
+        SELECT source_entity_id, target_entity_id, valence_current
+        FROM entity_relationships_v
+        WHERE relationship_scope = 'character'
+          AND source_entity_id = ANY(:character_ids)
+          AND target_entity_id = ANY(:character_ids)
+        """,
+        {"character_ids": list(character_ids)},
+    )
+    valences = {
+        (int(row["source_entity_id"]), int(row["target_entity_id"])): float(
+            row["valence_current"]
+        )
+        for row in _rows(relationship_result)
+        if row.get("valence_current") is not None
+    }
+    edge_result = _execute(
+        session_or_cur,
+        """
+        SELECT edge.subject_entity_id, edge.object_entity_id, pair_tag.tag,
+               subject.kind::text AS subject_kind,
+               object.kind::text AS object_kind
+        FROM entity_pair_tags edge
+        JOIN pair_tags pair_tag ON pair_tag.id = edge.pair_tag_id
+        JOIN entities subject ON subject.id = edge.subject_entity_id
+        JOIN entities object ON object.id = edge.object_entity_id
+        WHERE edge.cleared_at IS NULL
+          AND NOT pair_tag.deprecated
+          AND (pair_tag.tag LIKE 'status:%' OR pair_tag.tag = 'obligation')
+          AND (
+              edge.subject_entity_id = ANY(:character_ids)
+              OR edge.object_entity_id = ANY(:character_ids)
+          )
+        """,
+        {"character_ids": list(character_ids)},
+    )
+    affiliations: dict[int, set[int]] = {value: set() for value in character_ids}
+    obligations: dict[int, set[int]] = {value: set() for value in character_ids}
+    direct_status_edges: set[tuple[int, int]] = set()
+    for row in _rows(edge_result):
+        subject_id = int(row["subject_entity_id"])
+        object_id = int(row["object_entity_id"])
+        tag = str(row["tag"])
+        if tag.startswith("status:"):
+            if row["subject_kind"] == "character" and row["object_kind"] == "faction":
+                affiliations.setdefault(subject_id, set()).add(object_id)
+            elif row["subject_kind"] == "faction" and row["object_kind"] == "character":
+                affiliations.setdefault(object_id, set()).add(subject_id)
+            elif (
+                row["subject_kind"] == "character" and row["object_kind"] == "character"
+            ):
+                direct_status_edges.add((subject_id, object_id))
+        elif (
+            tag == "obligation"
+            and row["subject_kind"] == "character"
+            and row["object_kind"] == "faction"
+        ):
+            obligations.setdefault(subject_id, set()).add(object_id)
+    return valences, affiliations, obligations, direct_status_edges
+
+
+def _disclosure_decision(
+    candidate: _Candidate,
+    *,
+    present_character_ids: Sequence[int],
+    valences: Mapping[tuple[int, int], float],
+    affiliations: Mapping[int, set[int]],
+    obligations: Mapping[int, set[int]],
+    direct_status_edges: set[tuple[int, int]],
+    settings: OrreryDisclosureSettings,
+) -> tuple[bool, str, dict[str, Any]]:
+    audience = [
+        entity_id
+        for entity_id in present_character_ids
+        if entity_id != candidate.character_entity_id
+    ]
+    if not audience:
+        return (
+            True,
+            "disclosed",
             {
-                "anchor_chunk_id": anchor_chunk_id,
-                "window_chunks": recent_reveal_window_chunks,
-                "present_entity_ids": list(present_entity_ids),
-                "limit": limit,
+                "audience_count": 0,
+                "secrecy_marker": float(candidate.claim_scope == "private"),
+                "relationship_valence": 1.0,
+                "status_edge_match": 1.0,
+                "role_obligation_risk": 0.0,
+                "score": 1.0,
+                "threshold": settings.minimum_score,
             },
         )
-        return [dict(row) for row in result.mappings()]
-
-    cursor_statement = sql.format(
-        anchor="%s",
-        window="%s",
-        present_ids="%s",
-        limit="%s",
-    )
-    session_or_cur.execute(
-        cursor_statement,
-        (
-            anchor_chunk_id,
-            recent_reveal_window_chunks,
-            anchor_chunk_id,
-            list(present_entity_ids),
-            anchor_chunk_id,
-            limit,
-        ),
-    )
-    rows = session_or_cur.fetchall()
-    if rows and isinstance(rows[0], Mapping):
-        return [dict(row) for row in rows]
-    description = getattr(session_or_cur, "description", None)
-    if description is None:
-        raise TypeError(
-            "session_or_cur must be a SQLAlchemy session/connection or DB-API cursor"
+    relationship = min(
+        valences.get(
+            (candidate.character_entity_id, audience_id),
+            settings.missing_relationship_valence,
         )
-    column_names = [column[0] for column in description]
-    return [dict(zip(column_names, row, strict=True)) for row in rows]
+        for audience_id in audience
+    )
+    owner_affiliations = affiliations.get(candidate.character_entity_id, set())
+    status_edge_match = sum(
+        bool(
+            owner_affiliations & affiliations.get(audience_id, set())
+            or (candidate.character_entity_id, audience_id) in direct_status_edges
+        )
+        for audience_id in audience
+    ) / len(audience)
+    owner_obligations = obligations.get(candidate.character_entity_id, set())
+    obligation_risk = float(
+        bool(owner_obligations)
+        and any(
+            not owner_obligations.issubset(affiliations.get(audience_id, set()))
+            for audience_id in audience
+        )
+    )
+    secrecy = float(candidate.claim_scope == "private")
+    disclosure_score = (
+        settings.relationship_valence_weight * relationship
+        + settings.shared_status_bonus * status_edge_match
+        - settings.secrecy_penalty * secrecy
+        - settings.role_obligation_penalty * obligation_risk
+    )
+    threshold = (
+        settings.private_claim_minimum_score if secrecy else settings.minimum_score
+    )
+    components = {
+        "audience_count": len(audience),
+        "secrecy_marker": secrecy,
+        "relationship_valence": round(relationship, 8),
+        "status_edge_match": round(status_edge_match, 8),
+        "role_obligation_risk": obligation_risk,
+        "score": round(disclosure_score, 8),
+        "threshold": threshold,
+    }
+    if disclosure_score >= threshold:
+        return True, "disclosed", components
+    if secrecy:
+        reason = "secrecy_threshold"
+    elif obligation_risk:
+        reason = "role_obligation_threshold"
+    elif relationship < 0:
+        reason = "relationship_threshold"
+    else:
+        reason = "disclosure_threshold"
+    return False, reason, components
 
 
-def _acquisition(row: Mapping[str, Any]) -> dict[str, Any]:
-    """Translate storage provenance into Storyteller-facing acquisition shape."""
-
-    source_tier = str(row["source_tier"])
-    source_id = row["immediate_source_entity_id"]
-    if source_tier in {"participant", "witness"}:
+def _acquisition(candidate: _Candidate) -> dict[str, Any]:
+    if candidate.source_tier in {"participant", "witness"}:
         return {"kind": "firsthand"}
-    if source_id is not None:
-        source_name = row["immediate_source_name"]
-        if not source_name:
+    if candidate.immediate_source_entity_id is not None:
+        if not candidate.immediate_source_name:
             raise ValueError(
                 "Told knowledge has no display name for immediate source entity "
-                f"{source_id}"
+                f"{candidate.immediate_source_entity_id}"
             )
         return {
             "kind": "told",
-            "source_entity_id": int(source_id),
-            "source_name": str(source_name),
+            "source_entity_id": candidate.immediate_source_entity_id,
+            "source_name": candidate.immediate_source_name,
         }
     return {"kind": "granted"}
 
 
-def _entry(row: Mapping[str, Any]) -> dict[str, Any]:
-    """Project one safe row without account payload or sibling expansion."""
-
-    acquired = row["acquired_at_world_time"]
+def _entry(candidate: _Candidate) -> dict[str, Any]:
     entry: dict[str, Any] = {
-        "character_entity_id": int(row["character_entity_id"]),
-        "character_name": str(row["character_name"]),
-        "claim_id": int(row["claim_id"]),
-        "summary": str(row["summary"]),
-        "acquisition": _acquisition(row),
+        "character_entity_id": candidate.character_entity_id,
+        "character_name": candidate.character_name,
+        "summary": candidate.summary,
+        "acquisition": _acquisition(candidate),
         "acquired_at_world_time": (
-            acquired.isoformat() if isinstance(acquired, datetime) else None
+            candidate.acquired_at_world_time.isoformat()
+            if candidate.acquired_at_world_time is not None
+            else None
         ),
+        "source": {
+            "kind": candidate.kind,
+            "id": (
+                candidate.claim_id
+                if candidate.kind == "claim"
+                else candidate.candidate_id
+            ),
+        },
     }
-    if bool(row["freshly_revealed"]):
+    if candidate.claim_id is not None:
+        entry["claim_id"] = candidate.claim_id
+    if candidate.kind == "experience":
+        entry["experience_id"] = candidate.candidate_id
+    if candidate.freshly_revealed:
         entry["freshly_revealed"] = True
     return entry
 
 
 def _final_order(entry: Mapping[str, Any]) -> tuple[Any, ...]:
-    """Sort by character, acquisition world time, and claim id."""
-
     acquired = entry["acquired_at_world_time"]
+    source = entry["source"]
     return (
         int(entry["character_entity_id"]),
         acquired is not None,
         acquired or "",
-        int(entry["claim_id"]),
+        str(source["kind"]),
+        int(source["id"]),
     )
+
+
+def _write_trace(
+    session_or_cur: Any,
+    *,
+    turn_id: str,
+    anchor_chunk_id: int,
+    candidates: Sequence[_Candidate],
+    decisions: Mapping[tuple[str, int], tuple[str, str]],
+    trace_rows_per_character: int,
+) -> None:
+    for candidate in candidates:
+        decision, reason = decisions[(candidate.kind, candidate.candidate_id)]
+        _execute(
+            session_or_cur,
+            """
+            INSERT INTO orrery_recall_trace (
+                turn_id, anchor_chunk_id, character_entity_id,
+                candidate_kind, candidate_id, claim_id, decision, reason,
+                mandatory, score, score_components
+            ) VALUES (
+                :turn_id, :anchor_chunk_id, :character_entity_id,
+                :candidate_kind, :candidate_id, :claim_id, :decision, :reason,
+                :mandatory, :score, CAST(:score_components AS jsonb)
+            )
+            ON CONFLICT (
+                turn_id, character_entity_id, candidate_kind, candidate_id
+            ) DO UPDATE SET
+                anchor_chunk_id = EXCLUDED.anchor_chunk_id,
+                claim_id = EXCLUDED.claim_id,
+                decision = EXCLUDED.decision,
+                reason = EXCLUDED.reason,
+                mandatory = EXCLUDED.mandatory,
+                score = EXCLUDED.score,
+                score_components = EXCLUDED.score_components,
+                created_at = now()
+            """,
+            {
+                "turn_id": turn_id,
+                "anchor_chunk_id": anchor_chunk_id,
+                "character_entity_id": candidate.character_entity_id,
+                "candidate_kind": candidate.kind,
+                "candidate_id": candidate.candidate_id,
+                "claim_id": candidate.claim_id,
+                "decision": decision,
+                "reason": reason,
+                "mandatory": candidate.mandatory,
+                "score": candidate.score,
+                "score_components": json.dumps(
+                    candidate.score_components, sort_keys=True
+                ),
+            },
+        )
+    character_ids = sorted({item.character_entity_id for item in candidates})
+    if character_ids:
+        _execute(
+            session_or_cur,
+            """
+            DELETE FROM orrery_recall_trace
+            WHERE id IN (
+                SELECT id
+                FROM (
+                    SELECT id,
+                           row_number() OVER (
+                               PARTITION BY character_entity_id
+                               ORDER BY id DESC
+                           ) AS retention_rank
+                    FROM orrery_recall_trace
+                    WHERE character_entity_id = ANY(:character_ids)
+                ) ranked
+                WHERE retention_rank > :retention_cap
+            )
+            """,
+            {
+                "character_ids": character_ids,
+                "retention_cap": trace_rows_per_character,
+            },
+        )
 
 
 def build_knowledge_digest_sync(
@@ -249,38 +971,99 @@ def build_knowledge_digest_sync(
     present_entity_ids: Sequence[int],
     anchor_chunk_id: int,
     settings: Any,
+    recall_settings: Any = None,
+    disclosure_settings: Any = None,
+    turn_id: str | None = None,
+    current_turn_chunk_id: int | None = None,
 ) -> list[dict[str, Any]]:
-    """Build the bounded knowledge digest for characters present at an anchor.
+    """Build ranked, audience-filtered knowledge for present characters.
 
     SPOILER DISCIPLINE -- THIS IS THE GOVERNING CONSTRAINT:
-    ONLY the summary of the exact delivered claim named by a present character's
-    awareness row may cross this boundary. NEVER select or expose account_payload,
-    unpossessed sibling accounts, an unpossessed canonical account, or a latent
-    backstory secret. This is the scene's knowledge landscape, not the answer key.
+    Eligibility begins with possessed claim-awareness rows and actor-owned
+    character experiences only. Global MEMNON results, account payloads,
+    sibling accounts, canonical answers, and latent secrets never enter this
+    pipeline. Recall decay changes scores only; possession rows are read-only.
     """
 
-    config = _coerce_settings(settings)
-    if not config.enabled:
+    knowledge = _coerce_model(settings, OrreryKnowledgeSettings, "knowledge")
+    recall = _coerce_model(recall_settings, OrreryRecallSettings, "recall")
+    disclosure = _coerce_model(
+        disclosure_settings, OrreryDisclosureSettings, "disclosure"
+    )
+    if not knowledge.enabled:
         return KnowledgeDigest()
-
+    anchor = int(anchor_chunk_id)
+    if anchor <= 0:
+        raise ValueError("anchor_chunk_id must be positive")
     present_ids = tuple(sorted({int(entity_id) for entity_id in present_entity_ids}))
     if not present_ids:
         return KnowledgeDigest()
+    trace_turn_id = turn_id or f"anchor:{anchor}"
+    if not trace_turn_id.strip():
+        raise ValueError("turn_id must be nonempty")
+    raw_turn_chunk_id = int(current_turn_chunk_id or anchor)
 
-    rows = _query_rows(
+    eligible = _eligible_rows(
         session_or_cur,
         present_entity_ids=present_ids,
-        anchor_chunk_id=int(anchor_chunk_id),
-        recent_reveal_window_chunks=config.recent_reveal_window_chunks,
-        limit=config.max_entries + 1,
+        anchor_chunk_id=anchor,
+        recent_reveal_window_chunks=knowledge.recent_reveal_window_chunks,
     )
-    truncated = len(rows) > config.max_entries
+    candidates = _score_candidates(
+        eligible,
+        session_or_cur=session_or_cur,
+        current_turn_chunk_id=raw_turn_chunk_id,
+        settings=recall,
+    )
+    ranked, excluded = _select_ranked(
+        candidates,
+        shared_limit=knowledge.max_entries,
+        settings=recall,
+    )
+    character_ids = _present_character_ids(session_or_cur, present_ids)
+    valences, affiliations, obligations, direct_status_edges = _disclosure_context(
+        session_or_cur, character_ids=character_ids
+    )
+    decisions: dict[tuple[str, int], tuple[str, str]] = {
+        identity: ("excluded", reason) for identity, reason in excluded.items()
+    }
+    included: list[_Candidate] = []
+    for candidate in ranked:
+        allowed, reason, components = _disclosure_decision(
+            candidate,
+            present_character_ids=character_ids,
+            valences=valences,
+            affiliations=affiliations,
+            obligations=obligations,
+            direct_status_edges=direct_status_edges,
+            settings=disclosure,
+        )
+        candidate.score_components["disclosure"] = components
+        identity = (candidate.kind, candidate.candidate_id)
+        if allowed:
+            decisions[identity] = ("included", reason)
+            included.append(candidate)
+        else:
+            decisions[identity] = ("suppressed", reason)
+    for candidate in candidates:
+        if (candidate.kind, candidate.candidate_id) in excluded:
+            candidate.score_components["disclosure"] = {"evaluated": False}
+    _write_trace(
+        session_or_cur,
+        turn_id=trace_turn_id,
+        anchor_chunk_id=anchor,
+        candidates=candidates,
+        decisions=decisions,
+        trace_rows_per_character=recall.trace_rows_per_character,
+    )
+
+    truncated = bool(excluded)
     if truncated:
         logger.debug(
-            "World knowledge capped at %d entries; dropping oldest acquisitions",
-            config.max_entries,
+            "World knowledge capped at %d entries with a per-character cap of %d; "
+            "dropping oldest acquisitions or lower recall scores",
+            knowledge.max_entries,
+            recall.per_character_max_entries,
         )
-        rows = rows[: config.max_entries]
-
-    entries = sorted((_entry(row) for row in rows), key=_final_order)
+    entries = sorted((_entry(candidate) for candidate in included), key=_final_order)
     return KnowledgeDigest(entries, truncated=truncated)

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1868,7 +1868,11 @@ class OrreryRecallSettings(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    semantic_fit_weight: float = Field(default=0.35, ge=0.0)
+    semantic_fit_weight: float = Field(
+        default=0.35,
+        ge=0.0,
+        description="Semantic-fit weight for character experiences only.",
+    )
     event_severity_weight: float = Field(default=0.15, ge=0.0)
     actor_involvement_weight: float = Field(default=0.15, ge=0.0)
     emotional_salience_weight: float = Field(default=0.10, ge=0.0)

--- a/nexus/config/settings_models.py
+++ b/nexus/config/settings_models.py
@@ -1863,6 +1863,87 @@ class OrreryKnowledgeSettings(BaseModel):
     recent_reveal_window_chunks: int = Field(default=5, ge=1)
 
 
+class OrreryRecallSettings(BaseModel):
+    """Deterministic actor-owned recall policy for ``[orrery.recall]``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    semantic_fit_weight: float = Field(default=0.35, ge=0.0)
+    event_severity_weight: float = Field(default=0.15, ge=0.0)
+    actor_involvement_weight: float = Field(default=0.15, ge=0.0)
+    emotional_salience_weight: float = Field(default=0.10, ge=0.0)
+    recency_weight: float = Field(default=0.15, ge=0.0)
+    place_match_weight: float = Field(default=0.10, ge=0.0)
+    decay_half_life_hours: float = Field(default=720.0, gt=0.0)
+    recency_horizon_hours: float = Field(default=2160.0, gt=0.0)
+    missing_embedding_score: float = Field(default=0.0, ge=-1.0, le=1.0)
+    per_character_max_entries: int = Field(default=4, ge=1)
+    mandatory_reserved_entries: int = Field(default=2, ge=0)
+    trace_rows_per_character: int = Field(default=500, ge=1)
+    severity_scores: Dict[str, float] = Field(
+        default_factory=lambda: {
+            "minor": 0.25,
+            "moderate": 0.50,
+            "major": 0.75,
+            "critical": 1.0,
+        }
+    )
+    involvement_scores: Dict[str, float] = Field(
+        default_factory=lambda: {
+            "participant": 1.0,
+            "witness": 0.67,
+            "acquisition": 0.33,
+        }
+    )
+
+    @model_validator(mode="after")
+    def _validate_recall_policy(self) -> "OrreryRecallSettings":
+        """Require complete bounded component maps and a nonzero weight sum."""
+
+        expected_severities = {"minor", "moderate", "major", "critical"}
+        if set(self.severity_scores) != expected_severities:
+            raise ValueError(
+                f"severity_scores must contain exactly {sorted(expected_severities)}"
+            )
+        expected_involvement = {"participant", "witness", "acquisition"}
+        if set(self.involvement_scores) != expected_involvement:
+            raise ValueError(
+                "involvement_scores must contain exactly "
+                f"{sorted(expected_involvement)}"
+            )
+        bounded = {**self.severity_scores, **self.involvement_scores}
+        invalid = {
+            name: value for name, value in bounded.items() if not 0 <= value <= 1
+        }
+        if invalid:
+            raise ValueError(f"recall component scores must be in [0, 1]: {invalid}")
+        weights = (
+            self.semantic_fit_weight,
+            self.event_severity_weight,
+            self.actor_involvement_weight,
+            self.emotional_salience_weight,
+            self.recency_weight,
+            self.place_match_weight,
+        )
+        if sum(weights) <= 0:
+            raise ValueError("at least one recall component weight must be positive")
+        return self
+
+
+class OrreryDisclosureSettings(BaseModel):
+    """Audience-conditioned disclosure policy for ``[orrery.disclosure]``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    minimum_score: float = 0.0
+    private_claim_minimum_score: float = 0.20
+    secrecy_penalty: float = Field(default=0.40, ge=0.0)
+    relationship_valence_weight: float = Field(default=0.50, ge=0.0)
+    shared_status_bonus: float = Field(default=0.20, ge=0.0)
+    role_obligation_penalty: float = Field(default=0.50, ge=0.0)
+    missing_relationship_valence: float = Field(default=0.0, gt=-1.0, lt=1.0)
+
+
 class OrreryReconstructionSettings(BaseModel):
     """Reconstruction-sufficiency knobs (issue #426)."""
 
@@ -2534,6 +2615,10 @@ class OrrerySettings(BaseModel):
     drift: OrreryDriftSettings = Field(default_factory=OrreryDriftSettings)
     reveal: OrreryRevealSettings = Field(default_factory=OrreryRevealSettings)
     knowledge: OrreryKnowledgeSettings = Field(default_factory=OrreryKnowledgeSettings)
+    recall: OrreryRecallSettings = Field(default_factory=OrreryRecallSettings)
+    disclosure: OrreryDisclosureSettings = Field(
+        default_factory=OrreryDisclosureSettings
+    )
     epistemics: OrreryEpistemicsSettings = Field(
         default_factory=OrreryEpistemicsSettings
     )

--- a/tests/test_lore/test_logon_prompt_formatting.py
+++ b/tests/test_lore/test_logon_prompt_formatting.py
@@ -577,6 +577,29 @@ def test_context_prompt_renders_world_knowledge_without_answer_keys(
     assert prompt.count("(older knowledge omitted)") == int(truncated)
 
 
+def test_context_prompt_source_labels_character_experiences() -> None:
+    """Subjective recollections carry their corpus identity into the block."""
+
+    prompt = LogonUtility({})._format_context_prompt(
+        {
+            "user_input": "Continue.",
+            "world_knowledge": [
+                {
+                    "character_entity_id": 7,
+                    "character_name": "Mara",
+                    "experience_id": 44,
+                    "summary": "I still hear the river gate closing.",
+                    "acquisition": {"kind": "firsthand"},
+                    "source": {"kind": "experience", "id": 44},
+                }
+            ],
+        }
+    )
+
+    assert "Mara [firsthand; Character experience 44]" in prompt
+    assert "I still hear the river gate closing." in prompt
+
+
 def test_system_prompt_excludes_runtime_tag_library(monkeypatch) -> None:
     """The provider-cacheable system prompt no longer carries turn vocabulary."""
 

--- a/tests/test_lore/test_turn_cycle.py
+++ b/tests/test_lore/test_turn_cycle.py
@@ -758,8 +758,10 @@ def test_warm_analysis_ignores_parent_authorial_directives(
     )
 
 
-def test_deep_queries_use_raw_chunk_only(turn_manager: TurnCycleManager) -> None:
-    """Full chunk text should seed retrieval without successor directives."""
+def test_deep_queries_use_raw_scene_and_current_input(
+    turn_manager: TurnCycleManager,
+) -> None:
+    """One raw scene-and-input representation should seed retrieval."""
 
     class DummyMemnon:
         def __init__(self) -> None:
@@ -799,7 +801,8 @@ def test_deep_queries_use_raw_chunk_only(turn_manager: TurnCycleManager) -> None
     asyncio.run(turn_manager.execute_deep_queries(ctx))
 
     assert memnon.queries == [
-        "Full parent chunk text with all the messy narrative details."
+        "Full parent chunk text with all the messy narrative details.\n\n"
+        "CURRENT TURN INPUT:\nContinue."
     ]
     assert ctx.phase_states["deep_queries"]["query_sources"] == {
         "raw_chunk": 1,

--- a/tests/test_orrery/test_config.py
+++ b/tests/test_orrery/test_config.py
@@ -16,6 +16,7 @@ from nexus.config.settings_models import (
     OrreryContagionSettings,
     OrreryCompositionSettings,
     OrreryDashboardSettings,
+    OrreryDisclosureSettings,
     OrreryDistortionSettings,
     OrreryDriftSettings,
     OrreryEpistemicsSettings,
@@ -23,6 +24,7 @@ from nexus.config.settings_models import (
     OrreryMoodSettings,
     OrreryPromoteSettings,
     OrreryRevealSettings,
+    OrreryRecallSettings,
     OrrerySettings,
     OrreryRetrogradeMaturationSettings,
     OrreryRetrogradeProjectSettings,
@@ -311,6 +313,28 @@ def test_knowledge_defaults_off_and_requires_positive_windows() -> None:
         OrreryKnowledgeSettings(max_entries=0)
     with pytest.raises(ValidationError, match="greater than or equal to 1"):
         OrreryKnowledgeSettings(recent_reveal_window_chunks=0)
+
+
+def test_recall_and_disclosure_settings_validate_policy_bounds() -> None:
+    """Recall maps are complete and audience thresholds reject bad values."""
+
+    recall = OrreryRecallSettings()
+    assert recall.per_character_max_entries == 4
+    assert recall.mandatory_reserved_entries == 2
+    assert OrreryDisclosureSettings().private_claim_minimum_score == 0.20
+    with pytest.raises(ValidationError, match="at least one recall component"):
+        OrreryRecallSettings(
+            semantic_fit_weight=0,
+            event_severity_weight=0,
+            actor_involvement_weight=0,
+            emotional_salience_weight=0,
+            recency_weight=0,
+            place_match_weight=0,
+        )
+    with pytest.raises(ValidationError, match="severity_scores must contain exactly"):
+        OrreryRecallSettings(severity_scores={"critical": 1.0})
+    with pytest.raises(ValidationError, match="less than 1"):
+        OrreryDisclosureSettings(missing_relationship_valence=1.0)
 
 
 def test_distortion_defaults_off_when_block_is_absent() -> None:

--- a/tests/test_orrery/test_recall_disclosure_pg.py
+++ b/tests/test_orrery/test_recall_disclosure_pg.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
+import json
 import os
 from pathlib import Path
-from typing import Any, Iterator
+from types import SimpleNamespace
+from typing import Any, Iterator, cast
 from uuid import uuid4
 
 import psycopg2
@@ -16,7 +20,12 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import URL
 from sqlalchemy.orm import Session
 
-from nexus.agents.memnon.utils.embedding_tables import ensure_embedding_table
+from nexus.agents.lore.utils.turn_context import TurnContext
+from nexus.agents.lore.utils.turn_cycle import TurnCycleManager
+from nexus.agents.memnon.utils.embedding_tables import (
+    ensure_character_experience_embedding_table,
+    ensure_embedding_table,
+)
 from nexus.agents.orrery.knowledge_surfacing import build_knowledge_digest_sync
 
 
@@ -376,6 +385,7 @@ def _digest(
     turn_id: str,
     max_entries: int = 12,
     recall: dict[str, Any] | None = None,
+    query_embeddings: dict[str, list[float]] | None = None,
 ) -> list[dict[str, Any]]:
     return build_knowledge_digest_sync(
         session,
@@ -389,6 +399,7 @@ def _digest(
         recall_settings=recall or {},
         disclosure_settings={},
         turn_id=turn_id,
+        query_embeddings=query_embeddings,
     )
 
 
@@ -500,6 +511,16 @@ def test_ownership_and_anchor_validity_are_hard_boundaries(session: Session) -> 
     assert invalid_experience not in {entry.get("experience_id") for entry in digest}
     assert future_experience not in {entry.get("experience_id") for entry in digest}
     assert {entry["character_entity_id"] for entry in digest} == {alpha[0]}
+    semantic_status = session.execute(
+        text(
+            "SELECT score_components ->> 'semantic_status' "
+            "FROM orrery_recall_trace "
+            "WHERE turn_id = 'ownership-boundary' "
+            "AND candidate_kind = 'experience' AND candidate_id = :experience_id"
+        ),
+        {"experience_id": valid_experience},
+    ).scalar_one()
+    assert semantic_status == "skipped_no_query_embedding"
     raw_connection = session.connection().connection.driver_connection
     with raw_connection.cursor(cursor_factory=RealDictCursor) as cursor:
         cursor_digest = build_knowledge_digest_sync(
@@ -640,75 +661,279 @@ def test_world_clock_decay_lowers_rank_without_mutating_possession(
     assert awareness_ids == {old_awareness, recent_awareness}
 
 
-def test_semantic_fit_uses_raw_turn_and_eligible_corpus_vectors(
+def test_claim_rank_is_invariant_to_unpossessed_sibling_secret(
     session: Session,
 ) -> None:
     base = datetime(2078, 3, 15, tzinfo=timezone.utc)
-    relevant = _chunk(session, label="semantic relevant", world_time=base, scene=1)
-    irrelevant = _chunk(session, label="semantic irrelevant", world_time=base, scene=2)
-    anchor = _chunk(
-        session, label="semantic raw current turn", world_time=base, scene=3
-    )
-    alpha = _character(session, "semantic")
+    source = _chunk(session, label="distorted source", world_time=base, scene=1)
+    anchor = _chunk(session, label="claim invariance anchor", world_time=base, scene=2)
+    alpha = _character(session, "claim-invariance")
     _present(session, chunk_id=anchor, characters=[alpha])
-    relevant_claim, _ = _claim(
+    distorted_claim, _ = _claim(
         session,
         owner_entity_id=alpha[0],
-        chunk_id=relevant,
+        chunk_id=source,
         acquired_at=base,
-        label="semantic match",
+        label="distorted possessed account",
     )
-    irrelevant_claim, _ = _claim(
+    world_event_id = int(
+        session.execute(
+            text("SELECT world_event_id FROM claims WHERE id = :claim_id"),
+            {"claim_id": distorted_claim},
+        ).scalar_one()
+    )
+    _claim(
         session,
         owner_entity_id=alpha[0],
-        chunk_id=irrelevant,
+        chunk_id=source,
         acquired_at=base,
-        label="semantic mismatch",
+        label="possessed comparison account",
     )
     table_name = ensure_embedding_table(session.connection(), 2)
     session.execute(
         text(
             f"""
             INSERT INTO {table_name} (chunk_id, model, embedding)
-            VALUES
-                (:anchor, 'qa678', '[1,0]'::vector(2)),
-                (:relevant, 'qa678', '[1,0]'::vector(2)),
-                (:irrelevant, 'qa678', '[0,1]'::vector(2))
+            VALUES (:source, 'qa678', '[1,0]'::vector(2))
             """
         ),
-        {"anchor": anchor, "relevant": relevant, "irrelevant": irrelevant},
+        {"source": source},
     )
 
-    digest = _digest(
+    before_digest = _digest(
         session,
         present=[alpha[0]],
         anchor=anchor,
-        turn_id="semantic-fit",
-        max_entries=1,
-        recall={
-            "per_character_max_entries": 1,
-            "mandatory_reserved_entries": 0,
-            "semantic_fit_weight": 1.0,
-            "event_severity_weight": 0.0,
-            "actor_involvement_weight": 0.0,
-            "emotional_salience_weight": 0.0,
-            "recency_weight": 0.0,
-            "place_match_weight": 0.0,
-        },
+        turn_id="claim-invariance-before",
+        query_embeddings={"qa678": [1.0, 0.0]},
     )
-
-    assert [entry["claim_id"] for entry in digest] == [relevant_claim]
-    components = {
-        int(row["claim_id"]): row["score_components"]
-        for row in session.execute(
+    before_trace = (
+        session.execute(
             text(
-                "SELECT claim_id, score_components FROM orrery_recall_trace "
-                "WHERE turn_id = 'semantic-fit'"
-            )
-        ).mappings()
-    }
-    assert components[relevant_claim]["semantic_fit"] == pytest.approx(1.0)
-    assert components[irrelevant_claim]["semantic_fit"] == pytest.approx(0.0)
+                "SELECT score, score_components FROM orrery_recall_trace "
+                "WHERE turn_id = 'claim-invariance-before' AND claim_id = :claim_id"
+            ),
+            {"claim_id": distorted_claim},
+        )
+        .mappings()
+        .one()
+    )
+    before_rank = [entry.get("claim_id") for entry in before_digest].index(
+        distorted_claim
+    )
+    before_bytes = json.dumps(
+        {
+            "rank": before_rank,
+            "score": str(before_trace["score"]),
+            "components": before_trace["score_components"],
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+    secret_claim, _ = _claim(
+        session,
+        owner_entity_id=None,
+        chunk_id=source,
+        acquired_at=base,
+        label="unpossessed sibling secret",
+        scope="private",
+        world_event_id=world_event_id,
+    )
+    session.execute(
+        text(
+            f"UPDATE {table_name} SET embedding = '[0,1]'::vector(2) "
+            "WHERE chunk_id = :source AND model = 'qa678'"
+        ),
+        {"source": source},
+    )
+    after_digest = _digest(
+        session,
+        present=[alpha[0]],
+        anchor=anchor,
+        turn_id="claim-invariance-after",
+        query_embeddings={"qa678": [1.0, 0.0]},
+    )
+    after_trace = (
+        session.execute(
+            text(
+                "SELECT score, score_components FROM orrery_recall_trace "
+                "WHERE turn_id = 'claim-invariance-after' AND claim_id = :claim_id"
+            ),
+            {"claim_id": distorted_claim},
+        )
+        .mappings()
+        .one()
+    )
+    after_rank = [entry.get("claim_id") for entry in after_digest].index(
+        distorted_claim
+    )
+    after_bytes = json.dumps(
+        {
+            "rank": after_rank,
+            "score": str(after_trace["score"]),
+            "components": after_trace["score_components"],
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+    assert secret_claim not in {entry.get("claim_id") for entry in after_digest}
+    assert before_bytes == after_bytes
+    assert after_trace["score_components"]["semantic_fit"] is None
+    assert after_trace["score_components"]["semantic_status"] == "not_applicable_claim"
+
+
+class _TurnMemnonHarness:
+    def __init__(self, session: Session) -> None:
+        self.session = session
+        self.query_embedding_ids: list[int] = []
+
+    @contextmanager
+    def Session(self) -> Iterator[Session]:
+        yield self.session
+
+    def query_memory(
+        self,
+        query: str,
+        k: int,
+        use_hybrid: bool,
+        query_embeddings: dict[str, list[float]],
+        **_kwargs: Any,
+    ) -> dict[str, list[dict[str, Any]]]:
+        assert k == 15
+        assert use_hybrid is True
+        self.query_embedding_ids.append(id(query_embeddings))
+        query_embeddings["qa678"] = [1.0, 0.0] if "fire" in query else [0.0, 1.0]
+        return {"results": []}
+
+
+class _TurnLoreHarness:
+    token_manager = None
+    memory_manager = None
+    enable_logon = False
+
+    def __init__(self, session: Session) -> None:
+        self.memnon = _TurnMemnonHarness(session)
+        self.settings = {
+            "Agent Settings": {
+                "LORE": {
+                    "token_budget": {
+                        "apex_context_window": 75_000,
+                        "prompt_overhead_tokens": 4_000,
+                    }
+                },
+                "MEMNON": {
+                    "retrieval": {"hybrid_search": {"presence_boost_enabled": False}}
+                },
+            },
+            "orrery": {
+                "enabled": True,
+                "bleed": {"max_candidates": 0},
+                "knowledge": {
+                    "enabled": True,
+                    "max_entries": 1,
+                    "recent_reveal_window_chunks": 3,
+                },
+                "recall": {
+                    "semantic_fit_weight": 1.0,
+                    "event_severity_weight": 0.0,
+                    "actor_involvement_weight": 0.0,
+                    "emotional_salience_weight": 0.0,
+                    "recency_weight": 0.0,
+                    "place_match_weight": 0.0,
+                    "per_character_max_entries": 1,
+                    "mandatory_reserved_entries": 0,
+                },
+            },
+        }
+
+
+def test_turn_inputs_change_experience_ranking_via_shared_query_embedding(
+    session: Session,
+) -> None:
+    base = datetime(2078, 3, 20, tzinfo=timezone.utc)
+    fire_source = _chunk(session, label="fire experience", world_time=base, scene=1)
+    harbor_source = _chunk(session, label="harbor experience", world_time=base, scene=2)
+    anchor = _chunk(session, label="turn semantic anchor", world_time=base, scene=3)
+    alpha = _character(session, "turn-semantic")
+    _present(session, chunk_id=anchor, characters=[alpha])
+    fire_experience = _experience(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=fire_source,
+        world_time=base,
+        label="fire memory",
+    )
+    harbor_experience = _experience(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=harbor_source,
+        world_time=base,
+        label="harbor memory",
+    )
+    table_name = ensure_character_experience_embedding_table(session.connection(), 2)
+    session.execute(
+        text(
+            f"""
+            INSERT INTO {table_name} (experience_id, model, embedding)
+            VALUES
+                (:fire, 'qa678', '[1,0]'::vector(2)),
+                (:harbor, 'qa678', '[0,1]'::vector(2))
+            """
+        ),
+        {"fire": fire_experience, "harbor": harbor_experience},
+    )
+    lore = _TurnLoreHarness(session)
+    manager = TurnCycleManager(lore)
+
+    selected: list[int] = []
+    for turn_id, user_input in (
+        ("turn-semantic-fire", "Recall the fire at the gate."),
+        ("turn-semantic-harbor", "Recall the harbor at dawn."),
+    ):
+        context = TurnContext(
+            turn_id=turn_id,
+            user_input=user_input,
+            start_time=0,
+            warm_slice=[
+                {
+                    "id": anchor,
+                    "is_target": True,
+                    "full_text": "The same current scene anchor for both turns.",
+                }
+            ],
+        )
+        context.token_counts = {"total_available": 75_000}
+        context.orrery_proposal = cast(
+            Any,
+            SimpleNamespace(
+                anchor_chunk_id=anchor,
+                pressure_count=0,
+                resolution_count=0,
+                joint_beats=(),
+            ),
+        )
+
+        asyncio.run(manager.execute_deep_queries(context))
+        shared_mapping_id = id(context.recall_query_embeddings)
+        asyncio.run(manager.assemble_context_payload(context))
+
+        assert shared_mapping_id == lore.memnon.query_embedding_ids[-1]
+        entry = context.context_payload["world_knowledge"][0]
+        selected.append(int(entry["experience_id"]))
+        semantic_trace = session.execute(
+            text(
+                "SELECT score_components ->> 'semantic_status' "
+                "FROM orrery_recall_trace "
+                "WHERE turn_id = :turn_id AND candidate_kind = 'experience' "
+                "AND candidate_id = :candidate_id"
+            ),
+            {"turn_id": turn_id, "candidate_id": entry["experience_id"]},
+        ).scalar_one()
+        assert semantic_trace == "scored"
+
+    assert selected == [fire_experience, harbor_experience]
 
 
 def test_disclosure_suppression_is_logged_and_not_surfaced(session: Session) -> None:

--- a/tests/test_orrery/test_recall_disclosure_pg.py
+++ b/tests/test_orrery/test_recall_disclosure_pg.py
@@ -1,0 +1,992 @@
+"""Disposable-PostgreSQL proofs for entitlement-first recall and disclosure."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import os
+from pathlib import Path
+from typing import Any, Iterator
+from uuid import uuid4
+
+import psycopg2
+from psycopg2 import sql
+from psycopg2.extras import RealDictCursor
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import URL
+from sqlalchemy.orm import Session
+
+from nexus.agents.memnon.utils.embedding_tables import ensure_embedding_table
+from nexus.agents.orrery.knowledge_surfacing import build_knowledge_digest_sync
+
+
+pytestmark = pytest.mark.requires_postgres
+ROOT = Path(__file__).parents[2]
+MIGRATION = ROOT / "migrations" / "106_recall_trace.sql"
+
+
+def _connect(dbname: str) -> Any:
+    return psycopg2.connect(
+        dbname=dbname,
+        user=os.environ.get("PGUSER", "pythagor"),
+        host=os.environ.get("PGHOST", "localhost"),
+        port=os.environ.get("PGPORT", "5432"),
+        connect_timeout=2,
+    )
+
+
+@pytest.fixture(scope="module")
+def recall_database() -> Iterator[str]:
+    """Clone the template, apply migration 106 twice, and drop the clone."""
+
+    dbname = f"qa678_{uuid4().hex[:12]}"
+    source = os.environ.get("NEXUS_TEST_TEMPLATE_DB", "NEXUS_template")
+    assert source == "NEXUS_template" or source.startswith("qa678_")
+    admin: Any = None
+    try:
+        try:
+            admin = _connect("postgres")
+        except psycopg2.Error as exc:
+            pytest.skip(f"PostgreSQL admin connection unavailable: {exc}")
+        admin.autocommit = True
+        with admin.cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} TEMPLATE {}").format(
+                    sql.Identifier(dbname), sql.Identifier(source)
+                )
+            )
+        with _connect(dbname) as conn:
+            with conn.cursor() as cur:
+                migration_sql = MIGRATION.read_text()
+                cur.execute(migration_sql)
+                cur.execute(migration_sql)
+        yield dbname
+    finally:
+        if admin is not None:
+            with admin.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = %s AND pid <> pg_backend_pid()",
+                    (dbname,),
+                )
+                cur.execute(
+                    sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(dbname))
+                )
+            admin.close()
+
+
+@pytest.fixture()
+def session(recall_database: str) -> Iterator[Session]:
+    """Run each proof in a rollback-only transaction in the disposable clone."""
+
+    engine = create_engine(
+        URL.create(
+            "postgresql+psycopg2",
+            username=os.environ.get("PGUSER", "pythagor"),
+            host=os.environ.get("PGHOST", "localhost"),
+            port=int(os.environ.get("PGPORT", "5432")),
+            database=recall_database,
+        ),
+        future=True,
+    )
+    connection = engine.connect()
+    transaction = connection.begin()
+    test_session = Session(bind=connection)
+    try:
+        yield test_session
+    finally:
+        test_session.close()
+        if transaction.is_active:
+            transaction.rollback()
+        connection.close()
+        engine.dispose()
+
+
+def _chunk(
+    session: Session,
+    *,
+    label: str,
+    world_time: datetime,
+    scene: int,
+) -> int:
+    chunk_id = int(
+        session.execute(
+            text(
+                """
+                INSERT INTO narrative_chunks (raw_text, storyteller_text)
+                VALUES (:label, :label)
+                RETURNING id
+                """
+            ),
+            {"label": label},
+        ).scalar_one()
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO chunk_metadata (
+                chunk_id, season, episode, scene, world_layer, world_time
+            ) VALUES (:chunk_id, 1, 1, :scene, 'primary', :world_time)
+            """
+        ),
+        {"chunk_id": chunk_id, "scene": scene, "world_time": world_time},
+    )
+    session.execute(
+        text(
+            "UPDATE chunk_metadata SET world_time = :world_time "
+            "WHERE chunk_id = :chunk_id"
+        ),
+        {"chunk_id": chunk_id, "world_time": world_time},
+    )
+    return chunk_id
+
+
+def _character(session: Session, label: str) -> tuple[int, int]:
+    entity_id = int(
+        session.execute(
+            text(
+                "INSERT INTO entities (kind, is_active) "
+                "VALUES ('character', true) RETURNING id"
+            )
+        ).scalar_one()
+    )
+    character_id = int(
+        session.execute(
+            text(
+                "INSERT INTO characters (entity_id, name) "
+                "VALUES (:entity_id, :name) RETURNING id"
+            ),
+            {"entity_id": entity_id, "name": f"recall-{label}-{uuid4().hex[:6]}"},
+        ).scalar_one()
+    )
+    return entity_id, character_id
+
+
+def _faction(session: Session, label: str) -> int:
+    entity_id = int(
+        session.execute(
+            text(
+                "INSERT INTO entities (kind, is_active) "
+                "VALUES ('faction', true) RETURNING id"
+            )
+        ).scalar_one()
+    )
+    faction_row_id = int(
+        session.execute(
+            text("SELECT COALESCE(max(id), 0) + 1 FROM factions")
+        ).scalar_one()
+    )
+    session.execute(
+        text(
+            "INSERT INTO factions (id, entity_id, name) "
+            "VALUES (:id, :entity_id, :name)"
+        ),
+        {
+            "id": faction_row_id,
+            "entity_id": entity_id,
+            "name": f"recall-{label}-{uuid4().hex[:6]}",
+        },
+    )
+    return entity_id
+
+
+def _present(
+    session: Session, *, chunk_id: int, characters: list[tuple[int, int]]
+) -> None:
+    for _entity_id, character_id in characters:
+        session.execute(
+            text(
+                """
+                INSERT INTO chunk_character_references (
+                    chunk_id, character_id, reference
+                ) VALUES (:chunk_id, :character_id, 'present')
+                """
+            ),
+            {"chunk_id": chunk_id, "character_id": character_id},
+        )
+
+
+def _claim(
+    session: Session,
+    *,
+    owner_entity_id: int | None,
+    chunk_id: int,
+    acquired_at: datetime,
+    label: str,
+    severity: str = "moderate",
+    scope: str = "bounded",
+    source_tier: str = "participant",
+    world_event_id: int | None = None,
+) -> tuple[int, int | None]:
+    if world_event_id is None:
+        event_type = f"qa678_{severity}_{uuid4().hex[:8]}"
+        session.execute(
+            text(
+                """
+                INSERT INTO event_types (type, category, severity, description)
+                VALUES (
+                    :event_type, 'social',
+                    CAST(:severity AS event_severity_kind),
+                    'Issue 678 rollback-only fixture'
+                )
+                """
+            ),
+            {"event_type": event_type, "severity": severity},
+        )
+        event_id = int(
+            session.execute(
+                text(
+                    """
+                    INSERT INTO world_events (
+                        event_type, tick_chunk_id, world_layer, source,
+                        changed_fields, payload
+                    ) VALUES (
+                        :event_type, :chunk_id, 'primary', 'authored', '{}', '{}'
+                    ) RETURNING id
+                    """
+                ),
+                {"event_type": event_type, "chunk_id": chunk_id},
+            ).scalar_one()
+        )
+    else:
+        event_id = int(world_event_id)
+    claim_id = int(
+        session.execute(
+            text(
+                """
+                INSERT INTO claims (
+                    world_event_id, summary, scope, source_chunk_id,
+                    account_label
+                ) VALUES (
+                    :event_id, :summary, :scope, :chunk_id, :account_label
+                ) RETURNING id
+                """
+            ),
+            {
+                "event_id": event_id,
+                "summary": f"Recall fixture {label}",
+                "scope": scope,
+                "chunk_id": chunk_id,
+                "account_label": f"qa678-{uuid4().hex[:8]}",
+            },
+        ).scalar_one()
+    )
+    if owner_entity_id is None:
+        return claim_id, None
+    awareness_id = int(
+        session.execute(
+            text(
+                """
+                INSERT INTO claim_awareness (
+                    claim_id, knower_entity_id, source_tier,
+                    acquired_at_world_time, source_chunk_id
+                ) VALUES (
+                    :claim_id, :owner_id, :source_tier,
+                    :acquired_at, :chunk_id
+                ) RETURNING id
+                """
+            ),
+            {
+                "claim_id": claim_id,
+                "owner_id": owner_entity_id,
+                "source_tier": source_tier,
+                "acquired_at": acquired_at,
+                "chunk_id": chunk_id,
+            },
+        ).scalar_one()
+    )
+    return claim_id, awareness_id
+
+
+def _experience(
+    session: Session,
+    *,
+    owner_entity_id: int,
+    chunk_id: int,
+    world_time: datetime,
+    label: str,
+    invalidated: bool = False,
+) -> int:
+    event_type = f"qa678_experience_{uuid4().hex[:8]}"
+    session.execute(
+        text(
+            """
+            INSERT INTO event_types (type, category, severity, description)
+            VALUES (:event_type, 'social', 'moderate', 'Issue 678 experience')
+            """
+        ),
+        {"event_type": event_type},
+    )
+    event_id = int(
+        session.execute(
+            text(
+                """
+                INSERT INTO world_events (
+                    event_type, tick_chunk_id, actor_entity_id, world_layer,
+                    source, changed_fields, payload
+                ) VALUES (
+                    :event_type, :chunk_id, :owner_id, 'primary', 'authored',
+                    '{}', '{}'
+                ) RETURNING id
+                """
+            ),
+            {
+                "event_type": event_type,
+                "chunk_id": chunk_id,
+                "owner_id": owner_entity_id,
+            },
+        ).scalar_one()
+    )
+    return int(
+        session.execute(
+            text(
+                """
+                INSERT INTO character_experiences (
+                    character_entity_id, anchor_chunk_id, world_event_ids,
+                    basis, world_time, seed_summary, salience, source_digest,
+                    world_layer, invalidation_status, invalidated_at
+                ) VALUES (
+                    :owner_id, :chunk_id, ARRAY[:event_id]::bigint[],
+                    'participant', :world_time, :summary, 0.8, :digest,
+                    'primary',
+                    CAST(:status AS character_experience_invalidation_status),
+                    :invalidated_at
+                ) RETURNING id
+                """
+            ),
+            {
+                "owner_id": owner_entity_id,
+                "chunk_id": chunk_id,
+                "event_id": event_id,
+                "world_time": world_time,
+                "summary": f"Experience fixture {label}",
+                "digest": uuid4().hex,
+                "status": "invalidated" if invalidated else "valid",
+                "invalidated_at": datetime.now(timezone.utc) if invalidated else None,
+            },
+        ).scalar_one()
+    )
+
+
+def _digest(
+    session: Session,
+    *,
+    present: list[int],
+    anchor: int,
+    turn_id: str,
+    max_entries: int = 12,
+    recall: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    return build_knowledge_digest_sync(
+        session,
+        present_entity_ids=present,
+        anchor_chunk_id=anchor,
+        settings={
+            "enabled": True,
+            "max_entries": max_entries,
+            "recent_reveal_window_chunks": 3,
+        },
+        recall_settings=recall or {},
+        disclosure_settings={},
+        turn_id=turn_id,
+    )
+
+
+def test_ownership_and_anchor_validity_are_hard_boundaries(session: Session) -> None:
+    base = datetime(2078, 1, 1, tzinfo=timezone.utc)
+    source = _chunk(session, label="ownership source", world_time=base, scene=1)
+    future = _chunk(
+        session, label="future source", world_time=base + timedelta(hours=4), scene=3
+    )
+    anchor = _chunk(
+        session, label="ownership anchor", world_time=base + timedelta(hours=2), scene=2
+    )
+    alpha = _character(session, "ownership-alpha")
+    beta = _character(session, "ownership-beta")
+    _present(session, chunk_id=anchor, characters=[alpha, beta])
+    alpha_claim, _ = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=source,
+        acquired_at=base,
+        label="alpha owned claim",
+    )
+    unpossessed_claim, _ = _claim(
+        session,
+        owner_entity_id=None,
+        chunk_id=source,
+        acquired_at=base,
+        label="unpossessed canonical answer",
+    )
+    sibling_event_id = int(
+        session.execute(
+            text("SELECT world_event_id FROM claims WHERE id = :claim_id"),
+            {"claim_id": unpossessed_claim},
+        ).scalar_one()
+    )
+    possessed_sibling, _ = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=source,
+        acquired_at=base,
+        label="possessed sibling account",
+        world_event_id=sibling_event_id,
+    )
+    latent_claim, _ = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=source,
+        acquired_at=base,
+        label="latent secret",
+        scope="private",
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO backstory_secrets (
+                claim_id, gate_template_id, holder_entity_id,
+                source_chunk_id
+            ) VALUES (
+                :claim_id, 'qa678-never-reveal', :holder_id, :chunk_id
+            )
+            """
+        ),
+        {
+            "claim_id": latent_claim,
+            "holder_id": alpha[0],
+            "chunk_id": source,
+        },
+    )
+    valid_experience = _experience(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=source,
+        world_time=base,
+        label="alpha owned",
+    )
+    invalid_experience = _experience(
+        session,
+        owner_entity_id=beta[0],
+        chunk_id=source,
+        world_time=base,
+        label="invalidated",
+        invalidated=True,
+    )
+    future_experience = _experience(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=future,
+        world_time=base + timedelta(hours=4),
+        label="future timeline",
+    )
+
+    digest = _digest(
+        session,
+        present=[alpha[0], beta[0]],
+        anchor=anchor,
+        turn_id="ownership-boundary",
+    )
+    assert {entry.get("claim_id") for entry in digest} == {
+        alpha_claim,
+        possessed_sibling,
+        None,
+    }
+    assert {entry.get("experience_id") for entry in digest} == {
+        valid_experience,
+        None,
+    }
+    assert unpossessed_claim not in {entry.get("claim_id") for entry in digest}
+    assert latent_claim not in {entry.get("claim_id") for entry in digest}
+    assert invalid_experience not in {entry.get("experience_id") for entry in digest}
+    assert future_experience not in {entry.get("experience_id") for entry in digest}
+    assert {entry["character_entity_id"] for entry in digest} == {alpha[0]}
+    raw_connection = session.connection().connection.driver_connection
+    with raw_connection.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor_digest = build_knowledge_digest_sync(
+            cursor,
+            present_entity_ids=[alpha[0], beta[0]],
+            anchor_chunk_id=anchor,
+            settings={
+                "enabled": True,
+                "max_entries": 12,
+                "recent_reveal_window_chunks": 3,
+            },
+            recall_settings={},
+            disclosure_settings={},
+            turn_id="ownership-boundary-cursor",
+        )
+    assert cursor_digest == digest
+
+
+def test_critical_current_scene_account_bypasses_ranking(session: Session) -> None:
+    base = datetime(2078, 2, 1, tzinfo=timezone.utc)
+    old = _chunk(session, label="mandatory old", world_time=base, scene=1)
+    anchor = _chunk(
+        session, label="mandatory anchor", world_time=base + timedelta(hours=1), scene=2
+    )
+    alpha = _character(session, "mandatory")
+    _present(session, chunk_id=anchor, characters=[alpha])
+    old_claim, _ = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=old,
+        acquired_at=base,
+        label="high involvement old",
+        severity="major",
+        source_tier="participant",
+    )
+    critical_claim, _ = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=anchor,
+        acquired_at=base + timedelta(hours=1),
+        label="critical granted now",
+        severity="critical",
+        source_tier="granted",
+    )
+
+    digest = _digest(
+        session,
+        present=[alpha[0]],
+        anchor=anchor,
+        turn_id="mandatory-bypass",
+        max_entries=1,
+        recall={
+            "per_character_max_entries": 1,
+            "mandatory_reserved_entries": 1,
+            "semantic_fit_weight": 0.0,
+            "event_severity_weight": 0.0,
+            "actor_involvement_weight": 1.0,
+            "emotional_salience_weight": 0.0,
+            "recency_weight": 0.0,
+            "place_match_weight": 0.0,
+        },
+    )
+
+    assert [entry["claim_id"] for entry in digest] == [critical_claim]
+    trace = session.execute(
+        text(
+            """
+            SELECT claim_id, decision, reason, mandatory
+            FROM orrery_recall_trace
+            WHERE turn_id = 'mandatory-bypass'
+            ORDER BY claim_id
+            """
+        )
+    ).mappings()
+    by_claim = {int(row["claim_id"]): dict(row) for row in trace}
+    assert by_claim[critical_claim]["mandatory"] is True
+    assert by_claim[critical_claim]["decision"] == "included"
+    assert by_claim[old_claim]["decision"] == "excluded"
+
+
+def test_world_clock_decay_lowers_rank_without_mutating_possession(
+    session: Session,
+) -> None:
+    base = datetime(2078, 3, 1, tzinfo=timezone.utc)
+    old = _chunk(session, label="decay old", world_time=base, scene=1)
+    recent = _chunk(
+        session, label="decay recent", world_time=base + timedelta(hours=90), scene=2
+    )
+    anchor = _chunk(
+        session, label="decay anchor", world_time=base + timedelta(hours=100), scene=3
+    )
+    alpha = _character(session, "decay")
+    _present(session, chunk_id=anchor, characters=[alpha])
+    old_claim, old_awareness = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=old,
+        acquired_at=base,
+        label="old memory",
+    )
+    recent_claim, recent_awareness = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=recent,
+        acquired_at=base + timedelta(hours=90),
+        label="recent memory",
+    )
+
+    digest = _digest(
+        session,
+        present=[alpha[0]],
+        anchor=anchor,
+        turn_id="decay-rank",
+        max_entries=1,
+        recall={
+            "per_character_max_entries": 1,
+            "mandatory_reserved_entries": 0,
+            "decay_half_life_hours": 10.0,
+        },
+    )
+
+    assert [entry["claim_id"] for entry in digest] == [recent_claim]
+    scores = dict(
+        session.execute(
+            text(
+                "SELECT claim_id, score FROM orrery_recall_trace "
+                "WHERE turn_id = 'decay-rank'"
+            )
+        ).all()
+    )
+    assert scores[recent_claim] > scores[old_claim]
+    awareness_ids = set(
+        session.execute(
+            text("SELECT id FROM claim_awareness " "WHERE id = ANY(:awareness_ids)"),
+            {"awareness_ids": [old_awareness, recent_awareness]},
+        ).scalars()
+    )
+    assert awareness_ids == {old_awareness, recent_awareness}
+
+
+def test_semantic_fit_uses_raw_turn_and_eligible_corpus_vectors(
+    session: Session,
+) -> None:
+    base = datetime(2078, 3, 15, tzinfo=timezone.utc)
+    relevant = _chunk(session, label="semantic relevant", world_time=base, scene=1)
+    irrelevant = _chunk(session, label="semantic irrelevant", world_time=base, scene=2)
+    anchor = _chunk(
+        session, label="semantic raw current turn", world_time=base, scene=3
+    )
+    alpha = _character(session, "semantic")
+    _present(session, chunk_id=anchor, characters=[alpha])
+    relevant_claim, _ = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=relevant,
+        acquired_at=base,
+        label="semantic match",
+    )
+    irrelevant_claim, _ = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=irrelevant,
+        acquired_at=base,
+        label="semantic mismatch",
+    )
+    table_name = ensure_embedding_table(session.connection(), 2)
+    session.execute(
+        text(
+            f"""
+            INSERT INTO {table_name} (chunk_id, model, embedding)
+            VALUES
+                (:anchor, 'qa678', '[1,0]'::vector(2)),
+                (:relevant, 'qa678', '[1,0]'::vector(2)),
+                (:irrelevant, 'qa678', '[0,1]'::vector(2))
+            """
+        ),
+        {"anchor": anchor, "relevant": relevant, "irrelevant": irrelevant},
+    )
+
+    digest = _digest(
+        session,
+        present=[alpha[0]],
+        anchor=anchor,
+        turn_id="semantic-fit",
+        max_entries=1,
+        recall={
+            "per_character_max_entries": 1,
+            "mandatory_reserved_entries": 0,
+            "semantic_fit_weight": 1.0,
+            "event_severity_weight": 0.0,
+            "actor_involvement_weight": 0.0,
+            "emotional_salience_weight": 0.0,
+            "recency_weight": 0.0,
+            "place_match_weight": 0.0,
+        },
+    )
+
+    assert [entry["claim_id"] for entry in digest] == [relevant_claim]
+    components = {
+        int(row["claim_id"]): row["score_components"]
+        for row in session.execute(
+            text(
+                "SELECT claim_id, score_components FROM orrery_recall_trace "
+                "WHERE turn_id = 'semantic-fit'"
+            )
+        ).mappings()
+    }
+    assert components[relevant_claim]["semantic_fit"] == pytest.approx(1.0)
+    assert components[irrelevant_claim]["semantic_fit"] == pytest.approx(0.0)
+
+
+def test_disclosure_suppression_is_logged_and_not_surfaced(session: Session) -> None:
+    base = datetime(2078, 4, 1, tzinfo=timezone.utc)
+    anchor = _chunk(session, label="disclosure anchor", world_time=base, scene=1)
+    alpha = _character(session, "secret-holder")
+    beta = _character(session, "neutral-audience")
+    _present(session, chunk_id=anchor, characters=[alpha, beta])
+    private_claim, _ = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=anchor,
+        acquired_at=base,
+        label="private but possessed",
+        scope="private",
+    )
+
+    digest = _digest(
+        session,
+        present=[alpha[0], beta[0]],
+        anchor=anchor,
+        turn_id="disclosure-suppression",
+    )
+
+    assert private_claim not in {entry.get("claim_id") for entry in digest}
+    trace = (
+        session.execute(
+            text(
+                """
+            SELECT decision, reason, score_components
+            FROM orrery_recall_trace
+            WHERE turn_id = 'disclosure-suppression'
+              AND claim_id = :claim_id
+            """
+            ),
+            {"claim_id": private_claim},
+        )
+        .mappings()
+        .one()
+    )
+    assert trace["decision"] == "suppressed"
+    assert trace["reason"] == "secrecy_threshold"
+    assert trace["score_components"]["disclosure"]["secrecy_marker"] == 1.0
+    assert (
+        session.execute(
+            text("SELECT count(*) FROM claim_awareness WHERE claim_id = :claim_id"),
+            {"claim_id": private_claim},
+        ).scalar_one()
+        == 1
+    )
+
+
+def test_role_obligation_suppresses_unauthorized_audience(session: Session) -> None:
+    base = datetime(2078, 4, 15, tzinfo=timezone.utc)
+    anchor = _chunk(session, label="obligation anchor", world_time=base, scene=1)
+    alpha = _character(session, "obligated-holder")
+    beta = _character(session, "outside-audience")
+    faction_id = _faction(session, "protected-faction")
+    _present(session, chunk_id=anchor, characters=[alpha, beta])
+    bounded_claim, _ = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=anchor,
+        acquired_at=base,
+        label="faction-bound briefing",
+    )
+    obligation_tag_id = int(
+        session.execute(
+            text("SELECT id FROM pair_tags WHERE tag = 'obligation'")
+        ).scalar_one()
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO entity_pair_tags (
+                subject_entity_id, object_entity_id, pair_tag_id,
+                source_kind
+            ) VALUES (
+                :owner_id, :faction_id, :tag_id, 'authored'
+            )
+            """
+        ),
+        {
+            "owner_id": alpha[0],
+            "faction_id": faction_id,
+            "tag_id": obligation_tag_id,
+        },
+    )
+
+    digest = _digest(
+        session,
+        present=[alpha[0], beta[0]],
+        anchor=anchor,
+        turn_id="role-obligation-suppression",
+    )
+
+    assert bounded_claim not in {entry.get("claim_id") for entry in digest}
+    trace = (
+        session.execute(
+            text(
+                """
+                SELECT decision, reason, score_components
+                FROM orrery_recall_trace
+                WHERE turn_id = 'role-obligation-suppression'
+                  AND claim_id = :claim_id
+                """
+            ),
+            {"claim_id": bounded_claim},
+        )
+        .mappings()
+        .one()
+    )
+    assert trace["decision"] == "suppressed"
+    assert trace["reason"] == "role_obligation_threshold"
+    assert trace["score_components"]["disclosure"]["role_obligation_risk"] == 1.0
+
+
+def test_trust_and_shared_status_can_disclose_private_claim(session: Session) -> None:
+    base = datetime(2078, 4, 20, tzinfo=timezone.utc)
+    anchor = _chunk(session, label="trusted anchor", world_time=base, scene=1)
+    alpha = _character(session, "trusted-holder")
+    beta = _character(session, "trusted-audience")
+    faction_id = _faction(session, "shared-faction")
+    _present(session, chunk_id=anchor, characters=[alpha, beta])
+    private_claim, _ = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=anchor,
+        acquired_at=base,
+        label="trusted private briefing",
+        scope="private",
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO character_relationships (
+                character1_id, character2_id, relationship_type,
+                emotional_valence, valence_current, dynamic,
+                recent_events, history
+            ) VALUES (
+                :alpha_id, :beta_id, 'confidant', '+5|devoted', 0.84,
+                'Trusted disclosure fixture.', 'None.', 'Issue 678.'
+            )
+            """
+        ),
+        {"alpha_id": alpha[1], "beta_id": beta[1]},
+    )
+    for character in (alpha, beta):
+        session.execute(
+            text(
+                """
+                INSERT INTO entity_pair_tags (
+                    subject_entity_id, object_entity_id, pair_tag_id,
+                    source_kind
+                )
+                SELECT :character_id, :faction_id, pair_tag.id, 'authored'
+                FROM pair_tags pair_tag
+                WHERE pair_tag.tag = 'status:senior'
+                  AND NOT pair_tag.deprecated
+                """
+            ),
+            {"character_id": character[0], "faction_id": faction_id},
+        )
+
+    digest = _digest(
+        session,
+        present=[alpha[0], beta[0]],
+        anchor=anchor,
+        turn_id="trusted-private-disclosure",
+    )
+
+    assert private_claim in {entry.get("claim_id") for entry in digest}
+    disclosure = session.execute(
+        text(
+            """
+            SELECT score_components -> 'disclosure'
+            FROM orrery_recall_trace
+            WHERE turn_id = 'trusted-private-disclosure'
+              AND claim_id = :claim_id
+            """
+        ),
+        {"claim_id": private_claim},
+    ).scalar_one()
+    assert disclosure["relationship_valence"] == pytest.approx(0.84)
+    assert disclosure["status_edge_match"] == pytest.approx(1.0)
+
+
+def test_per_character_cap_preserves_shared_budget_for_other_actors(
+    session: Session,
+) -> None:
+    base = datetime(2078, 5, 1, tzinfo=timezone.utc)
+    anchor = _chunk(session, label="budget anchor", world_time=base, scene=1)
+    alpha = _character(session, "budget-alpha")
+    beta = _character(session, "budget-beta")
+    _present(session, chunk_id=anchor, characters=[alpha, beta])
+    for index in range(3):
+        _claim(
+            session,
+            owner_entity_id=alpha[0],
+            chunk_id=anchor,
+            acquired_at=base,
+            label=f"alpha-{index}",
+        )
+    beta_claim, _ = _claim(
+        session,
+        owner_entity_id=beta[0],
+        chunk_id=anchor,
+        acquired_at=base,
+        label="beta-only",
+    )
+
+    digest = _digest(
+        session,
+        present=[alpha[0], beta[0]],
+        anchor=anchor,
+        turn_id="per-character-budget",
+        max_entries=3,
+        recall={
+            "per_character_max_entries": 1,
+            "mandatory_reserved_entries": 0,
+        },
+    )
+
+    assert len(digest) == 2
+    assert {entry["character_entity_id"] for entry in digest} == {
+        alpha[0],
+        beta[0],
+    }
+    assert beta_claim in {entry.get("claim_id") for entry in digest}
+    excluded = session.execute(
+        text(
+            """
+            SELECT count(*)
+            FROM orrery_recall_trace
+            WHERE turn_id = 'per-character-budget'
+              AND character_entity_id = :alpha
+              AND decision = 'excluded'
+              AND reason = 'per_character_cap'
+            """
+        ),
+        {"alpha": alpha[0]},
+    ).scalar_one()
+    assert excluded == 2
+
+
+def test_trace_retention_prunes_oldest_rows_per_character(session: Session) -> None:
+    base = datetime(2078, 6, 1, tzinfo=timezone.utc)
+    anchor = _chunk(session, label="retention anchor", world_time=base, scene=1)
+    alpha = _character(session, "retention")
+    _present(session, chunk_id=anchor, characters=[alpha])
+    _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=anchor,
+        acquired_at=base,
+        label="retained knowledge",
+    )
+
+    for turn_id in ("retention-1", "retention-2", "retention-3"):
+        _digest(
+            session,
+            present=[alpha[0]],
+            anchor=anchor,
+            turn_id=turn_id,
+            recall={"trace_rows_per_character": 2},
+        )
+
+    retained_turns = list(
+        session.execute(
+            text(
+                """
+                SELECT turn_id
+                FROM orrery_recall_trace
+                WHERE character_entity_id = :alpha
+                ORDER BY id
+                """
+            ),
+            {"alpha": alpha[0]},
+        ).scalars()
+    )
+    assert retained_turns == ["retention-2", "retention-3"]


### PR DESCRIPTION
Closes #678. Loom-ruled: MECHANICAL — both layers, with logging.

Three questions, three layers, in strict order:

1. **Eligibility (hard boundary)**: possessed accounts + owned experiences only, anchor/timeline-valid. Global MEMNON structurally cannot enter (semantic fit computes from stored chunk/experience vectors only; a missing vector gets a configured trace-visible score rather than expanded entitlement).
2. **Recall ranking (deterministic)**: configurable component weights (`[orrery.recall]`), recall-strength decay as a score modifier that never mutates possession, a reserved mandatory slice for critical newly-acquired accounts, and a per-character budget preventing any actor from consuming the shared knowledge cap.
3. **Disclosure (separate, audience-aware)**: claim scope + directed valence + faction status edges/obligations; suppression is logged with reasons and excludes from the prompt while the character demonstrably still knows.

Migration 106: retention-bounded recall trace (FIFO-pruned per config) — every candidate's include/exclude/suppress decision with score components, the substrate #680's inspector reads. `claim_id` deliberately FK-free (audit-only; replay-safe).

Existing knowledge-surfacing spoiler tests pass unmodified. Zero LLM calls anywhere in the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG