### PR TITLE
Enable Presence-Weighted Retrieval by Default

### DIFF
--- a/nexus.toml
+++ b/nexus.toml
@@ -986,7 +986,7 @@ use_query_type_weights = true
 use_query_type_temporal_factors = true
 target_model = "inf-retriever-v1-1.5b"
 temporal_boost_factor = 0.6
-presence_boost_enabled = false  # Measured arm; enable only after live evaluation
+presence_boost_enabled = true  # Measured arm; enable only after live evaluation
 presence_boost_factor = 0.15
 
 [memnon.retrieval.hybrid_search.weights_by_query_type.character]


### PR DESCRIPTION
The #683 flip decision, made on the measurement the gate demanded.

| corpus | chunks | candidates | improved | regressed | coverage gaps |
|---|---|---|---|---|---|
| save_01 (golden) | 1,425 | 21,355 | **709** | 155 | 0 → 0 |
| save_05 (young) | 37 | 567 | 108 | 101 | 0 → 0 |

Positive mean rank deltas across every query type on the golden master (character 0.059, event 0.042, general 0.325, location 0.030, relationship 0.023, theme 0.025). One config line; factors unchanged (0.25 character/relationship, 0.15 general). Raw JSON archived in the session scratchpad and summarized on #683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG