### PR TITLE
Stamp Pre-Migration Provisional Drafts in the Baseline Boundary Helper

### DIFF
--- a/scripts/stamp_lore_pass_baseline.py
+++ b/scripts/stamp_lore_pass_baseline.py
@@ -26,8 +26,15 @@ from nexus.memory.context_state import bind_pass2_baseline  # noqa: E402
 from nexus.memory.manager import empty_pass2_baseline  # noqa: E402
 
 
-def stamp_slot_tail(slot: int) -> int:
-    """Stamp the slot's accepted tail and return its narrative chunk id."""
+def stamp_slot_tail(slot: int) -> tuple[int, bool, bool]:
+    """Stamp the slot's migration boundary.
+
+    Stamps the accepted tail's canonical baseline row when missing, and
+    backfills the staged (deliberately unbound) baseline onto a pre-migration
+    provisional incubator draft whose lore_pass_baseline is NULL. Returns
+    (tail_chunk_id, tail_stamped, incubator_stamped); raises when the slot has
+    no accepted tail or nothing needed stamping.
+    """
 
     settings = load_settings_as_dict()
     staged = empty_pass2_baseline(settings)
@@ -43,24 +50,37 @@ def stamp_slot_tail(slot: int) -> int:
                 "SELECT 1 FROM lore_pass_baselines WHERE chunk_id = %s",
                 (chunk_id,),
             )
-            if cur.fetchone() is not None:
-                raise RuntimeError(
-                    f"Slot {slot} tail chunk {chunk_id} already has a Pass-2 baseline"
+            tail_stamped = cur.fetchone() is None
+            if tail_stamped:
+                bound = bind_pass2_baseline(staged, chunk_id)
+                cur.execute(
+                    """
+                    INSERT INTO lore_pass_baselines (chunk_id, schema_version, payload)
+                    VALUES (%s, %s, %s::jsonb)
+                    """,
+                    (
+                        chunk_id,
+                        bound.schema_version,
+                        json.dumps(bound.model_dump(mode="json")),
+                    ),
                 )
 
-            bound = bind_pass2_baseline(staged, chunk_id)
             cur.execute(
                 """
-                INSERT INTO lore_pass_baselines (chunk_id, schema_version, payload)
-                VALUES (%s, %s, %s::jsonb)
+                UPDATE incubator
+                SET lore_pass_baseline = %s::jsonb
+                WHERE lore_pass_baseline IS NULL
                 """,
-                (
-                    chunk_id,
-                    bound.schema_version,
-                    json.dumps(bound.model_dump(mode="json")),
-                ),
+                (json.dumps(staged.model_dump(mode="json")),),
             )
-    return chunk_id
+            incubator_stamped = cur.rowcount > 0
+
+            if not tail_stamped and not incubator_stamped:
+                raise RuntimeError(
+                    f"Slot {slot} tail chunk {chunk_id} already has a Pass-2 "
+                    "baseline and no provisional draft needed stamping"
+                )
+    return chunk_id, tail_stamped, incubator_stamped
 
 
 def main(argv: Any = None) -> int:
@@ -69,10 +89,15 @@ def main(argv: Any = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--slot", type=int, choices=range(1, 6), required=True)
     args = parser.parse_args(argv)
-    chunk_id = stamp_slot_tail(args.slot)
+    chunk_id, tail_stamped, incubator_stamped = stamp_slot_tail(args.slot)
+    actions = []
+    if tail_stamped:
+        actions.append(f"tail chunk {chunk_id}")
+    if incubator_stamped:
+        actions.append("provisional incubator draft")
     print(
-        f"Stamped slot {args.slot} tail chunk {chunk_id} with an explicit empty "
-        "Pass-2 migration-boundary baseline."
+        f"Stamped slot {args.slot} {' and '.join(actions)} with an explicit "
+        "empty Pass-2 migration-boundary baseline."
     )
     return 0
 


### PR DESCRIPTION
Found by the #684 live cache validation on a save_05 clone: accepting a provisional draft staged **before** migration 107 fails commit validation on its NULL `lore_pass_baseline` — loud as designed, but the remedy helper only covered accepted tails. It now also backfills the staged (unbound, per the #675 design) empty baseline onto NULL-baseline incubator rows. save_04 and save_05 each carry one affected draft; fleet re-stamp follows merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG