### PR TITLE
Strip the Retired Observations Field from Staged Incubator Drafts

### DIFF
--- a/migrations/108_strip_retired_observations_from_drafts.sql
+++ b/migrations/108_strip_retired_observations_from_drafts.sql
@@ -1,0 +1,28 @@
+-- Remove the retired extra_observations field from staged incubator drafts.
+--
+-- PR #689 retired the observations wire arm: the field was hydrated and then
+-- ignored by both commit paths, so it never produced durable state. Drafts
+-- staged before the retirement still carry it, and the strict StateUpdates
+-- grammar now rejects them at accept time. Stripping the inert field lets
+-- pre-retirement drafts commit; nothing the commit path ever honored is lost.
+-- Idempotent: re-running matches no rows.
+
+UPDATE incubator
+SET entity_updates = jsonb_set(
+    entity_updates,
+    '{characters}',
+    (
+        SELECT jsonb_agg(character_entry - 'extra_observations')
+        FROM jsonb_array_elements(entity_updates -> 'characters')
+            AS character_entry
+    )
+)
+WHERE entity_updates -> 'characters' IS NOT NULL
+  AND jsonb_typeof(entity_updates -> 'characters') = 'array'
+  AND jsonb_array_length(entity_updates -> 'characters') > 0
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(entity_updates -> 'characters')
+          AS character_entry
+      WHERE character_entry ? 'extra_observations'
+  );


### PR DESCRIPTION
Second catch from the #684 live validation on a save_05 clone (first was #704): accepting a draft staged before PR #689's arm retirement fails the strict `StateUpdates` grammar on the retired `extra_observations` field. The field was hydrated-then-ignored by both commit paths for its whole life — stripping it from staged drafts is pure hygiene, losing nothing the engine ever honored. Idempotent migration; affects the provisional drafts on save_04/save_05 (and clones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG