### PR TITLE
Add the End-to-End Character Cognition Inspector

### DIFF
--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -1195,38 +1195,79 @@ def _cognition_source_chain(
     return chain
 
 
-def _cognition_effective_config(orrery_settings: Mapping[str, Any]) -> dict[str, Any]:
-    """Project only cognition-relevant, developer-adjustable configuration."""
+def _required_cognition_config_section(
+    orrery_settings: Mapping[str, Any], section: str
+) -> Mapping[str, Any]:
+    """Return one required Orrery config section or fail with its full name."""
 
-    knowledge = dict(orrery_settings.get("knowledge") or {})
-    recall = dict(orrery_settings.get("recall") or {})
-    disclosure = dict(orrery_settings.get("disclosure") or {})
-    experiences = dict(orrery_settings.get("experiences") or {})
-    epistemics = dict(orrery_settings.get("epistemics") or {})
-    prompt = dict(orrery_settings.get("prompt") or {})
+    if section not in orrery_settings:
+        raise KeyError(f"Missing required cognition config section [orrery.{section}]")
+    value = orrery_settings[section]
+    if not isinstance(value, Mapping):
+        raise TypeError(f"Cognition config [orrery.{section}] must be a mapping")
+    return value
+
+
+def _required_cognition_config_value(
+    section: Mapping[str, Any], section_name: str, key: str
+) -> Any:
+    """Return one required reported value without inventing a dashboard default."""
+
+    if key not in section:
+        raise KeyError(
+            f"Missing required cognition config key [orrery.{section_name}].{key}"
+        )
+    return section[key]
+
+
+def _cognition_effective_config(orrery_settings: Mapping[str, Any]) -> dict[str, Any]:
+    """Project only cognition-relevant config, failing on incomplete truth."""
+
+    knowledge = _required_cognition_config_section(orrery_settings, "knowledge")
+    recall = _required_cognition_config_section(orrery_settings, "recall")
+    disclosure = _required_cognition_config_section(orrery_settings, "disclosure")
+    experiences = _required_cognition_config_section(orrery_settings, "experiences")
+    epistemics = _required_cognition_config_section(orrery_settings, "epistemics")
+    prompt = _required_cognition_config_section(orrery_settings, "prompt")
+
+    def required(section: Mapping[str, Any], section_name: str, key: str) -> Any:
+        return _required_cognition_config_value(section, section_name, key)
+
     return {
         "enabled": {
-            "knowledge": bool(knowledge.get("enabled")),
-            "experiences": bool(experiences.get("enabled")),
-            "epistemics": bool(epistemics.get("enabled")),
+            "knowledge": bool(required(knowledge, "knowledge", "enabled")),
+            "experiences": bool(required(experiences, "experiences", "enabled")),
+            "epistemics": bool(required(epistemics, "epistemics", "enabled")),
         },
         "caps": {
-            "knowledge_max_entries": knowledge.get("max_entries"),
-            "recall_per_character_max_entries": recall.get("per_character_max_entries"),
-            "recall_mandatory_reserved_entries": recall.get(
-                "mandatory_reserved_entries"
+            "knowledge_max_entries": required(knowledge, "knowledge", "max_entries"),
+            "recall_per_character_max_entries": required(
+                recall, "recall", "per_character_max_entries"
             ),
-            "recall_trace_rows_per_character": recall.get("trace_rows_per_character"),
-            "experience_max_seeds_per_render": experiences.get("max_seeds_per_render"),
-            "experience_max_jobs_per_drain": experiences.get("max_jobs_per_drain"),
-            "prompt_max_rendered_proposals": prompt.get("max_rendered_proposals"),
-            "prompt_max_rendered_pressures": prompt.get("max_rendered_pressures"),
-            "prompt_max_rendered_recent_rulings": prompt.get(
-                "max_rendered_recent_rulings"
+            "recall_mandatory_reserved_entries": required(
+                recall, "recall", "mandatory_reserved_entries"
+            ),
+            "recall_trace_rows_per_character": required(
+                recall, "recall", "trace_rows_per_character"
+            ),
+            "experience_max_seeds_per_render": required(
+                experiences, "experiences", "max_seeds_per_render"
+            ),
+            "experience_max_jobs_per_drain": required(
+                experiences, "experiences", "max_jobs_per_drain"
+            ),
+            "prompt_max_rendered_proposals": required(
+                prompt, "prompt", "max_rendered_proposals"
+            ),
+            "prompt_max_rendered_pressures": required(
+                prompt, "prompt", "max_rendered_pressures"
+            ),
+            "prompt_max_rendered_recent_rulings": required(
+                prompt, "prompt", "max_rendered_recent_rulings"
             ),
         },
         "weights": {
-            key: recall.get(key)
+            key: required(recall, "recall", key)
             for key in (
                 "semantic_fit_weight",
                 "event_severity_weight",
@@ -1237,16 +1278,24 @@ def _cognition_effective_config(orrery_settings: Mapping[str, Any]) -> dict[str,
             )
         },
         "thresholds": {
-            "disclosure_minimum_score": disclosure.get("minimum_score"),
-            "disclosure_private_claim_minimum_score": disclosure.get(
-                "private_claim_minimum_score"
+            "disclosure_minimum_score": required(
+                disclosure, "disclosure", "minimum_score"
             ),
-            "recall_decay_half_life_hours": recall.get("decay_half_life_hours"),
-            "recall_recency_horizon_hours": recall.get("recency_horizon_hours"),
+            "disclosure_private_claim_minimum_score": required(
+                disclosure, "disclosure", "private_claim_minimum_score"
+            ),
+            "recall_decay_half_life_hours": required(
+                recall, "recall", "decay_half_life_hours"
+            ),
+            "recall_recency_horizon_hours": required(
+                recall, "recall", "recency_horizon_hours"
+            ),
         },
         "producer_coverage": {
-            "claim_event_types": list(epistemics.get("claim_event_types") or []),
-            "aware_roles": list(epistemics.get("aware_roles") or []),
+            "claim_event_types": list(
+                required(epistemics, "epistemics", "claim_event_types")
+            ),
+            "aware_roles": list(required(epistemics, "epistemics", "aware_roles")),
             "experience_basis": ["participant", "witness", "acquisition"],
         },
     }
@@ -1333,15 +1382,10 @@ def cognition_trace(
                        claim.summary, claim.scope, claim.account_label,
                        claim.account_payload, claim.distorted_from_claim_id,
                        claim.distortion_min_depth,
-                       incident.event_type, incident.tick_chunk_id,
-                       incident.actor_entity_id, incident.target_entity_id,
-                       incident.location_id, incident.world_time,
-                       event_type.severity::text AS event_severity,
                        propagated.depth
                 FROM claim_awareness awareness
                 JOIN claims claim ON claim.id = awareness.claim_id
                 JOIN world_events incident ON incident.id = claim.world_event_id
-                JOIN event_types event_type ON event_type.type = incident.event_type
                 JOIN chunk_metadata source_meta ON source_meta.chunk_id =
                     COALESCE(awareness.source_chunk_id, claim.source_chunk_id)
                 CROSS JOIN anchor
@@ -1370,7 +1414,14 @@ def cognition_trace(
                   AND NOT EXISTS (
                       SELECT 1 FROM backstory_secrets secret
                       WHERE secret.claim_id = claim.id
-                        AND secret.status = 'latent'
+                        AND COALESCE(
+                            secret.source_chunk_id, claim.source_chunk_id
+                        ) <= :anchor_chunk_id
+                        AND (
+                            secret.revealed_by_chunk_id IS NULL
+                            OR secret.revealed_by_chunk_id > :anchor_chunk_id
+                        )
+                        AND secret.status <> 'retired'
                   )
                 ORDER BY awareness.id
                 """
@@ -1383,8 +1434,6 @@ def cognition_trace(
         for key in (
             "immediate_source_entity_id",
             "root_source_entity_id",
-            "actor_entity_id",
-            "target_entity_id",
         ):
             if row[key] is not None:
                 referenced_ids.add(int(row[key]))
@@ -1412,13 +1461,6 @@ def cognition_trace(
                 },
                 "source_event": {
                     "event_id": int(row["world_event_id"]),
-                    "event_type": str(row["event_type"]),
-                    "severity": row["event_severity"],
-                    "tick_chunk_id": int(row["tick_chunk_id"]),
-                    "actor_entity_id": row["actor_entity_id"],
-                    "target_entity_id": row["target_entity_id"],
-                    "location_id": row["location_id"],
-                    "world_time": _iso(row["world_time"]),
                 },
             }
         )
@@ -1442,8 +1484,16 @@ def cognition_trace(
                   )
                   AND NOT EXISTS (
                       SELECT 1 FROM backstory_secrets secret
+                      JOIN claims secret_claim ON secret_claim.id = secret.claim_id
                       WHERE secret.claim_id = experience.claim_id
-                        AND secret.status = 'latent'
+                        AND COALESCE(
+                            secret.source_chunk_id, secret_claim.source_chunk_id
+                        ) <= :anchor_chunk_id
+                        AND (
+                            secret.revealed_by_chunk_id IS NULL
+                            OR secret.revealed_by_chunk_id > :anchor_chunk_id
+                        )
+                        AND secret.status <> 'retired'
                   )
                 ORDER BY experience.anchor_chunk_id, experience.id
                 """
@@ -1456,41 +1506,6 @@ def cognition_trace(
             },
         ).mappings()
     )
-    event_ids = sorted(
-        {
-            int(event_id)
-            for row in experience_rows
-            for event_id in row["world_event_ids"]
-        }
-    )
-    events_by_id: dict[int, dict[str, Any]] = {}
-    if event_ids:
-        for row in session.execute(
-            text(
-                """
-                /* orrery_audit:cognition_experience_events */
-                SELECT event.id, event.event_type, event.tick_chunk_id,
-                       event.actor_entity_id, event.target_entity_id,
-                       event.location_id, event.world_time,
-                       event_type.severity::text AS severity
-                FROM world_events event
-                JOIN event_types event_type ON event_type.type = event.event_type
-                WHERE event.id = ANY(:event_ids)
-                ORDER BY event.tick_chunk_id, event.id
-                """
-            ),
-            {"event_ids": event_ids},
-        ).mappings():
-            events_by_id[int(row["id"])] = {
-                "event_id": int(row["id"]),
-                "event_type": str(row["event_type"]),
-                "severity": row["severity"],
-                "tick_chunk_id": int(row["tick_chunk_id"]),
-                "actor_entity_id": row["actor_entity_id"],
-                "target_entity_id": row["target_entity_id"],
-                "location_id": row["location_id"],
-                "world_time": _iso(row["world_time"]),
-            }
     experiences: list[dict[str, Any]] = []
     for row in experience_rows:
         rendered = row["experience_text"] is not None
@@ -1523,8 +1538,8 @@ def cognition_trace(
                 "source_digest": str(row["source_digest"]),
                 "world_layer": str(row["world_layer"]),
                 "invalidated_at": _iso(row["invalidated_at"]),
-                "source_events": [
-                    events_by_id[int(event_id)] for event_id in row["world_event_ids"]
+                "source_event_ids": [
+                    int(event_id) for event_id in row["world_event_ids"]
                 ],
             }
         )
@@ -1536,8 +1551,13 @@ def cognition_trace(
                 /* orrery_audit:cognition_recall_trace */
                 SELECT trace.*,
                        COALESCE(claim.summary, experience.seed_summary) AS summary,
-                       COALESCE(claim.source_chunk_id,
-                                experience.anchor_chunk_id) AS source_chunk_id
+                       CASE
+                           WHEN trace.candidate_kind = 'claim'
+                           THEN COALESCE(
+                               awareness.source_chunk_id, claim.source_chunk_id
+                           )
+                           ELSE experience.anchor_chunk_id
+                       END AS source_chunk_id
                 FROM orrery_recall_trace trace
                 LEFT JOIN claim_awareness awareness
                   ON trace.candidate_kind = 'claim'
@@ -1730,17 +1750,31 @@ def cognition_trace(
             text(
                 """
                 /* orrery_audit:cognition_unpossessed_siblings */
-                WITH possessed_incidents AS (
+                WITH anchor AS (
+                    SELECT cm.world_time, nc.created_at
+                    FROM chunk_metadata cm
+                    JOIN narrative_chunks nc ON nc.id = cm.chunk_id
+                    WHERE cm.chunk_id = :anchor_chunk_id
+                ),
+                possessed_incidents AS (
                     SELECT DISTINCT claim.world_event_id
                     FROM claim_awareness awareness
                     JOIN claims claim ON claim.id = awareness.claim_id
+                    CROSS JOIN anchor
                     WHERE awareness.knower_entity_id = :entity_id
                       AND (
-                          awareness.source_chunk_id <= :anchor_chunk_id
+                          (
+                              awareness.source_chunk_id IS NOT NULL
+                              AND awareness.source_chunk_id <= :anchor_chunk_id
+                          )
                           OR (
                               awareness.source_chunk_id IS NULL
-                              AND claim.source_chunk_id <= :anchor_chunk_id
+                              AND awareness.created_at <= anchor.created_at
                           )
+                      )
+                      AND (
+                          awareness.acquired_at_world_time IS NULL
+                          OR awareness.acquired_at_world_time <= anchor.world_time
                       )
                 )
                 SELECT claim.id AS claim_id, claim.world_event_id,
@@ -1751,11 +1785,26 @@ def cognition_trace(
                 JOIN possessed_incidents incident
                   ON incident.world_event_id = claim.world_event_id
                 JOIN world_events event ON event.id = claim.world_event_id
+                CROSS JOIN anchor
                 WHERE event.tick_chunk_id <= :anchor_chunk_id
                   AND NOT EXISTS (
                       SELECT 1 FROM claim_awareness awareness
                       WHERE awareness.claim_id = claim.id
                         AND awareness.knower_entity_id = :entity_id
+                        AND (
+                            (
+                                awareness.source_chunk_id IS NOT NULL
+                                AND awareness.source_chunk_id <= :anchor_chunk_id
+                            )
+                            OR (
+                                awareness.source_chunk_id IS NULL
+                                AND awareness.created_at <= anchor.created_at
+                            )
+                        )
+                        AND (
+                            awareness.acquired_at_world_time IS NULL
+                            OR awareness.acquired_at_world_time <= anchor.world_time
+                        )
                   )
                 ORDER BY claim.world_event_id, claim.id
                 """
@@ -1767,26 +1816,36 @@ def cognition_trace(
         {
             "secret_id": int(row["secret_id"]),
             "claim_id": int(row["claim_id"]),
+            "world_event_id": int(row["world_event_id"]),
             "summary": str(row["summary"]),
             "account_payload": row["account_payload"],
             "gate_template_id": str(row["gate_template_id"]),
             "holder_entity_id": int(row["holder_entity_id"]),
             "source_chunk_id": row["source_chunk_id"],
-            "status": str(row["status"]),
+            "status": str(row["status_at_anchor"]),
         }
         for row in session.execute(
             text(
                 """
                 /* orrery_audit:cognition_latent_secrets */
                 SELECT secret.id AS secret_id, secret.claim_id,
+                       claim.world_event_id,
                        claim.summary, claim.account_payload,
                        secret.gate_template_id, secret.holder_entity_id,
-                       secret.source_chunk_id, secret.status
+                       secret.source_chunk_id,
+                       'latent'::text AS status_at_anchor
                 FROM backstory_secrets secret
                 JOIN claims claim ON claim.id = secret.claim_id
                 JOIN world_events event ON event.id = claim.world_event_id
                 WHERE secret.holder_entity_id = :entity_id
-                  AND secret.status = 'latent'
+                  AND COALESCE(
+                      secret.source_chunk_id, claim.source_chunk_id
+                  ) <= :anchor_chunk_id
+                  AND (
+                      secret.revealed_by_chunk_id IS NULL
+                      OR secret.revealed_by_chunk_id > :anchor_chunk_id
+                  )
+                  AND secret.status <> 'retired'
                   AND event.tick_chunk_id <= :anchor_chunk_id
                 ORDER BY secret.id
                 """
@@ -1794,6 +1853,46 @@ def cognition_trace(
             {"entity_id": entity_id, "anchor_chunk_id": anchor_chunk_id},
         ).mappings()
     ]
+
+    canonical_event_ids = (
+        {int(row["world_event_id"]) for row in account_rows}
+        | {int(row["world_event_id"]) for row in sibling_accounts}
+        | {int(row["world_event_id"]) for row in latent_secrets}
+    )
+    canonical_event_ids.update(
+        int(event_id) for row in experience_rows for event_id in row["world_event_ids"]
+    )
+    canonical_source_events: list[dict[str, Any]] = []
+    if canonical_event_ids:
+        for row in session.execute(
+            text(
+                """
+                /* orrery_audit:cognition_canonical_source_events */
+                SELECT event.id, event.event_type, event.tick_chunk_id,
+                       event.actor_entity_id, event.target_entity_id,
+                       event.location_id, event.world_time, event.payload,
+                       event_type.severity::text AS severity
+                FROM world_events event
+                JOIN event_types event_type ON event_type.type = event.event_type
+                WHERE event.id = ANY(:event_ids)
+                ORDER BY event.tick_chunk_id, event.id
+                """
+            ),
+            {"event_ids": sorted(canonical_event_ids)},
+        ).mappings():
+            canonical_source_events.append(
+                {
+                    "event_id": int(row["id"]),
+                    "event_type": str(row["event_type"]),
+                    "severity": row["severity"],
+                    "tick_chunk_id": int(row["tick_chunk_id"]),
+                    "actor_entity_id": row["actor_entity_id"],
+                    "target_entity_id": row["target_entity_id"],
+                    "location_id": row["location_id"],
+                    "world_time": _iso(row["world_time"]),
+                    "payload": row["payload"],
+                }
+            )
 
     render_generation_ids = sorted(
         {
@@ -1836,6 +1935,7 @@ def cognition_trace(
         "effective_config": _cognition_effective_config(orrery_settings),
         "canonical_truth": {
             "guarded": True,
+            "source_events": canonical_source_events,
             "unpossessed_sibling_accounts": sibling_accounts,
             "latent_secrets": latent_secrets,
         },

--- a/nexus/agents/orrery/audit.py
+++ b/nexus/agents/orrery/audit.py
@@ -1158,6 +1158,690 @@ def _iso(value: Optional[datetime]) -> Optional[str]:
     return value.isoformat() if value is not None else None
 
 
+def _cognition_source_chain(
+    row: Mapping[str, Any], entity_names: Mapping[int, str]
+) -> list[dict[str, Any]]:
+    """Build an ordered acquisition chain without inferring missing sources."""
+
+    chain: list[dict[str, Any]] = []
+    root_id = row.get("root_source_entity_id")
+    immediate_id = row.get("immediate_source_entity_id")
+    if root_id is not None:
+        root = int(root_id)
+        chain.append(
+            {
+                "kind": "root_source",
+                "entity_id": root,
+                "name": _entity_label(root, entity_names),
+            }
+        )
+    if immediate_id is not None and immediate_id != root_id:
+        immediate = int(immediate_id)
+        chain.append(
+            {
+                "kind": "immediate_source",
+                "entity_id": immediate,
+                "name": _entity_label(immediate, entity_names),
+            }
+        )
+    owner = int(row["character_entity_id"])
+    chain.append(
+        {
+            "kind": "possession",
+            "entity_id": owner,
+            "name": _entity_label(owner, entity_names),
+        }
+    )
+    return chain
+
+
+def _cognition_effective_config(orrery_settings: Mapping[str, Any]) -> dict[str, Any]:
+    """Project only cognition-relevant, developer-adjustable configuration."""
+
+    knowledge = dict(orrery_settings.get("knowledge") or {})
+    recall = dict(orrery_settings.get("recall") or {})
+    disclosure = dict(orrery_settings.get("disclosure") or {})
+    experiences = dict(orrery_settings.get("experiences") or {})
+    epistemics = dict(orrery_settings.get("epistemics") or {})
+    prompt = dict(orrery_settings.get("prompt") or {})
+    return {
+        "enabled": {
+            "knowledge": bool(knowledge.get("enabled")),
+            "experiences": bool(experiences.get("enabled")),
+            "epistemics": bool(epistemics.get("enabled")),
+        },
+        "caps": {
+            "knowledge_max_entries": knowledge.get("max_entries"),
+            "recall_per_character_max_entries": recall.get("per_character_max_entries"),
+            "recall_mandatory_reserved_entries": recall.get(
+                "mandatory_reserved_entries"
+            ),
+            "recall_trace_rows_per_character": recall.get("trace_rows_per_character"),
+            "experience_max_seeds_per_render": experiences.get("max_seeds_per_render"),
+            "experience_max_jobs_per_drain": experiences.get("max_jobs_per_drain"),
+            "prompt_max_rendered_proposals": prompt.get("max_rendered_proposals"),
+            "prompt_max_rendered_pressures": prompt.get("max_rendered_pressures"),
+            "prompt_max_rendered_recent_rulings": prompt.get(
+                "max_rendered_recent_rulings"
+            ),
+        },
+        "weights": {
+            key: recall.get(key)
+            for key in (
+                "semantic_fit_weight",
+                "event_severity_weight",
+                "actor_involvement_weight",
+                "emotional_salience_weight",
+                "recency_weight",
+                "place_match_weight",
+            )
+        },
+        "thresholds": {
+            "disclosure_minimum_score": disclosure.get("minimum_score"),
+            "disclosure_private_claim_minimum_score": disclosure.get(
+                "private_claim_minimum_score"
+            ),
+            "recall_decay_half_life_hours": recall.get("decay_half_life_hours"),
+            "recall_recency_horizon_hours": recall.get("recency_horizon_hours"),
+        },
+        "producer_coverage": {
+            "claim_event_types": list(epistemics.get("claim_event_types") or []),
+            "aware_roles": list(epistemics.get("aware_roles") or []),
+            "experience_basis": ["participant", "witness", "acquisition"],
+        },
+    }
+
+
+def cognition_trace(
+    session: Any,
+    entity_id: int,
+    *,
+    anchor_chunk_id: int,
+    orrery_settings: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return one character's cognition chain at an accepted scene anchor.
+
+    Actor-facing material is assembled only from possession rows, actor-owned
+    experiences, and durable recall/exposure traces. Unpossessed sibling
+    accounts and latent secrets are queried independently into
+    ``canonical_truth`` so callers cannot accidentally interleave them.
+    """
+
+    if entity_id <= 0 or anchor_chunk_id <= 0:
+        raise ValueError("entity_id and anchor_chunk_id must be positive")
+    anchor = (
+        session.execute(
+            text(
+                """
+            /* orrery_audit:cognition_anchor */
+            SELECT cm.chunk_id, cm.world_time,
+                   cm.world_layer::text AS world_layer,
+                   cm.season, cm.episode, cm.scene,
+                   nc.created_at
+            FROM chunk_metadata cm
+            JOIN narrative_chunks nc ON nc.id = cm.chunk_id
+            WHERE cm.chunk_id = :anchor_chunk_id
+            """
+            ),
+            {"anchor_chunk_id": anchor_chunk_id},
+        )
+        .mappings()
+        .first()
+    )
+    if anchor is None:
+        raise ValueError(f"Anchor chunk {anchor_chunk_id} has no timeline metadata")
+    character = (
+        session.execute(
+            text(
+                """
+            /* orrery_audit:cognition_character */
+            SELECT character.entity_id, character.name
+            FROM characters character
+            JOIN entities entity ON entity.id = character.entity_id
+            WHERE character.entity_id = :entity_id
+              AND entity.is_active = true
+            """
+            ),
+            {"entity_id": entity_id},
+        )
+        .mappings()
+        .first()
+    )
+    if character is None:
+        raise ValueError(f"Entity {entity_id} is not an active character")
+
+    account_rows = list(
+        session.execute(
+            text(
+                """
+                /* orrery_audit:cognition_possessed_accounts */
+                WITH anchor AS (
+                    SELECT cm.world_layer::text AS world_layer,
+                           cm.world_time, nc.created_at
+                    FROM chunk_metadata cm
+                    JOIN narrative_chunks nc ON nc.id = cm.chunk_id
+                    WHERE cm.chunk_id = :anchor_chunk_id
+                )
+                SELECT awareness.id AS awareness_id,
+                       awareness.knower_entity_id AS character_entity_id,
+                       awareness.source_tier, awareness.channel,
+                       awareness.immediate_source_entity_id,
+                       awareness.root_source_entity_id,
+                       awareness.acquired_at_world_time,
+                       awareness.source_chunk_id AS acquisition_chunk_id,
+                       claim.id AS claim_id, claim.world_event_id,
+                       claim.summary, claim.scope, claim.account_label,
+                       claim.account_payload, claim.distorted_from_claim_id,
+                       claim.distortion_min_depth,
+                       incident.event_type, incident.tick_chunk_id,
+                       incident.actor_entity_id, incident.target_entity_id,
+                       incident.location_id, incident.world_time,
+                       event_type.severity::text AS event_severity,
+                       propagated.depth
+                FROM claim_awareness awareness
+                JOIN claims claim ON claim.id = awareness.claim_id
+                JOIN world_events incident ON incident.id = claim.world_event_id
+                JOIN event_types event_type ON event_type.type = incident.event_type
+                JOIN chunk_metadata source_meta ON source_meta.chunk_id =
+                    COALESCE(awareness.source_chunk_id, claim.source_chunk_id)
+                CROSS JOIN anchor
+                LEFT JOIN LATERAL (
+                    SELECT (event.payload ->> 'depth')::integer AS depth
+                    FROM world_events event
+                    WHERE event.event_type = 'claim_propagated'
+                      AND event.payload ? 'awareness_id'
+                      AND (event.payload ->> 'awareness_id')::bigint = awareness.id
+                    ORDER BY event.id DESC
+                    LIMIT 1
+                ) propagated ON TRUE
+                WHERE awareness.knower_entity_id = :entity_id
+                  AND incident.tick_chunk_id <= :anchor_chunk_id
+                  AND source_meta.chunk_id <= :anchor_chunk_id
+                  AND source_meta.world_layer::text IS NOT DISTINCT FROM
+                      anchor.world_layer
+                  AND (
+                      awareness.acquired_at_world_time IS NULL
+                      OR awareness.acquired_at_world_time <= anchor.world_time
+                  )
+                  AND (
+                      awareness.source_chunk_id IS NOT NULL
+                      OR awareness.created_at <= anchor.created_at
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM backstory_secrets secret
+                      WHERE secret.claim_id = claim.id
+                        AND secret.status = 'latent'
+                  )
+                ORDER BY awareness.id
+                """
+            ),
+            {"entity_id": entity_id, "anchor_chunk_id": anchor_chunk_id},
+        ).mappings()
+    )
+    referenced_ids = {entity_id}
+    for row in account_rows:
+        for key in (
+            "immediate_source_entity_id",
+            "root_source_entity_id",
+            "actor_entity_id",
+            "target_entity_id",
+        ):
+            if row[key] is not None:
+                referenced_ids.add(int(row[key]))
+    entity_names = _load_entity_names(session, referenced_ids)
+
+    accounts: list[dict[str, Any]] = []
+    for row in account_rows:
+        accounts.append(
+            {
+                "awareness_id": int(row["awareness_id"]),
+                "claim_id": int(row["claim_id"]),
+                "summary": str(row["summary"]),
+                "scope": str(row["scope"]),
+                "account_label": str(row["account_label"]),
+                "account_payload": row["account_payload"],
+                "distorted_from_claim_id": row["distorted_from_claim_id"],
+                "distortion_min_depth": row["distortion_min_depth"],
+                "possession": {
+                    "source_tier": str(row["source_tier"]),
+                    "channel": row["channel"],
+                    "acquisition_chunk_id": row["acquisition_chunk_id"],
+                    "acquired_at_world_time": _iso(row["acquired_at_world_time"]),
+                    "propagation_depth": row["depth"],
+                    "source_chain": _cognition_source_chain(row, entity_names),
+                },
+                "source_event": {
+                    "event_id": int(row["world_event_id"]),
+                    "event_type": str(row["event_type"]),
+                    "severity": row["event_severity"],
+                    "tick_chunk_id": int(row["tick_chunk_id"]),
+                    "actor_entity_id": row["actor_entity_id"],
+                    "target_entity_id": row["target_entity_id"],
+                    "location_id": row["location_id"],
+                    "world_time": _iso(row["world_time"]),
+                },
+            }
+        )
+
+    experience_rows = list(
+        session.execute(
+            text(
+                """
+                /* orrery_audit:cognition_experiences */
+                SELECT experience.*
+                FROM character_experiences experience
+                JOIN chunk_metadata source_meta
+                  ON source_meta.chunk_id = experience.anchor_chunk_id
+                WHERE experience.character_entity_id = :entity_id
+                  AND experience.anchor_chunk_id <= :anchor_chunk_id
+                  AND source_meta.world_layer::text IS NOT DISTINCT FROM
+                      :world_layer
+                  AND (
+                      experience.world_time IS NULL
+                      OR experience.world_time <= :anchor_world_time
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM backstory_secrets secret
+                      WHERE secret.claim_id = experience.claim_id
+                        AND secret.status = 'latent'
+                  )
+                ORDER BY experience.anchor_chunk_id, experience.id
+                """
+            ),
+            {
+                "entity_id": entity_id,
+                "anchor_chunk_id": anchor_chunk_id,
+                "world_layer": anchor["world_layer"],
+                "anchor_world_time": anchor["world_time"],
+            },
+        ).mappings()
+    )
+    event_ids = sorted(
+        {
+            int(event_id)
+            for row in experience_rows
+            for event_id in row["world_event_ids"]
+        }
+    )
+    events_by_id: dict[int, dict[str, Any]] = {}
+    if event_ids:
+        for row in session.execute(
+            text(
+                """
+                /* orrery_audit:cognition_experience_events */
+                SELECT event.id, event.event_type, event.tick_chunk_id,
+                       event.actor_entity_id, event.target_entity_id,
+                       event.location_id, event.world_time,
+                       event_type.severity::text AS severity
+                FROM world_events event
+                JOIN event_types event_type ON event_type.type = event.event_type
+                WHERE event.id = ANY(:event_ids)
+                ORDER BY event.tick_chunk_id, event.id
+                """
+            ),
+            {"event_ids": event_ids},
+        ).mappings():
+            events_by_id[int(row["id"])] = {
+                "event_id": int(row["id"]),
+                "event_type": str(row["event_type"]),
+                "severity": row["severity"],
+                "tick_chunk_id": int(row["tick_chunk_id"]),
+                "actor_entity_id": row["actor_entity_id"],
+                "target_entity_id": row["target_entity_id"],
+                "location_id": row["location_id"],
+                "world_time": _iso(row["world_time"]),
+            }
+    experiences: list[dict[str, Any]] = []
+    for row in experience_rows:
+        rendered = row["experience_text"] is not None
+        status = (
+            "invalidated"
+            if str(row["invalidation_status"]) == "invalidated"
+            else ("rendered" if rendered else "unrendered")
+        )
+        experiences.append(
+            {
+                "experience_id": int(row["id"]),
+                "anchor_chunk_id": int(row["anchor_chunk_id"]),
+                "basis": str(row["basis"]),
+                "claim_id": row["claim_id"],
+                "claim_awareness_id": row["claim_awareness_id"],
+                "location_id": row["location_id"],
+                "world_time": _iso(row["world_time"]),
+                "seed_summary": str(row["seed_summary"]),
+                "experience_text": row["experience_text"],
+                "emotion": row["emotion"],
+                "salience": float(row["salience"]),
+                "render_status": status,
+                "render_model": row["render_model"],
+                "renderer_version": row["renderer_version"],
+                "render_generation_id": (
+                    str(row["render_generation_id"])
+                    if row["render_generation_id"] is not None
+                    else None
+                ),
+                "source_digest": str(row["source_digest"]),
+                "world_layer": str(row["world_layer"]),
+                "invalidated_at": _iso(row["invalidated_at"]),
+                "source_events": [
+                    events_by_id[int(event_id)] for event_id in row["world_event_ids"]
+                ],
+            }
+        )
+
+    trace_rows = list(
+        session.execute(
+            text(
+                """
+                /* orrery_audit:cognition_recall_trace */
+                SELECT trace.*,
+                       COALESCE(claim.summary, experience.seed_summary) AS summary,
+                       COALESCE(claim.source_chunk_id,
+                                experience.anchor_chunk_id) AS source_chunk_id
+                FROM orrery_recall_trace trace
+                LEFT JOIN claim_awareness awareness
+                  ON trace.candidate_kind = 'claim'
+                 AND awareness.id = trace.candidate_id
+                LEFT JOIN claims claim ON claim.id = awareness.claim_id
+                LEFT JOIN character_experiences experience
+                  ON trace.candidate_kind = 'experience'
+                 AND experience.id = trace.candidate_id
+                WHERE trace.character_entity_id = :entity_id
+                  AND trace.anchor_chunk_id = :anchor_chunk_id
+                ORDER BY trace.created_at, trace.id
+                """
+            ),
+            {"entity_id": entity_id, "anchor_chunk_id": anchor_chunk_id},
+        ).mappings()
+    )
+    recall_candidates: list[dict[str, Any]] = []
+    disclosure_results: list[dict[str, Any]] = []
+    knowledge_exposures: list[dict[str, Any]] = []
+    for row in trace_rows:
+        components = dict(row["score_components"])
+        disclosure = dict(components.get("disclosure") or {})
+        candidate = {
+            "trace_id": int(row["id"]),
+            "turn_id": str(row["turn_id"]),
+            "candidate_kind": str(row["candidate_kind"]),
+            "candidate_id": int(row["candidate_id"]),
+            "claim_id": row["claim_id"],
+            "summary": row["summary"],
+            "source_chunk_id": row["source_chunk_id"],
+            "decision": str(row["decision"]),
+            "reason": str(row["reason"]),
+            "mandatory": bool(row["mandatory"]),
+            "score": float(row["score"]),
+            "score_components": components,
+            "threshold": disclosure.get("threshold"),
+            "truncated": str(row["decision"]) == "excluded",
+            "created_at": _iso(row["created_at"]),
+        }
+        recall_candidates.append(candidate)
+        if row["decision"] in {"included", "suppressed"}:
+            disclosure_results.append(
+                {
+                    "trace_id": int(row["id"]),
+                    "candidate_kind": str(row["candidate_kind"]),
+                    "candidate_id": int(row["candidate_id"]),
+                    "allowed": row["decision"] == "included",
+                    "reason": str(row["reason"]),
+                    "blocking_reasons": (
+                        [] if row["decision"] == "included" else [str(row["reason"])]
+                    ),
+                    "components": disclosure,
+                }
+            )
+        if row["decision"] == "included":
+            knowledge_exposures.append(
+                {
+                    "kind": "knowledge_surfacing",
+                    "trace_id": int(row["id"]),
+                    "turn_id": str(row["turn_id"]),
+                    "candidate_kind": str(row["candidate_kind"]),
+                    "candidate_id": int(row["candidate_id"]),
+                    "summary": row["summary"],
+                    "position": len(knowledge_exposures),
+                }
+            )
+
+    proposal_exposures: list[dict[str, Any]] = []
+    for row in session.execute(
+        text(
+            """
+            /* orrery_audit:cognition_prompt_exposures */
+            SELECT exposure.id, exposure.kind, exposure.proposal_id,
+                   exposure.template_id, exposure.binding_hash,
+                   exposure.position, exposure.created_at,
+                   resolution.actor_entity_id AS resolution_actor_entity_id,
+                   resolution.brief, resolution.state_delta,
+                   pressure.actor_entity_id AS pressure_actor_entity_id,
+                   pressure.target_entity_id AS pressure_target_entity_id,
+                   pressure.prompt_text, pressure.bindings
+            FROM orrery_prompt_exposures exposure
+            LEFT JOIN orrery_resolutions resolution
+              ON exposure.kind = 'resolution'
+             AND resolution.tick_chunk_id = exposure.tick_chunk_id
+             AND resolution.template_id = exposure.template_id
+             AND resolution.binding_hash = exposure.binding_hash
+            LEFT JOIN orrery_scene_pressures pressure
+              ON exposure.kind = 'scene_pressure'
+             AND pressure.tick_chunk_id = exposure.tick_chunk_id
+             AND pressure.template_id = exposure.template_id
+             AND pressure.binding_hash = exposure.binding_hash
+            WHERE exposure.tick_chunk_id = :anchor_chunk_id
+              AND (
+                  resolution.actor_entity_id = :entity_id
+                  OR pressure.actor_entity_id = :entity_id
+                  OR pressure.target_entity_id = :entity_id
+              )
+            ORDER BY exposure.kind, exposure.position, exposure.id
+            """
+        ),
+        {"entity_id": entity_id, "anchor_chunk_id": anchor_chunk_id},
+    ).mappings():
+        proposal_exposures.append(
+            {
+                "kind": str(row["kind"]),
+                "exposure_id": int(row["id"]),
+                "proposal_id": str(row["proposal_id"]),
+                "template_id": str(row["template_id"]),
+                "binding_hash": str(row["binding_hash"]),
+                "position": int(row["position"]),
+                "created_at": _iso(row["created_at"]),
+                "actor_entity_id": (
+                    row["resolution_actor_entity_id"]
+                    if row["kind"] == "resolution"
+                    else row["pressure_actor_entity_id"]
+                ),
+                "target_entity_id": row["pressure_target_entity_id"],
+                "payload": (
+                    {
+                        "brief": row["brief"],
+                        "state_delta": row["state_delta"],
+                    }
+                    if row["kind"] == "resolution"
+                    else {
+                        "prompt_text": row["prompt_text"],
+                        "bindings": row["bindings"],
+                    }
+                ),
+            }
+        )
+
+    experience_ids = [row["experience_id"] for row in experiences]
+    jobs: list[dict[str, Any]] = []
+    if experience_ids:
+        for row in session.execute(
+            text(
+                """
+                /* orrery_audit:cognition_experience_jobs */
+                SELECT *
+                FROM character_experience_jobs
+                WHERE experience_ids && CAST(:experience_ids AS bigint[])
+                ORDER BY boundary_chunk_id, batch_ordinal, id
+                """
+            ),
+            {"experience_ids": experience_ids},
+        ).mappings():
+            jobs.append(
+                {
+                    "job_id": int(row["id"]),
+                    "state": str(row["state"]),
+                    "attempts": int(row["attempts"]),
+                    "available_at": _iso(row["available_at"]),
+                    "lease_until": _iso(row["lease_until"]),
+                    "locked_by": row["locked_by"],
+                    "lease_nonce": (
+                        str(row["lease_nonce"])
+                        if row["lease_nonce"] is not None
+                        else None
+                    ),
+                    "last_error": row["last_error"],
+                    "requested_model": str(row["requested_model"]),
+                    "source_digest": str(row["source_digest"]),
+                    "experience_ids": list(row["experience_ids"]),
+                    "timeline_identity": {
+                        "world_layer": str(row["world_layer"]),
+                        "boundary_chunk_id": int(row["boundary_chunk_id"]),
+                        "boundary_season": int(row["boundary_season"]),
+                        "boundary_episode": int(row["boundary_episode"]),
+                        "boundary_scene": int(row["boundary_scene"]),
+                        "scene_end_chunk_id": int(row["scene_end_chunk_id"]),
+                        "scene_end_season": int(row["scene_end_season"]),
+                        "scene_end_episode": int(row["scene_end_episode"]),
+                        "scene_end_scene": int(row["scene_end_scene"]),
+                    },
+                }
+            )
+
+    sibling_accounts = [
+        {
+            "claim_id": int(row["claim_id"]),
+            "world_event_id": int(row["world_event_id"]),
+            "summary": str(row["summary"]),
+            "scope": str(row["scope"]),
+            "account_label": str(row["account_label"]),
+            "account_payload": row["account_payload"],
+            "distorted_from_claim_id": row["distorted_from_claim_id"],
+            "distortion_min_depth": row["distortion_min_depth"],
+        }
+        for row in session.execute(
+            text(
+                """
+                /* orrery_audit:cognition_unpossessed_siblings */
+                WITH possessed_incidents AS (
+                    SELECT DISTINCT claim.world_event_id
+                    FROM claim_awareness awareness
+                    JOIN claims claim ON claim.id = awareness.claim_id
+                    WHERE awareness.knower_entity_id = :entity_id
+                      AND (
+                          awareness.source_chunk_id <= :anchor_chunk_id
+                          OR (
+                              awareness.source_chunk_id IS NULL
+                              AND claim.source_chunk_id <= :anchor_chunk_id
+                          )
+                      )
+                )
+                SELECT claim.id AS claim_id, claim.world_event_id,
+                       claim.summary, claim.scope, claim.account_label,
+                       claim.account_payload, claim.distorted_from_claim_id,
+                       claim.distortion_min_depth
+                FROM claims claim
+                JOIN possessed_incidents incident
+                  ON incident.world_event_id = claim.world_event_id
+                JOIN world_events event ON event.id = claim.world_event_id
+                WHERE event.tick_chunk_id <= :anchor_chunk_id
+                  AND NOT EXISTS (
+                      SELECT 1 FROM claim_awareness awareness
+                      WHERE awareness.claim_id = claim.id
+                        AND awareness.knower_entity_id = :entity_id
+                  )
+                ORDER BY claim.world_event_id, claim.id
+                """
+            ),
+            {"entity_id": entity_id, "anchor_chunk_id": anchor_chunk_id},
+        ).mappings()
+    ]
+    latent_secrets = [
+        {
+            "secret_id": int(row["secret_id"]),
+            "claim_id": int(row["claim_id"]),
+            "summary": str(row["summary"]),
+            "account_payload": row["account_payload"],
+            "gate_template_id": str(row["gate_template_id"]),
+            "holder_entity_id": int(row["holder_entity_id"]),
+            "source_chunk_id": row["source_chunk_id"],
+            "status": str(row["status"]),
+        }
+        for row in session.execute(
+            text(
+                """
+                /* orrery_audit:cognition_latent_secrets */
+                SELECT secret.id AS secret_id, secret.claim_id,
+                       claim.summary, claim.account_payload,
+                       secret.gate_template_id, secret.holder_entity_id,
+                       secret.source_chunk_id, secret.status
+                FROM backstory_secrets secret
+                JOIN claims claim ON claim.id = secret.claim_id
+                JOIN world_events event ON event.id = claim.world_event_id
+                WHERE secret.holder_entity_id = :entity_id
+                  AND secret.status = 'latent'
+                  AND event.tick_chunk_id <= :anchor_chunk_id
+                ORDER BY secret.id
+                """
+            ),
+            {"entity_id": entity_id, "anchor_chunk_id": anchor_chunk_id},
+        ).mappings()
+    ]
+
+    render_generation_ids = sorted(
+        {
+            row["render_generation_id"]
+            for row in experiences
+            if row["render_generation_id"] is not None
+        }
+    )
+    return {
+        "entity": {"entity_id": entity_id, "name": str(character["name"])},
+        "anchor": {
+            "chunk_id": int(anchor["chunk_id"]),
+            "world_time": _iso(anchor["world_time"]),
+            "world_layer": str(anchor["world_layer"]),
+            "season": int(anchor["season"]),
+            "episode": int(anchor["episode"]),
+            "scene": int(anchor["scene"]),
+        },
+        "actor_facing": {
+            "possessed_accounts": accounts,
+            "experiences": experiences,
+            "recall_candidates": recall_candidates,
+            "recall_truncated": any(row["truncated"] for row in recall_candidates),
+            "disclosure_results": disclosure_results,
+            "prompt_exposure": {
+                "orrery_proposals": proposal_exposures,
+                "knowledge_surfacing": knowledge_exposures,
+            },
+            "experience_jobs": jobs,
+            "generation_identity": {
+                "render_generation_ids": render_generation_ids,
+                "timeline": {
+                    "world_layer": str(anchor["world_layer"]),
+                    "season": int(anchor["season"]),
+                    "episode": int(anchor["episode"]),
+                    "scene": int(anchor["scene"]),
+                },
+            },
+        },
+        "effective_config": _cognition_effective_config(orrery_settings),
+        "canonical_truth": {
+            "guarded": True,
+            "unpossessed_sibling_accounts": sibling_accounts,
+            "latent_secrets": latent_secrets,
+        },
+    }
+
+
 def entity_context(
     session: Any,
     entity_ids: Iterable[int],

--- a/nexus/api/orrery_dev_endpoints.py
+++ b/nexus/api/orrery_dev_endpoints.py
@@ -21,7 +21,12 @@ from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
-from nexus.agents.orrery.audit import build_catalog, entity_context, explain_dry_run
+from nexus.agents.orrery.audit import (
+    build_catalog,
+    cognition_trace,
+    entity_context,
+    explain_dry_run,
+)
 from nexus.agents.orrery.coverage import analyze_coverage, sample_anchor_ids
 from nexus.agents.orrery.history import adjudication_history
 from nexus.agents.orrery.overrides import (
@@ -232,6 +237,16 @@ class OrreryEntityContextRequest(BaseModel):
     recent_events_limit: int = Field(default=5, ge=1, le=50)
 
 
+class OrreryCognitionTraceRequest(BaseModel):
+    """Parameters for one anchor-aware character cognition trace."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    slot: Optional[int] = Field(default=None)
+    entity_id: int = Field(ge=1)
+    anchor_chunk_id: int = Field(ge=1)
+
+
 def _orrery_settings() -> dict[str, Any]:
     from nexus.config import load_settings_as_dict
 
@@ -353,6 +368,21 @@ async def post_entity_context(
             recent_events_limit=request.recent_events_limit,
             sunhelm_settings=orrery.get("sunhelm"),
             contagion_settings=orrery.get("contagion"),
+        )
+
+
+@router.post("/cognition/trace")
+async def post_cognition_trace(
+    request: OrreryCognitionTraceRequest,
+) -> dict[str, Any]:
+    """Anchor-aware character cognition trace. Read-only and dev-gated."""
+
+    with _slot_session(request.slot) as session:
+        return cognition_trace(
+            session,
+            request.entity_id,
+            anchor_chunk_id=request.anchor_chunk_id,
+            orrery_settings=_orrery_settings(),
         )
 
 

--- a/tests/test_api/test_orrery_dev_endpoints.py
+++ b/tests/test_api/test_orrery_dev_endpoints.py
@@ -729,6 +729,7 @@ def test_dashboard_flag_gates_router_registration(tmp_path: Path) -> None:
     }
     assert registered == {
         "/api/dev/orrery/catalog",
+        "/api/dev/orrery/cognition/trace",
         "/api/dev/orrery/resolve",
         "/api/dev/orrery/context/entities",
         "/api/dev/orrery/coverage",

--- a/tests/test_orrery/test_audit.py
+++ b/tests/test_orrery/test_audit.py
@@ -8,10 +8,14 @@ no mocks, no database.
 
 from __future__ import annotations
 
+from copy import deepcopy
 import json
+
+import pytest
 
 from nexus.agents.orrery.audit import (
     NOT_APPLICABLE_REASON,
+    _cognition_effective_config,
     build_catalog,
 )
 from nexus.agents.orrery.substrate import (
@@ -35,6 +39,21 @@ def _catalog() -> dict:
         sunhelm_settings=orrery.get("sunhelm"),
         promote_settings=orrery.get("promote"),
     )
+
+
+def test_cognition_config_projection_names_missing_sections_and_keys() -> None:
+    """The dev trace reports config truth instead of dashboard defaults."""
+
+    with pytest.raises(KeyError, match=r"\[orrery\.knowledge\]"):
+        _cognition_effective_config({})
+
+    orrery = deepcopy(load_settings_as_dict()["orrery"])
+    del orrery["recall"]["semantic_fit_weight"]
+    with pytest.raises(
+        KeyError,
+        match=r"\[orrery\.recall\]\.semantic_fit_weight",
+    ):
+        _cognition_effective_config(orrery)
 
 
 def test_catalog_covers_every_template_exactly_once() -> None:

--- a/tests/test_orrery/test_recall_disclosure_pg.py
+++ b/tests/test_orrery/test_recall_disclosure_pg.py
@@ -9,7 +9,7 @@ import json
 import os
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Iterator, cast
+from typing import Any, Iterator, Mapping, cast
 from uuid import uuid4
 
 import psycopg2
@@ -28,8 +28,13 @@ from nexus.agents.memnon.utils.embedding_tables import (
     ensure_character_experience_embedding_table,
     ensure_embedding_table,
 )
+from nexus.agents.orrery.audit import cognition_trace
+from nexus.agents.orrery.events import commit_orrery_tick_sync
 from nexus.agents.orrery.knowledge_surfacing import build_knowledge_digest_sync
+from nexus.agents.orrery.resolver import resolve_dry_run
+from nexus.agents.orrery.substrate import ALWAYS, Branch, DriveBand, Slot, Template
 from nexus.api import orrery_dev_endpoints
+from nexus.config import load_settings_as_dict
 
 
 pytestmark = pytest.mark.requires_postgres
@@ -172,6 +177,27 @@ def _character(session: Session, label: str) -> tuple[int, int]:
         ).scalar_one()
     )
     return entity_id, character_id
+
+
+def _place(session: Session, label: str) -> tuple[int, int]:
+    entity_id = int(
+        session.execute(
+            text(
+                "INSERT INTO entities (kind, is_active) "
+                "VALUES ('place', true) RETURNING id"
+            )
+        ).scalar_one()
+    )
+    place_id = int(
+        session.execute(
+            text(
+                "INSERT INTO places (entity_id, name, type) "
+                "VALUES (:entity_id, :name, 'fixed_location') RETURNING id"
+            ),
+            {"entity_id": entity_id, "name": f"recall-{label}-{uuid4().hex[:6]}"},
+        ).scalar_one()
+    )
+    return entity_id, place_id
 
 
 def _faction(session: Session, label: str) -> int:
@@ -421,7 +447,6 @@ def test_cognition_trace_endpoint_keeps_canonical_truth_guarded(
     )
     alpha = _character(session, "cognition-alpha")
     beta = _character(session, "cognition-beta")
-    _present(session, chunk_id=anchor, characters=[alpha, beta])
 
     possessed_claim, awareness_id = _claim(
         session,
@@ -525,36 +550,51 @@ def test_cognition_trace_endpoint_keeps_canonical_truth_guarded(
         ),
         {"anchor": anchor, "source": source, "experience_id": experience_id},
     )
-    session.execute(
-        text(
-            """
-            INSERT INTO orrery_resolutions (
-                tick_chunk_id, template_id, binding_hash, actor_entity_id,
-                priority, magnitude, state_delta, brief
-            ) VALUES (
-                :anchor, 'qa680_resolution', 'qa680-binding', :actor_id,
-                50, 0.5, '{"character.current_activity": "investigating"}',
-                'A cognition-relevant proposal.'
-            )
-            """
-        ),
-        {"anchor": anchor, "actor_id": alpha[0]},
-    )
-    session.execute(
-        text(
-            """
-            INSERT INTO orrery_prompt_exposures (
-                tick_chunk_id, kind, proposal_id, template_id,
-                binding_hash, position
-            ) VALUES (
-                :anchor, 'resolution', 'qa680-proposal',
-                'qa680_resolution', 'qa680-binding', 0
-            )
-            """
-        ),
-        {"anchor": anchor},
-    )
     session.flush()
+
+    def actor_is_alpha(_state: Any, bindings: Mapping[Slot, Any]) -> bool:
+        return bindings.get(Slot.ACTOR) == alpha[0]
+
+    actor_is_alpha.__name__ = "qa680_actor_is_alpha"
+    template = Template(
+        id="qa680_cognition_probe",
+        priority=50,
+        drive_band=DriveBand.AFFILIATION,
+        blurb="Exercise cognition exposure persistence.",
+        required_slots=(Slot.ACTOR,),
+        package_gate=actor_is_alpha,
+        branches=(
+            Branch(
+                label="Inspect a private account",
+                conditions=ALWAYS,
+                narrative_stub="{actor} reviews what they believe happened.",
+                magnitude=0.5,
+            ),
+        ),
+    )
+    proposal = resolve_dry_run(
+        session,
+        (template,),
+        anchor_chunk_id=anchor,
+        window_chunks=3,
+        epistemics_settings={"enabled": False},
+    )
+    assert len(proposal.resolutions) == 1
+    assert proposal.resolutions[0].bindings == {"actor": alpha[0]}
+    raw_connection = session.connection().connection.driver_connection
+    committed = commit_orrery_tick_sync(
+        raw_connection,
+        proposal,
+        tick_chunk_id=anchor,
+        prompt_settings={
+            "max_rendered_proposals": 1,
+            "max_rendered_pressures": 1,
+        },
+        epistemics_settings={"enabled": False},
+    )
+    assert committed.resolution_count == 1
+    assert committed.prompt_exposure_count == 1
+    session.expire_all()
 
     @contextmanager
     def seeded_session(_slot: int | None) -> Iterator[Session]:
@@ -575,7 +615,7 @@ def test_cognition_trace_endpoint_keeps_canonical_truth_guarded(
         actor["possessed_accounts"][0]["possession"]["source_chain"][-1]["entity_id"]
         == alpha[0]
     )
-    assert actor["experiences"][0]["source_events"][0]["event_id"]
+    assert actor["experiences"][0]["source_event_ids"]
     assert {row["decision"] for row in actor["recall_candidates"]} >= {
         "included",
         "suppressed",
@@ -585,7 +625,7 @@ def test_cognition_trace_endpoint_keeps_canonical_truth_guarded(
         for row in actor["disclosure_results"]
     )
     assert actor["prompt_exposure"]["orrery_proposals"][0]["template_id"] == (
-        "qa680_resolution"
+        "qa680_cognition_probe"
     )
     assert actor["prompt_exposure"]["knowledge_surfacing"]
     assert actor["experience_jobs"][0]["state"] == "stale_rejected"
@@ -603,6 +643,188 @@ def test_cognition_trace_endpoint_keeps_canonical_truth_guarded(
         row["claim_id"] for row in canonical["unpossessed_sibling_accounts"]
     }
     assert latent_claim in {row["claim_id"] for row in canonical["latent_secrets"]}
+
+
+def _nested_keys(value: Any) -> set[str]:
+    if isinstance(value, dict):
+        return set(value) | {
+            key for child in value.values() for key in _nested_keys(child)
+        }
+    if isinstance(value, list):
+        return {key for child in value for key in _nested_keys(child)}
+    return set()
+
+
+def test_distorted_account_never_leaks_canonical_event_adjacency(
+    session: Session,
+) -> None:
+    """Possession exposes account content, while event canon stays guarded."""
+
+    base = datetime(2078, 3, 1, tzinfo=timezone.utc)
+    source = _chunk(session, label="distorted source", world_time=base, scene=1)
+    anchor = _chunk(
+        session,
+        label="distorted anchor",
+        world_time=base + timedelta(hours=1),
+        scene=2,
+    )
+    knower = _character(session, "distorted-knower")
+    canonical_actor = _character(session, "distorted-canonical-actor")
+    canonical_target = _character(session, "distorted-canonical-target")
+    _place_entity_id, canonical_place = _place(session, "distorted-place")
+    claim_id, awareness_id = _claim(
+        session,
+        owner_entity_id=knower[0],
+        chunk_id=source,
+        acquired_at=base,
+        label="distorted account only",
+        scope="private",
+        source_tier="told",
+    )
+    assert awareness_id is not None
+    event_id = int(
+        session.execute(
+            text("SELECT world_event_id FROM claims WHERE id = :claim_id"),
+            {"claim_id": claim_id},
+        ).scalar_one()
+    )
+    session.execute(
+        text(
+            """
+            UPDATE world_events
+            SET actor_entity_id = :actor_id,
+                target_entity_id = :target_id,
+                location_id = :location_id,
+                payload = '{"canonical_detail": "unseen"}'::jsonb
+            WHERE id = :event_id
+            """
+        ),
+        {
+            "actor_id": canonical_actor[0],
+            "target_id": canonical_target[0],
+            "location_id": canonical_place,
+            "event_id": event_id,
+        },
+    )
+    session.execute(
+        text(
+            """
+            UPDATE claims
+            SET summary = 'A masked figure crossed the square.',
+                account_label = 'distorted',
+                account_payload = '{"heard": "a masked figure crossed the square"}'
+            WHERE id = :claim_id
+            """
+        ),
+        {"claim_id": claim_id},
+    )
+    payload = cognition_trace(
+        session,
+        knower[0],
+        anchor_chunk_id=anchor,
+        orrery_settings=load_settings_as_dict()["orrery"],
+    )
+
+    actor_facing = payload["actor_facing"]
+    forbidden = {"actor_entity_id", "target_entity_id", "location_id"}
+    assert not (_nested_keys(actor_facing) & forbidden)
+    assert actor_facing["possessed_accounts"][0]["account_label"] == "distorted"
+    canonical_event = next(
+        row
+        for row in payload["canonical_truth"]["source_events"]
+        if row["event_id"] == event_id
+    )
+    assert canonical_event["actor_entity_id"] == canonical_actor[0]
+    assert canonical_event["target_entity_id"] == canonical_target[0]
+    assert canonical_event["location_id"] == canonical_place
+
+
+def test_cognition_trace_rolls_awareness_and_secret_status_back_to_anchor(
+    session: Session,
+) -> None:
+    """A later reveal and acquisition do not rewrite a pre-reveal trace."""
+
+    base = datetime(2078, 4, 1, tzinfo=timezone.utc)
+    source = _chunk(session, label="rollback source 915", world_time=base, scene=1)
+    pre_reveal = _chunk(
+        session,
+        label="rollback pre-reveal 916",
+        world_time=base + timedelta(hours=1),
+        scene=2,
+    )
+    reveal = _chunk(
+        session,
+        label="rollback reveal 917",
+        world_time=base + timedelta(hours=2),
+        scene=3,
+    )
+    knower = _character(session, "rollback-knower")
+    secret_claim, _ = _claim(
+        session,
+        owner_entity_id=knower[0],
+        chunk_id=source,
+        acquired_at=base,
+        label="later revealed secret",
+        scope="private",
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO backstory_secrets (
+                claim_id, gate_template_id, holder_entity_id, source_chunk_id,
+                status, revealed_at_world_time, revealed_by_chunk_id
+            ) VALUES (
+                :claim_id, 'qa680_rollback_gate', :holder_id, :source_chunk_id,
+                'revealed', :revealed_at, :revealed_by_chunk_id
+            )
+            """
+        ),
+        {
+            "claim_id": secret_claim,
+            "holder_id": knower[0],
+            "source_chunk_id": source,
+            "revealed_at": base + timedelta(hours=2),
+            "revealed_by_chunk_id": reveal,
+        },
+    )
+    future_claim, _ = _claim(
+        session,
+        owner_entity_id=knower[0],
+        chunk_id=reveal,
+        acquired_at=base + timedelta(hours=2),
+        label="future acquisition",
+        scope="private",
+    )
+    settings = load_settings_as_dict()["orrery"]
+
+    before = cognition_trace(
+        session,
+        knower[0],
+        anchor_chunk_id=pre_reveal,
+        orrery_settings=settings,
+    )
+    before_claims = {
+        row["claim_id"] for row in before["actor_facing"]["possessed_accounts"]
+    }
+    assert secret_claim not in before_claims
+    assert future_claim not in before_claims
+    assert secret_claim in {
+        row["claim_id"] for row in before["canonical_truth"]["latent_secrets"]
+    }
+
+    after = cognition_trace(
+        session,
+        knower[0],
+        anchor_chunk_id=reveal,
+        orrery_settings=settings,
+    )
+    after_claims = {
+        row["claim_id"] for row in after["actor_facing"]["possessed_accounts"]
+    }
+    assert {secret_claim, future_claim} <= after_claims
+    assert secret_claim not in {
+        row["claim_id"] for row in after["canonical_truth"]["latent_secrets"]
+    }
 
 
 def test_ownership_and_anchor_validity_are_hard_boundaries(session: Session) -> None:

--- a/tests/test_orrery/test_recall_disclosure_pg.py
+++ b/tests/test_orrery/test_recall_disclosure_pg.py
@@ -16,6 +16,8 @@ import psycopg2
 from psycopg2 import sql
 from psycopg2.extras import RealDictCursor
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import URL
 from sqlalchemy.orm import Session
@@ -27,6 +29,7 @@ from nexus.agents.memnon.utils.embedding_tables import (
     ensure_embedding_table,
 )
 from nexus.agents.orrery.knowledge_surfacing import build_knowledge_digest_sync
+from nexus.api import orrery_dev_endpoints
 
 
 pytestmark = pytest.mark.requires_postgres
@@ -401,6 +404,205 @@ def _digest(
         turn_id=turn_id,
         query_embeddings=query_embeddings,
     )
+
+
+def test_cognition_trace_endpoint_keeps_canonical_truth_guarded(
+    session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dev endpoint links the durable chain without leaking canon."""
+
+    base = datetime(2078, 2, 1, tzinfo=timezone.utc)
+    source = _chunk(session, label="cognition source", world_time=base, scene=1)
+    anchor = _chunk(
+        session,
+        label="cognition anchor",
+        world_time=base + timedelta(hours=2),
+        scene=2,
+    )
+    alpha = _character(session, "cognition-alpha")
+    beta = _character(session, "cognition-beta")
+    _present(session, chunk_id=anchor, characters=[alpha, beta])
+
+    possessed_claim, awareness_id = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=source,
+        acquired_at=base,
+        label="possessed private account",
+        scope="private",
+    )
+    assert awareness_id is not None
+    session.execute(
+        text(
+            """
+            UPDATE claim_awareness
+            SET source_tier = 'told',
+                immediate_source_entity_id = :source_entity_id,
+                root_source_entity_id = :source_entity_id,
+                channel = 'message'
+            WHERE id = :awareness_id
+            """
+        ),
+        {"source_entity_id": beta[0], "awareness_id": awareness_id},
+    )
+    world_event_id = int(
+        session.execute(
+            text("SELECT world_event_id FROM claims WHERE id = :claim_id"),
+            {"claim_id": possessed_claim},
+        ).scalar_one()
+    )
+    sibling_claim, _ = _claim(
+        session,
+        owner_entity_id=None,
+        chunk_id=source,
+        acquired_at=base,
+        label="guarded sibling answer",
+        scope="private",
+        world_event_id=world_event_id,
+    )
+    latent_claim, _ = _claim(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=source,
+        acquired_at=base,
+        label="guarded latent secret",
+        scope="private",
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO backstory_secrets (
+                claim_id, gate_template_id, holder_entity_id, source_chunk_id
+            ) VALUES (
+                :claim_id, 'qa680_gate', :holder_entity_id, :source_chunk_id
+            )
+            """
+        ),
+        {
+            "claim_id": latent_claim,
+            "holder_entity_id": alpha[0],
+            "source_chunk_id": source,
+        },
+    )
+    experience_id = _experience(
+        session,
+        owner_entity_id=alpha[0],
+        chunk_id=source,
+        world_time=base,
+        label="actor-owned recollection",
+    )
+
+    digest = build_knowledge_digest_sync(
+        session,
+        present_entity_ids=[alpha[0], beta[0]],
+        anchor_chunk_id=anchor,
+        settings={
+            "enabled": True,
+            "max_entries": 12,
+            "recent_reveal_window_chunks": 3,
+        },
+        recall_settings={},
+        disclosure_settings={},
+        turn_id="qa680-cognition-trace",
+    )
+    assert any(row.get("experience_id") == experience_id for row in digest)
+
+    session.execute(
+        text(
+            """
+            INSERT INTO character_experience_jobs (
+                boundary_chunk_id, scene_end_chunk_id, world_layer,
+                boundary_season, boundary_episode, boundary_scene,
+                scene_end_season, scene_end_episode, scene_end_scene,
+                batch_ordinal, experience_ids, slot, state, attempts,
+                last_error, requested_model, source_digest
+            ) VALUES (
+                :anchor, :source, 'primary', 1, 1, 2, 1, 1, 1, 0,
+                ARRAY[:experience_id]::bigint[], 'qa680', 'stale_rejected', 2,
+                'boundary timeline is stale', 'qa680-model', 'qa680-job-digest'
+            )
+            """
+        ),
+        {"anchor": anchor, "source": source, "experience_id": experience_id},
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO orrery_resolutions (
+                tick_chunk_id, template_id, binding_hash, actor_entity_id,
+                priority, magnitude, state_delta, brief
+            ) VALUES (
+                :anchor, 'qa680_resolution', 'qa680-binding', :actor_id,
+                50, 0.5, '{"character.current_activity": "investigating"}',
+                'A cognition-relevant proposal.'
+            )
+            """
+        ),
+        {"anchor": anchor, "actor_id": alpha[0]},
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO orrery_prompt_exposures (
+                tick_chunk_id, kind, proposal_id, template_id,
+                binding_hash, position
+            ) VALUES (
+                :anchor, 'resolution', 'qa680-proposal',
+                'qa680_resolution', 'qa680-binding', 0
+            )
+            """
+        ),
+        {"anchor": anchor},
+    )
+    session.flush()
+
+    @contextmanager
+    def seeded_session(_slot: int | None) -> Iterator[Session]:
+        yield session
+
+    monkeypatch.setattr(orrery_dev_endpoints, "_slot_session", seeded_session)
+    app = FastAPI()
+    app.include_router(orrery_dev_endpoints.router)
+    response = TestClient(app).post(
+        "/api/dev/orrery/cognition/trace",
+        json={"slot": 1, "entity_id": alpha[0], "anchor_chunk_id": anchor},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+
+    actor = payload["actor_facing"]
+    assert (
+        actor["possessed_accounts"][0]["possession"]["source_chain"][-1]["entity_id"]
+        == alpha[0]
+    )
+    assert actor["experiences"][0]["source_events"][0]["event_id"]
+    assert {row["decision"] for row in actor["recall_candidates"]} >= {
+        "included",
+        "suppressed",
+    }
+    assert any(
+        row["blocking_reasons"] == ["secrecy_threshold"]
+        for row in actor["disclosure_results"]
+    )
+    assert actor["prompt_exposure"]["orrery_proposals"][0]["template_id"] == (
+        "qa680_resolution"
+    )
+    assert actor["prompt_exposure"]["knowledge_surfacing"]
+    assert actor["experience_jobs"][0]["state"] == "stale_rejected"
+    assert actor["experience_jobs"][0]["attempts"] == 2
+
+    actor_json = json.dumps(actor, sort_keys=True)
+    assert str(sibling_claim) not in {
+        str(row["claim_id"]) for row in actor["possessed_accounts"]
+    }
+    assert "guarded sibling answer" not in actor_json
+    assert "guarded latent secret" not in actor_json
+    canonical = payload["canonical_truth"]
+    assert canonical["guarded"] is True
+    assert sibling_claim in {
+        row["claim_id"] for row in canonical["unpossessed_sibling_accounts"]
+    }
+    assert latent_claim in {row["claim_id"] for row in canonical["latent_secrets"]}
 
 
 def test_ownership_and_anchor_validity_are_hard_boundaries(session: Session) -> None:

--- a/ui/client/src/pages/dev-orrery/CognitionTrace.tsx
+++ b/ui/client/src/pages/dev-orrery/CognitionTrace.tsx
@@ -1,0 +1,595 @@
+import { useState } from "react";
+import type { CSSProperties } from "react";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+import type { CognitionSourceNodeVM, CognitionTraceVM } from "./types";
+
+const SECTION_LABEL: CSSProperties = {
+  fontSize: 8,
+  letterSpacing: "0.2em",
+  textTransform: "uppercase",
+  color: "hsl(var(--muted-foreground))",
+};
+
+function EmptyRow() {
+  return (
+    <div
+      className="font-mono"
+      style={{ fontSize: 10, color: "hsl(var(--muted-foreground))", padding: 12 }}
+    >
+      —
+    </div>
+  );
+}
+
+function SourceNode({ node, depth = 0 }: { node: CognitionSourceNodeVM; depth?: number }) {
+  return (
+    <Collapsible defaultOpen>
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="font-mono"
+          style={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            padding: `3px 5px 3px ${6 + depth * 14}px`,
+            border: 0,
+            background: "transparent",
+            color: "hsl(var(--foreground) / 0.85)",
+            fontSize: 9,
+            textAlign: "left",
+          }}
+        >
+          <span style={{ color: "hsl(var(--muted-foreground))" }}>⌄</span>
+          <Badge variant="outline" style={{ fontSize: 7.5 }}>
+            {node.kind}
+          </Badge>
+          {node.label}
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        {node.children.map((child) => (
+          <SourceNode key={child.key} node={child} depth={depth + 1} />
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function TraceTagChip({
+  label,
+  sourceKey,
+  onHover,
+}: {
+  label: string;
+  sourceKey: string;
+  onHover: (key: string | null) => void;
+}) {
+  return (
+    <span
+      className="font-mono"
+      onMouseEnter={() => onHover(sourceKey)}
+      onMouseLeave={() => onHover(null)}
+      style={{
+        display: "inline-flex",
+        border: "1px dashed hsl(var(--chart-2) / 0.6)",
+        borderRadius: 99,
+        padding: "1px 7px",
+        fontSize: 8.5,
+        color: "hsl(var(--chart-2))",
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function AccountsTab({ vm, activeSource }: { vm: CognitionTraceVM; activeSource: string | null }) {
+  return (
+    <div data-screen-label="Cognition accounts" style={{ display: "grid", gap: 10 }}>
+      <span className="font-mono" style={SECTION_LABEL}>
+        Possession
+      </span>
+      {vm.accounts.length ? (
+        <Accordion type="multiple">
+          {vm.accounts.map((account) => (
+            <AccordionItem
+              key={account.key}
+              value={account.key}
+              style={{
+                border: "1px solid hsl(var(--border))",
+                borderColor:
+                  activeSource === account.sourceKey
+                    ? "hsl(var(--accent))"
+                    : "hsl(var(--border))",
+                padding: "0 10px",
+              }}
+            >
+              <AccordionTrigger style={{ padding: "8px 0", textDecoration: "none" }}>
+                <span style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+                  <span className="font-mono" style={{ fontSize: 9 }}>
+                    {account.claim}
+                  </span>
+                  <span style={{ fontSize: 10.5 }}>{account.summary}</span>
+                </span>
+              </AccordionTrigger>
+              <AccordionContent>
+                <div style={{ display: "grid", gap: 6 }}>
+                  <span
+                    className="font-mono"
+                    style={{ fontSize: 8, color: "hsl(var(--muted-foreground))" }}
+                  >
+                    {account.meta}
+                  </span>
+                  <HoverCard>
+                    <HoverCardTrigger asChild>
+                      <button
+                        type="button"
+                        className="font-mono"
+                        style={{
+                          width: "fit-content",
+                          border: 0,
+                          background: "transparent",
+                          color: "hsl(var(--chart-5))",
+                          fontSize: 9,
+                        }}
+                      >
+                        {account.sourceChunk}
+                      </button>
+                    </HoverCardTrigger>
+                    <HoverCardContent className="font-mono text-xs">
+                      {account.sourcePreview}
+                    </HoverCardContent>
+                  </HoverCard>
+                  {account.chain.map((node) => (
+                    <SourceNode key={node.key} node={node} />
+                  ))}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      ) : (
+        <EmptyRow />
+      )}
+      <span className="font-mono" style={SECTION_LABEL}>
+        Experience
+      </span>
+      {vm.experiences.length ? (
+        vm.experiences.map((experience) => (
+          <div
+            key={experience.key}
+            style={{
+              border: "1px solid hsl(var(--border))",
+              borderColor:
+                activeSource === experience.sourceKey
+                  ? "hsl(var(--accent))"
+                  : "hsl(var(--border))",
+              padding: 9,
+              display: "grid",
+              gap: 4,
+            }}
+          >
+            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <span className="font-mono" style={{ fontSize: 9 }}>
+                {experience.id}
+              </span>
+              <Badge variant="outline">{experience.renderStatus}</Badge>
+              <span
+                className="font-mono"
+                style={{ marginLeft: "auto", fontSize: 8.5 }}
+              >
+                {experience.salience}
+              </span>
+            </div>
+            <span style={{ fontSize: 10.5 }}>{experience.summary}</span>
+            <HoverCard>
+              <HoverCardTrigger asChild>
+                <span
+                  className="font-mono"
+                  style={{ fontSize: 8, color: "hsl(var(--muted-foreground))" }}
+                >
+                  {experience.meta}
+                </span>
+              </HoverCardTrigger>
+              <HoverCardContent className="font-mono whitespace-pre-line text-xs">
+                {experience.sourcePreview}
+              </HoverCardContent>
+            </HoverCard>
+          </div>
+        ))
+      ) : (
+        <EmptyRow />
+      )}
+    </div>
+  );
+}
+
+function RecallTab({
+  vm,
+  onHover,
+}: {
+  vm: CognitionTraceVM;
+  onHover: (key: string | null) => void;
+}) {
+  return (
+    <div data-screen-label="Cognition recall">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>source</TableHead>
+            <TableHead>decision</TableHead>
+            <TableHead>score</TableHead>
+            <TableHead>components</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {vm.recalls.map((row) => (
+            <TableRow key={row.key} style={{ borderStyle: "dashed" }}>
+              <TableCell>
+                <TraceTagChip label={row.sourceLabel} sourceKey={row.sourceKey} onHover={onHover} />
+                <div style={{ fontSize: 9.5, marginTop: 4 }}>{row.summary}</div>
+              </TableCell>
+              <TableCell>
+                <Badge variant={row.decision === "suppressed" ? "destructive" : "outline"}>
+                  {row.decision}
+                </Badge>
+                <div className="font-mono" style={{ fontSize: 8, marginTop: 3 }}>
+                  {row.reason}
+                </div>
+              </TableCell>
+              <TableCell className="font-mono text-xs">
+                {row.score} / {row.threshold}
+              </TableCell>
+              <TableCell style={{ minWidth: 190 }}>
+                {row.components.map((component) => (
+                  <div key={component.label} style={{ display: "grid", gap: 2, marginBottom: 4 }}>
+                    <div
+                      className="font-mono"
+                      style={{ display: "flex", fontSize: 7.5, justifyContent: "space-between" }}
+                    >
+                      <span>{component.label}</span>
+                      <span>{component.value}</span>
+                    </div>
+                    <div
+                      style={{
+                        height: 3,
+                        background: "hsl(var(--muted) / 0.3)",
+                        overflow: "hidden",
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: component.pct,
+                          height: "100%",
+                          background: "hsl(var(--chart-5))",
+                        }}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {!vm.recalls.length && <EmptyRow />}
+    </div>
+  );
+}
+
+function DisclosureTab({
+  vm,
+  onHover,
+}: {
+  vm: CognitionTraceVM;
+  onHover: (key: string | null) => void;
+}) {
+  return (
+    <div data-screen-label="Cognition disclosure">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>source</TableHead>
+            <TableHead>result</TableHead>
+            <TableHead>reason</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {vm.disclosures.map((row) => (
+            <TableRow key={row.key}>
+              <TableCell>
+                <TraceTagChip label={row.sourceLabel} sourceKey={row.sourceKey} onHover={onHover} />
+              </TableCell>
+              <TableCell>
+                <Badge variant={row.allowed ? "outline" : "destructive"}>
+                  {row.allowed ? "disclosed" : "blocked"}
+                </Badge>
+              </TableCell>
+              <TableCell>
+                {row.reasons.length > 1 ? (
+                  <HoverCard>
+                    <HoverCardTrigger className="font-mono text-xs">{row.reason}</HoverCardTrigger>
+                    <HoverCardContent className="font-mono whitespace-pre-line text-xs">
+                      {row.reasons.join("\n")}
+                    </HoverCardContent>
+                  </HoverCard>
+                ) : (
+                  <span className="font-mono" style={{ fontSize: 9 }}>
+                    {row.reason}
+                  </span>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {!vm.disclosures.length && <EmptyRow />}
+    </div>
+  );
+}
+
+function ExposureTab({ vm, onPayload }: { vm: CognitionTraceVM; onPayload: (title: string, payload: string) => void }) {
+  return (
+    <div data-screen-label="Cognition prompt exposure">
+      {vm.exposures.map((row) => (
+        <Collapsible key={row.key}>
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              style={{
+                width: "100%",
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "8px 4px",
+                border: 0,
+                borderTop: "1px solid hsl(var(--border))",
+                background: "transparent",
+                color: "hsl(var(--foreground))",
+                textAlign: "left",
+              }}
+            >
+              <Badge variant="outline">{row.kind}</Badge>
+              <span className="font-mono" style={{ fontSize: 9 }}>
+                {row.label}
+              </span>
+              <span
+                className="font-mono"
+                style={{ marginLeft: "auto", fontSize: 8, color: "hsl(var(--muted-foreground))" }}
+              >
+                {row.meta}
+              </span>
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div style={{ padding: "0 4px 10px", display: "grid", gap: 6 }}>
+              <span style={{ fontSize: 10 }}>{row.preview}</span>
+              <ScrollArea style={{ height: 110 }}>
+                <pre className="font-mono" style={{ fontSize: 8.5, whiteSpace: "pre-wrap" }}>
+                  {row.payload}
+                </pre>
+              </ScrollArea>
+              <Button variant="outline" size="sm" onClick={() => onPayload(row.label, row.payload)}>
+                payload
+              </Button>
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      ))}
+      {!vm.exposures.length && <EmptyRow />}
+    </div>
+  );
+}
+
+function JobsTab({ vm }: { vm: CognitionTraceVM }) {
+  return (
+    <div data-screen-label="Cognition jobs" style={{ display: "grid", gap: 10 }}>
+      {vm.jobs.map((job) => (
+        <div key={job.key} style={{ border: "1px solid hsl(var(--border))", padding: 9 }}>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <span className="font-mono" style={{ fontSize: 9 }}>
+              {job.id}
+            </span>
+            <Badge variant={job.state === "failed" || job.state === "stale_rejected" ? "destructive" : "outline"}>
+              {job.state}
+            </Badge>
+            <span className="font-mono" style={{ fontSize: 8.5, marginLeft: "auto" }}>
+              attempts {job.attempts}
+            </span>
+          </div>
+          <div className="font-mono" style={{ fontSize: 8, marginTop: 5, color: "hsl(var(--muted-foreground))" }}>
+            {job.timeline}
+          </div>
+          <div className="font-mono" style={{ fontSize: 8, marginTop: 3 }}>
+            lease {job.lease} · generation {job.generations}
+          </div>
+          {job.error && (
+            <div className="font-mono" style={{ fontSize: 8.5, color: "hsl(var(--destructive))", marginTop: 4 }}>
+              {job.error}
+            </div>
+          )}
+        </div>
+      ))}
+      {!vm.jobs.length && <EmptyRow />}
+      <span className="font-mono" style={SECTION_LABEL}>
+        Effective config
+      </span>
+      {vm.config.map((section) => (
+        <div key={section.section} style={{ borderTop: "1px solid hsl(var(--border))", paddingTop: 6 }}>
+          <span className="font-mono" style={SECTION_LABEL}>
+            {section.section}
+          </span>
+          {section.values.map((row) => (
+            <div key={row.key} className="font-mono" style={{ display: "flex", gap: 12, fontSize: 8.5 }}>
+              <span style={{ color: "hsl(var(--muted-foreground))" }}>{row.key}</span>
+              <span style={{ marginLeft: "auto", textAlign: "right" }}>{row.value}</span>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CanonicalTruth({ vm }: { vm: CognitionTraceVM }) {
+  return (
+    <Card style={{ borderStyle: "dashed", borderColor: "hsl(var(--destructive) / 0.65)" }}>
+      <Collapsible>
+        <CardHeader style={{ padding: 10 }}>
+          <CollapsibleTrigger asChild>
+            <Button variant="outline" size="sm" className="font-mono tracking-widest uppercase">
+              canonical_truth
+            </Button>
+          </CollapsibleTrigger>
+        </CardHeader>
+        <CollapsibleContent>
+          <CardContent style={{ padding: "0 10px 10px", display: "grid", gap: 8 }}>
+            {[...vm.canonical.siblings, ...vm.canonical.secrets].map((row) => (
+              <div key={row.key} style={{ borderTop: "1px solid hsl(var(--border))", paddingTop: 6 }}>
+                <div className="font-mono" style={{ fontSize: 8.5, color: "hsl(var(--destructive))" }}>
+                  {row.label}
+                </div>
+                <div style={{ fontSize: 10 }}>{row.summary}</div>
+                <pre className="font-mono" style={{ fontSize: 8, whiteSpace: "pre-wrap" }}>
+                  {row.payload}
+                </pre>
+              </div>
+            ))}
+            {!vm.canonical.siblings.length && !vm.canonical.secrets.length && <EmptyRow />}
+          </CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  );
+}
+
+export default function CognitionTrace({
+  open,
+  onOpenChange,
+  vm,
+  loading,
+  error,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  vm: CognitionTraceVM | null;
+  loading: boolean;
+  error: string | null;
+}) {
+  const [activeSource, setActiveSource] = useState<string | null>(null);
+  const [payloadDialog, setPayloadDialog] = useState<{ title: string; payload: string } | null>(null);
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        data-screen-label="Character cognition inspector"
+        style={{ width: "min(1040px, 94vw)", maxWidth: "none", height: "88vh", display: "flex", flexDirection: "column" }}
+      >
+        <DialogHeader>
+          <DialogTitle className="font-mono" style={{ fontSize: 13 }}>
+            {vm?.title ?? "Character cognition"}
+          </DialogTitle>
+          {vm && (
+            <div className="font-mono" style={{ fontSize: 8.5, color: "hsl(var(--muted-foreground))" }}>
+              {vm.anchor} · {vm.timeline}
+            </div>
+          )}
+        </DialogHeader>
+        {loading && (
+          <div style={{ display: "grid", gap: 10 }}>
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-64 w-full" />
+          </div>
+        )}
+        {error && <div className="font-mono text-destructive text-sm">{error}</div>}
+        {vm && !loading && !error && (
+          <ScrollArea style={{ flex: 1, minHeight: 0 }}>
+            <Card>
+              <CardContent style={{ padding: 10 }}>
+                <Tabs defaultValue="accounts">
+                  <TabsList className="grid w-full grid-cols-5">
+                    <TabsTrigger value="accounts">accounts</TabsTrigger>
+                    <TabsTrigger value="recall">recall</TabsTrigger>
+                    <TabsTrigger value="disclosure">disclosure</TabsTrigger>
+                    <TabsTrigger value="exposure">exposure</TabsTrigger>
+                    <TabsTrigger value="jobs">jobs</TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="accounts">
+                    <AccountsTab vm={vm} activeSource={activeSource} />
+                  </TabsContent>
+                  <TabsContent value="recall">
+                    <RecallTab vm={vm} onHover={setActiveSource} />
+                  </TabsContent>
+                  <TabsContent value="disclosure">
+                    <DisclosureTab vm={vm} onHover={setActiveSource} />
+                  </TabsContent>
+                  <TabsContent value="exposure">
+                    <ExposureTab
+                      vm={vm}
+                      onPayload={(title, payload) => setPayloadDialog({ title, payload })}
+                    />
+                  </TabsContent>
+                  <TabsContent value="jobs">
+                    <JobsTab vm={vm} />
+                  </TabsContent>
+                </Tabs>
+              </CardContent>
+            </Card>
+            <div style={{ height: 10 }} />
+            <CanonicalTruth vm={vm} />
+          </ScrollArea>
+        )}
+      </DialogContent>
+      <Dialog open={payloadDialog != null} onOpenChange={(next) => !next && setPayloadDialog(null)}>
+        <DialogContent style={{ maxWidth: 760 }}>
+          <DialogHeader>
+            <DialogTitle className="font-mono">{payloadDialog?.title}</DialogTitle>
+          </DialogHeader>
+          <ScrollArea style={{ height: "60vh" }}>
+            <pre className="font-mono" style={{ fontSize: 9, whiteSpace: "pre-wrap" }}>
+              {payloadDialog?.payload}
+            </pre>
+          </ScrollArea>
+        </DialogContent>
+      </Dialog>
+    </Dialog>
+  );
+}

--- a/ui/client/src/pages/dev-orrery/CognitionTrace.tsx
+++ b/ui/client/src/pages/dev-orrery/CognitionTrace.tsx
@@ -483,7 +483,11 @@ function CanonicalTruth({ vm }: { vm: CognitionTraceVM }) {
         </CardHeader>
         <CollapsibleContent>
           <CardContent style={{ padding: "0 10px 10px", display: "grid", gap: 8 }}>
-            {[...vm.canonical.siblings, ...vm.canonical.secrets].map((row) => (
+            {[
+              ...vm.canonical.events,
+              ...vm.canonical.siblings,
+              ...vm.canonical.secrets,
+            ].map((row) => (
               <div key={row.key} style={{ borderTop: "1px solid hsl(var(--border))", paddingTop: 6 }}>
                 <div className="font-mono" style={{ fontSize: 8.5, color: "hsl(var(--destructive))" }}>
                   {row.label}
@@ -494,7 +498,9 @@ function CanonicalTruth({ vm }: { vm: CognitionTraceVM }) {
                 </pre>
               </div>
             ))}
-            {!vm.canonical.siblings.length && !vm.canonical.secrets.length && <EmptyRow />}
+            {!vm.canonical.events.length &&
+              !vm.canonical.siblings.length &&
+              !vm.canonical.secrets.length && <EmptyRow />}
           </CardContent>
         </CollapsibleContent>
       </Collapsible>

--- a/ui/client/src/pages/dev-orrery/EntityAudit.tsx
+++ b/ui/client/src/pages/dev-orrery/EntityAudit.tsx
@@ -6,6 +6,7 @@
 
 import { useState } from "react";
 import type { CSSProperties } from "react";
+import { Button } from "@/components/ui/button";
 import type { EntityAuditTagVM, EntityAuditVM } from "./types";
 
 function initialsOf(name: string): string {
@@ -380,6 +381,14 @@ export default function EntityAudit({ ent }: { ent: EntityAuditVM }) {
           ))}
         </div>
       )}
+      <Button
+        variant="outline"
+        size="sm"
+        className="font-mono uppercase tracking-widest"
+        onClick={ent.onOpenCognition}
+      >
+        Cognition
+      </Button>
     </div>
   );
 }

--- a/ui/client/src/pages/dev-orrery/api.ts
+++ b/ui/client/src/pages/dev-orrery/api.ts
@@ -5,6 +5,7 @@
 
 import type {
   CatalogPayload,
+  CognitionTracePayload,
   ContextPayload,
   CoveragePayload,
   OverridesRequest,
@@ -72,6 +73,21 @@ export function fetchEntityContext(params: {
       entity_ids: params.entityIds,
       anchor_chunk_id: params.anchorChunkId ?? null,
       recent_events_limit: 3,
+    }),
+  });
+}
+
+export function fetchCognitionTrace(params: {
+  slot: number;
+  entityId: number;
+  anchorChunkId: number;
+}): Promise<CognitionTracePayload> {
+  return request<CognitionTracePayload>("/cognition/trace", {
+    method: "POST",
+    body: JSON.stringify({
+      slot: params.slot,
+      entity_id: params.entityId,
+      anchor_chunk_id: params.anchorChunkId,
     }),
   });
 }

--- a/ui/client/src/pages/dev-orrery/index.tsx
+++ b/ui/client/src/pages/dev-orrery/index.tsx
@@ -53,6 +53,7 @@ import { Switch } from "@/components/ui/switch";
 import {
   OrreryApiError,
   fetchCatalog,
+  fetchCognitionTrace,
   fetchCoverage,
   fetchEntityContext,
   fetchResolve,
@@ -63,6 +64,7 @@ import {
   BAND_ORDER,
   NEEDS,
   bandColor,
+  buildCognitionTrace,
   buildEntityAudit,
   buildGroups,
   buildInspector,
@@ -73,6 +75,7 @@ import type { GroupBuildCtx } from "./vm";
 import type {
   ActorGroupVM,
   CatalogPayload,
+  CognitionTracePayload,
   ContextEntity,
   ContextPayload,
   CoveragePayload,
@@ -92,6 +95,7 @@ import HoverAudit from "./HoverAudit";
 import InteractionGraph from "./InteractionGraph";
 import ResolutionCard from "./ResolutionCard";
 import WhatIfDrawer from "./WhatIfDrawer";
+import CognitionTrace from "./CognitionTrace";
 
 // ---------------------------------------------------------------------------
 // Constants (the prototype's density/magnitudeStyle editor props, frozen)
@@ -1038,6 +1042,10 @@ export default function DevOrreryPage() {
   const [healthOpen, setHealthOpen] = useState(false);
   const [whatifOpen, setWhatifOpen] = useState(false);
   const [hoverEnt, setHoverEnt] = useState<number | null>(null);
+  const [cognitionEnt, setCognitionEnt] = useState<{
+    id: number;
+    name: string;
+  } | null>(null);
   const [hoverPos, setHoverPos] = useState({ x: 0, y: 0 });
   const hoverTimer = useRef<number | null>(null);
   const closeTimer = useRef<number | null>(null);
@@ -1088,6 +1096,21 @@ export default function DevOrreryPage() {
   const payload = resolveQ.data;
   const catalog = catalogQ.data;
   const coverage = coverageQ.data;
+  const cognitionAnchor = payload?.anchor_chunk_id ?? null;
+  const cognitionQ = useQuery<CognitionTracePayload, Error>({
+    queryKey: ["orrery", "cognition", slot, cognitionAnchor, cognitionEnt?.id],
+    queryFn: () =>
+      fetchCognitionTrace({
+        slot,
+        entityId: cognitionEnt?.id as number,
+        anchorChunkId: cognitionAnchor as number,
+      }),
+    enabled: cognitionEnt != null && cognitionAnchor != null,
+  });
+  const cognitionVM = useMemo(
+    () => (cognitionQ.data ? buildCognitionTrace(cognitionQ.data) : null),
+    [cognitionQ.data],
+  );
 
   // Head anchor: the first at-head resolve fixes the stepper's upper bound.
   useEffect(() => {
@@ -1423,6 +1446,10 @@ export default function DevOrreryPage() {
     return buildEntityAudit(ent, !offScreen, {
       onTagEnter: (tag) => setHoverTag(tag),
       onTagLeave: () => setHoverTag(null),
+      onOpenCognition: () => {
+        setCognitionEnt({ id: ent.entity_id, name: ent.name });
+        setHoverEnt(null);
+      },
     });
   }, [hoverEnt, payload, hoverCtxQ.data]);
 
@@ -1436,6 +1463,7 @@ export default function DevOrreryPage() {
     setGroupOpen({});
     setShadowOpen({});
     setHoverEnt(null);
+    setCognitionEnt(null);
     setMode("current");
   };
   const stepTo = (next: number) => {
@@ -2471,6 +2499,14 @@ export default function DevOrreryPage() {
         y={hoverPos.y}
         onEnter={hoverPanelEnter}
         onLeave={hoverOut}
+      />
+
+      <CognitionTrace
+        open={cognitionEnt != null}
+        onOpenChange={(open) => !open && setCognitionEnt(null)}
+        vm={cognitionVM}
+        loading={cognitionQ.isFetching}
+        error={cognitionQ.error?.message ?? null}
       />
 
       {/* ═══════════════ WHAT-IF DRAWER ═══════════════ */}

--- a/ui/client/src/pages/dev-orrery/types.ts
+++ b/ui/client/src/pages/dev-orrery/types.ts
@@ -334,7 +334,7 @@ export interface CognitionTracePayload {
           name: string;
         }[];
       };
-      source_event: CognitionSourceEvent;
+      source_event: { event_id: number };
     }[];
     experiences: {
       experience_id: number;
@@ -349,7 +349,7 @@ export interface CognitionTracePayload {
       render_model: string | null;
       renderer_version: string | null;
       render_generation_id: string | null;
-      source_events: CognitionSourceEvent[];
+      source_event_ids: number[];
     }[];
     recall_candidates: {
       trace_id: number;
@@ -429,6 +429,7 @@ export interface CognitionTracePayload {
   };
   canonical_truth: {
     guarded: true;
+    source_events: CognitionSourceEvent[];
     unpossessed_sibling_accounts: {
       claim_id: number;
       world_event_id: number;
@@ -670,6 +671,7 @@ export interface CognitionTraceVM {
   }[];
   config: { section: string; values: { key: string; value: string }[] }[];
   canonical: {
+    events: { key: string; label: string; summary: string; payload: string }[];
     siblings: { key: string; label: string; summary: string; payload: string }[];
     secrets: { key: string; label: string; summary: string; payload: string }[];
   };

--- a/ui/client/src/pages/dev-orrery/types.ts
+++ b/ui/client/src/pages/dev-orrery/types.ts
@@ -291,6 +291,165 @@ export interface ContextPayload {
   entities: ContextEntity[];
 }
 
+// --- character cognition trace ---------------------------------------------
+
+export interface CognitionSourceEvent {
+  event_id: number;
+  event_type: string;
+  severity: string | null;
+  tick_chunk_id: number;
+  actor_entity_id: number | null;
+  target_entity_id: number | null;
+  location_id: number | null;
+  world_time: string | null;
+}
+
+export interface CognitionTracePayload {
+  entity: { entity_id: number; name: string };
+  anchor: {
+    chunk_id: number;
+    world_time: string | null;
+    world_layer: string;
+    season: number;
+    episode: number;
+    scene: number;
+  };
+  actor_facing: {
+    possessed_accounts: {
+      awareness_id: number;
+      claim_id: number;
+      summary: string;
+      scope: string;
+      account_label: string;
+      account_payload: unknown;
+      possession: {
+        source_tier: string;
+        channel: string | null;
+        acquisition_chunk_id: number | null;
+        acquired_at_world_time: string | null;
+        propagation_depth: number | null;
+        source_chain: {
+          kind: string;
+          entity_id: number;
+          name: string;
+        }[];
+      };
+      source_event: CognitionSourceEvent;
+    }[];
+    experiences: {
+      experience_id: number;
+      anchor_chunk_id: number;
+      basis: string;
+      claim_id: number | null;
+      claim_awareness_id: number | null;
+      seed_summary: string;
+      experience_text: string | null;
+      salience: number;
+      render_status: string;
+      render_model: string | null;
+      renderer_version: string | null;
+      render_generation_id: string | null;
+      source_events: CognitionSourceEvent[];
+    }[];
+    recall_candidates: {
+      trace_id: number;
+      turn_id: string;
+      candidate_kind: "claim" | "experience";
+      candidate_id: number;
+      claim_id: number | null;
+      summary: string | null;
+      source_chunk_id: number | null;
+      decision: "included" | "excluded" | "suppressed";
+      reason: string;
+      mandatory: boolean;
+      score: number;
+      score_components: Record<string, unknown>;
+      threshold: number | null;
+      truncated: boolean;
+      created_at: string;
+    }[];
+    recall_truncated: boolean;
+    disclosure_results: {
+      trace_id: number;
+      candidate_kind: "claim" | "experience";
+      candidate_id: number;
+      allowed: boolean;
+      reason: string;
+      blocking_reasons: string[];
+      components: Record<string, unknown>;
+    }[];
+    prompt_exposure: {
+      orrery_proposals: {
+        kind: string;
+        exposure_id: number;
+        proposal_id: string;
+        template_id: string;
+        binding_hash: string;
+        position: number;
+        created_at: string;
+        actor_entity_id: number | null;
+        target_entity_id: number | null;
+        payload: unknown;
+      }[];
+      knowledge_surfacing: {
+        kind: string;
+        trace_id: number;
+        turn_id: string;
+        candidate_kind: "claim" | "experience";
+        candidate_id: number;
+        summary: string | null;
+        position: number;
+      }[];
+    };
+    experience_jobs: {
+      job_id: number;
+      state: string;
+      attempts: number;
+      available_at: string;
+      lease_until: string | null;
+      locked_by: string | null;
+      lease_nonce: string | null;
+      last_error: string | null;
+      requested_model: string;
+      source_digest: string;
+      experience_ids: number[];
+      timeline_identity: Record<string, string | number>;
+    }[];
+    generation_identity: {
+      render_generation_ids: string[];
+      timeline: Record<string, string | number>;
+    };
+  };
+  effective_config: {
+    enabled: Record<string, boolean>;
+    caps: Record<string, number | null>;
+    weights: Record<string, number | null>;
+    thresholds: Record<string, number | null>;
+    producer_coverage: Record<string, string[]>;
+  };
+  canonical_truth: {
+    guarded: true;
+    unpossessed_sibling_accounts: {
+      claim_id: number;
+      world_event_id: number;
+      summary: string;
+      scope: string;
+      account_label: string;
+      account_payload: unknown;
+    }[];
+    latent_secrets: {
+      secret_id: number;
+      claim_id: number;
+      summary: string;
+      account_payload: unknown;
+      gate_template_id: string;
+      holder_entity_id: number;
+      source_chunk_id: number | null;
+      status: string;
+    }[];
+  };
+}
+
 // --- coverage ----------------------------------------------------------------
 
 export interface CoveragePayload {
@@ -402,6 +561,7 @@ export interface ResolutionCardVM {
 }
 
 export interface EntityAuditVM {
+  entityId: number;
   name: string;
   place: string;
   classes: string;
@@ -422,6 +582,7 @@ export interface EntityAuditVM {
   hasKnowledge: boolean;
   events: { t: string; type: string }[];
   hasEvents: boolean;
+  onOpenCognition: () => void;
 }
 
 export interface EntityAuditTagVM {
@@ -432,6 +593,86 @@ export interface EntityAuditTagVM {
   dotTitle: string;
   onEnter?: () => void;
   onLeave?: () => void;
+}
+
+export interface CognitionSourceNodeVM {
+  key: string;
+  kind: string;
+  label: string;
+  children: CognitionSourceNodeVM[];
+}
+
+export interface CognitionTraceVM {
+  title: string;
+  anchor: string;
+  timeline: string;
+  accounts: {
+    key: string;
+    sourceKey: string;
+    claim: string;
+    meta: string;
+    summary: string;
+    sourceChunk: string;
+    sourcePreview: string;
+    chain: CognitionSourceNodeVM[];
+    payload: string;
+  }[];
+  experiences: {
+    key: string;
+    sourceKey: string;
+    id: string;
+    meta: string;
+    summary: string;
+    sourcePreview: string;
+    renderStatus: string;
+    salience: string;
+  }[];
+  recalls: {
+    key: string;
+    sourceKey: string;
+    sourceLabel: string;
+    summary: string;
+    decision: string;
+    reason: string;
+    score: string;
+    threshold: string;
+    mandatory: boolean;
+    truncated: boolean;
+    components: { label: string; value: string; pct: string }[];
+  }[];
+  truncated: boolean;
+  disclosures: {
+    key: string;
+    sourceKey: string;
+    sourceLabel: string;
+    allowed: boolean;
+    reason: string;
+    reasons: string[];
+    components: string;
+  }[];
+  exposures: {
+    key: string;
+    kind: string;
+    label: string;
+    meta: string;
+    preview: string;
+    payload: string;
+  }[];
+  jobs: {
+    key: string;
+    id: string;
+    state: string;
+    attempts: string;
+    lease: string;
+    error: string | null;
+    timeline: string;
+    generations: string;
+  }[];
+  config: { section: string; values: { key: string; value: string }[] }[];
+  canonical: {
+    siblings: { key: string; label: string; summary: string; payload: string }[];
+    secrets: { key: string; label: string; summary: string; payload: string }[];
+  };
 }
 
 export type RowStatus = "winner" | "shadowed" | "gate_failed" | "not_applicable";

--- a/ui/client/src/pages/dev-orrery/vm.ts
+++ b/ui/client/src/pages/dev-orrery/vm.ts
@@ -13,6 +13,9 @@ import type {
   ActorGroupVM,
   ContextEntity,
   EntityAuditVM,
+  CognitionSourceNodeVM,
+  CognitionTracePayload,
+  CognitionTraceVM,
   EvaluatedGateNode,
   GhostRowVM,
   InspectorVM,
@@ -777,6 +780,7 @@ export function buildEntityAudit(
   hover: {
     onTagEnter: (tag: string) => void;
     onTagLeave: () => void;
+    onOpenCognition: () => void;
   },
 ): EntityAuditVM {
   const needByType = new Map(ent.needs.map((n) => [n.need_type, n]));
@@ -859,6 +863,7 @@ export function buildEntityAudit(
   }));
 
   return {
+    entityId: ent.entity_id,
     name: ent.name,
     place: ent.place?.name ?? "—",
     classes: ent.place?.classes.join(" · ") ?? "",
@@ -873,6 +878,159 @@ export function buildEntityAudit(
     hasKnowledge: knowledge.length > 0,
     events,
     hasEvents: events.length > 0,
+    onOpenCognition: hover.onOpenCognition,
+  };
+}
+
+function sourceChain(nodes: { kind: string; entity_id: number; name: string }[]): CognitionSourceNodeVM[] {
+  let children: CognitionSourceNodeVM[] = [];
+  for (const node of [...nodes].reverse()) {
+    children = [
+      {
+        key: `${node.kind}:${node.entity_id}`,
+        kind: node.kind,
+        label: `${node.name} · #${node.entity_id}`,
+        children,
+      },
+    ];
+  }
+  return children;
+}
+
+function componentRows(value: Record<string, unknown>): { label: string; value: string; pct: string }[] {
+  return Object.entries(value)
+    .filter(([, item]) => typeof item === "number")
+    .map(([label, item]) => {
+      const numeric = Number(item);
+      return {
+        label,
+        value: numeric.toFixed(3),
+        pct: `${Math.max(0, Math.min(100, Math.round(numeric * 100)))}%`,
+      };
+    });
+}
+
+function configValue(value: unknown): string {
+  return Array.isArray(value) ? value.join(", ") : String(value ?? "—");
+}
+
+/** Adapt the durable cognition payload into presentation-only trace rows. */
+export function buildCognitionTrace(payload: CognitionTracePayload): CognitionTraceVM {
+  const actor = payload.actor_facing;
+  const accounts = actor.possessed_accounts.map((row) => ({
+    key: `claim:${row.awareness_id}`,
+    sourceKey: `claim:${row.awareness_id}`,
+    claim: `claim #${row.claim_id}`,
+    meta: [row.scope, row.account_label, row.possession.source_tier, row.possession.channel]
+      .filter(Boolean)
+      .join(" · "),
+    summary: row.summary,
+    sourceChunk: `chunk ${row.source_event.tick_chunk_id}`,
+    sourcePreview: `${row.source_event.event_type} · ${row.source_event.world_time ?? "world time unstamped"}`,
+    chain: sourceChain(row.possession.source_chain),
+    payload: JSON.stringify(row.account_payload, null, 2),
+  }));
+  const experiences = actor.experiences.map((row) => ({
+    key: `experience:${row.experience_id}`,
+    sourceKey: `experience:${row.experience_id}`,
+    id: `experience #${row.experience_id}`,
+    meta: `${row.basis} · chunk ${row.anchor_chunk_id}`,
+    summary: row.experience_text ?? row.seed_summary,
+    sourcePreview: row.source_events
+      .map((event) => `${event.event_type} #${event.event_id}`)
+      .join("\n"),
+    renderStatus: row.render_status,
+    salience: row.salience.toFixed(3),
+  }));
+  const recalls = actor.recall_candidates.map((row) => {
+    const recallComponents = Object.fromEntries(
+      Object.entries(row.score_components).filter(([key]) => key !== "disclosure"),
+    );
+    return {
+      key: `trace:${row.trace_id}`,
+      sourceKey: `${row.candidate_kind}:${row.candidate_id}`,
+      sourceLabel: `${row.candidate_kind} #${row.candidate_id}`,
+      summary: row.summary ?? "—",
+      decision: row.decision,
+      reason: row.reason,
+      score: row.score.toFixed(3),
+      threshold: row.threshold == null ? "—" : row.threshold.toFixed(3),
+      mandatory: row.mandatory,
+      truncated: row.truncated,
+      components: componentRows(recallComponents),
+    };
+  });
+  const disclosures = actor.disclosure_results.map((row) => ({
+    key: `disclosure:${row.trace_id}`,
+    sourceKey: `${row.candidate_kind}:${row.candidate_id}`,
+    sourceLabel: `${row.candidate_kind} #${row.candidate_id}`,
+    allowed: row.allowed,
+    reason: row.reason,
+    reasons: row.blocking_reasons,
+    components: JSON.stringify(row.components, null, 2),
+  }));
+  const proposalExposures = actor.prompt_exposure.orrery_proposals.map((row) => ({
+    key: `proposal:${row.exposure_id}`,
+    kind: row.kind,
+    label: row.template_id,
+    meta: `position ${row.position} · ${row.binding_hash}`,
+    preview: row.kind === "resolution" ? "brief · state delta" : "prompt · bindings",
+    payload: JSON.stringify(row.payload, null, 2),
+  }));
+  const knowledgeExposures = actor.prompt_exposure.knowledge_surfacing.map((row) => ({
+    key: `knowledge:${row.trace_id}`,
+    kind: row.kind,
+    label: `${row.candidate_kind} #${row.candidate_id}`,
+    meta: `position ${row.position} · ${row.turn_id}`,
+    preview: row.summary ?? "—",
+    payload: JSON.stringify(row, null, 2),
+  }));
+  const generationIds = actor.generation_identity.render_generation_ids.join(", ") || "—";
+  const jobs = actor.experience_jobs.map((row) => ({
+    key: `job:${row.job_id}`,
+    id: `job #${row.job_id}`,
+    state: row.state,
+    attempts: String(row.attempts),
+    lease: row.lease_until ?? "—",
+    error: row.last_error,
+    timeline: Object.entries(row.timeline_identity)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(" · "),
+    generations: generationIds,
+  }));
+  const config = Object.entries(payload.effective_config).map(([section, values]) => ({
+    section,
+    values: Object.entries(values).map(([key, value]) => ({
+      key,
+      value: configValue(value),
+    })),
+  }));
+  return {
+    title: `${payload.entity.name} · #${payload.entity.entity_id}`,
+    anchor: `chunk ${payload.anchor.chunk_id}`,
+    timeline: `${payload.anchor.world_layer} · S${payload.anchor.season} E${payload.anchor.episode} SC${payload.anchor.scene}`,
+    accounts,
+    experiences,
+    recalls,
+    truncated: actor.recall_truncated,
+    disclosures,
+    exposures: [...proposalExposures, ...knowledgeExposures],
+    jobs,
+    config,
+    canonical: {
+      siblings: payload.canonical_truth.unpossessed_sibling_accounts.map((row) => ({
+        key: `sibling:${row.claim_id}`,
+        label: `${row.account_label} · claim #${row.claim_id}`,
+        summary: row.summary,
+        payload: JSON.stringify(row.account_payload, null, 2),
+      })),
+      secrets: payload.canonical_truth.latent_secrets.map((row) => ({
+        key: `secret:${row.secret_id}`,
+        label: `${row.gate_template_id} · claim #${row.claim_id}`,
+        summary: row.summary,
+        payload: JSON.stringify(row.account_payload, null, 2),
+      })),
+    },
   };
 }
 

--- a/ui/client/src/pages/dev-orrery/vm.ts
+++ b/ui/client/src/pages/dev-orrery/vm.ts
@@ -925,8 +925,11 @@ export function buildCognitionTrace(payload: CognitionTracePayload): CognitionTr
       .filter(Boolean)
       .join(" · "),
     summary: row.summary,
-    sourceChunk: `chunk ${row.source_event.tick_chunk_id}`,
-    sourcePreview: `${row.source_event.event_type} · ${row.source_event.world_time ?? "world time unstamped"}`,
+    sourceChunk:
+      row.possession.acquisition_chunk_id == null
+        ? "acquisition chunk unstamped"
+        : `chunk ${row.possession.acquisition_chunk_id}`,
+    sourcePreview: `source event #${row.source_event.event_id} · ${row.possession.acquired_at_world_time ?? "world time unstamped"}`,
     chain: sourceChain(row.possession.source_chain),
     payload: JSON.stringify(row.account_payload, null, 2),
   }));
@@ -936,8 +939,8 @@ export function buildCognitionTrace(payload: CognitionTracePayload): CognitionTr
     id: `experience #${row.experience_id}`,
     meta: `${row.basis} · chunk ${row.anchor_chunk_id}`,
     summary: row.experience_text ?? row.seed_summary,
-    sourcePreview: row.source_events
-      .map((event) => `${event.event_type} #${event.event_id}`)
+    sourcePreview: row.source_event_ids
+      .map((eventId) => `source event #${eventId}`)
       .join("\n"),
     renderStatus: row.render_status,
     salience: row.salience.toFixed(3),
@@ -1018,6 +1021,12 @@ export function buildCognitionTrace(payload: CognitionTracePayload): CognitionTr
     jobs,
     config,
     canonical: {
+      events: payload.canonical_truth.source_events.map((row) => ({
+        key: `event:${row.event_id}`,
+        label: `${row.event_type} · event #${row.event_id}`,
+        summary: `actor ${row.actor_entity_id ?? "—"} · target ${row.target_entity_id ?? "—"} · location ${row.location_id ?? "—"}`,
+        payload: JSON.stringify(row, null, 2),
+      })),
       siblings: payload.canonical_truth.unpossessed_sibling_accounts.map((row) => ({
         key: `sibling:${row.claim_id}`,
         label: `${row.account_label} · claim #${row.claim_id}`,


### PR DESCRIPTION
Closes #680 — the last item of the MGO board; the focused child of #625, which stays open.

One trace, source event → possession → experience → recall → disclosure → prompt exposure, for a selected character and anchor:

- **Backend**: extends `audit.py` + the dev endpoints (same gating; no new auth). Durable #678 trace rows stay authoritative; recomputable material is recomputed, not persisted. Source-event payloads are withheld from the actor-facing block so distorted accounts can't leak canonical facts; `canonical_truth` (unpossessed siblings, latent secrets) is a structurally separate guarded block.
- **UI**: `CognitionTrace.tsx` in the dev-orrery page's established idiom — theme tokens, dashed-border ephemera, 3px score meters, hover cross-highlight — vendored components only, zero installs (per the component scout). Dev dashboard ship-off invariant untouched.
- The SkyrimNet lesson that motivated this (its dashboard was the one part of its stack that made memory debuggable) lands here with NEXUS's spoiler discipline intact.

Backend suites green; UI bundle builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMYpCu8kEVEw9CaUUsB9wG